### PR TITLE
fix: resolve screen transition stutter with native stack

### DIFF
--- a/src/navigators/AssistantMarketStackNavigator.tsx
+++ b/src/navigators/AssistantMarketStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import AssistantMarketScreen from '@/screens/assistant/AssistantMarketScreen'
@@ -7,15 +7,15 @@ export type AssistantMarketStackParamList = {
   AssistantMarketScreen: undefined
 }
 
-const Stack = createStackNavigator<AssistantMarketStackParamList>()
+const Stack = createNativeStackNavigator<AssistantMarketStackParamList>()
 
 export default function AssistantMarketStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="AssistantMarketScreen" component={AssistantMarketScreen} />
     </Stack.Navigator>

--- a/src/navigators/AssistantMarketStackNavigator.tsx
+++ b/src/navigators/AssistantMarketStackNavigator.tsx
@@ -15,7 +15,8 @@ export default function AssistantMarketStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="AssistantMarketScreen" component={AssistantMarketScreen} />
     </Stack.Navigator>

--- a/src/navigators/AssistantStackNavigator.tsx
+++ b/src/navigators/AssistantStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import AssistantDetailScreen from '@/screens/assistant/AssistantDetailScreen'
@@ -10,15 +10,15 @@ export type AssistantStackParamList = {
   AssistantDetailScreen: AssistantDetailScreenParams
 }
 
-const Stack = createStackNavigator<AssistantStackParamList>()
+const Stack = createNativeStackNavigator<AssistantStackParamList>()
 
 export default function AssistantStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="AssistantScreen" component={AssistantScreen} />
       <Stack.Screen name="AssistantDetailScreen" component={AssistantDetailScreen} />

--- a/src/navigators/AssistantStackNavigator.tsx
+++ b/src/navigators/AssistantStackNavigator.tsx
@@ -18,10 +18,15 @@ export default function AssistantStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="AssistantScreen" component={AssistantScreen} />
-      <Stack.Screen name="AssistantDetailScreen" component={AssistantDetailScreen} />
+      <Stack.Screen
+        name="AssistantDetailScreen"
+        component={AssistantDetailScreen}
+        options={{ gestureEnabled: false, fullScreenGestureEnabled: false }}
+      />
     </Stack.Navigator>
   )
 }

--- a/src/navigators/HomeStackNavigator.tsx
+++ b/src/navigators/HomeStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import AssistantDetailScreen from '@/screens/assistant/AssistantDetailScreen'
@@ -29,15 +29,15 @@ export type HomeStackParamList = {
   AboutSettings: { screen?: string; params?: any } | undefined
 }
 
-const Stack = createStackNavigator<HomeStackParamList>()
+const Stack = createNativeStackNavigator<HomeStackParamList>()
 
 export default function HomeStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="ChatScreen" component={ChatScreen} />
       <Stack.Screen name="TopicScreen" component={TopicScreen} />

--- a/src/navigators/HomeStackNavigator.tsx
+++ b/src/navigators/HomeStackNavigator.tsx
@@ -37,12 +37,21 @@ export default function HomeStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="ChatScreen" component={ChatScreen} />
       <Stack.Screen name="TopicScreen" component={TopicScreen} />
