### PR TITLE
fix: generalize formatApiHost to fix provider 404

### DIFF
--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -1,0 +1,28 @@
+import { formatApiHost } from './api'
+
+describe('formatApiHost', () => {
+  it('appends the default version for bare OpenAI-compatible hosts', () => {
+    expect(formatApiHost('https://api.deepseek.com')).toBe('https://api.deepseek.com/v1/')
+  })
+
+  it('keeps existing numeric version paths and only adds a trailing slash', () => {
+    expect(formatApiHost('https://api.minimaxi.com/v1')).toBe('https://api.minimaxi.com/v1/')
+    expect(formatApiHost('https://open.bigmodel.cn/api/paas/v4')).toBe('https://open.bigmodel.cn/api/paas/v4/')
+    expect(formatApiHost('https://ark.cn-beijing.volces.com/api/v3')).toBe('https://ark.cn-beijing.volces.com/api/v3/')
+  })
+
+  it('keeps non-terminal version segments and only adds a trailing slash', () => {
+    expect(formatApiHost('https://cephalon.cloud/user-center/v1/model')).toBe(
+      'https://cephalon.cloud/user-center/v1/model/'
+    )
+  })
+
+  it('supports non-numeric api versions such as v1beta', () => {
+    expect(formatApiHost('https://generativelanguage.googleapis.com', 'v1beta')).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/'
+    )
+    expect(formatApiHost('https://generativelanguage.googleapis.com/v1beta', 'v1beta')).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/'
+    )
+  })
+})

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,24 +1,35 @@
+const VERSION_SEGMENT_RE = /^v\d+(?:[a-z]+\d*)?$/i
+
+function hasVersionSegment(host: string, apiVersion: string): boolean {
+  try {
+    const segments = new URL(host).pathname.split('/').filter(Boolean)
+    return segments.some(segment => segment === apiVersion || VERSION_SEGMENT_RE.test(segment))
+  } catch {
+    return host.includes(`/${apiVersion}`) || VERSION_SEGMENT_RE.test(host.split('/').filter(Boolean).at(-1) ?? '')
+  }
+}
+
 /**
  * 格式化 API 主机地址。
  *
- * 根据传入的 host 判断是否需要在其末尾加 `/v1/`。
- * - 不加：host 以 `/` 结尾，或以 `volces.com/api/v3` 结尾。
- * - 要加：其余情况。
+ * - host 以 `/` 结尾 → 原样返回
+ * - 路径中已包含版本段（如 `v1`、`v4`、`v1beta`）→ 只补尾部 `/`
+ * - 其余情况 → 追加 `/${apiVersion}/`
  *
  * @param {string} host - 需要格式化的 API 主机地址。
- * @param {string} apiVersion - 需要添加的 API 版本。
+ * @param {string} apiVersion - 需要追加的 API 版本，默认 `v1`。
  * @returns {string} 格式化后的 API 主机地址。
  */
 export function formatApiHost(host: string, apiVersion: string = 'v1'): string {
-  const forceUseOriginalHost = () => {
-    if (host.endsWith('/')) {
-      return true
-    }
-
-    return host.endsWith('volces.com/api/v3')
+  if (!host || host.endsWith('/')) {
+    return host
   }
 
-  return forceUseOriginalHost() ? host : `${host}/${apiVersion}/`
+  if (hasVersionSegment(host, apiVersion)) {
+    return `${host}/`
+  }
+
+  return `${host}/${apiVersion}/`
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #328 — multiple providers (MiniMax, Zhipu, Volcengine, etc.) returning 404 due to incorrect API host formatting.

The root cause was a hardcoded check (`host.endsWith('volces.com/api/v3')`) that only handled Volcengine's versioned path. Any provider whose host already included a version segment (e.g. `v1`, `v4`, `v1beta`) would have the version appended again, resulting in a malformed URL.

**Changes:**
- Replace the hardcoded check with a generic `hasVersionSegment` helper that uses a regex (`/^v\d+(?:[a-z]+\d*)?$/i`) to detect any version-like segment in the URL path
- Handles edge cases: non-numeric versions (`v1beta` for Google), mid-path version segments (`/user-center/v1/model`), and invalid URLs (falls back to string matching)
- Add unit tests covering DeepSeek (no version), MiniMax/Zhipu/Volcengine (numeric version), Cephalon (mid-path version), and Google (v1beta)

## Test Plan

- [x] Locally tested: MiniMax API connectivity confirmed fixed
- [x] Unit tests pass for all covered providers
- [x] DeepSeek (no version in host) still appends `/v1/` correctly