### PR TITLE
fix(ui): improve dark mode for markdown and OAuth card

### DIFF
--- a/src/screens/ChatScreen/messageContent/components/PartMarkdown.tsx
+++ b/src/screens/ChatScreen/messageContent/components/PartMarkdown.tsx
@@ -25,54 +25,54 @@ export function PartMarkdown({ markdown }: PartMarkdownProps) {
 
   const markdownStyle: MarkdownStyle | undefined = isDark
     ? {
-      paragraph: { color: foreground },
-      h1: { color: foreground },
-      h2: { color: foreground },
-      h3: { color: foreground },
-      h4: { color: foreground },
-      h5: { color: foreground },
-      h6: { color: foreground },
-      blockquote: {
-        color: muted,
-        borderColor: muted,
-        backgroundColor: background,
-      },
-      list: {
-        color: foreground,
-        bulletColor: foreground,
-        markerColor: foreground,
-      },
-      code: {
-        color: foreground,
-        borderColor: border,
-        backgroundColor: defaultColor,
-      },
-      link: {
-        color: accent
-      },
-      strong: { color: foreground },
-      em: { color: foreground },
-      strikethrough: { color: muted },
-      underline: { color: foreground },
-      thematicBreak: { color: muted },
-      table: {
-        color: foreground,
-        headerTextColor: foreground,
-        headerBackgroundColor: defaultColor,
-        rowEvenBackgroundColor: background,
-        rowOddBackgroundColor: background,
-        borderColor: border,
-      },
-      taskList: {
-        checkedColor: accent,
-        borderColor: muted,
-        checkmarkColor: foreground,
-        checkedTextColor: muted,
-      },
-      math: { color: foreground, backgroundColor: defaultColor },
-      inlineMath: { color: foreground },
-      spoiler: { color: foreground }
-    }
+        paragraph: { color: foreground },
+        h1: { color: foreground },
+        h2: { color: foreground },
+        h3: { color: foreground },
+        h4: { color: foreground },
+        h5: { color: foreground },
+        h6: { color: foreground },
+        blockquote: {
+          color: muted,
+          borderColor: muted,
+          backgroundColor: background,
+        },
+        list: {
+          color: foreground,
+          bulletColor: foreground,
+          markerColor: foreground,
+        },
+        code: {
+          color: foreground,
+          borderColor: border,
+          backgroundColor: defaultColor,
+        },
+        link: {
+          color: accent,
+        },
+        strong: { color: foreground },
+        em: { color: foreground },
+        strikethrough: { color: muted },
+        underline: { color: foreground },
+        thematicBreak: { color: muted },
+        table: {
+          color: foreground,
+          headerTextColor: foreground,
+          headerBackgroundColor: defaultColor,
+          rowEvenBackgroundColor: background,
+          rowOddBackgroundColor: background,
+          borderColor: border,
+        },
+        taskList: {
+          checkedColor: accent,
+          borderColor: muted,
+          checkmarkColor: foreground,
+          checkedTextColor: muted,
+        },
+        math: { color: foreground, backgroundColor: defaultColor },
+        inlineMath: { color: foreground },
+        spoiler: { color: foreground },
+      }
     : undefined;
 
   return (

--- a/src/screens/ChatScreen/messageContent/components/PartMarkdown.tsx
+++ b/src/screens/ChatScreen/messageContent/components/PartMarkdown.tsx
@@ -1,4 +1,7 @@
+import { useThemeColor } from 'heroui-native/hooks';
+import { useColorScheme } from 'react-native';
 import { StreamdownText } from 'react-native-streamdown';
+import type { MarkdownStyle } from 'react-native-enriched-markdown';
 
 import { useMarkdownLinkPress } from '../hooks/useMarkdownLinkPress';
 
@@ -8,12 +11,76 @@ type PartMarkdownProps = {
 
 export function PartMarkdown({ markdown }: PartMarkdownProps) {
   const { handleLinkPress } = useMarkdownLinkPress();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const [foreground, background, muted, accent, border, defaultColor] = useThemeColor([
+    'foreground',
+    'background',
+    'muted',
+    'accent',
+    'border',
+    'default',
+  ]);
+
+  const markdownStyle: MarkdownStyle | undefined = isDark
+    ? {
+      paragraph: { color: foreground },
+      h1: { color: foreground },
+      h2: { color: foreground },
+      h3: { color: foreground },
+      h4: { color: foreground },
+      h5: { color: foreground },
+      h6: { color: foreground },
+      blockquote: {
+        color: muted,
+        borderColor: muted,
+        backgroundColor: background,
+      },
+      list: {
+        color: foreground,
+        bulletColor: foreground,
+        markerColor: foreground,
+      },
+      code: {
+        color: foreground,
+        borderColor: border,
+        backgroundColor: defaultColor,
+      },
+      link: {
+        color: accent
+      },
+      strong: { color: foreground },
+      em: { color: foreground },
+      strikethrough: { color: muted },
+      underline: { color: foreground },
+      thematicBreak: { color: muted },
+      table: {
+        color: foreground,
+        headerTextColor: foreground,
+        headerBackgroundColor: defaultColor,
+        rowEvenBackgroundColor: background,
+        rowOddBackgroundColor: background,
+        borderColor: border,
+      },
+      taskList: {
+        checkedColor: accent,
+        borderColor: muted,
+        checkmarkColor: foreground,
+        checkedTextColor: muted,
+      },
+      math: { color: foreground, backgroundColor: defaultColor },
+      inlineMath: { color: foreground },
+      spoiler: { color: foreground }
+    }
+    : undefined;
 
   return (
     <StreamdownText
       allowTrailingMargin={false}
       flavor="github"
       markdown={markdown}
+      markdownStyle={markdownStyle}
       md4cFlags={{ latexMath: true, underline: false }}
       onLinkPress={handleLinkPress}
       selectable

--- a/src/screens/SettingsScreen/ProviderScreen/components/CherryInOAuth.tsx
+++ b/src/screens/SettingsScreen/ProviderScreen/components/CherryInOAuth.tsx
@@ -141,12 +141,12 @@ export function CherryInOAuth({ providerId, onOAuthComplete }: CherryInOAuthProp
             )}
 
             <View className="ml-2 gap-1">
-              <Text className="font-semibold text-base">{provider.name}</Text>
+              <Text className="font-semibold text-base text-foreground">{provider.name}</Text>
               <View className="flex flex-row gap-3">
                 <Button isDisabled={isLoadingData} onPress={fetchData} variant="tertiary" size="sm">
                   <Button.Label className="p-0">
-                    <Text className="text-sm">{t('settings.provider.oauth.cherryIn.balance')}</Text>
-                    <Text className="text-sm">
+                    <Text className="text-sm text-foreground">{t('settings.provider.oauth.cherryIn.balance')}</Text>
+                    <Text className="text-sm text-foreground">
                       {isLoadingData && balance === null ? '···' : formatCurrency(balance)}
                     </Text>
                   </Button.Label>
@@ -177,7 +177,7 @@ export function CherryInOAuth({ providerId, onOAuthComplete }: CherryInOAuthProp
         <Card.Footer className="mt-2">
           <Text
             accessibilityRole="link"
-            className="text-xs text-default-400 underline"
+            className="text-xs text-foreground-muted underline"
             onPress={() => Linking.openURL('https://open.cherryin.ai')}
           >
             {t('settings.provider.oauth.cherryIn.service_attribution')}

--- a/src/screens/SettingsScreen/ProviderScreen/components/CherryInOAuth.tsx
+++ b/src/screens/SettingsScreen/ProviderScreen/components/CherryInOAuth.tsx
@@ -145,7 +145,9 @@ export function CherryInOAuth({ providerId, onOAuthComplete }: CherryInOAuthProp
               <View className="flex flex-row gap-3">
                 <Button isDisabled={isLoadingData} onPress={fetchData} variant="tertiary" size="sm">
                   <Button.Label className="p-0">
-                    <Text className="text-sm text-foreground">{t('settings.provider.oauth.cherryIn.balance')}</Text>
+                    <Text className="text-sm text-foreground">
+                      {t('settings.provider.oauth.cherryIn.balance')}
+                    </Text>
                     <Text className="text-sm text-foreground">
                       {isLoadingData && balance === null ? '···' : formatCurrency(balance)}
                     </Text>


### PR DESCRIPTION
## Before

<img width="367" height="741" alt="屏幕截图 2026-06-13 154258" src="https://github.com/user-attachments/assets/725862da-652e-4b49-830d-b4be57434017" />


## Now

<img width="373" height="842" alt="image" src="https://github.com/user-attachments/assets/02b0a9a5-22b5-470a-bf51-231ff5afb921" />

<img width="359" height="128" alt="image" src="https://github.com/user-attachments/assets/c770a9bc-7ef3-4704-8371-121aa08f4e53" />
