### PR TITLE
feat: add n1n.ai provider preset

### DIFF
--- a/src/config/models/default.ts
+++ b/src/config/models/default.ts
@@ -238,6 +238,26 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       group: 'llama'
     }
   ],
+  n1n: [
+    {
+      id: 'claude-3-5-sonnet-20240620',
+      name: 'Claude 3.5 Sonnet',
+      provider: 'n1n',
+      group: 'Anthropic'
+    },
+    {
+      id: 'gpt-4o',
+      name: 'GPT-4o',
+      provider: 'n1n',
+      group: 'OpenAI'
+    },
+    {
+      id: 'gemini-1.5-pro-latest',
+      name: 'Gemini 1.5 Pro',
+      provider: 'n1n',
+      group: 'Gemini'
+    }
+  ],
 
   burncloud: [
     { id: 'claude-3-7-sonnet-20250219-thinking', provider: 'burncloud', name: 'Claude 3.7 thinking', group: 'Claude' },

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -629,6 +629,17 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     models: SYSTEM_MODELS.cerebras,
     isSystem: true,
     enabled: false
+  },
+  n1n: {
+    id: 'n1n',
+    name: 'n1n.ai',
+    type: 'openai',
+    apiKey: '',
+    apiHost: 'https://api.n1n.ai/v1',
+    anthropicApiHost: 'https://api.n1n.ai/v1',
+    models: SYSTEM_MODELS.n1n,
+    isSystem: true,
+    enabled: false
   }
 } as const
 
@@ -800,10 +811,21 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
       url: 'https://api.perplexity.ai/'
     },
     websites: {
-      official: 'https://perplexity.ai/',
+      official: 'https://www.perplexity.ai/',
       apiKey: 'https://www.perplexity.ai/settings/api',
-      docs: 'https://docs.perplexity.ai/home',
-      models: 'https://docs.perplexity.ai/guides/model-cards'
+      docs: 'https://docs.perplexity.ai/',
+      models: 'https://docs.perplexity.ai/docs/model-cards'
+    }
+  },
+  n1n: {
+    api: {
+      url: 'https://api.n1n.ai/v1'
+    },
+    websites: {
+      official: 'https://n1n.ai',
+      apiKey: 'https://n1n.ai',
+      docs: 'https://docs.n1n.ai',
+      models: 'https://docs.n1n.ai/llm-api-quickstart'
     }
   },
   infini: {

--- a/src/types/assistant.ts
+++ b/src/types/assistant.ts
@@ -344,7 +344,8 @@ export const SystemProviderIds = {
   longcat: 'longcat',
   huggingface: 'huggingface',
   'ai-gateway': 'ai-gateway',
-  cerebras: 'cerebras'
+  cerebras: 'cerebras',
+  n1n: 'n1n'
 } as const
 export type SystemProviderId = keyof typeof SystemProviderIds
 


### PR DESCRIPTION
This PR adds n1n.ai as a system provider.

Changes:
- Added `n1n` to provider types.
- Registered `n1n` in default models configuration.
- Added `n1n` provider configuration in providers list and URL maps.

