### PR TITLE
feat(data-layer): align desktop schemas and services

### DIFF
--- a/docs/architecture/mobile-data-layer.md
+++ b/docs/architecture/mobile-data-layer.md
@@ -119,6 +119,14 @@ Provider, Model, Assistant, Tag, Pin, Prompt, Topic, and Message schemas are not
 
 During mobile development, these local schemas may still reset when desktop alignment requires breaking structure or behavior changes. When desktop changes a shared domain, mobile should update both schema and local service behavior rather than preserving a mobile-only interpretation for compatibility.
 
+Development-stage legacy migration-ledger adoption and downgrade bridges are intentionally out of scope. Desktop and mobile also cannot safely open the same physical SQLite file today because their Drizzle timelines differ. Future sharing should use an explicit shared-entity export or sync contract rather than file-level interchange.
+
+## Startup Measurement Boundary
+
+`InitialDataGate` currently includes database open/configuration, bundled migrations, custom FTS SQL, seeding, cached boot preferences, i18n initialization, and orphan pending-Message reconciliation. These consistency steps must finish before the Data Runtime is exposed; they must not be skipped merely to shorten the splash screen.
+
+No physical-device cold-start timing has been captured for this V1 change. Type checking, Jest duration, Metro readiness, and Expo export time are not substitutes for first-frame measurements. A future performance pass should record each startup step and first chat paint on release-like iOS and Android builds, then move only measured nonessential work such as catalog refresh or non-current history prefetch behind the first screen. Until that evidence exists, this change makes no startup-speed improvement claim.
+
 ## Reopen When
 
 - Mobile brings a new desktop domain into scope.

--- a/migrations/sqlite-drizzle/0001_mixed_night_thrasher.sql
+++ b/migrations/sqlite-drizzle/0001_mixed_night_thrasher.sql
@@ -1,0 +1,3 @@
+DROP INDEX `message_trace_id_idx`;--> statement-breakpoint
+ALTER TABLE `message` DROP COLUMN `trace_id`;--> statement-breakpoint
+ALTER TABLE `topic` ADD `trace_id` text;

