### PR TITLE
fix(ci): disable react-hooks/immutability false positive, mock Skia RuntimeEffect

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,14 @@
 const expoConfig = require('eslint-config-expo/flat');
 const { defineConfig } = require('eslint/config');
 
-module.exports = defineConfig([expoConfig]);
+module.exports = defineConfig([
+  expoConfig,
+  {
+    rules: {
+      // react-hooks/immutability is a React Compiler rule that doesn't understand
+      // react-native-reanimated's SharedValue.value mutation pattern, which is the
+      // idiomatic way to update shared values from worklets and gesture callbacks.
+      'react-hooks/immutability': 'off',
+    },
+  },
+]);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,11 +21,20 @@ jest.mock('@shopify/react-native-skia', () => {
     Group: inert('SkiaGroup'),
     Text: inert('SkiaText'),
     BlurMask: inert('SkiaBlurMask'),
+    RoundedRect: inert('SkiaRoundedRect'),
+    Shader: inert('SkiaShader'),
     matchFont: () => ({
       getGlyphIDs: (text: string) => Array.from(text).map((_, index) => index),
       getGlyphWidths: (ids: number[]) => ids.map(() => 8),
       getMetrics: () => ({ ascent: -11, descent: 3 }),
     }),
+    // thinkingPixelField.ts compiles its SkSL at module scope, so RuntimeEffect.Make
+    // must return a truthy stub or the ChatInputSurface import chain throws under test.
+    Skia: {
+      RuntimeEffect: {
+        Make: () => ({}),
+      },
+    },
   };
 });
 


### PR DESCRIPTION
## Summary
- The Expo 57 dependency bump pulled in eslint-plugin-react-hooks's new React Compiler rules; `react-hooks/immutability` flags Reanimated's idiomatic `sharedValue.value = ...` mutation inside worklet/gesture callbacks (`useEffortSliderGesture.ts`, `ChatInputPhotoGrid.tsx`) as a lint error, so it's disabled in `eslint.config.js`.
- The jest Skia mock in `jest.setup.ts` is extended with `RoundedRect`, `Shader`, and a truthy `Skia.RuntimeEffect.Make` stub so the `ChatInputSurface` test suite can import the new thinking pixel field shader without crashing.
- Verified locally: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and `pnpm test` all pass (92 suites / 575 tests).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)