### PR TITLE
 fix：修复从 cherry-studio 导入备份数据时，请求自定义模型报错

### DIFF
--- a/src/aiCore/provider/providerConfig.ts
+++ b/src/aiCore/provider/providerConfig.ts
@@ -70,7 +70,7 @@ function formatProviderApiHost(provider: Provider): Provider {
   const formatted = { ...provider }
 
   if (formatted.type === 'gemini') {
-    formatted.apiHost = formatApiHost(formatted.apiHost, 'v1beta')
+    formatted.apiHost = formatApiHost(formatted.apiHost, true, 'v1beta')
   } else {
     formatted.apiHost = formatApiHost(formatted.apiHost)
   }

--- a/src/utils/__tests__/api.test.ts
+++ b/src/utils/__tests__/api.test.ts
@@ -1,0 +1,135 @@
+import { formatApiHost, hasAPIVersion } from '../api'
+
+describe('api utils', () => {
+  describe('formatApiHost', () => {
+    describe('empty and edge cases', () => {
+      it('should return empty string when host is undefined', () => {
+        expect(formatApiHost(undefined)).toBe('')
+      })
+
+      it('should return empty string when host is empty string', () => {
+        expect(formatApiHost('')).toBe('')
+      })
+
+      it('should return empty string when host is only whitespace', () => {
+        expect(formatApiHost('   ')).toBe('')
+      })
+    })
+
+    describe('basic formatting', () => {
+      it('should append default version v1 to host without trailing slash', () => {
+        expect(formatApiHost('https://api.example.com')).toBe('https://api.example.com/v1')
+      })
+
+      it('should append default version v1 to host with trailing slash and remove slash', () => {
+        expect(formatApiHost('https://api.example.com/')).toBe('https://api.example.com/v1')
+      })
+
+      it('should append custom version', () => {
+        expect(formatApiHost('https://api.example.com', true, 'v2')).toBe('https://api.example.com/v2')
+      })
+
+      it('should trim trailing whitespace', () => {
+        expect(formatApiHost('  https://api.example.com  ')).toBe('https://api.example.com/v1')
+      })
+    })
+
+    describe('hosts that already contain version', () => {
+      it('should not append version when host already contains /v1', () => {
+        expect(formatApiHost('https://api.example.com/v1')).toBe('https://api.example.com/v1')
+      })
+
+      it('should not append version when host already contains /v2', () => {
+        expect(formatApiHost('https://api.example.com/v2')).toBe('https://api.example.com/v2')
+      })
+
+      it('should not append version when host already contains /v3alpha', () => {
+        expect(formatApiHost('https://api.example.com/v3alpha')).toBe('https://api.example.com/v3alpha')
+      })
+
+      it('should not append version when host already contains /v4beta', () => {
+        expect(formatApiHost('https://api.example.com/v4beta')).toBe('https://api.example.com/v4beta')
+      })
+
+      it('should not append version to path that already contains version', () => {
+        expect(formatApiHost('https://api.example.com/v1/resources')).toBe('https://api.example.com/v1/resources')
+      })
+    })
+
+    describe('supportApiVersion parameter', () => {
+      it('should skip appending version when supportApiVersion is false', () => {
+        expect(formatApiHost('https://api.example.com', false)).toBe('https://api.example.com')
+      })
+
+      it('should skip appending version when supportApiVersion is false even with trailing slash', () => {
+        expect(formatApiHost('https://api.example.com/', false)).toBe('https://api.example.com')
+      })
+    })
+
+    describe('hosts ending with #', () => {
+      it('should remove trailing # and return host without appending version', () => {
+        expect(formatApiHost('https://api.example.com#')).toBe('https://api.example.com')
+      })
+
+      it('should remove trailing # and return host without appending version (trailing slash is preserved)', () => {
+        expect(formatApiHost('https://api.example.com/#')).toBe('https://api.example.com/')
+      })
+    })
+
+    describe('various URL formats', () => {
+      it('should handle http protocol', () => {
+        expect(formatApiHost('http://api.example.com')).toBe('http://api.example.com/v1')
+      })
+
+      it('should handle URL with port', () => {
+        expect(formatApiHost('https://api.example.com:8080')).toBe('https://api.example.com:8080/v1')
+      })
+
+      it('should handle URL with path', () => {
+        expect(formatApiHost('https://api.example.com/path')).toBe('https://api.example.com/path/v1')
+      })
+
+      it('should handle localhost URL', () => {
+        expect(formatApiHost('http://localhost:3000')).toBe('http://localhost:3000/v1')
+      })
+
+      it('should handle host without protocol', () => {
+        expect(formatApiHost('api.example.com')).toBe('api.example.com/v1')
+      })
+    })
+  })
+
+  describe('hasAPIVersion', () => {
+    it('should return false when host is undefined', () => {
+      expect(hasAPIVersion(undefined)).toBe(false)
+    })
+
+    it('should return false when host is empty string', () => {
+      expect(hasAPIVersion('')).toBe(false)
+    })
+
+    it('should return true when host contains /v1', () => {
+      expect(hasAPIVersion('https://api.example.com/v1')).toBe(true)
+    })
+
+    it('should return true when host contains /v2beta', () => {
+      expect(hasAPIVersion('https://api.example.com/v2beta')).toBe(true)
+    })
+
+    it('should return true when host contains /v3alpha', () => {
+      expect(hasAPIVersion('https://api.example.com/v3alpha')).toBe(true)
+    })
+
+    it('should return true when version is in path', () => {
+      expect(hasAPIVersion('https://api.example.com/v1/resources')).toBe(true)
+    })
+
+    it('should return false when host does not contain version', () => {
+      expect(hasAPIVersion('https://api.example.com')).toBe(false)
+    })
+
+    it('should match version case-insensitively', () => {
+      expect(hasAPIVersion('https://api.example.com/V1')).toBe(true)
+    })
+  })
+})

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,24 +1,95 @@
-/**
- * 格式化 API 主机地址。
- *
- * 根据传入的 host 判断是否需要在其末尾加 `/v1/`。
- * - 不加：host 以 `/` 结尾，或以 `volces.com/api/v3` 结尾。
- * - 要加：其余情况。
- *
- * @param {string} host - 需要格式化的 API 主机地址。
- * @param {string} apiVersion - 需要添加的 API 版本。
- * @returns {string} 格式化后的 API 主机地址。
- */
-export function formatApiHost(host: string, apiVersion: string = 'v1'): string {
-  const forceUseOriginalHost = () => {
-    if (host.endsWith('/')) {
-      return true
-    }
+import { trim } from 'lodash'
 
-    return host.endsWith('volces.com/api/v3')
+/**
+ * Matches a version segment in a path that starts with `/v<number>` and optionally
+ * continues with `alpha` or `beta`. The segment may be followed by `/` or the end
+ * of the string (useful for cases like `/v3alpha/resources`).
+ */
+const VERSION_REGEX_PATTERN = '\\/v\\d+(?:alpha|beta)?(?=\\/|$)'
+
+/**
+ * Checks whether the path of the host contains a version-like string (e.g., /v1, /v2beta, etc.).
+ *
+ * @param host - The host or path string to check
+ * @returns Returns true if the path contains a version string, otherwise false
+ */
+export function hasAPIVersion(host?: string): boolean {
+  if (!host) return false
+
+  const regex = new RegExp(VERSION_REGEX_PATTERN, 'i')
+
+  try {
+    const url = new URL(host)
+    return regex.test(url.pathname)
+  } catch {
+    // If it cannot be parsed as a complete URL, treat it as a path directly for detection
+    return regex.test(host)
+  }
+}
+
+/**
+ * Removes the trailing slash from a URL string if it exists.
+ *
+ * @template T - The string type to preserve type safety
+ * @param {T} url - The URL string to process
+ * @returns {T} The URL string without a trailing slash
+ *
+ * @example
+ * ```ts
+ * withoutTrailingSlash('https://example.com/') // 'https://example.com'
+ * withoutTrailingSlash('https://example.com')  // 'https://example.com'
+ * ```
+ */
+export function withoutTrailingSlash<T extends string>(url: T): T {
+  return url.replace(/\/$/, '') as T
+}
+
+/**
+ * Removes the trailing '#' from a URL string if it exists.
+ *
+ * @template T - The string type to preserve type safety
+ * @param {T} url - The URL string to process
+ * @returns {T} The URL string without a trailing '#'
+ *
+ * @example
+ * ```ts
+ * withoutTrailingSharp('https://example.com#') // 'https://example.com'
+ * withoutTrailingSharp('https://example.com')  // 'https://example.com'
+ * ```
+ */
+export function withoutTrailingSharp<T extends string>(url: T): T {
+  return url.replace(/#$/, '') as T
+}
+
+/**
+ * Formats an API host URL by normalizing it and optionally appending an API version.
+ *
+ * @param host - The API host URL to format. Leading/trailing whitespace will be trimmed and trailing slashes removed.
+ * @param supportApiVersion - Whether the API version is supported. Defaults to `true`.
+ * @param apiVersion - The API version to append if needed. Defaults to `'v1'`.
+ *
+ * @returns The formatted API host URL. If the host is empty after normalization, returns an empty string.
+ *          If the host ends with '#', API version is not supported, or the host already contains a version, returns the normalized host with trailing '#' removed.
+ *          Otherwise, returns the host with the API version appended.
+ *
+ * @example
+ * formatApiHost('https://api.example.com/') // Returns 'https://api.example.com/v1'
+ * formatApiHost('https://api.example.com#') // Returns 'https://api.example.com'
+ * formatApiHost('https://api.example.com/v2', true, 'v1') // Returns 'https://api.example.com/v2'
+ */
+export function formatApiHost(host?: string, supportApiVersion: boolean = true, apiVersion: string = 'v1'): string {
+  const normalizedHost = withoutTrailingSlash(trim(host))
+  if (!normalizedHost) {
+    return ''
   }
 
-  return forceUseOriginalHost() ? host : `${host}/${apiVersion}/`
+  const shouldAppendApiVersion = !(normalizedHost.endsWith('#') || !supportApiVersion || hasAPIVersion(normalizedHost))
+
+  if (shouldAppendApiVersion) {
+    return `${normalizedHost}/${apiVersion}`
+  } else {
+    return withoutTrailingSharp(normalizedHost)
+  }
 }
 
 /**


### PR DESCRIPTION
## 历史逻辑
1. 在 `cherry-studio` pc应用里，会经过 `formatApiHost `将所有的 `apiHost`格式化，去掉了末尾的 `/`
	a. 例如：百炼平台： https://dashscope.aliyuncs.com/compatible-mode/v1
2. 但是 `cherry-studio` app 应用里 `formatApiHost` 会根据 `apiHost` 是否以 `/` 结尾判断是否加 `/v1/`,
3. 因此，遇到上述情况， `cherry-studio-app`, 发起请求的最终 url 会处理成 `https://dashscope.aliyuncs.com/compatible-mode/v1/v1/chat/completions`, 最终导致请求 404

## 现在逻辑
1. 将` cherry-studio` `formatApiHost` 的方法迁移过来，增加了多种 api 格式化的分支，具体可参考测试用例