### PR TITLE
fix:The tablet's settings interface cannot scroll

### DIFF
--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { View } from 'react-native'
+import { ScrollView, View } from 'react-native'
 import { GestureDetector } from 'react-native-gesture-handler'
 
 import {
@@ -110,21 +110,23 @@ export default function SettingsScreen() {
           <HeaderBar title={t('settings.title')} />
 
           <Container>
-            <YStack className="flex-1 gap-6">
-              {settingsItems.map((group, index) => (
-                <SettingGroup key={index} title={group.title}>
-                  {group.items.map((item, index) => (
-                    <SettingItem
-                      key={index}
-                      title={item.title}
-                      screen={item.screen}
-                      icon={item.icon}
-                      specificScreen={item.specificScreen}
-                    />
-                  ))}
-                </SettingGroup>
-              ))}
-            </YStack>
+            <ScrollView showsVerticalScrollIndicator={false}>
+              <YStack className="gap-6">
+                {settingsItems.map((group, index) => (
+                  <SettingGroup key={index} title={group.title}>
+                    {group.items.map((item, index) => (
+                      <SettingItem
+                        key={index}
+                        title={item.title}
+                        screen={item.screen}
+                        icon={item.icon}
+                        specificScreen={item.specificScreen}
+                      />
+                    ))}
+                  </SettingGroup>
+                ))}
+              </YStack>
+            </ScrollView>
           </Container>
         </View>
       </GestureDetector>


### PR DESCRIPTION
The inability to scroll through the settings interface results in the inability to click below, which greatly affects the tablet user experience