### PR TITLE
fix: increase Android swipe threshold

### DIFF
--- a/src/screens/home/ChatScreen.tsx
+++ b/src/screens/home/ChatScreen.tsx
@@ -79,7 +79,7 @@ const ChatScreen = () => {
       <PanGestureHandler
         onGestureEvent={handleSwipeGesture}
         onHandlerStateChange={handleSwipeGesture}
-        activeOffsetX={[-10, 10]}
+        activeOffsetX={Platform.OS === 'android' ? [-50, 50] : [-10, 10]}
         failOffsetY={[-20, 20]}>
         <KeyboardAvoidingView
           style={{ flex: 1 }}


### PR DESCRIPTION
### Summary
Fixes screen jumping/flickering when selecting text on Android.

### Root Cause
`PanGestureHandler` had `activeOffsetX` of `[-10, 10]` on Android—too sensitive. Text selection involves small horizontal movements misinterpreted as swipe gestures.

### Fix
Increased Android threshold to `[-50, 50]`, requiring more deliberate swipes.

Closes #359 