### PR TITLE
Fix serveral ui bugs

### DIFF
--- a/src/components/assistant/PromptTabContent.tsx
+++ b/src/components/assistant/PromptTabContent.tsx
@@ -32,6 +32,7 @@ export function PromptTabContent({ assistant, updateAssistant }: PromptTabConten
           value={assistant?.prompt}
           multiline
           onChangeText={prompt => updateAssistant({ ...assistant, prompt })}
+          verticalAlign="top"
         />
       </YStack>
     </YStack>

--- a/src/components/assistant/PromptTabContent.tsx
+++ b/src/components/assistant/PromptTabContent.tsx
@@ -9,6 +9,7 @@ interface PromptTabContentProps {
   assistant: Assistant
   updateAssistant: (assistant: Assistant) => void
 }
+
 export function PromptTabContent({ assistant, updateAssistant }: PromptTabContentProps) {
   const { t } = useTranslation()
 
@@ -17,7 +18,8 @@ export function PromptTabContent({ assistant, updateAssistant }: PromptTabConten
       <YStack width="100%" gap={8}>
         <SettingRowTitle paddingHorizontal={10}>{t('common.name')}</SettingRowTitle>
         <Input
-          padding={15}
+          height={49}
+          padding={16}
           placeholder={t('assistants.name')}
           value={assistant?.name}
           onChangeText={name => updateAssistant({ ...assistant, name })}

--- a/src/components/assistant/ReasoningSelect.tsx
+++ b/src/components/assistant/ReasoningSelect.tsx
@@ -30,7 +30,7 @@ export function ReasoningSelect({ assistant, onValueChange }: ReasoningSelectPro
   return (
     <>
       <Button
-        width="30%"
+        width="auto"
         backgroundColor="$colorTransparent"
         borderWidth={0}
         iconAfter={ChevronRight}


### PR DESCRIPTION
1. On iPad, ReasoningSelect didn't align itself to right because button has a minumum 30% width constraint. Fix it by change width to 'auto'.
2. Add verticalAlign="top" to make text align to top in prompt input textarea.
3. Text overlapped because Input height is 44, which is a bit smaller. Fix it by setting Input height to 49 according to figma.