-      <Stack.Screen name="AssistantDetailScreen" component={AssistantDetailScreen} />
-      <Stack.Screen name="SettingsScreen" component={SettingsScreen} />
+      <Stack.Screen
+        name="AssistantDetailScreen"
+        component={AssistantDetailScreen}
+        options={{ gestureEnabled: false, fullScreenGestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="SettingsScreen"
+        component={SettingsScreen}
+        options={{ gestureEnabled: false, fullScreenGestureEnabled: false }}
+      />
       <Stack.Screen name="HtmlPreviewScreen" component={HtmlPreviewScreen} />
       <Stack.Screen name="GeneralSettings" component={GeneralSettingsStackNavigator} />
       <Stack.Screen name="AssistantSettings" component={AssistantSettingsStackNavigator} />

--- a/src/navigators/McpStackNavigator.tsx
+++ b/src/navigators/McpStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import McpDetailScreen from '@/screens/mcp/McpDetailScreen'
@@ -11,15 +11,15 @@ export type McpStackParamList = {
   McpDetailScreen: { mcpId?: string }
 }
 
-const Stack = createStackNavigator<McpStackParamList>()
+const Stack = createNativeStackNavigator<McpStackParamList>()
 
 export default function McpStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="McpScreen" component={McpScreen} />
       <Stack.Screen name="McpMarketScreen" component={McpMarketScreen} />

--- a/src/navigators/McpStackNavigator.tsx
+++ b/src/navigators/McpStackNavigator.tsx
@@ -19,7 +19,8 @@ export default function McpStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="McpScreen" component={McpScreen} />
       <Stack.Screen name="McpMarketScreen" component={McpMarketScreen} />

--- a/src/navigators/SettingsStackNavigator.tsx
+++ b/src/navigators/SettingsStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import SettingsScreen from '@/screens/settings/SettingsScreen'
@@ -20,15 +20,15 @@ export type SettingsStackParamList = {
   AboutSettings: undefined
 }
 
-const Stack = createStackNavigator<SettingsStackParamList>()
+const Stack = createNativeStackNavigator<SettingsStackParamList>()
 
 export default function SettingsStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="SettingsScreen" component={SettingsScreen} />
       <Stack.Screen name="GeneralSettings" component={GeneralSettingsStackNavigator} />

--- a/src/navigators/SettingsStackNavigator.tsx
+++ b/src/navigators/SettingsStackNavigator.tsx
@@ -28,9 +28,14 @@ export default function SettingsStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
-      <Stack.Screen name="SettingsScreen" component={SettingsScreen} />
+      <Stack.Screen
+        name="SettingsScreen"
+        component={SettingsScreen}
+        options={{ gestureEnabled: false, fullScreenGestureEnabled: false }}
+      />
       <Stack.Screen name="GeneralSettings" component={GeneralSettingsStackNavigator} />
       <Stack.Screen name="AssistantSettings" component={AssistantSettingsStackNavigator} />
       <Stack.Screen name="ProvidersSettings" component={ProvidersStackNavigator} />

--- a/src/navigators/WelcomeStackNavigator.tsx
+++ b/src/navigators/WelcomeStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import WelcomeScreen from '@/screens/welcome/WelcomeScreen'
@@ -7,14 +7,14 @@ export type WelcomeStackParamList = {
   WelcomeScreen: undefined
 }
 
-const Stack = createStackNavigator<WelcomeStackParamList>()
+const Stack = createNativeStackNavigator<WelcomeStackParamList>()
 
 export default function WelcomeStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right'
       }}>
       <Stack.Screen name="WelcomeScreen" component={WelcomeScreen} />
     </Stack.Navigator>

--- a/src/navigators/settings/AboutStackNavigator.tsx
+++ b/src/navigators/settings/AboutStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import AboutScreen from '@/screens/settings/about/AboutScreen'
@@ -9,15 +9,15 @@ export type AboutStackParamList = {
   AboutScreen: undefined
 }
 
-const Stack = createStackNavigator<AboutStackParamList>()
+const Stack = createNativeStackNavigator<AboutStackParamList>()
 
 export default function AboutStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="PersonalScreen" component={PersonalScreen} />
       <Stack.Screen name="AboutScreen" component={AboutScreen} />

--- a/src/navigators/settings/AboutStackNavigator.tsx
+++ b/src/navigators/settings/AboutStackNavigator.tsx
@@ -17,7 +17,8 @@ export default function AboutStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="PersonalScreen" component={PersonalScreen} />
       <Stack.Screen name="AboutScreen" component={AboutScreen} />

--- a/src/navigators/settings/AssistantSettingsStackNavigator.tsx
+++ b/src/navigators/settings/AssistantSettingsStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import AssistantDetailScreen from '@/screens/assistant/AssistantDetailScreen'
@@ -9,15 +9,15 @@ export type AssistantSettingsStackParamList = {
   AssistantDetailScreen: { assistantId: string; tab?: string }
 }
 
-const Stack = createStackNavigator<AssistantSettingsStackParamList>()
+const Stack = createNativeStackNavigator<AssistantSettingsStackParamList>()
 
 export default function AssistantSettingsStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="AssistantSettingsScreen" component={AssistantSettingsScreen} />
       <Stack.Screen name="AssistantDetailScreen" component={AssistantDetailScreen} />

--- a/src/navigators/settings/AssistantSettingsStackNavigator.tsx
+++ b/src/navigators/settings/AssistantSettingsStackNavigator.tsx
@@ -17,10 +17,15 @@ export default function AssistantSettingsStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="AssistantSettingsScreen" component={AssistantSettingsScreen} />
-      <Stack.Screen name="AssistantDetailScreen" component={AssistantDetailScreen} />
+      <Stack.Screen
+        name="AssistantDetailScreen"
+        component={AssistantDetailScreen}
+        options={{ gestureEnabled: false, fullScreenGestureEnabled: false }}
+      />
     </Stack.Navigator>
   )
 }

--- a/src/navigators/settings/DataSourcesStackNavigator.tsx
+++ b/src/navigators/settings/DataSourcesStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import BasicDataSettingsScreen from '@/screens/settings/data/BasicDataSettingsScreen'
@@ -11,15 +11,15 @@ export type DataSourcesStackParamList = {
   LanTransferScreen: { redirectToHome?: boolean } | undefined
 }
 
-const Stack = createStackNavigator<DataSourcesStackParamList>()
+const Stack = createNativeStackNavigator<DataSourcesStackParamList>()
 
 export default function DataSourcesStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="DataSettingsScreen" component={DataSettingsScreen} />
       <Stack.Screen name="BasicDataSettingsScreen" component={BasicDataSettingsScreen} />

