### PR TITLE
fix(chat): adjust text area vertical padding

### DIFF
--- a/src/screens/ChatScreen/input/components/ChatInputTextArea.tsx
+++ b/src/screens/ChatScreen/input/components/ChatInputTextArea.tsx
@@ -1,19 +1,19 @@
-import { TextArea } from 'heroui-native/text-area';
-import { cn } from 'heroui-native/utils';
-import { useTranslation } from 'react-i18next';
-import { StyleSheet } from 'react-native';
+import { TextArea } from "heroui-native/text-area";
+import { cn } from "heroui-native/utils";
+import { useTranslation } from "react-i18next";
+import { StyleSheet } from "react-native";
 import {
   chatInputMaxTextAreaHeight,
   chatInputMinTextAreaHeight,
-} from '@/screens/ChatScreen/input/chatInputLayout';
+} from "@/screens/ChatScreen/input/chatInputLayout";
 import {
   useChatInputActions,
   useChatInputMeta,
   useChatInputState,
-} from '@/screens/ChatScreen/input/context/ChatInputProvider';
+} from "@/screens/ChatScreen/input/context/ChatInputProvider";
 
 const transparentInputSurfaceClassName =
-  'border-0 bg-transparent shadow-none ios:shadow-none android:shadow-none';
+  "border-0 bg-transparent shadow-none ios:shadow-none android:shadow-none";
 
 export function ChatInputTextArea() {
   const { t } = useTranslation();
@@ -26,11 +26,11 @@ export function ChatInputTextArea() {
       ref={inputRef}
       multiline
       className={cn(
-        'h-auto min-h-11 flex-1 rounded-3xl pt-3! pr-12! pb-1! pl-3! text-base leading-5',
+        "h-auto min-h-11 flex-1 rounded-3xl pr-12! pt-2! pb-4! text-base leading-5",
         transparentInputSurfaceClassName,
       )}
       numberOfLines={6}
-      placeholder={t('chat.inputPlaceholder')}
+      placeholder={t("chat.inputPlaceholder")}
       style={[
         styles.transparentInputSurface,
         {
@@ -49,10 +49,10 @@ export function ChatInputTextArea() {
 
 const styles = StyleSheet.create({
   transparentInputSurface: {
-    backgroundColor: 'transparent',
-    borderColor: 'transparent',
+    backgroundColor: "transparent",
+    borderColor: "transparent",
     borderWidth: 0,
-    boxShadow: 'none',
+    boxShadow: "none",
     elevation: 0,
   },
 });


### PR DESCRIPTION
## Before
<img width="1176" height="272" alt="old-input" src="https://github.com/user-attachments/assets/7ffc1508-de3e-4982-af07-13ab3b4d6acc" />

## Now

<img width="1176" height="389" alt="new-input" src="https://github.com/user-attachments/assets/957be46e-165b-44b4-94df-44d23bdfe33e" />

