### PR TITLE
fix: add Qwen3.5 and Qwen3.6 to vision model regex

### DIFF
--- a/src/config/models/vision.ts
+++ b/src/config/models/vision.ts
@@ -25,7 +25,7 @@ const visionAllowedModels = [
   'qwen-vl',
   'qwen2-vl',
   'qwen2.5-vl',
-  'qwen3-vl',
+  'qwen3\\.[5-9](?:-[\\w-]+)?',
   'qwen2.5-omni',
   'qwen3-omni(?:-[\\w-]+)?',
   'qvq',


### PR DESCRIPTION
## Summary
- Add Qwen3.5 and Qwen3.6 series to vision model regex
- Previous pattern `qwen3-vl` didn't match Qwen3.5/3.6 model IDs (e.g. `Qwen3.6-35B`) which don't contain 'vl' suffix
- New pattern `qwen3\.[5-9](?:-[\w-]+)?` covers Qwen3.5 through Qwen3.9

## Test plan
- [ ] Select Qwen3.5 or Qwen3.6 model in mobile app
- [ ] Upload an image and send a message asking about the image
- [ ] Verify the model receives the image and responds correctly