### PR TITLE
fix: set default assistant tool calling method to function call

### DIFF
--- a/src/config/assistants.ts
+++ b/src/config/assistants.ts
@@ -24,7 +24,10 @@ export function getSystemAssistants(): Assistant[] {
     emoji: '😀',
     prompt: '',
     topics: [],
-    type: 'system'
+    type: 'system',
+    settings: {
+      toolUseMode: 'function'
+    }
   }
   const translateAssistant: Assistant = {
     id: 'translate',

--- a/src/services/AssistantService.ts
+++ b/src/services/AssistantService.ts
@@ -872,7 +872,10 @@ export async function createAssistant(): Promise<Assistant> {
     name: i18n.t('settings.assistant.title'),
     prompt: '',
     topics: [],
-    type: 'external'
+    type: 'external',
+    settings: {
+      toolUseMode: 'function'
+    }
   }
 
   await assistantService.createAssistant(newAssistant)


### PR DESCRIPTION
Fix #82