--- a/src/navigators/settings/DataSourcesStackNavigator.tsx
+++ b/src/navigators/settings/DataSourcesStackNavigator.tsx
@@ -19,7 +19,8 @@ export default function DataSourcesStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="DataSettingsScreen" component={DataSettingsScreen} />
       <Stack.Screen name="BasicDataSettingsScreen" component={BasicDataSettingsScreen} />

--- a/src/navigators/settings/GeneralSettingsStackNavigator.tsx
+++ b/src/navigators/settings/GeneralSettingsStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import GeneralSettingsScreen from '@/screens/settings/general/GeneralSettingsScreen'
@@ -7,15 +7,15 @@ export type GeneralSettingsStackParamList = {
   GeneralSettingsScreen: undefined
 }
 
-const Stack = createStackNavigator<GeneralSettingsStackParamList>()
+const Stack = createNativeStackNavigator<GeneralSettingsStackParamList>()
 
 export default function GeneralSettingsStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="GeneralSettingsScreen" component={GeneralSettingsScreen} />
     </Stack.Navigator>

--- a/src/navigators/settings/GeneralSettingsStackNavigator.tsx
+++ b/src/navigators/settings/GeneralSettingsStackNavigator.tsx
@@ -15,7 +15,8 @@ export default function GeneralSettingsStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="GeneralSettingsScreen" component={GeneralSettingsScreen} />
     </Stack.Navigator>

--- a/src/navigators/settings/ProvidersStackNavigator.tsx
+++ b/src/navigators/settings/ProvidersStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import AddProviderScreen from '@/screens/settings/providers/AddProviderScreen'
@@ -15,15 +15,15 @@ export type ProvidersStackParamList = {
   AddProviderScreen: undefined
 }
 
-const Stack = createStackNavigator<ProvidersStackParamList>()
+const Stack = createNativeStackNavigator<ProvidersStackParamList>()
 
 export default function ProvidersStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="ProviderSettingsScreen" component={ProviderSettingsScreen} />
       <Stack.Screen name="ProviderListScreen" component={ProviderListScreen} />

--- a/src/navigators/settings/ProvidersStackNavigator.tsx
+++ b/src/navigators/settings/ProvidersStackNavigator.tsx
@@ -23,7 +23,8 @@ export default function ProvidersStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="ProviderSettingsScreen" component={ProviderSettingsScreen} />
       <Stack.Screen name="ProviderListScreen" component={ProviderListScreen} />

--- a/src/navigators/settings/WebSearchStackNavigator.tsx
+++ b/src/navigators/settings/WebSearchStackNavigator.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, TransitionPresets } from '@react-navigation/stack'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React from 'react'
 
 import WebSearchProviderSettingsScreen from '@/screens/settings/websearch/WebSearchProviderSettingsScreen'
@@ -9,15 +9,15 @@ export type WebSearchStackParamList = {
   WebSearchProviderSettingsScreen: { providerId: string }
 }
 
-const Stack = createStackNavigator<WebSearchStackParamList>()
+const Stack = createNativeStackNavigator<WebSearchStackParamList>()
 
 export default function WebSearchStackNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        gestureResponseDistance: 9999,
-        ...TransitionPresets.SlideFromRightIOS
+        animation: 'ios_from_right',
+        gestureEnabled: true
       }}>
       <Stack.Screen name="WebSearchSettingsScreen" component={WebSearchSettingsScreen} />
       <Stack.Screen name="WebSearchProviderSettingsScreen" component={WebSearchProviderSettingsScreen} />

--- a/src/navigators/settings/WebSearchStackNavigator.tsx
+++ b/src/navigators/settings/WebSearchStackNavigator.tsx
@@ -17,7 +17,8 @@ export default function WebSearchStackNavigator() {
       screenOptions={{
         headerShown: false,
         animation: 'ios_from_right',
-        gestureEnabled: true
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true
       }}>
       <Stack.Screen name="WebSearchSettingsScreen" component={WebSearchSettingsScreen} />
       <Stack.Screen name="WebSearchProviderSettingsScreen" component={WebSearchProviderSettingsScreen} />


### PR DESCRIPTION
## 问题描述
切换动画会卡一下
#### 相关Issue
#111 #116

## 解决方案
改用 `@react-navigation/native-stack`，解决卡顿问题



## 测试情况
- **Android**: 已测试 Android 16
- **iOS**: 麻烦作者帮忙一下

## 待讨论
1. **动画速度**：默认动画好像比之前快了一点，需要调慢吗？  ~~可能是个人感觉~~
 - `gestureResponseDistance: 9999` 这个感觉没必要，我没加。如果作者觉得需要可以再加。
### 其他解决方案
https://github.com/react-navigation/react-navigation/issues/10179 (但是这个用 `detachPreviousScreen: false`好像点击之后要一会才反应)

https://github.com/CherryHQ/cherry-studio-app/pull/349 好像也不会了
