### PR TITLE
chore(pnpm): migrate to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,22 +138,5 @@
     "typescript": "~6.0.3"
   },
   "private": true,
-  "packageManager": "pnpm@10.33.2",
-  "pnpm": {
-    "overrides": {
-      "react-native-svg": "15.15.4"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp",
-      "unrs-resolver"
-    ],
-    "patchedDependencies": {
-      "@magrinj/expo-quick-look@0.3.1": "patches/@magrinj__expo-quick-look@0.3.1.patch",
-      "metro@0.84.4": "patches/metro@0.84.4.patch",
-      "metro-runtime@0.84.4": "patches/metro-runtime@0.84.4.patch",
-      "react-native-worklets@0.8.3": "patches/react-native-worklets@0.8.3.patch",
-      "react-native-reanimated@4.3.1": "patches/react-native-reanimated@4.3.1.patch"
-    }
-  }
+  "packageManager": "pnpm@10.33.2"
 }

--- a/package.json
+++ b/package.json
@@ -138,5 +138,5 @@
     "typescript": "~6.0.3"
   },
   "private": true,
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,17 @@
 packages:
   - packages/*
+
+overrides:
+  react-native-svg: 15.15.4
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - unrs-resolver
+
+patchedDependencies:
+  "@magrinj/expo-quick-look@0.3.1": patches/@magrinj__expo-quick-look@0.3.1.patch
+  metro@0.84.4: patches/metro@0.84.4.patch
+  metro-runtime@0.84.4: patches/metro-runtime@0.84.4.patch
+  react-native-worklets@0.8.3: patches/react-native-worklets@0.8.3.patch
+  react-native-reanimated@4.3.1: patches/react-native-reanimated@4.3.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,12 @@ packages:
 overrides:
   react-native-svg: 15.15.4
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  esbuild: true
+  msgpackr-extract: true
+  sharp: true
+  unrs-resolver: true
+  core-js: true
 
 patchedDependencies:
   "@magrinj/expo-quick-look@0.3.1": patches/@magrinj__expo-quick-look@0.3.1.patch


### PR DESCRIPTION
The pnpm settings live in pnpm-workspace.yaml, onlyBuiltDependencies has been migrated to allowBuilds, the lockfile records the workspace configuration expected by pnpm 11, and .pnpm-store/ is ignored.