--- a/migrations/sqlite-drizzle/meta/0001_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1403 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "502fbbf9-8609-4738-a34e-83cb82f5682f",
+  "prevId": "dc86a6c3-0f05-4471-881f-e72d6b5305e0",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": [
+            "assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": [
+            "assistant_id",
+            "knowledge_base_id"
+          ],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": [
+            "assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": [
+            "assistant_id",
+            "mcp_server_id"
+          ],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "assistant_order_key_idx": {
+          "name": "assistant_order_key_idx",
+          "columns": [
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "tag_id"
+          ],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": [
+            "entity_type",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": [
+            "topic_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "message_fts_rowid_uniq": {
+          "name": "message_fts_rowid_uniq",
+          "columns": [
+            "fts_rowid"
+          ],
+          "isUnique": true
+        },
+        "message_topic_root_uniq": {
+          "name": "message_topic_root_uniq",
+          "columns": [
+            "topic_id"
+          ],
+          "isUnique": true,
+          "where": "\"message\".\"parent_id\" is null and \"message\".\"deleted_at\" is null"
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system', 'root')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        },
+        "message_root_parent_check": {
+          "name": "message_root_parent_check",
+          "value": "(\"message\".\"role\" = 'root') = (\"message\".\"parent_id\" is null)"
+        }
+      }
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": [
+            "entity_type",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": [
+            "scope",
+            "key"
+          ],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt": {
+      "name": "prompt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_order_key_idx": {
+          "name": "prompt_order_key_idx",
+          "columns": [
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": [
+            "group_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "topic_group_id_order_key_idx": {
+          "name": "topic_group_id_order_key_idx",
+          "columns": [
+            "group_id",
+            "order_key"
+          ],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": [
+            "assistant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": [
+            "assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owned_by": {
+          "name": "owned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_endpoint_url": {
+          "name": "custom_endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_overrides": {
+          "name": "user_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": [
+            "preset_model_id"
+          ],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": [
+            "provider_id",
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": [
+            "provider_id",
+            "order_key"
+          ],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": [
+            "preset_provider_id"
+          ],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": [
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1782885899481,
       "tag": "0000_pink_the_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1783684061253,
+      "tag": "0001_mixed_night_thrasher",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/AiService.ts
+++ b/src/ai/AiService.ts
@@ -7,7 +7,13 @@ import type { WebSearchPluginConfig } from '@cherrystudio/ai-core/built-in/plugi
 import { providerToolPlugin } from '@cherrystudio/ai-core/built-in/plugins';
 import { extensionRegistry } from '@cherrystudio/ai-core/provider';
 import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import { type LanguageModelUsage, type ModelMessage, type UIMessageChunk } from 'ai';
+import {
+  type LanguageModelUsage,
+  type ModelMessage,
+  stepCountIs,
+  type ToolSet,
+  type UIMessageChunk,
+} from 'ai';
 import type { AssistantService } from '@/data/services/AssistantService';
 import type { ModelService } from '@/data/services/ModelService';
 import type { PreferenceService } from '@/data/services/PreferenceService';
@@ -16,7 +22,9 @@ import type { Assistant } from '@/data/types/assistant';
 import type { Model, UniqueModelId } from '@/data/types/model';
 import { isUniqueModelId, parseUniqueModelId } from '@/data/types/model';
 import type { Provider } from '@/data/types/provider';
+import type { WebSearchService } from '@/services/webSearch/WebSearchService';
 
+import { createWebSearchTool, WEB_SEARCH_TOOL_NAME } from './createWebSearchTool';
 import { resolveMediaCapabilities } from './messages/messageCapabilities';
 import { resolveUIMessageFileUrls } from './messages/messageConverter';
 import { providerToAiSdkConfig } from './provider/config';
@@ -33,7 +41,13 @@ import { createSimulateStreamingPlugin } from './runtime/aiSdk/plugins/simulateS
 import type { AppProviderId, AppProviderSettingsMap } from './types';
 import type { AiBaseRequest, AiStreamRequest, ListModelsRequest } from './types/requests';
 import { addAnthropicHeaders } from './utils/anthropicHeaders';
-import { isAnthropicModel, isGeminiModel, isGrokModel, isOpenAIModel } from './utils/model';
+import {
+  isAnthropicModel,
+  isFunctionCallingModel,
+  isGeminiModel,
+  isGrokModel,
+  isOpenAIModel,
+} from './utils/model';
 import {
   filterStandardParams,
   getMaxTokens,
@@ -89,6 +103,7 @@ export interface AiServiceDependencies {
   model: ModelService;
   preference: PreferenceService;
   provider: ProviderService;
+  webSearch: WebSearchService;
 }
 
 /**
@@ -116,7 +131,10 @@ export class AiService {
       );
     }
 
-    const { sdkConfig, model, system, plugins, options } = await this.buildAgentParamsFor(request);
+    const { sdkConfig, model, system, tools, plugins, options } = await this.buildAgentParamsFor(
+      request,
+      { shouldIncludeExternalTools: true },
+    );
     const preparedMessages = await resolveUIMessageFileUrls(request.messages ?? []);
 
     const agent = new Agent({
@@ -127,6 +145,7 @@ export class AiService {
       mediaCapabilities: resolveMediaCapabilities(model),
       plugins,
       system,
+      tools,
       options,
     });
 
@@ -304,6 +323,7 @@ export class AiService {
 
   private async buildAgentParamsFor(
     request: AiBaseRequest & { apiKeyOverride?: string; chatId?: string },
+    buildOptions: { shouldIncludeExternalTools?: boolean } = {},
   ) {
     const { provider, model, assistant } = await this.getProviderAndModel(request);
     const sdkConfig = await providerToAiSdkConfig(provider, model, {
@@ -311,6 +331,13 @@ export class AiService {
         request.apiKeyOverride ?? this.services.provider.getRotatedApiKey(providerId),
       getAuthConfig: (providerId) => this.services.provider.getAuthConfig(providerId),
     });
+    const externalWebSearchProviderId =
+      buildOptions.shouldIncludeExternalTools && assistant?.settings.enableWebSearch
+        ? await this.services.preference.get('chat.web_search.default_search_keywords_provider')
+        : null;
+    const shouldUseExternalWebSearch = Boolean(
+      externalWebSearchProviderId && isFunctionCallingModel(model),
+    );
     const capabilities = assistant
       ? resolveCapabilities(
           model,
@@ -318,6 +345,11 @@ export class AiService {
           assistant,
           sdkConfig.providerId,
           this.services.preference,
+          {
+            webSearchProviderId: shouldUseExternalWebSearch
+              ? (externalWebSearchProviderId ?? undefined)
+              : undefined,
+          },
         )
       : undefined;
     const providerOptions =
@@ -353,6 +385,12 @@ export class AiService {
       streamOutput: capabilities?.streamOutput ?? true,
       webSearchPluginConfig: capabilities?.webSearchPluginConfig,
     });
+    const tools =
+      shouldUseExternalWebSearch && assistant?.settings.enableWebSearch
+        ? ({
+            [WEB_SEARCH_TOOL_NAME]: createWebSearchTool(this.services.webSearch),
+          } satisfies ToolSet)
+        : undefined;
     const system = assistant?.prompt
       ? await replacePromptVariables(assistant.prompt, model.name, this.services.preference)
       : undefined;
@@ -367,6 +405,7 @@ export class AiService {
       assistant,
       system,
       plugins,
+      tools,
       options: {
         maxRetries: request.requestOptions?.maxRetries ?? 0,
         timeout: request.requestOptions?.timeout ?? getTimeout(model),
@@ -376,6 +415,11 @@ export class AiService {
         }),
         ...standardParams,
         ...filteredStandardParams,
+        ...(tools && {
+          stopWhen: stepCountIs(
+            assistant?.settings.enableMaxToolCalls ? assistant.settings.maxToolCalls : 20,
+          ),
+        }),
       },
     };
   }
@@ -465,12 +509,15 @@ function resolveCapabilities(
   assistant: Assistant,
   aiSdkProviderId: string,
   preference: PreferenceService,
+  options: { webSearchProviderId?: string } = {},
 ) {
   const enableReasoning = Boolean(
     model.reasoning && assistant.settings?.reasoning_effort !== undefined,
   );
   const enableWebSearch = Boolean(
-    assistant.settings?.enableWebSearch && model.capabilities.includes('web-search'),
+    !options.webSearchProviderId &&
+      assistant.settings?.enableWebSearch &&
+      model.capabilities.includes('web-search'),
   );
   const enableGenerateImage = model.capabilities.includes('image-generation');
 

--- a/src/ai/__tests__/AiService.test.ts
+++ b/src/ai/__tests__/AiService.test.ts
@@ -6,6 +6,14 @@ import { createUniqueModelId, type Model, type UniqueModelId } from '@/data/type
 import type { Provider } from '@/data/types/provider';
 
 const mockGenerate = jest.fn(async () => ({ text: 'ok', usage: undefined }));
+const mockStream = jest.fn(
+  () =>
+    new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+);
 const mockAgentConstructor = jest.fn();
 
 jest.mock('@cherrystudio/ai-core', () => ({
@@ -21,7 +29,7 @@ jest.mock('@/integration/cherryAi', () => ({
 jest.mock('@/ai/runtime/aiSdk/Agent', () => ({
   Agent: jest.fn().mockImplementation((params) => {
     mockAgentConstructor(params);
-    return { generate: mockGenerate };
+    return { generate: mockGenerate, stream: mockStream };
   }),
 }));
 
@@ -256,6 +264,106 @@ describe('AiService web search plugin wiring', () => {
       }),
     );
   });
+
+  it('exposes configured external web search as a bounded agent tool', async () => {
+    const model = createModel('gpt-4o-mini', {
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL, MODEL_CAPABILITY.WEB_SEARCH],
+    });
+    const assistant = createAssistant(model.id);
+    assistant.settings.enableWebSearch = true;
+    assistant.settings.enableMaxToolCalls = true;
+    assistant.settings.maxToolCalls = 3;
+    const services = createServices({ assistant, model, webSearchProviderId: 'tavily' });
+    const service = new AiService(services);
+    const controller = new AbortController();
+
+    await service.streamText({
+      assistantId: assistant.id,
+      chatId: 'topic-1',
+      messages: [],
+      requestOptions: { signal: controller.signal },
+      trigger: 'submit-message',
+    });
+
+    const params = mockAgentConstructor.mock.calls.at(-1)?.[0];
+    expect(params).toEqual(
+      expect.objectContaining({
+        options: expect.objectContaining({ stopWhen: expect.any(Function) }),
+        plugins: expect.not.arrayContaining([expect.objectContaining({ name: 'webSearch' })]),
+        tools: expect.objectContaining({ web_search: expect.any(Object) }),
+      }),
+    );
+    expect(params.options.stopWhen({ steps: Array.from({ length: 2 }, () => ({})) })).toBe(false);
+    expect(params.options.stopWhen({ steps: Array.from({ length: 3 }, () => ({})) })).toBe(true);
+
+    const result = await params.tools.web_search.execute(
+      { query: 'Cherry Studio mobile' },
+      { abortSignal: controller.signal },
+    );
+
+    expect(services.webSearch.searchKeywords).toHaveBeenCalledWith(
+      { keywords: ['Cherry Studio mobile'] },
+      { signal: controller.signal },
+    );
+    expect(result).toEqual([
+      {
+        content: 'Mobile result',
+        id: 1,
+        title: 'Cherry Studio',
+        url: 'https://example.com/cherry',
+      },
+    ]);
+  });
+
+  it('uses provider-native web search alone when no external provider is configured', async () => {
+    const model = createModel('gpt-4o-mini', {
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL, MODEL_CAPABILITY.WEB_SEARCH],
+    });
+    const assistant = createAssistant(model.id);
+    assistant.settings.enableWebSearch = true;
+    const service = new AiService(createServices({ assistant, model }));
+
+    await service.streamText({
+      assistantId: assistant.id,
+      chatId: 'topic-1',
+      messages: [],
+      requestOptions: { signal: new AbortController().signal },
+      trigger: 'submit-message',
+    });
+
+    expect(mockAgentConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.arrayContaining([expect.objectContaining({ name: 'webSearch' })]),
+        tools: undefined,
+      }),
+    );
+  });
+
+  it('falls back to provider-native search when the model cannot call the external tool', async () => {
+    const model = createModel('gpt-4o-mini', {
+      capabilities: [MODEL_CAPABILITY.WEB_SEARCH],
+    });
+    const assistant = createAssistant(model.id);
+    assistant.settings.enableWebSearch = true;
+    const service = new AiService(
+      createServices({ assistant, model, webSearchProviderId: 'tavily' }),
+    );
+
+    await service.streamText({
+      assistantId: assistant.id,
+      chatId: 'topic-1',
+      messages: [],
+      requestOptions: { signal: new AbortController().signal },
+      trigger: 'submit-message',
+    });
+
+    expect(mockAgentConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.arrayContaining([expect.objectContaining({ name: 'webSearch' })]),
+        tools: undefined,
+      }),
+    );
+  });
 });
 
 function createServices({
@@ -264,6 +372,7 @@ function createServices({
   model,
   models,
   provider = createProvider(),
+  webSearchProviderId = null,
   webSearchPreferences = {
     'chat.web_search.max_results': 5,
     'chat.web_search.exclude_domains': [],
@@ -274,6 +383,7 @@ function createServices({
   model?: Model;
   models?: Model[];
   provider?: Provider;
+  webSearchProviderId?: string | null;
   webSearchPreferences?: {
     'chat.web_search.max_results': number;
     'chat.web_search.exclude_domains': string[];
@@ -290,13 +400,31 @@ function createServices({
       getById: jest.fn(async (id: UniqueModelId) => modelsById.get(id)),
     },
     preference: {
-      get: jest.fn(async () => defaultModelId ?? null),
+      get: jest.fn(async (key: string) =>
+        key === 'chat.default_model_id' ? (defaultModelId ?? null) : webSearchProviderId,
+      ),
       getMultipleRawCached: jest.fn(() => webSearchPreferences),
     },
     provider: {
       getAuthConfig: jest.fn(async () => null),
       getByProviderId: jest.fn(async () => provider),
       getRotatedApiKey: jest.fn(async () => 'rotated-key'),
+    },
+    webSearch: {
+      searchKeywords: jest.fn(async () => ({
+        capability: 'searchKeywords',
+        inputs: ['Cherry Studio mobile'],
+        providerId: 'tavily',
+        query: 'Cherry Studio mobile',
+        results: [
+          {
+            content: 'Mobile result',
+            sourceInput: 'Cherry Studio mobile',
+            title: 'Cherry Studio',
+            url: 'https://example.com/cherry',
+          },
+        ],
+      })),
     },
   } as unknown as AiServiceDependencies;
 }
@@ -355,6 +483,7 @@ function createAssistant(modelId: Model['id'] | null): Assistant {
     modelId,
     modelName: null,
     name: 'Assistant',
+    orderKey: 'a0',
     prompt: '',
     settings: {
       ...DEFAULT_ASSISTANT_SETTINGS,

--- a/src/ai/__tests__/createWebSearchTool.test.ts
+++ b/src/ai/__tests__/createWebSearchTool.test.ts
@@ -1,0 +1,38 @@
+import type { WebSearchService } from '@/services/webSearch/WebSearchService';
+
+import { createWebSearchTool } from '../createWebSearchTool';
+
+jest.mock('@/core/logger/LoggerService', () => ({
+  loggerService: {
+    withContext: () => ({ warn: jest.fn() }),
+  },
+}));
+
+describe('createWebSearchTool', () => {
+  it.each([
+    'Default web search provider is not configured for capability searchKeywords',
+    'Unknown web search provider: removed-provider',
+    'Web search provider jina does not support capability searchKeywords',
+    'Web search provider jina does not implement capability searchKeywords',
+  ])('marks permanent configuration errors as non-retryable: %s', async (message) => {
+    const webSearchService = {
+      searchKeywords: jest.fn(async () => {
+        throw new Error(message);
+      }),
+    } as unknown as WebSearchService;
+    const searchTool = createWebSearchTool(webSearchService);
+
+    await expect(
+      searchTool.execute?.(
+        { query: 'Cherry Studio mobile' },
+        {
+          abortSignal: new AbortController().signal,
+          messages: [],
+          toolCallId: 'web-search-1',
+        },
+      ),
+    ).resolves.toEqual({
+      error: expect.stringMatching(/configure.*Settings.*do not retry/i),
+    });
+  });
+});

--- a/src/ai/createWebSearchTool.ts
+++ b/src/ai/createWebSearchTool.ts
@@ -1,0 +1,66 @@
+import { tool } from 'ai';
+import * as z from 'zod';
+
+import { loggerService } from '@/core/logger/LoggerService';
+import { isAbortError, isPermanentWebSearchConfigError } from '@/services/webSearch/utils/errors';
+import type { WebSearchService } from '@/services/webSearch/WebSearchService';
+
+const logger = loggerService.withContext('WebSearchTool');
+
+export const WEB_SEARCH_TOOL_NAME = 'web_search';
+
+export const WEB_SEARCH_PROVIDER_NOT_CONFIGURED_MESSAGE =
+  'No usable web search provider is configured. Tell the user to configure one in Settings (Web Search); do not retry because it cannot succeed until the configuration is fixed.';
+
+const WEB_SEARCH_DESCRIPTION = `Search the web for current information, news, and real-time data.
+
+Use this when facts may have changed or when the user asks for current information. You may refine
+the query and search more than once. Cite sources by their [id] in the final answer.`;
+
+const webSearchResultSchema = z.object({
+  content: z.string(),
+  id: z.number().int().positive(),
+  title: z.string(),
+  url: z.url(),
+});
+
+const webSearchOutputSchema = z.union([
+  z.array(webSearchResultSchema),
+  z.object({ error: z.string() }),
+]);
+
+export function createWebSearchTool(webSearchService: WebSearchService) {
+  return tool({
+    description: WEB_SEARCH_DESCRIPTION,
+    inputSchema: z.object({ query: z.string().trim().min(1) }),
+    outputSchema: webSearchOutputSchema,
+    strict: true,
+    execute: async ({ query }, options) => {
+      try {
+        const response = await webSearchService.searchKeywords(
+          { keywords: [query] },
+          { signal: options.abortSignal },
+        );
+
+        return response.results.map((result, index) => ({
+          content: result.content,
+          id: index + 1,
+          title: result.title,
+          url: result.url,
+        }));
+      } catch (error) {
+        if (options.abortSignal?.aborted || isAbortError(error)) {
+          throw error;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn('External web search failed', { error: message, query });
+        return {
+          error: isPermanentWebSearchConfigError(message)
+            ? WEB_SEARCH_PROVIDER_NOT_CONFIGURED_MESSAGE
+            : message,
+        };
+      }
+    },
+  });
+}

--- a/src/ai/runtime/aiSdk/Agent.ts
+++ b/src/ai/runtime/aiSdk/Agent.ts
@@ -12,7 +12,15 @@
 import type { AiPlugin } from '@cherrystudio/ai-core';
 import { createAgent } from '@cherrystudio/ai-core';
 import type { StringKeys } from '@cherrystudio/ai-core/provider';
-import type { JSONValue, LanguageModelUsage, ModelMessage, UIMessage, UIMessageChunk } from 'ai';
+import type {
+  JSONValue,
+  LanguageModelUsage,
+  ModelMessage,
+  StopCondition,
+  ToolSet,
+  UIMessage,
+  UIMessageChunk,
+} from 'ai';
 import * as Crypto from 'expo-crypto';
 
 import type { MediaCapabilities } from '../../messages/messageCapabilities';
@@ -36,6 +44,7 @@ export interface AgentOptions {
   timeout?: number;
   headers?: Record<string, string | undefined>;
   providerOptions?: Record<string, Record<string, JSONValue>>;
+  stopWhen?: StopCondition<ToolSet> | StopCondition<ToolSet>[];
 }
 
 export interface AgentParams<T extends AppProviderKey = AppProviderKey> {
@@ -46,6 +55,7 @@ export interface AgentParams<T extends AppProviderKey = AppProviderKey> {
   mediaCapabilities?: MediaCapabilities;
   plugins?: AiPlugin[];
   system?: string;
+  tools?: ToolSet;
   options?: AgentOptions;
 }
 
@@ -55,12 +65,13 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
   private async buildAiSdkAgent() {
     const params = this.params;
     const opts = params.options ?? {};
-    return createAgent<AppProviderSettingsMap, T>({
+    return createAgent<AppProviderSettingsMap, T, ToolSet>({
       providerId: params.providerId,
       providerSettings: params.providerSettings,
       modelId: params.modelId,
       plugins: params.plugins,
       agentSettings: {
+        tools: params.tools,
         // System
         instructions: params.system,
         // CallSettings (model parameters)
@@ -77,6 +88,7 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
         headers: opts.headers,
         // Provider-specific
         providerOptions: opts.providerOptions,
+        stopWhen: opts.stopWhen,
       },
     });
   }

--- a/src/ai/utils/__tests__/anthropicHeaders.test.ts
+++ b/src/ai/utils/__tests__/anthropicHeaders.test.ts
@@ -50,6 +50,7 @@ function createAssistant(overrides: Partial<Assistant['settings']> = {}): Assist
     modelId: null,
     modelName: null,
     name: 'Assistant',
+    orderKey: 'a0',
     prompt: '',
     settings: { ...DEFAULT_ASSISTANT_SETTINGS, ...overrides },
     tags: [],

--- a/src/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/ai/utils/__tests__/modelParameters.test.ts
@@ -19,6 +19,7 @@ function createAssistant(overrides: Partial<Assistant['settings']> = {}): Assist
     modelId: null,
     modelName: null,
     name: 'Assistant',
+    orderKey: 'a0',
     prompt: '',
     settings: { ...DEFAULT_ASSISTANT_SETTINGS, enableTemperature: true, ...overrides },
     tags: [],

--- a/src/ai/utils/model.ts
+++ b/src/ai/utils/model.ts
@@ -29,6 +29,9 @@ export const isGenerateImageModel = (model: Model): boolean =>
 export const isWebSearchModel = (model: Model): boolean =>
   model.capabilities.includes(MODEL_CAPABILITY.WEB_SEARCH);
 
+export const isFunctionCallingModel = (model: Model): boolean =>
+  model.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL);
+
 export const isSupportedThinkingTokenModel = (model: Model): boolean =>
   model.reasoning?.thinkingTokenLimits != null;
 

--- a/src/data/api/schemas/__tests__/assistants.test.ts
+++ b/src/data/api/schemas/__tests__/assistants.test.ts
@@ -17,4 +17,20 @@ describe('assistant api schemas', () => {
 
     expect(result.success).toBe(true);
   });
+
+  test('keeps unknown settings fields in partial update payloads', () => {
+    expect(
+      UpdateAssistantSchema.parse({
+        settings: {
+          futureDesktopSetting: { enabled: true },
+          toolUseMode: 'prompt',
+        },
+      }),
+    ).toEqual({
+      settings: {
+        futureDesktopSetting: { enabled: true },
+        toolUseMode: 'prompt',
+      },
+    });
+  });
 });

--- a/src/data/api/schemas/__tests__/messages.test.ts
+++ b/src/data/api/schemas/__tests__/messages.test.ts
@@ -1,0 +1,18 @@
+import { CreateMessageSchema, UpdateMessageSchema } from '../messages';
+
+describe('message API schemas', () => {
+  test('reject message-scoped trace ids because traces belong to topics', () => {
+    expect(
+      CreateMessageSchema.safeParse({
+        data: { parts: [] },
+        role: 'user',
+        traceId: '000102030405060708090a0b0c0d0e0f',
+      }).success,
+    ).toBe(false);
+    expect(
+      UpdateMessageSchema.safeParse({
+        traceId: '000102030405060708090a0b0c0d0e0f',
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/data/api/schemas/messages.ts
+++ b/src/data/api/schemas/messages.ts
@@ -25,7 +25,6 @@ export const CreateMessageSchema = z.strictObject({
   siblingsGroupId: z.number().optional(),
   stats: MessageStatsSchema.optional(),
   status: MessageStatusSchema.optional(),
-  traceId: z.string().optional(),
 });
 export type CreateMessageDto = z.infer<typeof CreateMessageSchema>;
 
@@ -35,7 +34,6 @@ export const UpdateMessageSchema = z.strictObject({
   siblingsGroupId: z.number().optional(),
   stats: MessageStatsSchema.nullable().optional(),
   status: MessageStatusSchema.optional(),
-  traceId: z.string().nullable().optional(),
 });
 export type UpdateMessageDto = z.infer<typeof UpdateMessageSchema>;
 

--- a/src/data/db/__tests__/migrations.test.ts
+++ b/src/data/db/__tests__/migrations.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+
+type MigrationJournal = {
+  entries: { tag: string }[];
+};
+
+describe('bundled SQLite migrations', () => {
+  test('build topic-scoped trace identity without a message trace column', () => {
+    const database = new DatabaseSync(':memory:');
+
+    try {
+      for (const migrationSql of readMigrationSqlFiles()) {
+        for (const statement of migrationSql.split('--> statement-breakpoint')) {
+          if (statement.trim()) {
+            database.exec(statement);
+          }
+        }
+      }
+
+      const topicColumns = database.prepare("PRAGMA table_info('topic')").all() as {
+        name: string;
+      }[];
+      const messageColumns = database.prepare("PRAGMA table_info('message')").all() as {
+        name: string;
+      }[];
+      const messageIndexes = database.prepare("PRAGMA index_list('message')").all() as {
+        name: string;
+      }[];
+      expect(topicColumns.map((column) => column.name)).toContain('trace_id');
+      expect(messageColumns.map((column) => column.name)).not.toContain('trace_id');
+      expect(messageIndexes.map((index) => index.name)).not.toContain('message_trace_id_idx');
+    } finally {
+      database.close();
+    }
+  });
+});
+
+function readMigrationSqlFiles(): string[] {
+  const migrationDirectory = `${process.cwd()}/migrations/sqlite-drizzle`;
+  const journal = JSON.parse(
+    readFileSync(`${migrationDirectory}/meta/_journal.json`, 'utf8'),
+  ) as MigrationJournal;
+
+  return journal.entries.map(({ tag }) => readFileSync(`${migrationDirectory}/${tag}.sql`, 'utf8'));
+}

--- a/src/data/db/migrations.ts
+++ b/src/data/db/migrations.ts
@@ -1,4 +1,5 @@
 import m0000 from '../../../migrations/sqlite-drizzle/0000_pink_the_fury.sql';
+import m0001 from '../../../migrations/sqlite-drizzle/0001_mixed_night_thrasher.sql';
 import journal from '../../../migrations/sqlite-drizzle/meta/_journal.json';
 
 // Expo SQLite migrations must be bundled into JS; unlike the desktop main
@@ -9,5 +10,6 @@ export const migrations = {
   journal,
   migrations: {
     m0000,
+    m0001,
   },
 };

--- a/src/data/db/schemas/message.ts
+++ b/src/data/db/schemas/message.ts
@@ -49,8 +49,6 @@ export const messageTable = sqliteTable(
     modelId: text().references(() => userModelTable.id, { onDelete: 'set null' }),
     // Snapshot of model at message creation time
     modelSnapshot: text({ mode: 'json' }).$type<ModelSnapshot>(),
-    // Trace for tracking
-    traceId: text(),
     // Statistics: token usage, performance metrics, etc.
     stats: text({ mode: 'json' }).$type<MessageStats>(),
 
@@ -70,7 +68,6 @@ export const messageTable = sqliteTable(
     // Indexes
     index('message_parent_id_idx').on(table.parentId),
     index('message_topic_created_idx').on(table.topicId, table.createdAt),
-    index('message_trace_id_idx').on(table.traceId),
     // FTS5 content_rowid key (see the fts_rowid column). UNIQUE so its backing index makes the
     // per-row `MAX(fts_rowid)+1` assignment in the FTS INSERT trigger an O(log N) lookup (a bare
     // column would make a bulk migration O(N²)), and rejects any duplicate value loudly.
@@ -91,10 +88,7 @@ export const messageTable = sqliteTable(
     // Structural role<->null coupling: the virtual root (role='root') is the only row with a
     // null parent, and every content row must have a parent. Makes "content always has a
     // parent" and "root <=> parentId IS NULL" DB invariants, not service-layer discipline.
-    check(
-      'message_root_parent_check',
-      sql`(${table.role} = 'root') = (${table.parentId} is null)`,
-    ),
+    check('message_root_parent_check', sql`(${table.role} = 'root') = (${table.parentId} is null)`),
   ],
 );
 

--- a/src/data/db/schemas/topic.ts
+++ b/src/data/db/schemas/topic.ts
@@ -31,6 +31,8 @@ export const topicTable = sqliteTable(
     // SET NULL: preserve topic when group is deleted
     groupId: text().references(() => groupTable.id, { onDelete: 'set null' }),
 
+    traceId: text(),
+
     // Fractional-indexing order key, partitioned by groupId.
     ...orderKeyColumns,
 

--- a/src/data/db/seeding/seeders/PresetProviderSeeder.ts
+++ b/src/data/db/seeding/seeders/PresetProviderSeeder.ts
@@ -1,5 +1,6 @@
 import type { ProtoProviderConfig } from '@cherrystudio/provider-registry';
 import { buildRuntimeEndpointConfigs, ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
+import { PinService } from '@/data/services/PinService';
 import { providerRegistryService } from '@/data/services/ProviderRegistryService';
 import { type CreateProviderInput, ProviderService } from '@/data/services/ProviderService';
 import type { ApiFeatures, AuthConfig } from '@/data/types/provider';
@@ -86,6 +87,6 @@ export class PresetProviderSeeder implements DatabaseSeeder {
       providerId: 'cherryai',
     });
 
-    await new ProviderService(dbService).batchUpsert(rows);
+    await new ProviderService(dbService, new PinService(dbService)).batchUpsert(rows);
   }
 }

--- a/src/data/services/AssistantService.ts
+++ b/src/data/services/AssistantService.ts
@@ -53,6 +53,7 @@ function rowToAssistant(
     modelId: row.modelId as UniqueModelId | null,
     modelName,
     name: row.name,
+    orderKey: row.orderKey,
     prompt: row.prompt,
     settings: row.settings,
     tags,

--- a/src/data/services/MessageService.ts
+++ b/src/data/services/MessageService.ts
@@ -442,7 +442,6 @@ export class MessageService {
           stats: dto.stats ?? null,
           status: dto.status ?? 'pending',
           topicId,
-          traceId: dto.traceId ?? null,
         })
         .returning();
 
@@ -487,7 +486,6 @@ export class MessageService {
             stats: dto.stats ?? null,
             status: dto.status ?? 'pending',
             topicId: input.topicId,
-            traceId: dto.traceId ?? null,
           })
           .returning();
         userMessage = rowToMessage(row);
@@ -533,7 +531,6 @@ export class MessageService {
             stats: placeholder.stats ?? null,
             status: placeholder.status ?? 'pending',
             topicId: input.topicId,
-            traceId: placeholder.traceId ?? null,
           })
           .returning();
         placeholders.push(rowToMessage(row));
@@ -597,10 +594,6 @@ export class MessageService {
       if (dto.status !== undefined) {
         updates.status = dto.status;
       }
-      if (dto.traceId !== undefined) {
-        updates.traceId = dto.traceId;
-      }
-
       const [row] = await tx
         .update(messageTable)
         .set(updates)
@@ -674,6 +667,13 @@ export class MessageService {
       }
 
       if (newActiveNodeId !== undefined) {
+        if (
+          newActiveNodeId !== null &&
+          newActiveNodeId === (await getRootMessageIdTx(tx, message.topicId))
+        ) {
+          newActiveNodeId = null;
+        }
+
         if (newActiveNodeId === null) {
           await tx
             .update(topicTable)
@@ -879,7 +879,6 @@ export function rowToMessage(row: MessageRow): Message {
     stats: row.stats ?? null,
     status: row.status as Message['status'],
     topicId: row.topicId,
-    traceId: row.traceId,
     updatedAt: timestampToISO(row.updatedAt),
   };
 }

--- a/src/data/services/ProviderRegistryService.ts
+++ b/src/data/services/ProviderRegistryService.ts
@@ -304,6 +304,10 @@ export class ProviderRegistryService {
     return this.loader.loadProviders();
   }
 
+  isRegistryProvider(providerId: string): boolean {
+    return this.loader.findProvider(providerId) !== null;
+  }
+
   getProviderDisplayMetadata(
     providerId: string,
     presetProviderId?: string,

--- a/src/data/services/ProviderService.ts
+++ b/src/data/services/ProviderService.ts
@@ -3,6 +3,7 @@ import { asc, eq, inArray } from 'drizzle-orm';
 import * as Crypto from 'expo-crypto';
 
 import type { DbService } from '@/data/db/DbService';
+import { userModelTable } from '@/data/db/schemas/userModel';
 import type { InsertUserProviderRow, UserProviderRow } from '@/data/db/schemas/userProvider';
 import { userProviderTable } from '@/data/db/schemas/userProvider';
 import { DataApiErrorFactory } from '@/data/types/apiTypes';
@@ -22,6 +23,7 @@ import {
   DEFAULT_PROVIDER_SETTINGS,
 } from '@/data/types/provider';
 
+import type { PinService } from './PinService';
 import { providerRegistryService } from './ProviderRegistryService';
 import { insertManyWithOrderKey, insertWithOrderKey } from './utils/orderKey';
 
@@ -47,6 +49,13 @@ export type UpdateProviderInput = {
   name?: string;
   providerSettings?: ProviderSettings | null;
 };
+
+export function canDeleteProvider(provider: Pick<Provider, 'id' | 'presetProviderId'>): boolean {
+  return (
+    provider.presetProviderId !== provider.id &&
+    !providerRegistryService.isRegistryProvider(provider.id)
+  );
+}
 
 function mergeCatalogEndpointConfigs(
   existing: EndpointConfigs | null | undefined,
@@ -213,7 +222,10 @@ function toInsert(input: CreateProviderInput): ProviderInputWithoutOrderKey {
 export class ProviderService {
   private readonly lastUsedApiKeyIds = new Map<string, string>();
 
-  constructor(private readonly dbService: DbService) {}
+  constructor(
+    private readonly dbService: DbService,
+    private readonly pinService: PinService,
+  ) {}
 
   private get db() {
     return this.dbService.getDb();
@@ -353,17 +365,34 @@ export class ProviderService {
     if (input.name !== undefined) {
       updates.name = input.name;
     }
-    if (input.providerSettings !== undefined) {
-      updates.providerSettings = input.providerSettings;
-    }
+    const [row] = await this.dbService.withWriteTx(async (tx) => {
+      if (input.providerSettings !== undefined) {
+        if (input.providerSettings === null) {
+          updates.providerSettings = null;
+        } else {
+          const [current] = await tx
+            .select({ providerSettings: userProviderTable.providerSettings })
+            .from(userProviderTable)
+            .where(eq(userProviderTable.providerId, providerId))
+            .limit(1);
 
-    const [row] = await this.dbService.withWriteTx((tx) =>
-      tx
+          if (!current) {
+            throw DataApiErrorFactory.notFound('Provider', providerId);
+          }
+
+          updates.providerSettings = {
+            ...(current.providerSettings as Partial<ProviderSettings> | null),
+            ...input.providerSettings,
+          };
+        }
+      }
+
+      return tx
         .update(userProviderTable)
         .set(updates)
         .where(eq(userProviderTable.providerId, providerId))
-        .returning(),
-    );
+        .returning();
+    });
 
     if (!row) {
       throw DataApiErrorFactory.notFound('Provider', providerId);
@@ -419,6 +448,51 @@ export class ProviderService {
     );
 
     return this.replaceApiKeys(providerId, nextKeys);
+  }
+
+  async delete(providerId: string): Promise<void> {
+    await this.dbService.withWriteTx(async (tx) => {
+      const [provider] = await tx
+        .select({ presetProviderId: userProviderTable.presetProviderId })
+        .from(userProviderTable)
+        .where(eq(userProviderTable.providerId, providerId))
+        .limit(1);
+
+      if (!provider) {
+        throw DataApiErrorFactory.notFound('Provider', providerId);
+      }
+
+      if (
+        !canDeleteProvider({
+          id: providerId,
+          presetProviderId: provider.presetProviderId ?? undefined,
+        })
+      ) {
+        throw DataApiErrorFactory.invalidOperation(`Cannot delete preset provider '${providerId}'`);
+      }
+
+      const models = await tx
+        .select({ id: userModelTable.id })
+        .from(userModelTable)
+        .where(eq(userModelTable.providerId, providerId));
+
+      await this.pinService.purgeForEntitiesTx(
+        tx,
+        'model',
+        models.map((model) => model.id),
+      );
+
+      const deletedProviders = await tx
+        .delete(userProviderTable)
+        .where(eq(userProviderTable.providerId, providerId))
+        .returning({ providerId: userProviderTable.providerId });
+
+      if (deletedProviders.length === 0) {
+        throw DataApiErrorFactory.notFound('Provider', providerId);
+      }
+    });
+
+    this.lastUsedApiKeyIds.delete(providerId);
   }
 
   async batchUpsert(inputs: CreateProviderInput[]): Promise<void> {

--- a/src/data/services/TopicService.ts
+++ b/src/data/services/TopicService.ts
@@ -12,6 +12,7 @@ import {
   type SQL,
   sql,
 } from 'drizzle-orm';
+import * as Crypto from 'expo-crypto';
 
 import type { OrderRequest } from '@/data/api/schemas/_endpointHelpers';
 import type {
@@ -64,6 +65,29 @@ export class TopicService {
     }
 
     return rowToTopic(row);
+  }
+
+  async ensureTraceId(topicId: string): Promise<string> {
+    return await this.dbService.withWriteTx(async (tx) => {
+      const [row] = await tx
+        .select({ traceId: topicTable.traceId })
+        .from(topicTable)
+        .where(and(eq(topicTable.id, topicId), isNull(topicTable.deletedAt)))
+        .limit(1);
+
+      if (!row) {
+        throw DataApiErrorFactory.notFound('Topic', topicId);
+      }
+      if (row.traceId) {
+        return row.traceId;
+      }
+
+      const traceId = [...Crypto.getRandomBytes(16)]
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+      await tx.update(topicTable).set({ traceId }).where(eq(topicTable.id, topicId));
+      return traceId;
+    });
   }
 
   async create(dto: CreateTopicDto): Promise<Topic> {
@@ -356,6 +380,7 @@ export function rowToTopic(row: TopicRow): Topic {
     isNameManuallyEdited: row.isNameManuallyEdited,
     name: row.name,
     orderKey: row.orderKey,
+    ...(row.traceId ? { traceId: row.traceId } : {}),
     updatedAt: timestampToISO(row.updatedAt),
   };
 }

--- a/src/data/services/__tests__/AssistantService.test.ts
+++ b/src/data/services/__tests__/AssistantService.test.ts
@@ -1,0 +1,174 @@
+import type { DbService } from '@/data/db/DbService';
+import type { AssistantRow } from '@/data/db/schemas';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/data/types/assistant';
+
+import { AssistantService } from '../AssistantService';
+import type { ModelService } from '../ModelService';
+import type { PinService } from '../PinService';
+import type { PreferenceService } from '../PreferenceService';
+import type { TagService } from '../TagService';
+
+jest.mock('uuid', () => ({ v7: jest.fn(() => '00000000-0000-7000-8000-000000000000') }));
+jest.mock('../utils/orderKey', () => ({
+  applyMoves: jest.fn(),
+  insertWithOrderKey: jest.fn(),
+}));
+
+describe('AssistantService', () => {
+  test('reads desktop order and opaque knowledge/MCP relation ids without resolving targets', async () => {
+    const row = createAssistantRow({
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        futureDesktopSetting: { enabled: true },
+        toolUseMode: 'prompt',
+      },
+    });
+    const db = createReadDb(row);
+    const tagService = {
+      getTagsByEntitiesTx: jest.fn(async () => new Map([[row.id, []]])),
+    } as unknown as TagService;
+    const service = new AssistantService(
+      { getDb: () => db } as unknown as DbService,
+      {} as ModelService,
+      {} as PreferenceService,
+      tagService,
+      {} as PinService,
+    );
+
+    const assistant = await service.getById(row.id);
+
+    expect(assistant).toMatchObject({
+      knowledgeBaseIds: ['unknown-knowledge-id'],
+      mcpServerIds: ['unknown-mcp-id'],
+      orderKey: 'a0',
+      settings: {
+        futureDesktopSetting: { enabled: true },
+        toolUseMode: 'prompt',
+      },
+    });
+  });
+
+  test('preserves unknown settings and relation ids on an unrelated settings update', async () => {
+    const row = createAssistantRow({
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        futureDesktopSetting: { enabled: true },
+        toolUseMode: 'prompt',
+      },
+    });
+    const db = createReadDb(row);
+    const { transaction, writtenSettings } = createUpdateTransaction(row);
+    const tagService = {
+      getTagsByEntitiesTx: jest.fn(async () => new Map([[row.id, []]])),
+    } as unknown as TagService;
+    const service = new AssistantService(
+      {
+        getDb: () => db,
+        withWriteTx: async (callback: (tx: unknown) => Promise<unknown>) => callback(transaction),
+      } as unknown as DbService,
+      {} as ModelService,
+      {} as PreferenceService,
+      tagService,
+      {} as PinService,
+    );
+
+    const assistant = await service.update(row.id, { settings: { temperature: 0.7 } });
+
+    expect(writtenSettings()).toMatchObject({
+      futureDesktopSetting: { enabled: true },
+      temperature: 0.7,
+      toolUseMode: 'prompt',
+    });
+    expect(assistant).toMatchObject({
+      knowledgeBaseIds: ['unknown-knowledge-id'],
+      mcpServerIds: ['unknown-mcp-id'],
+      orderKey: 'a0',
+      settings: {
+        futureDesktopSetting: { enabled: true },
+        temperature: 0.7,
+        toolUseMode: 'prompt',
+      },
+    });
+    expect(transaction.delete).not.toHaveBeenCalled();
+    expect(transaction.insert).not.toHaveBeenCalled();
+  });
+});
+
+function createReadDb(row: AssistantRow) {
+  return {
+    select: jest.fn((projection: Record<string, unknown>) => {
+      if ('assistant' in projection) {
+        return {
+          from: jest.fn(() => ({
+            leftJoin: jest.fn(() => ({
+              where: jest.fn(() => ({
+                limit: jest.fn(async () => [{ assistant: row, modelName: null }]),
+              })),
+            })),
+          })),
+        };
+      }
+
+      if ('mcpServerId' in projection) {
+        return createRelationQuery([{ assistantId: row.id, mcpServerId: 'unknown-mcp-id' }]);
+      }
+
+      if ('knowledgeBaseId' in projection) {
+        return createRelationQuery([
+          { assistantId: row.id, knowledgeBaseId: 'unknown-knowledge-id' },
+        ]);
+      }
+
+      throw new Error(
+        `Unexpected assistant select projection: ${Object.keys(projection).join(', ')}`,
+      );
+    }),
+  };
+}
+
+function createRelationQuery(rows: Record<string, string>[]) {
+  return {
+    from: jest.fn(() => ({
+      where: jest.fn(() => ({
+        orderBy: jest.fn(async () => rows),
+      })),
+    })),
+  };
+}
+
+function createUpdateTransaction(row: AssistantRow) {
+  let settings: AssistantRow['settings'] | undefined;
+  const transaction = {
+    delete: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(() => ({
+      set: jest.fn((updates: Partial<AssistantRow>) => {
+        settings = updates.settings;
+        return {
+          where: jest.fn(() => ({
+            returning: jest.fn(async () => [{ ...row, ...updates }]),
+          })),
+        };
+      }),
+    })),
+  };
+
+  return { transaction, writtenSettings: () => settings };
+}
+
+function createAssistantRow(overrides: Partial<AssistantRow> = {}): AssistantRow {
+  return {
+    createdAt: 1_767_225_600_000,
+    deletedAt: null,
+    description: '',
+    emoji: 'A',
+    id: '00000000-0000-4000-8000-000000000001',
+    modelId: null,
+    name: 'Assistant',
+    orderKey: 'a0',
+    prompt: '',
+    settings: DEFAULT_ASSISTANT_SETTINGS,
+    updatedAt: 1_767_225_600_000,
+    ...overrides,
+  };
+}

--- a/src/data/services/__tests__/MessageService.test.ts
+++ b/src/data/services/__tests__/MessageService.test.ts
@@ -3,8 +3,18 @@ import type { Message } from '@/data/types/message';
 import { MessageService } from '../MessageService';
 
 jest.mock('@/data/db/schemas', () => ({
-  messageTable: {},
-  topicTable: {},
+  messageTable: {
+    deletedAt: 'message.deletedAt',
+    id: 'message.id',
+    parentId: 'message.parentId',
+    role: 'message.role',
+    topicId: 'message.topicId',
+  },
+  topicTable: {
+    activeNodeId: 'topic.activeNodeId',
+    deletedAt: 'topic.deletedAt',
+    id: 'topic.id',
+  },
 }));
 
 describe('MessageService', () => {
@@ -55,7 +65,7 @@ describe('MessageService', () => {
   });
 
   test('markMessagesError updates the given ids to error status', async () => {
-    const updateCalls: Array<{ status: string }> = [];
+    const updateCalls: { status: string }[] = [];
     const tx = {
       update: () => ({
         set: (values: { status: string }) => ({
@@ -86,6 +96,52 @@ describe('MessageService', () => {
     await service.markMessagesError([]);
 
     expect(withWriteTx).not.toHaveBeenCalled();
+  });
+
+  test('clears the active node when deleting the first branch below the virtual root', async () => {
+    const topicId = '750e8400-e29b-41d4-a716-446655440000';
+    const message = { ...createMessage('message-1', 'user'), parentId: 'root-1', topicId };
+    const topic = { activeNodeId: message.id, id: topicId };
+    const topicUpdates: Record<string, unknown>[] = [];
+    const db = {
+      all: jest.fn(async () => []),
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({ limit: jest.fn(async () => [topic]) })),
+        })),
+      })),
+    };
+    const tx = {
+      delete: jest.fn(() => ({ where: jest.fn(async () => undefined) })),
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({ limit: jest.fn(async () => [{ id: 'root-1' }]) })),
+        })),
+      })),
+      update: jest.fn(() => ({
+        set: jest.fn((values: Record<string, unknown>) => ({
+          where: jest.fn(async () => {
+            topicUpdates.push(values);
+          }),
+        })),
+      })),
+    };
+    const dbService = {
+      getDb: () => db,
+      withWriteTx: jest.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+        callback(tx),
+      ),
+    } as unknown as DbService;
+    const topicService = { setActiveNodeTx: jest.fn() };
+    const service = new MessageService(dbService, topicService as never);
+    jest.spyOn(service, 'getById').mockResolvedValue(message);
+
+    await expect(service.delete(message.id, true, 'parent')).resolves.toEqual({
+      deletedIds: [message.id],
+      newActiveNodeId: null,
+    });
+    expect(topicUpdates).toContainEqual({ activeNodeId: null });
+    expect(topicService.setActiveNodeTx).not.toHaveBeenCalled();
   });
 });
 

--- a/src/data/services/__tests__/ProviderRegistryService.test.ts
+++ b/src/data/services/__tests__/ProviderRegistryService.test.ts
@@ -80,8 +80,12 @@ describe('provider-registry-service', () => {
   });
 
   test('returns image-generation support from override or model metadata', () => {
-    expect(providerRegistryService.getImageGenerationSupport('aihubmix', 'ernie-irag-edit')).toBeDefined();
-    expect(providerRegistryService.getImageGenerationSupport('dashscope', 'qwen-image')).toBeDefined();
+    expect(
+      providerRegistryService.getImageGenerationSupport('aihubmix', 'ernie-irag-edit'),
+    ).toBeDefined();
+    expect(
+      providerRegistryService.getImageGenerationSupport('dashscope', 'qwen-image'),
+    ).toBeDefined();
   });
 
   test('exposes provider model-list and auth metadata', () => {
@@ -109,5 +113,7 @@ describe('provider-registry-service', () => {
       modelListSource: 'registry',
       websites: { official: 'https://example.com' },
     });
+    expect(service.isRegistryProvider('login-provider')).toBe(true);
+    expect(service.isRegistryProvider('custom-provider')).toBe(false);
   });
 });

--- a/src/data/services/__tests__/ProviderService.test.ts
+++ b/src/data/services/__tests__/ProviderService.test.ts
@@ -1,0 +1,196 @@
+import type { DbService } from '@/data/db/DbService';
+import type { UserProviderRow } from '@/data/db/schemas/userProvider';
+import type { ProviderSettings } from '@/data/types/provider';
+
+import type { PinService } from '../PinService';
+import { providerRegistryService } from '../ProviderRegistryService';
+import { canDeleteProvider, ProviderService } from '../ProviderService';
+
+jest.mock('uuid', () => ({ v7: jest.fn(() => '00000000-0000-7000-8000-000000000000') }));
+jest.mock('../utils/orderKey', () => ({
+  insertManyWithOrderKey: jest.fn(),
+  insertWithOrderKey: jest.fn(),
+}));
+jest.mock('../ProviderRegistryService', () => ({
+  providerRegistryService: {
+    getProviderDisplayMetadata: jest.fn(() => ({})),
+    isRegistryProvider: jest.fn(() => false),
+  },
+}));
+
+describe('ProviderService', () => {
+  test('only exposes deletion for custom providers and user-created preset clones', () => {
+    expect(canDeleteProvider({ id: 'custom-provider' })).toBe(true);
+    expect(canDeleteProvider({ id: 'openai-work', presetProviderId: 'openai' })).toBe(true);
+    expect(canDeleteProvider({ id: 'openai', presetProviderId: 'openai' })).toBe(false);
+
+    jest.mocked(providerRegistryService.isRegistryProvider).mockReturnValueOnce(true);
+    expect(canDeleteProvider({ id: 'zai', presetProviderId: 'zhipu' })).toBe(false);
+  });
+
+  test('preserves unknown stored provider settings when applying a patch', async () => {
+    const storedSettings = {
+      futureDesktopSetting: { enabled: true },
+      notes: 'keep me',
+    } as unknown as ProviderSettings;
+    const row = createProviderRow(storedSettings);
+    let writtenSettings: UserProviderRow['providerSettings'] = null;
+
+    const tx = {
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({
+            limit: jest.fn(async () => [{ providerSettings: storedSettings }]),
+          })),
+        })),
+      })),
+      update: jest.fn(() => ({
+        set: jest.fn((updates: Partial<UserProviderRow>) => {
+          writtenSettings = updates.providerSettings ?? null;
+          return {
+            where: jest.fn(() => ({
+              returning: jest.fn(async () => [{ ...row, ...updates }]),
+            })),
+          };
+        }),
+      })),
+    };
+    const service = new ProviderService(
+      {
+        getDb: () => ({}),
+        withWriteTx: async (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx),
+      } as unknown as DbService,
+      createPinServiceStub(),
+    );
+
+    const provider = await service.update(row.providerId, {
+      providerSettings: { timeout: 30_000 },
+    });
+
+    expect(writtenSettings).toEqual({
+      futureDesktopSetting: { enabled: true },
+      notes: 'keep me',
+      timeout: 30_000,
+    });
+    expect(provider.settings).toMatchObject({
+      futureDesktopSetting: { enabled: true },
+      notes: 'keep me',
+      timeout: 30_000,
+    });
+  });
+
+  test('deletes a custom provider after purging pins for its models', async () => {
+    const tx = createDeleteTransaction({
+      modelIds: ['custom-provider::model-a', 'custom-provider::model-b'],
+      presetProviderId: null,
+      providerId: 'custom-provider',
+    });
+    const pinService = {
+      purgeForEntitiesTx: jest.fn(async () => undefined),
+    } as unknown as PinService;
+    const service = createService(tx, pinService);
+
+    await service.delete('custom-provider');
+
+    expect(pinService.purgeForEntitiesTx).toHaveBeenCalledWith(tx, 'model', [
+      'custom-provider::model-a',
+      'custom-provider::model-b',
+    ]);
+    expect(tx.delete).toHaveBeenCalledTimes(1);
+  });
+
+  test('allows deleting a user clone of a registry provider', async () => {
+    const tx = createDeleteTransaction({
+      modelIds: [],
+      presetProviderId: 'openai',
+      providerId: 'openai-clone',
+    });
+    const service = createService(tx);
+
+    await expect(service.delete('openai-clone')).resolves.toBeUndefined();
+    expect(tx.delete).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects deleting registry and canonical preset providers', async () => {
+    const registryTx = createDeleteTransaction({
+      modelIds: [],
+      presetProviderId: null,
+      providerId: 'openai',
+    });
+    jest.mocked(providerRegistryService.isRegistryProvider).mockReturnValueOnce(true);
+
+    await expect(createService(registryTx).delete('openai')).rejects.toThrow(
+      "Cannot delete preset provider 'openai'",
+    );
+    expect(registryTx.delete).not.toHaveBeenCalled();
+
+    const canonicalTx = createDeleteTransaction({
+      modelIds: [],
+      presetProviderId: 'canonical',
+      providerId: 'canonical',
+    });
+    await expect(createService(canonicalTx).delete('canonical')).rejects.toThrow(
+      "Cannot delete preset provider 'canonical'",
+    );
+    expect(canonicalTx.delete).not.toHaveBeenCalled();
+  });
+});
+
+function createService(tx: object, pinService?: PinService): ProviderService {
+  return new ProviderService(
+    {
+      getDb: () => ({}),
+      withWriteTx: async (callback: (transaction: object) => Promise<unknown>) => callback(tx),
+    } as unknown as DbService,
+    pinService ?? createPinServiceStub(),
+  );
+}
+
+function createPinServiceStub(): PinService {
+  return {
+    purgeForEntitiesTx: jest.fn(async () => undefined),
+  } as unknown as PinService;
+}
+
+function createDeleteTransaction(input: {
+  modelIds: string[];
+  presetProviderId: string | null;
+  providerId: string;
+}) {
+  return {
+    delete: jest.fn(() => ({
+      where: jest.fn(() => ({
+        returning: jest.fn(async () => [{ providerId: input.providerId }]),
+      })),
+    })),
+    select: jest.fn((projection: Record<string, unknown>) => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() =>
+          'presetProviderId' in projection
+            ? {
+                limit: jest.fn(async () => [{ presetProviderId: input.presetProviderId }]),
+              }
+            : Promise.resolve(input.modelIds.map((id) => ({ id }))),
+        ),
+      })),
+    })),
+  };
+}
+
+function createProviderRow(providerSettings: ProviderSettings): UserProviderRow {
+  return {
+    apiFeatures: null,
+    apiKeys: [],
+    authConfig: null,
+    createdAt: 1_767_225_600_000,
+    defaultChatEndpoint: null,
+    endpointConfigs: null,
+    isEnabled: true,
+    name: 'Custom provider',
+    orderKey: 'a0',
+    presetProviderId: null,
+    providerId: 'custom-provider',
+    providerSettings,
+    updatedAt: 1_767_225_600_000,
+  };
+}

--- a/src/data/services/__tests__/TopicService.test.ts
+++ b/src/data/services/__tests__/TopicService.test.ts
@@ -1,3 +1,5 @@
+import * as Crypto from 'expo-crypto';
+
 import type { DbService } from '@/data/db/DbService';
 import type { PinService } from '@/data/services/PinService';
 import type { TagService } from '@/data/services/TagService';
@@ -10,8 +12,14 @@ jest.mock('@/data/db/schemas', () => ({
   },
   pinTable: {},
   topicTable: {
+    deletedAt: 'deletedAt',
     id: 'id',
+    traceId: 'traceId',
   },
+}));
+
+jest.mock('expo-crypto', () => ({
+  getRandomBytes: jest.fn(),
 }));
 
 jest.mock('../utils/orderKey', () => ({
@@ -20,6 +28,38 @@ jest.mock('../utils/orderKey', () => ({
 }));
 
 describe('TopicService', () => {
+  test('creates and persists a desktop-compatible trace id once', async () => {
+    const expectedTraceId = '000102030405060708090a0b0c0d0e0f';
+    jest
+      .mocked(Crypto.getRandomBytes)
+      .mockReturnValue(Uint8Array.from({ length: 16 }, (_, i) => i));
+    const updates: Record<string, unknown>[] = [];
+    const tx = {
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({ limit: jest.fn(async () => [{ traceId: null }]) })),
+        })),
+      })),
+      update: jest.fn(() => ({
+        set: jest.fn((values: Record<string, unknown>) => {
+          updates.push(values);
+          return { where: jest.fn(async () => undefined) };
+        }),
+      })),
+    };
+    const dbService = {
+      withWriteTx: jest.fn(async (callback: (transaction: typeof tx) => Promise<string>) =>
+        callback(tx),
+      ),
+    } as unknown as DbService;
+    const service = new TopicService(dbService, {} as PinService, {} as TagService);
+
+    await expect(service.ensureTraceId('550e8400-e29b-41d4-a716-446655440000')).resolves.toBe(
+      expectedTraceId,
+    );
+    expect(updates).toEqual([{ traceId: expectedTraceId }]);
+  });
+
   test('purges topic tag bindings when deleting a topic', async () => {
     const operations: string[] = [];
     type Tx = {

--- a/src/data/services/createDataServices.ts
+++ b/src/data/services/createDataServices.ts
@@ -1,5 +1,6 @@
 import { AiService } from '@/ai/AiService';
 import type { DbService } from '@/data/db/DbService';
+import { WebSearchService } from '@/services/webSearch/WebSearchService';
 
 import { AssistantService } from './AssistantService';
 import { GroupService } from './GroupService';
@@ -11,23 +12,22 @@ import { PromptService } from './PromptService';
 import { ProviderService } from './ProviderService';
 import { TagService } from './TagService';
 import { TopicService } from './TopicService';
-import { WebSearchService } from './WebSearchService';
 
 export type DataServices = ReturnType<typeof createDataServices>;
 
 export function createDataServices(dbService: DbService) {
   const preference = new PreferenceService(dbService);
-  const provider = new ProviderService(dbService);
+  const pin = new PinService(dbService);
+  const provider = new ProviderService(dbService, pin);
   const model = new ModelService(dbService);
   const tag = new TagService(dbService);
   const group = new GroupService(dbService);
-  const pin = new PinService(dbService);
   const prompt = new PromptService(dbService);
   const assistant = new AssistantService(dbService, model, preference, tag, pin);
   const topic = new TopicService(dbService, pin, tag);
   const message = new MessageService(dbService, topic);
   const webSearch = new WebSearchService(preference);
-  const ai = new AiService({ assistant, model, preference, provider });
+  const ai = new AiService({ assistant, model, preference, provider, webSearch });
 
   return {
     ai,

--- a/src/data/services/index.ts
+++ b/src/data/services/index.ts
@@ -9,4 +9,3 @@ export { ProviderRegistryService } from './ProviderRegistryService';
 export { ProviderService } from './ProviderService';
 export { TagService } from './TagService';
 export { TopicService } from './TopicService';
-export { WebSearchService } from './WebSearchService';

--- a/src/data/types/__tests__/assistant.test.ts
+++ b/src/data/types/__tests__/assistant.test.ts
@@ -1,7 +1,52 @@
-import { DEFAULT_ASSISTANT_SETTINGS } from '../assistant';
+import { AssistantSchema, AssistantSettingsSchema, DEFAULT_ASSISTANT_SETTINGS } from '../assistant';
 
 describe('assistant data schemas', () => {
   test('keeps reasoning effort in the default settings payload', () => {
     expect(DEFAULT_ASSISTANT_SETTINGS.reasoning_effort).toBe('default');
+  });
+
+  test('round-trips settings fields introduced by another Cherry client', () => {
+    const parsed = AssistantSettingsSchema.parse({
+      ...DEFAULT_ASSISTANT_SETTINGS,
+      futureDesktopSetting: { enabled: true },
+    });
+
+    expect(parsed).toMatchObject({
+      futureDesktopSetting: { enabled: true },
+    });
+  });
+
+  test('does not add the retired mobile-only tool use mode to new assistants', () => {
+    expect(DEFAULT_ASSISTANT_SETTINGS).not.toHaveProperty('toolUseMode');
+  });
+
+  test('still round-trips a tool use mode already stored by an older mobile build', () => {
+    const parsed = AssistantSettingsSchema.parse({
+      ...DEFAULT_ASSISTANT_SETTINGS,
+      toolUseMode: 'prompt',
+    });
+
+    expect(parsed).toHaveProperty('toolUseMode', 'prompt');
+  });
+
+  test('includes the desktop ordering key in assistant entities', () => {
+    const assistant = AssistantSchema.parse({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      description: '',
+      emoji: 'A',
+      id: '00000000-0000-4000-8000-000000000001',
+      knowledgeBaseIds: [],
+      mcpServerIds: [],
+      modelId: null,
+      modelName: null,
+      name: 'Assistant',
+      orderKey: 'a0',
+      prompt: '',
+      settings: DEFAULT_ASSISTANT_SETTINGS,
+      tags: [],
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(assistant.orderKey).toBe('a0');
   });
 });

--- a/src/data/types/__tests__/trace.test.ts
+++ b/src/data/types/__tests__/trace.test.ts
@@ -1,0 +1,9 @@
+import { TraceIdSchema } from '../trace';
+
+describe('TraceIdSchema', () => {
+  test('accepts a 32-character lowercase hex trace id', () => {
+    expect(TraceIdSchema.safeParse('000102030405060708090a0b0c0d0e0f').success).toBe(true);
+    expect(TraceIdSchema.safeParse('000102030405060708090A0B0C0D0E0F').success).toBe(false);
+    expect(TraceIdSchema.safeParse('short').success).toBe(false);
+  });
+});

--- a/src/data/types/assistant.ts
+++ b/src/data/types/assistant.ts
@@ -5,29 +5,30 @@ import { TagSchema } from './tag';
 export const McpModeSchema = z.enum(['disabled', 'auto', 'manual']);
 export type McpMode = z.infer<typeof McpModeSchema>;
 
-export const AssistantSettingsSchema = z.object({
-  customParameters: z.array(
-    z.discriminatedUnion('type', [
-      z.object({ name: z.string(), type: z.literal('string'), value: z.string() }),
-      z.object({ name: z.string(), type: z.literal('number'), value: z.number() }),
-      z.object({ name: z.string(), type: z.literal('boolean'), value: z.boolean() }),
-      z.object({ name: z.string(), type: z.literal('json'), value: z.unknown() }),
-    ]),
-  ),
-  enableMaxTokens: z.boolean(),
-  enableMaxToolCalls: z.boolean(),
-  enableTemperature: z.boolean(),
-  enableTopP: z.boolean(),
-  enableWebSearch: z.boolean(),
-  maxTokens: z.number().int().positive(),
-  maxToolCalls: z.number().int().positive(),
-  mcpMode: McpModeSchema,
-  reasoning_effort: z.string(),
-  streamOutput: z.boolean(),
-  temperature: z.number().min(0).max(2),
-  toolUseMode: z.enum(['function', 'prompt']),
-  topP: z.number().min(0).max(1),
-});
+export const AssistantSettingsSchema = z
+  .object({
+    customParameters: z.array(
+      z.discriminatedUnion('type', [
+        z.object({ name: z.string(), type: z.literal('string'), value: z.string() }),
+        z.object({ name: z.string(), type: z.literal('number'), value: z.number() }),
+        z.object({ name: z.string(), type: z.literal('boolean'), value: z.boolean() }),
+        z.object({ name: z.string(), type: z.literal('json'), value: z.unknown() }),
+      ]),
+    ),
+    enableMaxTokens: z.boolean(),
+    enableMaxToolCalls: z.boolean(),
+    enableTemperature: z.boolean(),
+    enableTopP: z.boolean(),
+    enableWebSearch: z.boolean(),
+    maxTokens: z.number().int().positive(),
+    maxToolCalls: z.number().int().positive(),
+    mcpMode: McpModeSchema,
+    reasoning_effort: z.string(),
+    streamOutput: z.boolean(),
+    temperature: z.number().min(0).max(2),
+    topP: z.number().min(0).max(1),
+  })
+  .passthrough();
 export type AssistantSettings = z.infer<typeof AssistantSettingsSchema>;
 
 export const DEFAULT_ASSISTANT_ID = 'default' as const;
@@ -45,7 +46,6 @@ export const DEFAULT_ASSISTANT_SETTINGS: AssistantSettings = {
   reasoning_effort: 'default',
   streamOutput: true,
   temperature: 1,
-  toolUseMode: 'function',
   topP: 1,
 };
 
@@ -61,6 +61,7 @@ export const AssistantSchema = z.strictObject({
   modelId: UniqueModelIdSchema.nullable(),
   modelName: z.string().nullable(),
   name: z.string().min(1),
+  orderKey: z.string(),
   prompt: z.string(),
   settings: AssistantSettingsSchema,
   tags: z.array(TagSchema),

--- a/src/data/types/index.ts
+++ b/src/data/types/index.ts
@@ -9,5 +9,6 @@ export * from './prompt';
 export * from './provider';
 export * from './tag';
 export * from './topic';
+export * from './trace';
 export * from './uiParts';
 export * from './webSearch';

--- a/src/data/types/message.ts
+++ b/src/data/types/message.ts
@@ -19,8 +19,11 @@ export const MessageIdSchema = z.uuid();
 export type MessageId = z.infer<typeof MessageIdSchema>;
 
 export const MessageStatsSchema = z.strictObject({
+  cacheReadTokens: z.number().optional(),
+  cacheWriteTokens: z.number().optional(),
   completionTokens: z.number().optional(),
   cost: z.number().optional(),
+  noCacheTokens: z.number().optional(),
   promptTokens: z.number().optional(),
   thoughtsTokens: z.number().optional(),
   timeCompletionMs: z.number().optional(),
@@ -37,10 +40,13 @@ export interface MessageData {
 }
 
 export interface CherryUIMessageMetadata {
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   completionTokens?: number;
   createdAt?: string;
   modelId?: string;
   modelSnapshot?: ModelSnapshot;
+  noCacheTokens?: number;
   parentId?: string | null;
   promptTokens?: number;
   siblingsGroupId?: number;
@@ -192,7 +198,6 @@ export const MessageSchema = z.strictObject({
   stats: MessageStatsSchema.nullable().optional(),
   status: MessageStatusSchema,
   topicId: z.string(),
-  traceId: z.string().nullable().optional(),
   updatedAt: z.iso.datetime(),
 });
 export type Message = z.infer<typeof MessageSchema>;

--- a/src/data/types/topic.ts
+++ b/src/data/types/topic.ts
@@ -7,6 +7,8 @@
 
 import * as z from 'zod';
 
+import { TraceIdSchema } from './trace';
+
 export const TopicIdSchema = z.uuidv4();
 export const TopicNameSchema = z.string().min(1).max(255);
 /** Entity-side name validator: DB DEFAULT '' means a stored row may have an empty name. */
@@ -28,6 +30,8 @@ export const TopicSchema = z.strictObject({
   activeNodeId: z.string().optional(),
   /** Group ID for organization */
   groupId: z.string().optional(),
+  /** Container-level OTel trace ID */
+  traceId: TraceIdSchema.optional(),
   /** Fractional-indexing order key, partitioned by groupId. */
   orderKey: z.string(),
   /** Creation timestamp (ISO string) */

--- a/src/data/types/trace.ts
+++ b/src/data/types/trace.ts
@@ -1,0 +1,6 @@
+import * as z from 'zod';
+
+export const TraceIdSchema = z
+  .string()
+  .regex(/^[0-9a-f]{32}$/, 'traceId must be 32 lowercase hex chars');
+export type TraceId = z.infer<typeof TraceIdSchema>;

--- a/src/hooks/chat/utils/defaultAssistant.ts
+++ b/src/hooks/chat/utils/defaultAssistant.ts
@@ -19,6 +19,7 @@ export function composeDefaultAssistant(modelId: UniqueModelId | null): Assistan
     modelId,
     modelName: null,
     name: i18n.t('chat.default.name'),
+    orderKey: '',
     prompt: '',
     settings: DEFAULT_ASSISTANT_SETTINGS,
     tags: [],

--- a/src/screens/ChatScreen/runtime/__tests__/ChatRuntime.test.ts
+++ b/src/screens/ChatScreen/runtime/__tests__/ChatRuntime.test.ts
@@ -935,6 +935,7 @@ function createAssistant(id: string, modelId: UniqueModelId | null): Assistant {
     modelId,
     modelName: modelId,
     name: 'Assistant',
+    orderKey: 'a0',
     prompt: '',
     settings: DEFAULT_ASSISTANT_SETTINGS,
     tags: [],

--- a/src/services/webSearch/WebSearchService.ts
+++ b/src/services/webSearch/WebSearchService.ts
@@ -9,17 +9,14 @@ import type {
   WebSearchResponse,
   WebSearchSearchKeywordsRequest,
 } from '@/data/types/webSearch';
-import { postProcessWebSearchResponse } from '@/services/webSearch/postProcessing';
-import type { WebSearchProviderDriver } from '@/services/webSearch/providers/factory';
-import { createWebSearchProvider } from '@/services/webSearch/providers/factory';
-import { filterWebSearchResponseWithBlacklist } from '@/services/webSearch/utils/blacklist';
-import { getProviderForCapability, getRuntimeConfig } from '@/services/webSearch/utils/config';
-import { isAbortError } from '@/services/webSearch/utils/errors';
-import {
-  normalizeWebSearchKeywords,
-  normalizeWebSearchUrls,
-} from '@/services/webSearch/utils/input';
-import { ApiKeyRotationState } from '@/services/webSearch/utils/provider';
+import { postProcessWebSearchResponse } from './postProcessing';
+import type { WebSearchProviderDriver } from './providers/factory';
+import { createWebSearchProvider } from './providers/factory';
+import { filterWebSearchResponseWithBlacklist } from './utils/blacklist';
+import { getProviderForCapability, getRuntimeConfig } from './utils/config';
+import { isAbortError } from './utils/errors';
+import { normalizeWebSearchKeywords, normalizeWebSearchUrls } from './utils/input';
+import { ApiKeyRotationState } from './utils/provider';
 
 const logger = loggerService.withContext('WebSearchService');
 

--- a/src/services/webSearch/__tests__/WebSearchService.test.ts
+++ b/src/services/webSearch/__tests__/WebSearchService.test.ts
@@ -1,6 +1,6 @@
 import type { PreferenceDefaultScopeType, PreferenceKeyType } from '@/data/preference';
 import type { PreferenceService } from '@/data/services/PreferenceService';
-import { WebSearchService } from '@/data/services/WebSearchService';
+import { WebSearchService } from '@/services/webSearch/WebSearchService';
 
 describe('WebSearchService', () => {
   const originalFetch = global.fetch;

--- a/src/services/webSearch/utils/errors.ts
+++ b/src/services/webSearch/utils/errors.ts
@@ -6,3 +6,10 @@ export function isAbortError(error: unknown): boolean {
     (error as { name: string }).name === 'AbortError'
   );
 }
+
+/** Configuration failures that cannot succeed until the user changes Web Search settings. */
+export function isPermanentWebSearchConfigError(message: string): boolean {
+  return /is not configured for capability|does not (support|implement) capability|Unknown web search provider/i.test(
+    message,
+  );
+}


### PR DESCRIPTION
## Summary
- Moves `traceId` from `message` to `topic` (new migration + `TopicService.ensureTraceId`), and updates the `assistant` schema (settings now `.passthrough()`, drops `toolUseMode`, adds `orderKey`) to track desktop.
- Adds `ProviderService.delete()` with a `canDeleteProvider` preset-provider guard, wires in `PinService` to purge model pins on provider deletion, and fixes `providerSettings` updates to merge instead of overwrite.
- Introduces a built-in `web_search` AI tool (`createWebSearchTool.ts`) used by `AiService` for function-calling models when external web search is configured, bounded by `stepCountIs`/`maxToolCalls`; relocates `WebSearchService` from `src/ai` to `src/services/webSearch`.
- Adds substantial test coverage across the touched data services, schemas, and AI tooling, plus a docs update recording the startup-measurement boundary and explicitly deferring physical-device cold-start claims.

## Test plan
- [ ] Run `yarn test` / relevant Jest suites for `src/data`, `src/ai`, and `src/services/webSearch`
- [ ] Verify SQLite migration `0001_mixed_night_thrasher.sql` applies cleanly on a fresh and an existing dev database
- [ ] Manually exercise provider deletion (preset provider blocked, custom provider deletable, pins purged) and web search tool invocation in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)