### PR TITLE
feat: add horizontal scroll support for wide tables

### DIFF
--- a/src/screens/home/markdown/markdownItem/MarkdownTable.tsx
+++ b/src/screens/home/markdown/markdownItem/MarkdownTable.tsx
@@ -1,11 +1,14 @@
 import type { ReactNode } from 'react'
 import React from 'react'
-import { View } from 'react-native'
+import { ScrollView, View } from 'react-native'
 
 interface MarkdownTableProps {
   children: ReactNode
 }
-
 export function MarkdownTable({ children }: MarkdownTableProps) {
-  return <View className="border-border my-4 rounded-md border">{children}</View>
+  return (
+    <ScrollView horizontal={true} showsHorizontalScrollIndicator={true}>
+      <View className="border-border my-4 rounded-md border">{children}</View>
+    </ScrollView>
+  )
 }

--- a/src/screens/home/markdown/markdownItem/MarkdownTableCell.tsx
+++ b/src/screens/home/markdown/markdownItem/MarkdownTableCell.tsx
@@ -8,10 +8,9 @@ interface MarkdownTableCellProps {
   isHeader?: boolean
   children: ReactNode
 }
-
 export function MarkdownTableCell({ isHeader, children }: MarkdownTableCellProps) {
   return (
-    <View className="flex-1 p-2">
+    <View className="min-w-25 p-2">
       <SelectableText className={isHeader ? 'text-foreground font-bold' : 'text-foreground'}>{children}</SelectableText>
     </View>
   )

--- a/src/screens/home/markdown/markdownItem/MarkdownTableHead.tsx
+++ b/src/screens/home/markdown/markdownItem/MarkdownTableHead.tsx
@@ -7,5 +7,5 @@ interface MarkdownTableHeadProps {
 }
 
 export function MarkdownTableHead({ children }: MarkdownTableHeadProps) {
-  return <View className="bg-muted">{children}</View>
+  return <View className="bg-muted min-w-25">{children}</View>
 }


### PR DESCRIPTION
### Before

<img width="361" height="637" alt="image" src="https://github.com/user-attachments/assets/1b1850ff-1337-40f9-8691-2952c457eab9" />

### Now

<img width="387" height="457" alt="image" src="https://github.com/user-attachments/assets/ccd13509-57b7-444d-9135-fdacf48b7759" />



### Issue
https://github.com/CherryHQ/cherry-studio-app/issues/196
