### PR TITLE
feat(cache): port desktop CacheService to mobile (memory+TTL + MMKV persist)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -65,6 +65,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["src/data/cache/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noTemplateCurlyInString": "off"
+          }
+        }
+      }
+    }
+  ],
   "assist": {
     "enabled": true,
     "actions": {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -81,6 +81,31 @@ jest.mock('@shopify/react-native-skia', () => {
   };
 });
 
+// react-native-mmkv is a Nitro HybridObject with no JS fallback and (as of
+// 4.3.2) no official jest mock entry. The cacheService singleton constructs an
+// MMKV instance at module scope, so any import chain reaching it needs this
+// Map-backed stand-in. CacheService unit tests bypass it by injecting
+// InMemoryKVStorage directly.
+jest.mock('react-native-mmkv', () => {
+  const createMMKV = () => {
+    const store = new Map<string, string>();
+    return {
+      set: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      getString: (key: string) => store.get(key),
+      contains: (key: string) => store.has(key),
+      remove: (key: string) => store.delete(key),
+      getAllKeys: () => [...store.keys()],
+      clearAll: () => {
+        store.clear();
+      },
+    };
+  };
+
+  return { createMMKV };
+});
+
 // gesture-handler 真模块在 jest 下要求 Reanimated.default.createAnimatedComponent，
 // 而 jest 环境的 reanimated 没有这个 API。GestureDetector 透传 children，
 // Gesture.* 返回任意链式调用都指向自身的构建器。

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-native-enriched-markdown": "0.7.3",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-keyboard-controller": "^1.21.6",
+    "react-native-mmkv": "4.3.2",
     "react-native-nitro-image": "0.15.1",
     "react-native-nitro-modules": "0.35.9",
     "react-native-pager-view": "8.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       react-native-keyboard-controller:
         specifier: ^1.21.6
         version: 1.21.9(react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-mmkv:
+        specifier: 4.3.2
+        version: 4.3.2(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-nitro-image:
         specifier: 0.15.1
         version: 0.15.1(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -6874,6 +6877,13 @@ packages:
       react: '*'
       react-native: '*'
       react-native-reanimated: '>=3.0.0'
+
+  react-native-mmkv@4.3.2:
+    resolution: {integrity: sha512-49OAyfkg0/TMWiWELZN6VuVQPZPhizwL4DTmp8b7B1md3dB/s3LH3mGfC3T+lp9W0y/rqxZMEnotLFTIbOAenQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+      react-native-nitro-modules: '*'
 
   react-native-nitro-image@0.15.1:
     resolution: {integrity: sha512-slrImfUgasAdzylTiNWuTkawE0R4t7LGh+7N2VFa/D9+SxlQbkKYp1J6hA3XkkEnTnUCKaea39ZVg+1xx665MQ==}
@@ -14809,6 +14819,12 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+
+  react-native-mmkv@4.3.2(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+      react-native-nitro-modules: 0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
 
   react-native-nitro-image@0.15.1(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/data/cache/CacheService.ts
+++ b/src/data/cache/CacheService.ts
@@ -1,0 +1,605 @@
+/**
+ * @fileoverview CacheService - Infrastructure component for two-tier caching
+ *
+ * Ported from the desktop renderer `CacheService` (three tiers). Mobile runs a
+ * single JS runtime with no multi-window IPC, so the desktop "shared" tier is
+ * folded into the memory tier; when porting desktop call sites, mechanically
+ * replace `getShared`/`setShared`/... with `get`/`set`/... and move the key
+ * into `UseCacheSchema`.
+ *
+ * NAMING NOTE:
+ * This component is named "CacheService" for management consistency, but it is
+ * actually an infrastructure component (cache manager) rather than a business
+ * service. It contains zero business logic.
+ *
+ * Tiers:
+ * 1. Memory cache — cross-component, TTL-capable, lost on app restart
+ * 2. Persist cache — survives restarts via a synchronous KV store (MMKV),
+ *    default-relative semantics (getPersist never returns undefined)
+ *
+ * Features:
+ * - All APIs are synchronous
+ * - TTL lazy cleanup (checked on get/has, no timers)
+ * - Hook reference tracking (prevents deletion of keys observed by mounted hooks)
+ * - Type-safe schema keys with template-key support, plus a casual dynamic-key API
+ *
+ * The module-level singleton {@link cacheService} is the runtime instance —
+ * hooks and services must share it. Tests construct their own
+ * `new CacheService(new InMemoryKVStorage())` to avoid cross-test pollution.
+ * Note the singleton survives DataProvider remounts and React Fast Refresh of
+ * consumer modules; the memory tier is session-scoped by design (cleared only
+ * by a full JS reload, equivalent to a desktop window refresh).
+ */
+
+import { loggerService } from '@logger';
+
+import type {
+  InferUseCacheValue,
+  PersistCacheKey,
+  PersistCacheSchema,
+  UseCacheKey,
+} from './cacheSchemas';
+import { DefaultPersistCache } from './cacheSchemas';
+import type {
+  CacheEntry,
+  CacheEntryDetail,
+  CacheStats,
+  CacheSubscriber,
+  CacheTierSummary,
+} from './cacheTypes';
+import { deepEqual } from './cacheUtils';
+import type { KVStorage } from './kvStorage';
+import { createMmkvStorage, InMemoryKVStorage } from './kvStorage';
+
+const logger = loggerService.withContext('CacheService');
+
+export class CacheService {
+  // Two-tier cache system
+  private memoryCache = new Map<string, CacheEntry>();
+  private persistCache = new Map<PersistCacheKey, unknown>();
+
+  // Hook reference tracking (reference-counted)
+  private activeHookCounts = new Map<string, number>();
+
+  // Subscription management
+  private subscribers = new Map<string, Set<CacheSubscriber>>();
+
+  // Persist tier backing store (one entry per schema key, JSON-encoded)
+  private readonly storage: KVStorage;
+
+  constructor(storage: KVStorage = new InMemoryKVStorage()) {
+    this.storage = storage;
+    this.loadPersistCache();
+  }
+
+  // ============ Memory Cache ============
+
+  /**
+   * Get value from memory cache with TTL validation (type-safe)
+   *
+   * Supports both fixed keys and template keys following the schema.
+   *
+   * DESIGN NOTE: Returns `undefined` when cache miss or TTL expired.
+   * This is intentional - developers need to know when a value doesn't exist
+   * (e.g., after explicit deletion) and handle it appropriately.
+   * For UI components that always need a value, use the `useCache` hook instead,
+   * which provides automatic default value fallback.
+   *
+   * @param key - Schema-defined cache key (fixed or matching template pattern)
+   * @returns Cached value or undefined if not found or expired
+   */
+  get<K extends UseCacheKey>(key: K): InferUseCacheValue<K> | undefined {
+    return this.getInternal(key);
+  }
+
+  /**
+   * Get value from memory cache with TTL validation (casual, dynamic key)
+   *
+   * Use this for fully dynamic keys that don't match any schema pattern.
+   * For keys matching schema patterns (including templates), use `get()` instead.
+   *
+   * Note: Due to TypeScript limitations with template literal types, compile-time
+   * blocking of schema keys works best with literal string arguments. Variable
+   * keys are accepted but may not trigger compile errors.
+   *
+   * @template T - The expected value type (must be specified manually)
+   * @param key - Dynamic cache key that doesn't match any schema pattern
+   * @returns Cached value or undefined if not found or expired
+   */
+  getCasual<T>(key: Exclude<string, UseCacheKey>): T | undefined {
+    return this.getInternal(key);
+  }
+
+  private getInternal(key: string): any {
+    const entry = this.memoryCache.get(key);
+    if (entry === undefined) {
+      return undefined;
+    }
+    // Check TTL (lazy cleanup)
+    if (entry.expireAt && Date.now() > entry.expireAt) {
+      this.memoryCache.delete(key);
+      this.notifySubscribers(key);
+      return undefined;
+    }
+
+    return entry.value;
+  }
+
+  /**
+   * Set value in memory cache with optional TTL (type-safe)
+   *
+   * @param key - Schema-defined cache key (fixed or matching template pattern)
+   * @param value - Value to cache (type inferred from schema via template matching)
+   * @param ttl - Time to live in milliseconds (optional)
+   */
+  set<K extends UseCacheKey>(key: K, value: InferUseCacheValue<K>, ttl?: number): void {
+    this.setInternal(key, value, ttl);
+  }
+
+  /**
+   * Set value in memory cache with optional TTL (casual, dynamic key)
+   *
+   * Use this for fully dynamic keys that don't match any schema pattern.
+   * For keys matching schema patterns (including templates), use `set()` instead.
+   *
+   * @param key - Dynamic cache key that doesn't match any schema pattern
+   * @param value - Value to cache
+   * @param ttl - Time to live in milliseconds (optional)
+   */
+  setCasual<T>(key: Exclude<string, UseCacheKey>, value: T, ttl?: number): void {
+    this.setInternal(key, value, ttl);
+  }
+
+  private setInternal(key: string, value: any, ttl?: number): void {
+    const existingEntry = this.memoryCache.get(key);
+
+    // Value comparison optimization: deep-equal value is treated as unchanged
+    // so object/array/Record values are short-circuited by content, not reference.
+    if (existingEntry && deepEqual(existingEntry.value, value)) {
+      // Value is same, only update TTL if needed
+      const newExpireAt = ttl ? Date.now() + ttl : undefined;
+      if (!Object.is(existingEntry.expireAt, newExpireAt)) {
+        existingEntry.expireAt = newExpireAt;
+      }
+      return; // Skip notification
+    }
+
+    const entry: CacheEntry = {
+      value,
+      expireAt: ttl ? Date.now() + ttl : undefined,
+    };
+
+    this.memoryCache.set(key, entry);
+    this.notifySubscribers(key);
+  }
+
+  /**
+   * Check if key exists in memory cache and is not expired (type-safe)
+   */
+  has<K extends UseCacheKey>(key: K): boolean {
+    return this.hasInternal(key);
+  }
+
+  /**
+   * Check if key exists in memory cache and is not expired (casual, dynamic key)
+   */
+  hasCasual(key: Exclude<string, UseCacheKey>): boolean {
+    return this.hasInternal(key);
+  }
+
+  private hasInternal(key: string): boolean {
+    const entry = this.memoryCache.get(key);
+    if (entry === undefined) {
+      return false;
+    }
+
+    // Check TTL
+    if (entry.expireAt && Date.now() > entry.expireAt) {
+      this.memoryCache.delete(key);
+      this.notifySubscribers(key);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Delete from memory cache with hook protection (type-safe)
+   * @returns True if deletion succeeded, false if key is protected by active hooks
+   */
+  delete<K extends UseCacheKey>(key: K): boolean {
+    return this.deleteInternal(key);
+  }
+
+  /**
+   * Delete from memory cache with hook protection (casual, dynamic key)
+   * @returns True if deletion succeeded, false if key is protected by active hooks
+   */
+  deleteCasual(key: Exclude<string, UseCacheKey>): boolean {
+    return this.deleteInternal(key);
+  }
+
+  private deleteInternal(key: string): boolean {
+    // Check if key is being used by hooks
+    if (this.activeHookCounts.get(key)) {
+      logger.error(`Cannot delete key "${key}" as it's being used by useCache hook`);
+      return false;
+    }
+
+    // Check if key exists before attempting deletion
+    if (!this.memoryCache.has(key)) {
+      return true;
+    }
+
+    this.memoryCache.delete(key);
+    this.notifySubscribers(key);
+    return true;
+  }
+
+  /**
+   * Check if a key has TTL set in memory cache (type-safe)
+   */
+  hasTTL<K extends UseCacheKey>(key: K): boolean {
+    const entry = this.memoryCache.get(key);
+    return entry?.expireAt !== undefined;
+  }
+
+  /**
+   * Check if a key has TTL set in memory cache (casual, dynamic key)
+   */
+  hasTTLCasual(key: Exclude<string, UseCacheKey>): boolean {
+    const entry = this.memoryCache.get(key);
+    return entry?.expireAt !== undefined;
+  }
+
+  // ============ Persist Cache (KV-store backed, default-relative) ============
+
+  /**
+   * Get value from persist cache with automatic default value fallback.
+   * Never returns undefined: an unset key yields its schema default.
+   */
+  getPersist<K extends PersistCacheKey>(key: K): PersistCacheSchema[K] {
+    const value = this.persistCache.get(key);
+    return (value !== undefined ? value : DefaultPersistCache[key]) as PersistCacheSchema[K];
+  }
+
+  /**
+   * Set value in persist cache with synchronous write-through to the KV store.
+   *
+   * No debounce: the MMKV-backed store makes single-key synchronous writes
+   * cheap, and React Native has no reliable beforeunload to flush a dirty
+   * buffer when the OS kills the app. A value deep-equal to the schema default
+   * removes the stored entry instead (absent = default), keeping the store
+   * minimal and making `deletePersist` a true removal.
+   */
+  setPersist<K extends PersistCacheKey>(key: K, value: PersistCacheSchema[K]): void {
+    const existingValue = this.getPersist(key);
+
+    // Use deep comparison for persist cache (usually objects)
+    if (deepEqual(existingValue, value)) {
+      return; // Skip all updates
+    }
+
+    this.persistCache.set(key, value);
+    this.notifySubscribers(key);
+
+    try {
+      if (deepEqual(value, DefaultPersistCache[key])) {
+        this.storage.delete(key);
+      } else {
+        this.storage.set(key, JSON.stringify(value));
+      }
+    } catch (error) {
+      logger.error(`Failed to persist cache key "${key}"`, error as Error);
+    }
+  }
+
+  /**
+   * Whether the key has been overridden — i.e. its effective value DIFFERS from
+   * the schema default. This is intentionally NOT "is the key in the backing
+   * store": a key whose stored value equals the default (or was never set)
+   * reports false.
+   */
+  hasPersist<K extends PersistCacheKey>(key: K): boolean {
+    return !deepEqual(this.getPersist(key), DefaultPersistCache[key]);
+  }
+
+  /**
+   * Reset a persist key to its schema default ("delete" the override).
+   *
+   * This tier has no absent state — getPersist always returns the default once
+   * the override is gone — so deletion is expressed as restoring the default.
+   * Delegates to setPersist, inheriting its same-value no-op, subscriber
+   * notify, and stored-entry removal.
+   */
+  deletePersist<K extends PersistCacheKey>(key: K): void {
+    this.setPersist(key, DefaultPersistCache[key]);
+  }
+
+  // ============ Hook Reference Management ============
+
+  /**
+   * Register a hook as using a specific cache key to prevent deletion
+   */
+  registerHook(key: string): void {
+    const currentCount = this.activeHookCounts.get(key) ?? 0;
+    this.activeHookCounts.set(key, currentCount + 1);
+  }
+
+  /**
+   * Unregister a hook from using a specific cache key
+   */
+  unregisterHook(key: string): void {
+    const currentCount = this.activeHookCounts.get(key);
+    if (!currentCount) {
+      return;
+    }
+
+    if (currentCount === 1) {
+      this.activeHookCounts.delete(key);
+      return;
+    }
+
+    this.activeHookCounts.set(key, currentCount - 1);
+  }
+
+  // ============ Subscription Management ============
+
+  /**
+   * Subscribe to cache changes for a specific key
+   * @returns Unsubscribe function
+   */
+  subscribe(key: string, callback: CacheSubscriber): () => void {
+    let keySubscribers = this.subscribers.get(key);
+    if (!keySubscribers) {
+      keySubscribers = new Set();
+      this.subscribers.set(key, keySubscribers);
+    }
+    keySubscribers.add(callback);
+
+    return () => {
+      keySubscribers.delete(callback);
+      if (keySubscribers.size === 0) {
+        this.subscribers.delete(key);
+      }
+    };
+  }
+
+  /**
+   * Notify all subscribers when a cache key changes
+   */
+  private notifySubscribers(key: string): void {
+    const keySubscribers = this.subscribers.get(key);
+    if (keySubscribers) {
+      keySubscribers.forEach((callback) => {
+        try {
+          callback();
+        } catch (error) {
+          logger.error(`Subscriber callback error for key ${key}`, error as Error);
+        }
+      });
+    }
+  }
+
+  // ============ Statistics ============
+
+  /**
+   * Get comprehensive statistics about all cache tiers
+   *
+   * @param includeDetails - Whether to include per-entry details (default: false)
+   */
+  getStats(includeDetails = false): CacheStats {
+    const now = Date.now();
+
+    const memory = this.processMemoryTier(now, includeDetails);
+    const persist = this.processPersistTier(includeDetails);
+
+    const totalBytes = memory.summary.estimatedBytes + persist.summary.estimatedBytes;
+
+    const total = {
+      totalCount: memory.summary.totalCount + persist.summary.totalCount,
+      validCount: memory.summary.validCount + persist.summary.validCount,
+      expiredCount: memory.summary.expiredCount,
+      withTTLCount: memory.summary.withTTLCount,
+      hookReferences: memory.summary.hookReferences + persist.summary.hookReferences,
+      estimatedBytes: totalBytes,
+      estimatedSize: formatBytes(totalBytes),
+    };
+
+    return {
+      collectedAt: now,
+      summary: {
+        memory: memory.summary,
+        persist: persist.summary,
+        total,
+      },
+      details: {
+        memory: memory.details,
+        persist: persist.details,
+      },
+    };
+  }
+
+  private processMemoryTier(
+    now: number,
+    includeDetails: boolean,
+  ): { summary: CacheTierSummary; details: CacheEntryDetail[] } {
+    let validCount = 0;
+    let expiredCount = 0;
+    let withTTLCount = 0;
+    let hookReferences = 0;
+    let estimatedBytes = 0;
+    const details: CacheEntryDetail[] = [];
+
+    for (const [key, entry] of this.memoryCache.entries()) {
+      const expireAt = entry.expireAt;
+      const hasTTL = expireAt !== undefined;
+      const isExpired = expireAt !== undefined && now > expireAt;
+      const hookCount = this.activeHookCounts.get(key) ?? 0;
+
+      estimatedBytes += estimateSize(key) + estimateSize(entry.value);
+      if (entry.expireAt) estimatedBytes += 8; // number size
+
+      if (hasTTL) withTTLCount++;
+      if (isExpired) {
+        expiredCount++;
+      } else {
+        validCount++;
+      }
+      hookReferences += hookCount;
+
+      if (includeDetails) {
+        details.push({
+          key,
+          hasValue: entry.value !== undefined,
+          hasTTL,
+          isExpired,
+          expireAt,
+          remainingTTL: expireAt !== undefined && !isExpired ? expireAt - now : undefined,
+          hookCount,
+        });
+      }
+    }
+
+    return {
+      summary: {
+        totalCount: this.memoryCache.size,
+        validCount,
+        expiredCount,
+        withTTLCount,
+        hookReferences,
+        estimatedBytes,
+      },
+      details,
+    };
+  }
+
+  /**
+   * Persist cache has no TTL support, all entries are always valid
+   */
+  private processPersistTier(includeDetails: boolean): {
+    summary: CacheTierSummary;
+    details: CacheEntryDetail[];
+  } {
+    let hookReferences = 0;
+    let estimatedBytes = 0;
+
+    for (const [key, value] of this.persistCache.entries()) {
+      hookReferences += this.activeHookCounts.get(key) ?? 0;
+      estimatedBytes += estimateSize(key) + estimateSize(value);
+    }
+
+    const details: CacheEntryDetail[] = includeDetails
+      ? Array.from(this.persistCache.keys()).map((key) => ({
+          key,
+          hasValue: true,
+          hasTTL: false,
+          isExpired: false,
+          hookCount: this.activeHookCounts.get(key) ?? 0,
+        }))
+      : [];
+
+    return {
+      summary: {
+        totalCount: this.persistCache.size,
+        validCount: this.persistCache.size,
+        expiredCount: 0,
+        withTTLCount: 0,
+        hookReferences,
+        estimatedBytes,
+      },
+      details,
+    };
+  }
+
+  // ============ Private Methods ============
+
+  /**
+   * Load persist cache from the KV store with default value initialization.
+   *
+   * Synchronous: defaults first, then per-key overrides from storage. A single
+   * corrupted entry is dropped back to its default without affecting other
+   * keys; keys no longer in the schema are pruned from storage.
+   */
+  private loadPersistCache(): void {
+    for (const [key, defaultValue] of Object.entries(DefaultPersistCache)) {
+      this.persistCache.set(key as PersistCacheKey, defaultValue);
+    }
+
+    const schemaKeys = Object.keys(DefaultPersistCache) as PersistCacheKey[];
+    for (const key of schemaKeys) {
+      let stored: string | undefined;
+      try {
+        stored = this.storage.getString(key);
+      } catch (error) {
+        logger.error(`Failed to read persist cache key "${key}"`, error as Error);
+        continue;
+      }
+      if (stored === undefined) {
+        continue;
+      }
+
+      try {
+        this.persistCache.set(key, JSON.parse(stored));
+      } catch (error) {
+        logger.error(
+          `Dropping corrupted persist cache entry "${key}", falling back to default`,
+          error as Error,
+        );
+        this.storage.delete(key);
+      }
+    }
+
+    // Prune storage entries whose keys left the schema
+    try {
+      for (const storedKey of this.storage.getAllKeys()) {
+        if (!(storedKey in DefaultPersistCache)) {
+          this.storage.delete(storedKey);
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to prune orphan persist cache keys', error as Error);
+    }
+  }
+
+  /**
+   * Cleanup service resources (tests / hot-reload helper)
+   */
+  cleanup(): void {
+    this.memoryCache.clear();
+    this.persistCache.clear();
+    this.activeHookCounts.clear();
+    this.subscribers.clear();
+  }
+}
+
+/**
+ * Estimate memory size of a value in bytes using JSON serialization.
+ * Rough estimate (UTF-16 code units ≈ bytes for ASCII-dominant JSON).
+ */
+function estimateSize(value: any): number {
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Format bytes to human-readable size
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / k ** i).toFixed(2)} ${sizes[i]}`;
+}
+
+/**
+ * Runtime singleton shared by hooks and services, persist tier backed by MMKV.
+ * In tests, construct an isolated `new CacheService(new InMemoryKVStorage())`
+ * instead (react-native-mmkv is also globally mocked in jest.setup.ts for
+ * anything that touches this singleton transitively).
+ */
+export const cacheService = new CacheService(createMmkvStorage());

--- a/src/data/cache/CacheService.ts
+++ b/src/data/cache/CacheService.ts
@@ -12,6 +12,13 @@
  * actually an infrastructure component (cache manager) rather than a business
  * service. It contains zero business logic.
  *
+ * Ported API identifiers keep their desktop spelling verbatim (`hasTTL`,
+ * `getCasual`, `DefaultUseCache`, ...) as a deliberate exception to the local
+ * acronym/constant naming rules — same precedent as `DefaultPreferences` in
+ * the preference domain — so desktop call sites and schema entries port
+ * mechanically. Mobile-only additions (e.g. `KvStorage`) follow the local
+ * rules.
+ *
  * Tiers:
  * 1. Memory cache — cross-component, TTL-capable, lost on app restart
  * 2. Persist cache — survives restarts via a synchronous KV store (MMKV),
@@ -25,7 +32,7 @@
  *
  * The module-level singleton {@link cacheService} is the runtime instance —
  * hooks and services must share it. Tests construct their own
- * `new CacheService(new InMemoryKVStorage())` to avoid cross-test pollution.
+ * `new CacheService(createInMemoryKvStorage())` to avoid cross-test pollution.
  * Note the singleton survives DataProvider remounts and React Fast Refresh of
  * consumer modules; the memory tier is session-scoped by design (cleared only
  * by a full JS reload, equivalent to a desktop window refresh).
@@ -48,8 +55,8 @@ import type {
   CacheTierSummary,
 } from './cacheTypes';
 import { deepEqual } from './cacheUtils';
-import type { KVStorage } from './kvStorage';
-import { createMmkvStorage, InMemoryKVStorage } from './kvStorage';
+import type { KvStorage } from './kvStorage';
+import { createInMemoryKvStorage, createMmkvStorage } from './kvStorage';
 
 const logger = loggerService.withContext('CacheService');
 
@@ -65,9 +72,9 @@ export class CacheService {
   private subscribers = new Map<string, Set<CacheSubscriber>>();
 
   // Persist tier backing store (one entry per schema key, JSON-encoded)
-  private readonly storage: KVStorage;
+  private readonly storage: KvStorage;
 
-  constructor(storage: KVStorage = new InMemoryKVStorage()) {
+  constructor(storage: KvStorage = createInMemoryKvStorage()) {
     this.storage = storage;
     this.loadPersistCache();
   }
@@ -273,15 +280,15 @@ export class CacheService {
    * minimal and making `deletePersist` a true removal.
    */
   setPersist<K extends PersistCacheKey>(key: K, value: PersistCacheSchema[K]): void {
-    const existingValue = this.getPersist(key);
-
-    // Use deep comparison for persist cache (usually objects)
-    if (deepEqual(existingValue, value)) {
-      return; // Skip all updates
+    // Deep comparison gates only the memory update + notification. Storage
+    // canonicalization below runs unconditionally so a previously failed MMKV
+    // write — or a stale stored entry that now equals the schema default —
+    // self-heals on the next setPersist instead of being blocked forever by
+    // this short-circuit. The redundant single-key write is µs-level.
+    if (!deepEqual(this.getPersist(key), value)) {
+      this.persistCache.set(key, value);
+      this.notifySubscribers(key);
     }
-
-    this.persistCache.set(key, value);
-    this.notifySubscribers(key);
 
     try {
       if (deepEqual(value, DefaultPersistCache[key])) {
@@ -598,7 +605,7 @@ function formatBytes(bytes: number): string {
 
 /**
  * Runtime singleton shared by hooks and services, persist tier backed by MMKV.
- * In tests, construct an isolated `new CacheService(new InMemoryKVStorage())`
+ * In tests, construct an isolated `new CacheService(createInMemoryKvStorage())`
  * instead (react-native-mmkv is also globally mocked in jest.setup.ts for
  * anything that touches this singleton transitively).
  */

--- a/src/data/cache/__tests__/CacheService.test.ts
+++ b/src/data/cache/__tests__/CacheService.test.ts
@@ -1,0 +1,246 @@
+import { CacheService } from '../CacheService';
+import { InMemoryKVStorage } from '../kvStorage';
+
+const PROVIDER_KEY = 'settings.provider.openai.last_used_key_id' as const;
+
+describe('CacheService memory tier', () => {
+  let service: CacheService;
+
+  beforeEach(() => {
+    service = new CacheService(new InMemoryKVStorage());
+  });
+
+  test('set/get roundtrip with typed template key', () => {
+    expect(service.get(PROVIDER_KEY)).toBeUndefined();
+    service.set(PROVIDER_KEY, 'key-1');
+    expect(service.get(PROVIDER_KEY)).toBe('key-1');
+    expect(service.has(PROVIDER_KEY)).toBe(true);
+  });
+
+  test('casual API stores dynamic keys', () => {
+    service.setCasual('my.dynamic.key', { a: 1 });
+    expect(service.getCasual<{ a: number }>('my.dynamic.key')).toEqual({ a: 1 });
+    expect(service.hasCasual('my.dynamic.key')).toBe(true);
+    expect(service.deleteCasual('my.dynamic.key')).toBe(true);
+    expect(service.getCasual('my.dynamic.key')).toBeUndefined();
+  });
+
+  test('delete removes the entry and tolerates missing keys', () => {
+    service.set(PROVIDER_KEY, 'key-1');
+    expect(service.delete(PROVIDER_KEY)).toBe(true);
+    expect(service.get(PROVIDER_KEY)).toBeUndefined();
+    expect(service.delete(PROVIDER_KEY)).toBe(true);
+  });
+
+  test('delete is refused while a hook references the key', () => {
+    service.set(PROVIDER_KEY, 'key-1');
+    service.registerHook(PROVIDER_KEY);
+    expect(service.delete(PROVIDER_KEY)).toBe(false);
+    expect(service.get(PROVIDER_KEY)).toBe('key-1');
+
+    service.unregisterHook(PROVIDER_KEY);
+    expect(service.delete(PROVIDER_KEY)).toBe(true);
+  });
+
+  test('hook reference counting requires all hooks to unregister', () => {
+    service.registerHook(PROVIDER_KEY);
+    service.registerHook(PROVIDER_KEY);
+    service.unregisterHook(PROVIDER_KEY);
+    expect(service.delete(PROVIDER_KEY)).toBe(false);
+    service.unregisterHook(PROVIDER_KEY);
+    expect(service.delete(PROVIDER_KEY)).toBe(true);
+  });
+
+  test('deep-equal set is a no-op and does not notify subscribers', () => {
+    const subscriber = jest.fn();
+    service.setCasual('some.object.key', { list: [1, 2] });
+    service.subscribe('some.object.key', subscriber);
+
+    service.setCasual('some.object.key', { list: [1, 2] });
+    expect(subscriber).not.toHaveBeenCalled();
+
+    service.setCasual('some.object.key', { list: [1, 2, 3] });
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  test('subscribers are notified on set and can unsubscribe', () => {
+    const subscriber = jest.fn();
+    const unsubscribe = service.subscribe(PROVIDER_KEY, subscriber);
+
+    service.set(PROVIDER_KEY, 'key-1');
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    service.set(PROVIDER_KEY, 'key-2');
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  test('a throwing subscriber does not break other subscribers', () => {
+    const broken = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const healthy = jest.fn();
+    service.subscribe(PROVIDER_KEY, broken);
+    service.subscribe(PROVIDER_KEY, healthy);
+
+    service.set(PROVIDER_KEY, 'key-1');
+    expect(broken).toHaveBeenCalledTimes(1);
+    expect(healthy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CacheService TTL', () => {
+  let service: CacheService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    service = new CacheService(new InMemoryKVStorage());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('entries expire lazily after their TTL', () => {
+    service.set(PROVIDER_KEY, 'key-1', 1000);
+    expect(service.get(PROVIDER_KEY)).toBe('key-1');
+    expect(service.hasTTL(PROVIDER_KEY)).toBe(true);
+
+    jest.advanceTimersByTime(1001);
+    expect(service.has(PROVIDER_KEY)).toBe(false);
+    expect(service.get(PROVIDER_KEY)).toBeUndefined();
+  });
+
+  test('expiry on read notifies subscribers', () => {
+    const subscriber = jest.fn();
+    service.set(PROVIDER_KEY, 'key-1', 1000);
+    service.subscribe(PROVIDER_KEY, subscriber);
+
+    jest.advanceTimersByTime(1001);
+    expect(service.get(PROVIDER_KEY)).toBeUndefined();
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-value set still refreshes the TTL', () => {
+    service.set(PROVIDER_KEY, 'key-1', 1000);
+    jest.advanceTimersByTime(900);
+    service.set(PROVIDER_KEY, 'key-1', 1000);
+
+    jest.advanceTimersByTime(900);
+    expect(service.get(PROVIDER_KEY)).toBe('key-1');
+
+    jest.advanceTimersByTime(200);
+    expect(service.get(PROVIDER_KEY)).toBeUndefined();
+  });
+
+  test('set without TTL clears a previous TTL', () => {
+    service.set(PROVIDER_KEY, 'key-1', 1000);
+    service.set(PROVIDER_KEY, 'key-1');
+    expect(service.hasTTL(PROVIDER_KEY)).toBe(false);
+
+    jest.advanceTimersByTime(2000);
+    expect(service.get(PROVIDER_KEY)).toBe('key-1');
+  });
+});
+
+describe('CacheService persist tier', () => {
+  test('getPersist falls back to schema default and never returns undefined', () => {
+    const service = new CacheService(new InMemoryKVStorage());
+    expect(service.getPersist('internal.persist_probe')).toBe(0);
+    expect(service.hasPersist('internal.persist_probe')).toBe(false);
+  });
+
+  test('setPersist writes through and survives a "restart" on the same storage', () => {
+    const storage = new InMemoryKVStorage();
+    const service = new CacheService(storage);
+
+    service.setPersist('internal.persist_probe', 42);
+    expect(service.getPersist('internal.persist_probe')).toBe(42);
+    expect(service.hasPersist('internal.persist_probe')).toBe(true);
+
+    const reloaded = new CacheService(storage);
+    expect(reloaded.getPersist('internal.persist_probe')).toBe(42);
+  });
+
+  test('setPersist notifies subscribers and skips no-op writes', () => {
+    const service = new CacheService(new InMemoryKVStorage());
+    const subscriber = jest.fn();
+    service.subscribe('internal.persist_probe', subscriber);
+
+    service.setPersist('internal.persist_probe', 42);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    service.setPersist('internal.persist_probe', 42);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  test('setting the default value removes the stored entry (absent = default)', () => {
+    const storage = new InMemoryKVStorage();
+    const service = new CacheService(storage);
+
+    service.setPersist('internal.persist_probe', 42);
+    expect(storage.getAllKeys()).toContain('internal.persist_probe');
+
+    service.setPersist('internal.persist_probe', 0);
+    expect(storage.getAllKeys()).not.toContain('internal.persist_probe');
+    expect(service.getPersist('internal.persist_probe')).toBe(0);
+  });
+
+  test('deletePersist resets to the schema default', () => {
+    const storage = new InMemoryKVStorage();
+    const service = new CacheService(storage);
+    const subscriber = jest.fn();
+    service.subscribe('internal.persist_probe', subscriber);
+
+    service.setPersist('internal.persist_probe', 7);
+    service.deletePersist('internal.persist_probe');
+
+    expect(service.getPersist('internal.persist_probe')).toBe(0);
+    expect(service.hasPersist('internal.persist_probe')).toBe(false);
+    expect(storage.getAllKeys()).not.toContain('internal.persist_probe');
+    expect(subscriber).toHaveBeenCalledTimes(2);
+  });
+
+  test('a corrupted stored entry falls back to default and is dropped', () => {
+    const storage = new InMemoryKVStorage();
+    storage.set('internal.persist_probe', '{not json');
+
+    const service = new CacheService(storage);
+    expect(service.getPersist('internal.persist_probe')).toBe(0);
+    expect(storage.getAllKeys()).not.toContain('internal.persist_probe');
+  });
+
+  test('storage keys that left the schema are pruned on load', () => {
+    const storage = new InMemoryKVStorage();
+    storage.set('legacy.removed_key', JSON.stringify('stale'));
+
+    new CacheService(storage);
+    expect(storage.getAllKeys()).not.toContain('legacy.removed_key');
+  });
+});
+
+describe('CacheService getStats', () => {
+  test('reports per-tier counts and details', () => {
+    jest.useFakeTimers();
+    try {
+      const service = new CacheService(new InMemoryKVStorage());
+      service.set(PROVIDER_KEY, 'key-1');
+      service.setCasual('temp.expiring_key', 'x', 1000);
+      service.registerHook(PROVIDER_KEY);
+      jest.advanceTimersByTime(1001);
+
+      const stats = service.getStats(true);
+      expect(stats.summary.memory.totalCount).toBe(2);
+      expect(stats.summary.memory.validCount).toBe(1);
+      expect(stats.summary.memory.expiredCount).toBe(1);
+      expect(stats.summary.memory.withTTLCount).toBe(1);
+      expect(stats.summary.memory.hookReferences).toBe(1);
+      expect(stats.summary.persist.totalCount).toBe(1);
+      expect(stats.summary.total.estimatedBytes).toBeGreaterThan(0);
+      expect(stats.details.memory).toHaveLength(2);
+      expect(stats.details.persist).toHaveLength(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/data/cache/__tests__/CacheService.test.ts
+++ b/src/data/cache/__tests__/CacheService.test.ts
@@ -1,5 +1,5 @@
 import { CacheService } from '../CacheService';
-import { InMemoryKVStorage } from '../kvStorage';
+import { createInMemoryKvStorage } from '../kvStorage';
 
 const PROVIDER_KEY = 'settings.provider.openai.last_used_key_id' as const;
 
@@ -7,7 +7,7 @@ describe('CacheService memory tier', () => {
   let service: CacheService;
 
   beforeEach(() => {
-    service = new CacheService(new InMemoryKVStorage());
+    service = new CacheService(createInMemoryKvStorage());
   });
 
   test('set/get roundtrip with typed template key', () => {
@@ -94,7 +94,7 @@ describe('CacheService TTL', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    service = new CacheService(new InMemoryKVStorage());
+    service = new CacheService(createInMemoryKvStorage());
   });
 
   afterEach(() => {
@@ -145,13 +145,13 @@ describe('CacheService TTL', () => {
 
 describe('CacheService persist tier', () => {
   test('getPersist falls back to schema default and never returns undefined', () => {
-    const service = new CacheService(new InMemoryKVStorage());
+    const service = new CacheService(createInMemoryKvStorage());
     expect(service.getPersist('internal.persist_probe')).toBe(0);
     expect(service.hasPersist('internal.persist_probe')).toBe(false);
   });
 
   test('setPersist writes through and survives a "restart" on the same storage', () => {
-    const storage = new InMemoryKVStorage();
+    const storage = createInMemoryKvStorage();
     const service = new CacheService(storage);
 
     service.setPersist('internal.persist_probe', 42);
@@ -163,7 +163,7 @@ describe('CacheService persist tier', () => {
   });
 
   test('setPersist notifies subscribers and skips no-op writes', () => {
-    const service = new CacheService(new InMemoryKVStorage());
+    const service = new CacheService(createInMemoryKvStorage());
     const subscriber = jest.fn();
     service.subscribe('internal.persist_probe', subscriber);
 
@@ -175,7 +175,7 @@ describe('CacheService persist tier', () => {
   });
 
   test('setting the default value removes the stored entry (absent = default)', () => {
-    const storage = new InMemoryKVStorage();
+    const storage = createInMemoryKvStorage();
     const service = new CacheService(storage);
 
     service.setPersist('internal.persist_probe', 42);
@@ -187,7 +187,7 @@ describe('CacheService persist tier', () => {
   });
 
   test('deletePersist resets to the schema default', () => {
-    const storage = new InMemoryKVStorage();
+    const storage = createInMemoryKvStorage();
     const service = new CacheService(storage);
     const subscriber = jest.fn();
     service.subscribe('internal.persist_probe', subscriber);
@@ -201,8 +201,43 @@ describe('CacheService persist tier', () => {
     expect(subscriber).toHaveBeenCalledTimes(2);
   });
 
+  test('a failed storage write self-heals on a same-value retry', () => {
+    const storage = createInMemoryKvStorage();
+    const originalSet = storage.set.bind(storage);
+    let failNext = true;
+    storage.set = (key, value) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('mmkv write failed');
+      }
+      originalSet(key, value);
+    };
+    const service = new CacheService(storage);
+
+    service.setPersist('internal.persist_probe', 42);
+    expect(service.getPersist('internal.persist_probe')).toBe(42);
+    expect(storage.getAllKeys()).not.toContain('internal.persist_probe');
+
+    // Same-value retry must not be short-circuited away from storage
+    service.setPersist('internal.persist_probe', 42);
+    expect(storage.getAllKeys()).toContain('internal.persist_probe');
+    expect(new CacheService(storage).getPersist('internal.persist_probe')).toBe(42);
+  });
+
+  test('a stale stored entry equal to the default is physically removed', () => {
+    const storage = createInMemoryKvStorage();
+    // e.g. an override persisted before a schema-default change made it default-equal
+    storage.set('internal.persist_probe', JSON.stringify(0));
+
+    const service = new CacheService(storage);
+    service.deletePersist('internal.persist_probe');
+
+    expect(storage.getAllKeys()).not.toContain('internal.persist_probe');
+    expect(service.getPersist('internal.persist_probe')).toBe(0);
+  });
+
   test('a corrupted stored entry falls back to default and is dropped', () => {
-    const storage = new InMemoryKVStorage();
+    const storage = createInMemoryKvStorage();
     storage.set('internal.persist_probe', '{not json');
 
     const service = new CacheService(storage);
@@ -211,7 +246,7 @@ describe('CacheService persist tier', () => {
   });
 
   test('storage keys that left the schema are pruned on load', () => {
-    const storage = new InMemoryKVStorage();
+    const storage = createInMemoryKvStorage();
     storage.set('legacy.removed_key', JSON.stringify('stale'));
 
     new CacheService(storage);
@@ -223,7 +258,7 @@ describe('CacheService getStats', () => {
   test('reports per-tier counts and details', () => {
     jest.useFakeTimers();
     try {
-      const service = new CacheService(new InMemoryKVStorage());
+      const service = new CacheService(createInMemoryKvStorage());
       service.set(PROVIDER_KEY, 'key-1');
       service.setCasual('temp.expiring_key', 'x', 1000);
       service.registerHook(PROVIDER_KEY);

--- a/src/data/cache/__tests__/cacheSchemas.test.ts
+++ b/src/data/cache/__tests__/cacheSchemas.test.ts
@@ -51,4 +51,13 @@ describe('deepEqual', () => {
     expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
     expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
   });
+
+  test('non-plain objects compare unequal unless reference-identical', () => {
+    const date = new Date(1000);
+    expect(deepEqual(date, date)).toBe(true);
+    expect(deepEqual(new Date(1000), new Date(1000))).toBe(false);
+    expect(deepEqual(new Map(), new Map())).toBe(false);
+    expect(deepEqual(new Set([1]), new Set([1]))).toBe(false);
+    expect(deepEqual({ a: new Date(1000) }, { a: new Date(1000) })).toBe(false);
+  });
 });

--- a/src/data/cache/__tests__/cacheSchemas.test.ts
+++ b/src/data/cache/__tests__/cacheSchemas.test.ts
@@ -1,0 +1,54 @@
+import type { InferUseCacheValue, UseCacheKey } from '../cacheSchemas';
+import { DefaultPersistCache, DefaultUseCache } from '../cacheSchemas';
+import { deepEqual } from '../cacheUtils';
+
+describe('cache schema defaults', () => {
+  test('every memory schema key has a default entry', () => {
+    expect(Object.keys(DefaultUseCache)).toEqual([
+      'settings.provider.${providerId}.last_used_key_id',
+    ]);
+  });
+
+  test('every persist schema key has a JSON-safe, non-undefined default', () => {
+    for (const [key, value] of Object.entries(DefaultPersistCache)) {
+      expect(value).not.toBeUndefined();
+      expect(() => JSON.stringify(value)).not.toThrow();
+      expect(JSON.parse(JSON.stringify({ [key]: value }))).toEqual({ [key]: value });
+    }
+  });
+
+  test('type-level: template key expansion accepts concrete instances', () => {
+    // Compile-time assertions — verified by `pnpm typecheck`, exercised here so
+    // the aliases are used at runtime too.
+    const concreteKey: UseCacheKey = 'settings.provider.openai.last_used_key_id';
+    const inferredValue: InferUseCacheValue<'settings.provider.openai.last_used_key_id'> = 'k1';
+
+    // @ts-expect-error unknown keys are rejected at compile time
+    const badKey: UseCacheKey = 'unknown.key';
+
+    expect(concreteKey).toBe('settings.provider.openai.last_used_key_id');
+    expect(typeof inferredValue).toBe('string');
+    expect(badKey).toBe('unknown.key');
+  });
+});
+
+describe('deepEqual', () => {
+  test('primitives and Object.is semantics', () => {
+    expect(deepEqual('a', 'a')).toBe(true);
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual(NaN, NaN)).toBe(true);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+
+  test('deep object and array content equality', () => {
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] })).toBe(false);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual({}, [])).toBe(false);
+  });
+
+  test('key order does not matter, extra keys do', () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+});

--- a/src/data/cache/__tests__/templateKey.test.ts
+++ b/src/data/cache/__tests__/templateKey.test.ts
@@ -1,0 +1,105 @@
+import {
+  findMatchingUseCacheSchemaKey,
+  getUseCacheDefaultValue,
+  isTemplateKey,
+  templateToRegex,
+} from '../templateKey';
+
+describe('isTemplateKey', () => {
+  test('returns true when key contains ${...} placeholder', () => {
+    expect(isTemplateKey('scroll.position.${id}')).toBe(true);
+    expect(isTemplateKey('entity.cache.${type}_${id}')).toBe(true);
+    expect(isTemplateKey('settings.provider.${providerId}.last_used_key_id')).toBe(true);
+  });
+
+  test('returns false for plain keys without placeholder', () => {
+    expect(isTemplateKey('app.user.avatar')).toBe(false);
+    expect(isTemplateKey('chat.multi_select_mode')).toBe(false);
+  });
+
+  test('returns false when only one of ${ or } is present', () => {
+    expect(isTemplateKey('app.$foo')).toBe(false);
+    expect(isTemplateKey('app.foo}')).toBe(false);
+  });
+});
+
+describe('templateToRegex', () => {
+  test('matches single placeholder with word characters and hyphens', () => {
+    const regex = templateToRegex('scroll.position.${id}');
+    expect(regex.test('scroll.position.topic123')).toBe(true);
+    expect(regex.test('scroll.position.topic-123')).toBe(true);
+    expect(regex.test('scroll.position.abc_def')).toBe(true);
+  });
+
+  test('rejects empty dynamic segment', () => {
+    const regex = templateToRegex('scroll.position.${id}');
+    expect(regex.test('scroll.position.')).toBe(false);
+  });
+
+  test('rejects dots in dynamic segment (dot is structural separator)', () => {
+    const regex = templateToRegex('scroll.position.${id}');
+    expect(regex.test('scroll.position.topic.123')).toBe(false);
+  });
+
+  test('rejects non-ASCII characters in dynamic segment (contract test for [\\w\\-]+)', () => {
+    const regex = templateToRegex('settings.provider.${providerId}.last_used_key_id');
+    expect(regex.test('settings.provider.中文id.last_used_key_id')).toBe(false);
+    expect(regex.test('settings.provider.emoji😀.last_used_key_id')).toBe(false);
+  });
+
+  test('does not match unrelated keys', () => {
+    const regex = templateToRegex('scroll.position.${id}');
+    expect(regex.test('other.key.123')).toBe(false);
+    expect(regex.test('scroll.positions.123')).toBe(false);
+  });
+
+  test('handles multiple placeholders', () => {
+    const regex = templateToRegex('entity.cache.${type}_${id}');
+    expect(regex.test('entity.cache.user_456')).toBe(true);
+    expect(regex.test('entity.cache.product_abc')).toBe(true);
+    expect(regex.test('entity.cache.user_')).toBe(false);
+    expect(regex.test('entity.cache._456')).toBe(false);
+  });
+
+  test('matches placeholder in the middle of the key', () => {
+    const regex = templateToRegex('settings.provider.${providerId}.last_used_key_id');
+    expect(regex.test('settings.provider.openai.last_used_key_id')).toBe(true);
+    expect(regex.test('settings.provider.my-provider_2.last_used_key_id')).toBe(true);
+    expect(regex.test('settings.provider..last_used_key_id')).toBe(false);
+    expect(regex.test('settings.provider.openai.other_field')).toBe(false);
+  });
+
+  test('placeholder variable name does not affect matching', () => {
+    const a = templateToRegex('settings.provider.${providerId}.last_used_key_id');
+    const b = templateToRegex('settings.provider.${foo}.last_used_key_id');
+    expect(a.source).toBe(b.source);
+    expect(a.test('settings.provider.google.last_used_key_id')).toBe(true);
+    expect(b.test('settings.provider.google.last_used_key_id')).toBe(true);
+  });
+
+  test('escapes regex special characters in the template prefix', () => {
+    // dots must be treated as literal dots, not "any character"
+    const regex = templateToRegex('a.b.${id}');
+    expect(regex.test('aXb.value')).toBe(false);
+    expect(regex.test('a.b.value')).toBe(true);
+  });
+});
+
+describe('findMatchingUseCacheSchemaKey', () => {
+  test('returns the template pattern when concrete key matches a template entry', () => {
+    expect(findMatchingUseCacheSchemaKey('settings.provider.openai.last_used_key_id')).toBe(
+      'settings.provider.${providerId}.last_used_key_id',
+    );
+  });
+
+  test('returns undefined when the key matches nothing', () => {
+    expect(findMatchingUseCacheSchemaKey('unknown.key')).toBeUndefined();
+    expect(findMatchingUseCacheSchemaKey('settings.provider..last_used_key_id')).toBeUndefined();
+  });
+});
+
+describe('getUseCacheDefaultValue', () => {
+  test('resolves a concrete template instance to the template default', () => {
+    expect(getUseCacheDefaultValue('settings.provider.openai.last_used_key_id')).toBe('');
+  });
+});

--- a/src/data/cache/cacheSchemas.ts
+++ b/src/data/cache/cacheSchemas.ts
@@ -122,6 +122,9 @@ export type UseCacheSchema = {
   'settings.provider.${providerId}.last_used_key_id': string;
 };
 
+// PascalCase kept verbatim from the desktop export of the same name (like
+// DefaultPreferences in the preference domain) so schema entries port with
+// zero rewrites — deliberate exception to the UPPER_SNAKE_CASE constant rule.
 export const DefaultUseCache: UseCacheSchema = {
   'settings.provider.${providerId}.last_used_key_id': '',
 };

--- a/src/data/cache/cacheSchemas.ts
+++ b/src/data/cache/cacheSchemas.ts
@@ -1,0 +1,210 @@
+/**
+ * Cache Schema Definitions
+ *
+ * Ported from desktop `src/shared/data/cache/cacheSchemas.ts`. Mobile has no
+ * multi-window shared tier, so desktop `SharedCacheSchema` entries that mobile
+ * needs get folded into {@link UseCacheSchema} (memory tier) instead.
+ *
+ * ## Key Naming Convention
+ *
+ * All cache keys (fixed and template) MUST follow the format: `namespace.sub.key_name`
+ *
+ * Rules:
+ * - At least 2 segments separated by dots (.)
+ * - Each segment uses lowercase letters, numbers, and underscores only
+ * - Pattern: /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/
+ * - Template placeholders `${xxx}` are treated as literal string segments
+ *
+ * Examples:
+ * - 'app.path.resources' (valid)
+ * - 'chat.multi_select_mode' (valid)
+ * - 'scroll.position.${topicId}' (valid template key)
+ * - 'userAvatar' (invalid - missing dot separator)
+ * - 'App.user' (invalid - uppercase not allowed)
+ * - 'scroll.position:${id}' (invalid - colon not allowed)
+ *
+ * Desktop enforces this via the `data-schema-key/valid-key` ESLint rule; mobile
+ * has no such rule yet, so the convention is upheld by review.
+ *
+ * ## Template Key Support
+ *
+ * Template keys allow type-safe dynamic keys using template literal syntax.
+ * Define in schema with `${variable}` placeholder, use with actual values.
+ * Template keys follow the same dot-separated pattern as fixed keys.
+ *
+ * Examples:
+ * - Schema: `'scroll.position.${topicId}': number`
+ * - Usage: `cacheService.get('scroll.position.topic123')` -> infers `number` type
+ *
+ * Multiple placeholders are supported:
+ * - Schema: `'entity.cache.${type}_${id}': CacheData`
+ * - Usage: `cacheService.get('entity.cache.user_456')` -> infers `CacheData` type
+ */
+
+// ============================================================================
+// Template Key Type Utilities
+// ============================================================================
+
+/**
+ * Detects whether a key string contains template placeholder syntax.
+ *
+ * Template keys use `${variable}` syntax to define dynamic segments.
+ * This type returns `true` if the key contains at least one `${...}` placeholder.
+ *
+ * @template K - The key string to check
+ * @returns `true` if K contains `${...}`, `false` otherwise
+ *
+ * @example
+ * ```typescript
+ * type Test1 = IsTemplateKey<'scroll.position.${id}'>     // true
+ * type Test2 = IsTemplateKey<'entity.cache.${a}_${b}'>    // true
+ * type Test3 = IsTemplateKey<'app.path.resources'>        // false
+ * ```
+ */
+export type IsTemplateKey<K extends string> = K extends `${string}\${${string}}${string}`
+  ? true
+  : false;
+
+/**
+ * Expands a template key pattern into a matching literal type.
+ *
+ * Replaces each `${variable}` placeholder with `string`, allowing
+ * TypeScript to match concrete keys against the template pattern.
+ * Recursively processes multiple placeholders.
+ *
+ * @template T - The template key pattern to expand
+ * @returns A template literal type that matches all valid concrete keys
+ *
+ * @example
+ * ```typescript
+ * type Test1 = ExpandTemplateKey<'scroll.position.${id}'>
+ * // Result: `scroll.position.${string}` (matches 'scroll.position.123', etc.)
+ *
+ * type Test2 = ExpandTemplateKey<'entity.cache.${type}_${id}'>
+ * // Result: `entity.cache.${string}_${string}` (matches 'entity.cache.user_123', etc.)
+ *
+ * type Test3 = ExpandTemplateKey<'app.path.resources'>
+ * // Result: 'app.path.resources' (unchanged for non-template keys)
+ * ```
+ */
+export type ExpandTemplateKey<T extends string> =
+  T extends `${infer Prefix}\${${string}}${infer Suffix}`
+    ? `${Prefix}${string}${ExpandTemplateKey<Suffix>}`
+    : T;
+
+/**
+ * Processes a cache key, expanding template patterns if present.
+ *
+ * For template keys (containing `${...}`), returns the expanded pattern.
+ * For fixed keys, returns the key unchanged.
+ *
+ * @template K - The key to process
+ * @returns The processed key type (expanded if template, unchanged if fixed)
+ *
+ * @example
+ * ```typescript
+ * type Test1 = ProcessKey<'scroll.position.${id}'>  // `scroll.position.${string}`
+ * type Test2 = ProcessKey<'app.path.resources'>     // 'app.path.resources'
+ * ```
+ */
+export type ProcessKey<K extends string> = IsTemplateKey<K> extends true ? ExpandTemplateKey<K> : K;
+
+// ============================================================================
+// Memory Cache Schema
+// ============================================================================
+
+/**
+ * Memory cache schema (TTL-capable, lost on app restart).
+ */
+export type UseCacheSchema = {
+  // LLM provider API key round-robin state, keyed per provider. Aligned with
+  // the desktop main-process ProviderService cache key of the same name.
+  'settings.provider.${providerId}.last_used_key_id': string;
+};
+
+export const DefaultUseCache: UseCacheSchema = {
+  'settings.provider.${providerId}.last_used_key_id': '',
+};
+
+// ============================================================================
+// Persist Cache Schema
+// ============================================================================
+
+/**
+ * Persist cache schema defining allowed keys and their value types (fixed keys
+ * only, no TTL). Values MUST be JSON-serializable (no Date/Map/Set/undefined)
+ * and defaults must not be `undefined` — the backing store round-trips every
+ * value through JSON.
+ *
+ * Division of labor vs. preferences: `PreferenceService` (SQLite) holds
+ * user-visible configuration; this tier holds recoverable UI state that merely
+ * benefits from surviving a restart.
+ */
+export type PersistCacheSchema = {
+  // Persist-layer self-test key: exercises the typed persist API and round-trip
+  // tests for the generic mechanism, independent of any real consumer.
+  'internal.persist_probe': number;
+};
+
+export const DefaultPersistCache: PersistCacheSchema = {
+  'internal.persist_probe': 0,
+};
+
+// ============================================================================
+// Cache Key Types
+// ============================================================================
+
+/**
+ * Key type for persist cache (fixed keys only)
+ */
+export type PersistCacheKey = keyof PersistCacheSchema;
+
+/**
+ * Key type for memory cache (supports both fixed and template keys).
+ *
+ * This type expands all schema keys using ProcessKey, which:
+ * - Keeps fixed keys unchanged (e.g., 'app.path.resources')
+ * - Expands template keys to match patterns (e.g., 'scroll.position.${id}' -> `scroll.position.${string}`)
+ *
+ * The resulting union type allows TypeScript to accept any concrete key
+ * that matches either a fixed key or an expanded template pattern.
+ */
+export type UseCacheKey = {
+  [K in keyof UseCacheSchema]: ProcessKey<K & string>;
+}[keyof UseCacheSchema];
+
+/**
+ * Infers the value type for a given cache key from UseCacheSchema.
+ *
+ * Works with both fixed keys and template keys:
+ * - For fixed keys, returns the exact value type from schema
+ * - For template keys, matches the key against expanded patterns and returns the value type
+ *
+ * If the key doesn't match any schema entry, returns `never`.
+ *
+ * @example
+ * ```typescript
+ * type T1 = InferUseCacheValue<'settings.provider.openai.last_used_key_id'>  // string
+ * type T2 = InferUseCacheValue<'unknown.key'>                                // never
+ * ```
+ */
+export type InferUseCacheValue<K extends string> = {
+  [S in keyof UseCacheSchema]: K extends ProcessKey<S & string> ? UseCacheSchema[S] : never;
+}[keyof UseCacheSchema];
+
+/**
+ * Type guard for casual cache keys that blocks schema-defined keys.
+ *
+ * Used to ensure casual API methods (getCasual, setCasual, etc.) cannot
+ * be called with keys that are defined in the schema (including template patterns).
+ * This enforces proper API usage: use type-safe methods for schema keys,
+ * use casual methods only for truly dynamic/unknown keys.
+ *
+ * Known limitation (inherited from desktop): this only bites on literal string
+ * arguments — variable keys widen to `string` and pass through unchecked. The
+ * runtime `templateToRegex` matching is the real gate.
+ *
+ * @template K - The key to check
+ * @returns `K` if the key doesn't match any schema pattern, `never` if it does
+ */
+export type UseCacheCasualKey<K extends string> = K extends UseCacheKey ? never : K;

--- a/src/data/cache/cacheTypes.ts
+++ b/src/data/cache/cacheTypes.ts
@@ -1,0 +1,94 @@
+/**
+ * Cache types and interfaces for CacheService.
+ *
+ * Mobile runs a single JS runtime, so the desktop three-tier architecture
+ * (memory / shared-over-IPC / persist) collapses into two tiers here:
+ * 1. Memory cache (cross-component, TTL-capable, lost on app restart)
+ * 2. Persist cache (survives restarts, backed by a synchronous KV store)
+ */
+
+/**
+ * Cache entry with optional TTL support
+ */
+export interface CacheEntry<T = any> {
+  value: T;
+  /** Absolute expiration timestamp (ms since epoch) */
+  expireAt?: number;
+}
+
+/**
+ * Cache subscription callback
+ */
+export type CacheSubscriber = () => void;
+
+// ============ Cache Statistics Types ============
+
+/**
+ * Summary statistics for a single cache tier
+ */
+export interface CacheTierSummary {
+  /** Total number of entries in this tier */
+  totalCount: number;
+  /** Number of valid (non-expired) entries */
+  validCount: number;
+  /** Number of expired entries (lazy cleanup pending) */
+  expiredCount: number;
+  /** Number of entries with TTL configured */
+  withTTLCount: number;
+  /** Total hook reference count for this tier */
+  hookReferences: number;
+  /** Estimated memory size in bytes (rough estimate via JSON serialization) */
+  estimatedBytes: number;
+}
+
+/**
+ * Detailed information for a single cache entry
+ */
+export interface CacheEntryDetail {
+  /** Cache key */
+  key: string;
+  /** Whether the entry has a value */
+  hasValue: boolean;
+  /** Whether TTL is configured */
+  hasTTL: boolean;
+  /** Whether the entry is expired */
+  isExpired: boolean;
+  /** Absolute expiration timestamp (ms since epoch) */
+  expireAt?: number;
+  /** Remaining time until expiration (ms), undefined if no TTL */
+  remainingTTL?: number;
+  /** Number of hooks currently referencing this key */
+  hookCount: number;
+}
+
+/**
+ * Complete cache statistics
+ */
+export interface CacheStats {
+  /** Timestamp when stats were collected */
+  collectedAt: number;
+
+  /** Summary statistics */
+  summary: {
+    memory: CacheTierSummary;
+    persist: CacheTierSummary;
+    /** Aggregated totals across all tiers */
+    total: {
+      totalCount: number;
+      validCount: number;
+      expiredCount: number;
+      withTTLCount: number;
+      hookReferences: number;
+      /** Total estimated memory in bytes */
+      estimatedBytes: number;
+      /** Human-readable memory size (e.g., "1.5 KB", "2.3 MB") */
+      estimatedSize: string;
+    };
+  };
+
+  /** Detailed per-entry information (optional, for debugging) */
+  details: {
+    memory: CacheEntryDetail[];
+    persist: CacheEntryDetail[];
+  };
+}

--- a/src/data/cache/cacheUtils.ts
+++ b/src/data/cache/cacheUtils.ts
@@ -1,0 +1,42 @@
+/**
+ * Deep equality over JSON-safe values (primitives, plain objects, arrays).
+ *
+ * Replaces the desktop's `es-toolkit/compat` `isEqual` for the cache's
+ * same-value write guards. Cache values are constrained to JSON-serializable
+ * shapes, so Map/Set/Date/class instances are deliberately unsupported and
+ * compare unequal unless reference-identical.
+ */
+export function deepEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (!isComparableObject(left) || !isComparableObject(right)) {
+    return false;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+
+    return left.every((item, index) => deepEqual(item, right[index]));
+  }
+
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return leftKeys.every(
+    (key, index) =>
+      key === rightKeys[index] &&
+      deepEqual((left as Record<string, unknown>)[key], (right as Record<string, unknown>)[key]),
+  );
+}
+
+function isComparableObject(value: unknown): value is Record<string, unknown> | unknown[] {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/data/cache/cacheUtils.ts
+++ b/src/data/cache/cacheUtils.ts
@@ -2,17 +2,15 @@
  * Deep equality over JSON-safe values (primitives, plain objects, arrays).
  *
  * Replaces the desktop's `es-toolkit/compat` `isEqual` for the cache's
- * same-value write guards. Cache values are constrained to JSON-serializable
- * shapes, so Map/Set/Date/class instances are deliberately unsupported and
- * compare unequal unless reference-identical.
+ * same-value write guards. Structural comparison applies ONLY to arrays and
+ * plain objects; any other object (Date, Map, Set, class instances, ...)
+ * compares unequal unless reference-identical. Cache values are constrained
+ * to JSON-serializable shapes, so for exotic types the safe failure mode is
+ * "not equal" — a redundant notify beats a swallowed update.
  */
 export function deepEqual(left: unknown, right: unknown): boolean {
   if (Object.is(left, right)) {
     return true;
-  }
-
-  if (!isComparableObject(left) || !isComparableObject(right)) {
-    return false;
   }
 
   if (Array.isArray(left) || Array.isArray(right)) {
@@ -23,6 +21,10 @@ export function deepEqual(left: unknown, right: unknown): boolean {
     return left.every((item, index) => deepEqual(item, right[index]));
   }
 
+  if (!isPlainObject(left) || !isPlainObject(right)) {
+    return false;
+  }
+
   const leftKeys = Object.keys(left).sort();
   const rightKeys = Object.keys(right).sort();
 
@@ -31,12 +33,14 @@ export function deepEqual(left: unknown, right: unknown): boolean {
   }
 
   return leftKeys.every(
-    (key, index) =>
-      key === rightKeys[index] &&
-      deepEqual((left as Record<string, unknown>)[key], (right as Record<string, unknown>)[key]),
+    (key, index) => key === rightKeys[index] && deepEqual(left[key], right[key]),
   );
 }
 
-function isComparableObject(value: unknown): value is Record<string, unknown> | unknown[] {
-  return typeof value === 'object' && value !== null;
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }

--- a/src/data/cache/index.ts
+++ b/src/data/cache/index.ts
@@ -1,0 +1,20 @@
+export { CacheService, cacheService } from './CacheService';
+export type {
+  InferUseCacheValue,
+  PersistCacheKey,
+  PersistCacheSchema,
+  UseCacheCasualKey,
+  UseCacheKey,
+  UseCacheSchema,
+} from './cacheSchemas';
+export { DefaultPersistCache, DefaultUseCache } from './cacheSchemas';
+export type { CacheEntry, CacheStats, CacheSubscriber } from './cacheTypes';
+export { deepEqual } from './cacheUtils';
+export type { KVStorage } from './kvStorage';
+export { createMmkvStorage, InMemoryKVStorage } from './kvStorage';
+export {
+  findMatchingUseCacheSchemaKey,
+  getUseCacheDefaultValue,
+  isTemplateKey,
+  templateToRegex,
+} from './templateKey';

--- a/src/data/cache/index.ts
+++ b/src/data/cache/index.ts
@@ -1,20 +1,16 @@
+// Narrow public surface (naming-conventions §6.4): only what callers outside
+// src/data/cache actually consume. The hooks in src/data/hooks/useCache.ts are
+// the hook-side half of this infrastructure and import leaf files directly,
+// mirroring the desktop layout; schema defaults, template helpers, deepEqual,
+// and the MMKV adapter stay internal.
 export { CacheService, cacheService } from './CacheService';
 export type {
   InferUseCacheValue,
   PersistCacheKey,
   PersistCacheSchema,
-  UseCacheCasualKey,
   UseCacheKey,
   UseCacheSchema,
 } from './cacheSchemas';
-export { DefaultPersistCache, DefaultUseCache } from './cacheSchemas';
-export type { CacheEntry, CacheStats, CacheSubscriber } from './cacheTypes';
-export { deepEqual } from './cacheUtils';
-export type { KVStorage } from './kvStorage';
-export { createMmkvStorage, InMemoryKVStorage } from './kvStorage';
-export {
-  findMatchingUseCacheSchemaKey,
-  getUseCacheDefaultValue,
-  isTemplateKey,
-  templateToRegex,
-} from './templateKey';
+export type { CacheStats } from './cacheTypes';
+export type { KvStorage } from './kvStorage';
+export { createInMemoryKvStorage } from './kvStorage';

--- a/src/data/cache/kvStorage.ts
+++ b/src/data/cache/kvStorage.ts
@@ -3,9 +3,9 @@ import { createMMKV } from 'react-native-mmkv';
 /**
  * Minimal synchronous key-value abstraction backing the CacheService persist
  * tier. Production uses {@link createMmkvStorage}; tests inject
- * {@link InMemoryKVStorage}.
+ * {@link createInMemoryKvStorage}.
  */
-export interface KVStorage {
+export interface KvStorage {
   getString(key: string): string | undefined;
   set(key: string, value: string): void;
   delete(key: string): void;
@@ -13,10 +13,10 @@ export interface KVStorage {
 }
 
 /**
- * MMKV-backed KVStorage for the persist tier. Dedicated instance id so cache
+ * MMKV-backed KvStorage for the persist tier. Dedicated instance id so cache
  * data never mixes with other future MMKV uses.
  */
-export function createMmkvStorage(): KVStorage {
+export function createMmkvStorage(): KvStorage {
   const mmkv = createMMKV({ id: 'cherry-cache-persist' });
   return {
     getString: (key) => mmkv.getString(key),
@@ -29,24 +29,18 @@ export function createMmkvStorage(): KVStorage {
 }
 
 /**
- * Map-backed KVStorage for tests and non-persistent fallbacks.
+ * Map-backed KvStorage for tests and non-persistent fallbacks.
  */
-export class InMemoryKVStorage implements KVStorage {
-  private store = new Map<string, string>();
-
-  getString(key: string): string | undefined {
-    return this.store.get(key);
-  }
-
-  set(key: string, value: string): void {
-    this.store.set(key, value);
-  }
-
-  delete(key: string): void {
-    this.store.delete(key);
-  }
-
-  getAllKeys(): string[] {
-    return [...this.store.keys()];
-  }
+export function createInMemoryKvStorage(): KvStorage {
+  const store = new Map<string, string>();
+  return {
+    getString: (key) => store.get(key),
+    set: (key, value) => {
+      store.set(key, value);
+    },
+    delete: (key) => {
+      store.delete(key);
+    },
+    getAllKeys: () => [...store.keys()],
+  };
 }

--- a/src/data/cache/kvStorage.ts
+++ b/src/data/cache/kvStorage.ts
@@ -1,0 +1,52 @@
+import { createMMKV } from 'react-native-mmkv';
+
+/**
+ * Minimal synchronous key-value abstraction backing the CacheService persist
+ * tier. Production uses {@link createMmkvStorage}; tests inject
+ * {@link InMemoryKVStorage}.
+ */
+export interface KVStorage {
+  getString(key: string): string | undefined;
+  set(key: string, value: string): void;
+  delete(key: string): void;
+  getAllKeys(): string[];
+}
+
+/**
+ * MMKV-backed KVStorage for the persist tier. Dedicated instance id so cache
+ * data never mixes with other future MMKV uses.
+ */
+export function createMmkvStorage(): KVStorage {
+  const mmkv = createMMKV({ id: 'cherry-cache-persist' });
+  return {
+    getString: (key) => mmkv.getString(key),
+    set: (key, value) => mmkv.set(key, value),
+    delete: (key) => {
+      mmkv.remove(key);
+    },
+    getAllKeys: () => mmkv.getAllKeys(),
+  };
+}
+
+/**
+ * Map-backed KVStorage for tests and non-persistent fallbacks.
+ */
+export class InMemoryKVStorage implements KVStorage {
+  private store = new Map<string, string>();
+
+  getString(key: string): string | undefined {
+    return this.store.get(key);
+  }
+
+  set(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  getAllKeys(): string[] {
+    return [...this.store.keys()];
+  }
+}

--- a/src/data/cache/templateKey.ts
+++ b/src/data/cache/templateKey.ts
@@ -1,0 +1,97 @@
+import type { InferUseCacheValue, UseCacheKey, UseCacheSchema } from './cacheSchemas';
+import { DefaultUseCache } from './cacheSchemas';
+
+/**
+ * Checks if a schema key is a template key (contains `${...}` placeholder).
+ *
+ * @example
+ * ```ts
+ * isTemplateKey('scroll.position.${id}')  // true
+ * isTemplateKey('app.user.avatar')        // false
+ * ```
+ */
+export function isTemplateKey(key: string): boolean {
+  return key.includes('${') && key.includes('}');
+}
+
+/**
+ * Converts a template key pattern into a RegExp for matching concrete keys.
+ *
+ * Each `${variable}` placeholder expands to `([\w\-]+)` — matches the same
+ * character set permitted by the cache key naming convention (ASCII word
+ * chars plus hyphens). Non-ASCII characters, dots, and colons are rejected
+ * by design: dots are structural separators. The placeholder variable name
+ * itself is ignored at runtime.
+ *
+ * @example
+ * ```ts
+ * const regex = templateToRegex('scroll.position.${id}')
+ * regex.test('scroll.position.topic123')   // true
+ * regex.test('scroll.position.topic-123')  // true
+ * regex.test('scroll.position.')           // false
+ * regex.test('other.key.123')              // false
+ * ```
+ */
+export function templateToRegex(template: string): RegExp {
+  const escaped = template.replace(/[.*+?^${}()|[\]\\]/g, (match) => {
+    if (match === '$' || match === '{' || match === '}') {
+      return match;
+    }
+    return `\\${match}`;
+  });
+
+  const pattern = escaped.replace(/\$\{[^}]+\}/g, '([\\w\\-]+)');
+
+  return new RegExp(`^${pattern}$`);
+}
+
+/**
+ * Finds the memory-cache schema key that matches a given concrete key.
+ *
+ * First checks for exact match (fixed keys), then checks template patterns.
+ * Returns the exact schema key (fixed or template pattern), not the concrete
+ * instance — callers use it to look up the template's default value.
+ *
+ * @example
+ * ```typescript
+ * findMatchingUseCacheSchemaKey('settings.provider.openai.last_used_key_id')
+ * // -> 'settings.provider.${providerId}.last_used_key_id'
+ * findMatchingUseCacheSchemaKey('unknown.key')  // undefined
+ * ```
+ */
+export function findMatchingUseCacheSchemaKey(key: string): keyof UseCacheSchema | undefined {
+  if (key in DefaultUseCache) {
+    return key as keyof UseCacheSchema;
+  }
+
+  const schemaKeys = Object.keys(DefaultUseCache) as Array<keyof UseCacheSchema>;
+  for (const schemaKey of schemaKeys) {
+    if (isTemplateKey(schemaKey as string)) {
+      const regex = templateToRegex(schemaKey as string);
+      if (regex.test(key)) {
+        return schemaKey;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Gets the default value for a memory-cache key from the schema.
+ *
+ * Works with both fixed keys (direct lookup) and concrete keys that match
+ * template patterns (finds template, returns its default). Template default
+ * values are shared across all instances — e.g. all
+ * `settings.provider.*.last_used_key_id` keys fall back to the single
+ * default `''`.
+ */
+export function getUseCacheDefaultValue<K extends UseCacheKey>(
+  key: K,
+): InferUseCacheValue<K> | undefined {
+  const schemaKey = findMatchingUseCacheSchemaKey(key);
+  if (schemaKey) {
+    return DefaultUseCache[schemaKey] as InferUseCacheValue<K>;
+  }
+  return undefined;
+}

--- a/src/data/db/seeding/seeders/PresetProviderSeeder.ts
+++ b/src/data/db/seeding/seeders/PresetProviderSeeder.ts
@@ -1,5 +1,6 @@
 import type { ProtoProviderConfig } from '@cherrystudio/provider-registry';
 import { buildRuntimeEndpointConfigs, ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
+import { cacheService } from '@/data/cache';
 import { PinService } from '@/data/services/PinService';
 import { providerRegistryService } from '@/data/services/ProviderRegistryService';
 import { type CreateProviderInput, ProviderService } from '@/data/services/ProviderService';
@@ -87,6 +88,6 @@ export class PresetProviderSeeder implements DatabaseSeeder {
       providerId: 'cherryai',
     });
 
-    await new ProviderService(dbService, new PinService(dbService)).batchUpsert(rows);
+    await new ProviderService(dbService, new PinService(dbService), cacheService).batchUpsert(rows);
   }
 }

--- a/src/data/hooks/__tests__/useCache.test.tsx
+++ b/src/data/hooks/__tests__/useCache.test.tsx
@@ -1,0 +1,173 @@
+import { Text } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { cacheService } from '@/data/cache';
+
+import { useCache, usePersistCache } from '../useCache';
+
+const PROVIDER_KEY = 'settings.provider.openai.last_used_key_id' as const;
+
+type CacheSetter = (value: string | ((prev: string) => string)) => void;
+
+function CacheProbe({
+  onSetter,
+  initValue,
+}: {
+  onSetter?: (setter: CacheSetter) => void;
+  initValue?: string;
+}) {
+  const [value, setValue] = useCache(PROVIDER_KEY, initValue);
+  onSetter?.(setValue);
+  return <Text testID="value">{value}</Text>;
+}
+
+function PersistProbe({ onSetter }: { onSetter?: (setter: (value: number) => void) => void }) {
+  const [value, setValue] = usePersistCache('internal.persist_probe');
+  onSetter?.(setValue);
+  return <Text testID="value">{String(value)}</Text>;
+}
+
+function renderedValue(renderer: ReactTestRenderer): string {
+  return renderer.root.findByProps({ testID: 'value' }).props.children;
+}
+
+afterEach(() => {
+  cacheService.cleanup();
+});
+
+describe('useCache', () => {
+  test('returns the schema default and materializes it into the cache', () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CacheProbe />);
+    });
+
+    expect(renderedValue(renderer)).toBe('');
+    expect(cacheService.has(PROVIDER_KEY)).toBe(true);
+
+    act(() => renderer.unmount());
+  });
+
+  test('initValue takes precedence over the schema default', () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CacheProbe initValue="seed" />);
+    });
+
+    expect(renderedValue(renderer)).toBe('seed');
+    expect(cacheService.get(PROVIDER_KEY)).toBe('seed');
+
+    act(() => renderer.unmount());
+  });
+
+  test('setter updates every mounted consumer of the key', () => {
+    let setter!: CacheSetter;
+    let a!: ReactTestRenderer;
+    let b!: ReactTestRenderer;
+    act(() => {
+      a = create(
+        <CacheProbe
+          onSetter={(s) => {
+            setter = s;
+          }}
+        />,
+      );
+      b = create(<CacheProbe />);
+    });
+
+    act(() => setter('key-2'));
+
+    expect(renderedValue(a)).toBe('key-2');
+    expect(renderedValue(b)).toBe('key-2');
+
+    act(() => {
+      a.unmount();
+      b.unmount();
+    });
+  });
+
+  test('imperative cacheService.set re-renders the hook', () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CacheProbe />);
+    });
+
+    act(() => cacheService.set(PROVIDER_KEY, 'external'));
+    expect(renderedValue(renderer)).toBe('external');
+
+    act(() => renderer.unmount());
+  });
+
+  test('functional updater resolves against the latest stored value', () => {
+    let setter!: CacheSetter;
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <CacheProbe
+          onSetter={(s) => {
+            setter = s;
+          }}
+        />,
+      );
+    });
+
+    act(() => cacheService.set(PROVIDER_KEY, 'base'));
+    act(() => setter((prev) => `${prev}+next`));
+    expect(renderedValue(renderer)).toBe('base+next');
+
+    act(() => renderer.unmount());
+  });
+
+  test('a mounted hook pins the key against deletion', () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CacheProbe />);
+    });
+
+    expect(cacheService.delete(PROVIDER_KEY)).toBe(false);
+
+    act(() => renderer.unmount());
+    expect(cacheService.delete(PROVIDER_KEY)).toBe(true);
+  });
+});
+
+describe('usePersistCache', () => {
+  test('returns the schema default and writes through on set', () => {
+    let setter!: (value: number) => void;
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <PersistProbe
+          onSetter={(s) => {
+            setter = s;
+          }}
+        />,
+      );
+    });
+
+    expect(renderedValue(renderer)).toBe('0');
+    expect(cacheService.hasPersist('internal.persist_probe')).toBe(false);
+
+    act(() => setter(42));
+    expect(renderedValue(renderer)).toBe('42');
+    expect(cacheService.getPersist('internal.persist_probe')).toBe(42);
+    expect(cacheService.hasPersist('internal.persist_probe')).toBe(true);
+
+    act(() => renderer.unmount());
+  });
+
+  test('imperative deletePersist resets the hook to the default', () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<PersistProbe />);
+    });
+
+    act(() => cacheService.setPersist('internal.persist_probe', 7));
+    expect(renderedValue(renderer)).toBe('7');
+
+    act(() => cacheService.deletePersist('internal.persist_probe'));
+    expect(renderedValue(renderer)).toBe('0');
+
+    act(() => renderer.unmount());
+  });
+});

--- a/src/data/hooks/index.ts
+++ b/src/data/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useCache, usePersistCache } from './useCache';
 export { useDataMutation } from './useDataMutation';
 export { useDataInfiniteQuery, useDataQuery } from './useDataQuery';
 export { useMultiplePreferences, usePreference } from './usePreference';

--- a/src/data/hooks/useCache.ts
+++ b/src/data/hooks/useCache.ts
@@ -1,0 +1,208 @@
+import { loggerService } from '@logger';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { cacheService } from '@/data/cache/CacheService';
+import type {
+  InferUseCacheValue,
+  PersistCacheKey,
+  PersistCacheSchema,
+  UseCacheKey,
+} from '@/data/cache/cacheSchemas';
+import { getUseCacheDefaultValue } from '@/data/cache/templateKey';
+
+const logger = loggerService.withContext('useCache');
+
+// ============================================================================
+// Functional Updater Types
+// ============================================================================
+
+/**
+ * Shallow-readonly view of a cache value, used for the `prev` argument of a
+ * functional updater. Containers (objects/arrays) become `Readonly<T>` so the
+ * most common footgun — mutating `prev` in place and returning it — fails to
+ * compile; primitives pass through unchanged so `prev => !prev` / `prev => prev + 1`
+ * still work.
+ *
+ * Shallow only: nested mutation (e.g. `prev.items[0].x = ...`) is NOT caught by
+ * the type — keep updaters pure (see {@link CacheSetStateAction}).
+ */
+type ReadonlyValue<T> = T extends object ? Readonly<T> : T;
+
+/**
+ * Setter input for cache hooks, mirroring React's `SetStateAction<T>`: either a
+ * concrete value or an updater `(prev) => next`.
+ *
+ * The updater is resolved against the **latest stored value** at write time (not
+ * the render-time snapshot), which is what makes read-modify-write safe across an
+ * `await`. It MUST be pure and return a new value: mutating `prev` in place and
+ * returning the same reference makes `CacheService` short-circuit on
+ * `deepEqual(stored, value)` and silently skip the subscriber notification.
+ *
+ * "Pure" also means no side effects inside the updater: do not smuggle a derived
+ * result out (e.g. by writing to an enclosing-scope variable) to drive post-write
+ * work, and do not assume how many times or when it runs. To react to *what
+ * changed* — e.g. dispose resources for items that were removed — derive it from
+ * the value transition in a `useEffect` that watches the value, not from inside
+ * the updater.
+ */
+type CacheSetStateAction<T> = T | ((prev: ReadonlyValue<T>) => T);
+
+// ============================================================================
+// Hooks
+// ============================================================================
+
+/**
+ * React hook for component-level memory cache
+ *
+ * Use this for data that needs to be shared between components. Data is lost
+ * when the app restarts.
+ *
+ * Supports both fixed keys and template keys:
+ * - Fixed keys: `useCache('app.user.avatar')`
+ * - Template keys: `useCache('scroll.position.topic123')` (matches schema `'scroll.position.${id}'`)
+ *
+ * @param key - Cache key from the predefined schema (fixed or matching template pattern)
+ * @param initValue - Initial value (optional, uses schema default if not provided)
+ * @returns [value, setValue] - Similar to useState but shared across components
+ *
+ * @remarks
+ * The setter accepts a value or an updater `(prev) => next`, like React's
+ * `useState`. The updater MUST be pure: it runs against the latest stored value
+ * and must return a new value — mutating `prev` in place and returning the same
+ * reference is short-circuited by `deepEqual` and silently skips the re-render.
+ */
+export function useCache<K extends UseCacheKey>(
+  key: K,
+  initValue?: InferUseCacheValue<K>,
+): [InferUseCacheValue<K>, (value: CacheSetStateAction<InferUseCacheValue<K>>) => void] {
+  // Get the default value for this key (works with both fixed and template keys)
+  const defaultValue = getUseCacheDefaultValue(key);
+
+  /**
+   * Subscribe to cache changes using React's useSyncExternalStore
+   * This ensures the component re-renders when the cache value changes
+   */
+  const value = useSyncExternalStore(
+    useCallback((callback) => cacheService.subscribe(key, callback), [key]),
+    useCallback(() => cacheService.get(key), [key]),
+    useCallback(() => cacheService.get(key), [key]), // SSR snapshot
+  );
+
+  /**
+   * Initialize cache with default value if it doesn't exist
+   * Priority: existing cache value > custom initValue > schema default (via template matching)
+   */
+  useEffect(() => {
+    if (cacheService.has(key)) {
+      return;
+    }
+
+    if (initValue !== undefined) {
+      cacheService.set(key, initValue);
+    } else if (defaultValue !== undefined) {
+      cacheService.set(key, defaultValue);
+    }
+  }, [key, initValue, defaultValue]);
+
+  /**
+   * Register this hook as actively using the cache key
+   * This prevents the cache service from deleting the key while the hook is active
+   */
+  useEffect(() => {
+    cacheService.registerHook(key);
+    return () => cacheService.unregisterHook(key);
+  }, [key]);
+
+  /**
+   * Warn developers when using TTL with hooks
+   * TTL can cause values to expire between renders, leading to unstable behavior
+   */
+  useEffect(() => {
+    if (cacheService.hasTTL(key)) {
+      logger.warn(
+        `useCache hook for key "${key}" is using a cache with TTL. This may cause unstable behavior as the value can expire between renders.`,
+      );
+    }
+  }, [key]);
+
+  /**
+   * Memoized setter function for updating the cache value.
+   * Accepts a concrete value or a functional updater `(prev) => next`. The
+   * updater is resolved against the latest stored value via the same default
+   * fallback chain as the hook return (`get ?? initValue ?? schema default`),
+   * so it stays correct across an `await`.
+   */
+  const setValue = useCallback(
+    (newValue: CacheSetStateAction<InferUseCacheValue<K>>) => {
+      if (typeof newValue === 'function') {
+        const prev = (cacheService.get(key) ?? initValue ?? defaultValue) as ReadonlyValue<
+          InferUseCacheValue<K>
+        >;
+        cacheService.set(key, newValue(prev));
+      } else {
+        cacheService.set(key, newValue);
+      }
+    },
+    [key, initValue, defaultValue],
+  );
+
+  // Every schema key ships a default, so the chain never actually falls through
+  // for valid keys; the cast documents that contract without a non-null assertion.
+  return [(value ?? initValue ?? defaultValue) as InferUseCacheValue<K>, setValue];
+}
+
+/**
+ * React hook for persistent cache
+ *
+ * Use this for data that needs to persist across app restarts. Data is
+ * synchronously written through to the MMKV-backed store.
+ *
+ * @param key - Cache key from the predefined schema
+ * @returns [value, setValue] - Similar to useState but persisted
+ *
+ * @remarks
+ * The setter accepts a value or an updater `(prev) => next`, resolved against the
+ * latest persisted value (`getPersist`, which always returns the stored value or
+ * the schema default). Keep the updater pure and return a new value (see `useCache`).
+ */
+export function usePersistCache<K extends PersistCacheKey>(
+  key: K,
+): [PersistCacheSchema[K], (value: CacheSetStateAction<PersistCacheSchema[K]>) => void] {
+  /**
+   * Subscribe to persist cache changes using React's useSyncExternalStore
+   * This ensures the component re-renders when the persist cache value changes
+   */
+  const value = useSyncExternalStore(
+    useCallback((callback) => cacheService.subscribe(key, callback), [key]),
+    useCallback(() => cacheService.getPersist(key), [key]),
+    useCallback(() => cacheService.getPersist(key), [key]), // SSR snapshot
+  );
+
+  /**
+   * Register this hook as actively using the persist cache key
+   * This prevents the cache service from deleting the key while the hook is active
+   * Note: Persist cache keys are predefined and generally not deleted
+   */
+  useEffect(() => {
+    cacheService.registerHook(key);
+    return () => cacheService.unregisterHook(key);
+  }, [key]);
+
+  /**
+   * Memoized setter function for updating the persist cache value.
+   * Accepts a concrete value or a functional updater `(prev) => next` resolved
+   * against the latest persisted value (`getPersist` never returns undefined).
+   */
+  const setValue = useCallback(
+    (newValue: CacheSetStateAction<PersistCacheSchema[K]>) => {
+      if (typeof newValue === 'function') {
+        const prev = cacheService.getPersist(key) as ReadonlyValue<PersistCacheSchema[K]>;
+        cacheService.setPersist(key, newValue(prev));
+      } else {
+        cacheService.setPersist(key, newValue);
+      }
+    },
+    [key],
+  );
+
+  return [value, setValue];
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,5 @@
 export { QueryProvider, queryKeys } from './api';
+export * from './cache';
 export * from './hooks';
 export * from './preference';
 export { DataProvider, InitialDataGate, useDataServices, useDataState } from './runtime';

--- a/src/data/services/ProviderService.ts
+++ b/src/data/services/ProviderService.ts
@@ -2,6 +2,7 @@ import { inferAdapterFamily } from '@cherrystudio/provider-registry';
 import { asc, eq, inArray } from 'drizzle-orm';
 import * as Crypto from 'expo-crypto';
 
+import type { CacheService } from '@/data/cache';
 import type { DbService } from '@/data/db/DbService';
 import { userModelTable } from '@/data/db/schemas/userModel';
 import type { InsertUserProviderRow, UserProviderRow } from '@/data/db/schemas/userProvider';
@@ -220,11 +221,10 @@ function toInsert(input: CreateProviderInput): ProviderInputWithoutOrderKey {
 }
 
 export class ProviderService {
-  private readonly lastUsedApiKeyIds = new Map<string, string>();
-
   constructor(
     private readonly dbService: DbService,
     private readonly pinService: PinService,
+    private readonly cacheService: CacheService,
   ) {}
 
   private get db() {
@@ -315,19 +315,21 @@ export class ProviderService {
       return enabledKeys[0].key;
     }
 
-    // Round-robin using in-memory runtime state. Mobile keeps this scoped to
-    // the active data service graph instead of the desktop CacheService.
-    const lastUsedKeyId = this.lastUsedApiKeyIds.get(providerId);
+    // Round-robin via the CacheService memory tier, same key as the desktop
+    // main-process ProviderService. The schema default is '' so a fresh
+    // provider falls into the falsy branch.
+    const cacheKey = `settings.provider.${providerId}.last_used_key_id` as const;
+    const lastUsedKeyId = this.cacheService.get(cacheKey);
 
     if (!lastUsedKeyId) {
-      this.lastUsedApiKeyIds.set(providerId, enabledKeys[0].id);
+      this.cacheService.set(cacheKey, enabledKeys[0].id);
       return enabledKeys[0].key;
     }
 
     const currentIndex = enabledKeys.findIndex((key) => key.id === lastUsedKeyId);
     const nextIndex = (currentIndex + 1) % enabledKeys.length;
     const nextKey = enabledKeys[nextIndex];
-    this.lastUsedApiKeyIds.set(providerId, nextKey.id);
+    this.cacheService.set(cacheKey, nextKey.id);
 
     return nextKey.key;
   }
@@ -492,7 +494,7 @@ export class ProviderService {
       }
     });
 
-    this.lastUsedApiKeyIds.delete(providerId);
+    this.cacheService.delete(`settings.provider.${providerId}.last_used_key_id` as const);
   }
 
   async batchUpsert(inputs: CreateProviderInput[]): Promise<void> {

--- a/src/data/services/__tests__/ProviderService.test.ts
+++ b/src/data/services/__tests__/ProviderService.test.ts
@@ -1,6 +1,7 @@
+import { CacheService, InMemoryKVStorage } from '@/data/cache';
 import type { DbService } from '@/data/db/DbService';
 import type { UserProviderRow } from '@/data/db/schemas/userProvider';
-import type { ProviderSettings } from '@/data/types/provider';
+import type { ApiKeyEntry, ProviderSettings } from '@/data/types/provider';
 
 import type { PinService } from '../PinService';
 import { providerRegistryService } from '../ProviderRegistryService';
@@ -61,6 +62,7 @@ describe('ProviderService', () => {
         withWriteTx: async (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx),
       } as unknown as DbService,
       createPinServiceStub(),
+      createCacheService(),
     );
 
     const provider = await service.update(row.providerId, {
@@ -115,6 +117,64 @@ describe('ProviderService', () => {
     expect(tx.delete).toHaveBeenCalledTimes(1);
   });
 
+  test('rotates enabled API keys round-robin via the cache service', async () => {
+    const service = createRotationService([
+      apiKey('a', 'key-a'),
+      apiKey('b', 'key-b', false),
+      apiKey('c', 'key-c'),
+    ]);
+
+    await expect(service.getRotatedApiKey('custom-provider')).resolves.toBe('key-a');
+    await expect(service.getRotatedApiKey('custom-provider')).resolves.toBe('key-c');
+    await expect(service.getRotatedApiKey('custom-provider')).resolves.toBe('key-a');
+  });
+
+  test('short-circuits rotation for zero or one enabled key', async () => {
+    const cacheService = createCacheService();
+
+    await expect(
+      createRotationService([apiKey('a', 'key-a', false)], cacheService).getRotatedApiKey(
+        'custom-provider',
+      ),
+    ).resolves.toBe('');
+    await expect(
+      createRotationService([apiKey('a', 'key-a')], cacheService).getRotatedApiKey(
+        'custom-provider',
+      ),
+    ).resolves.toBe('key-a');
+    expect(cacheService.get('settings.provider.custom-provider.last_used_key_id')).toBeUndefined();
+  });
+
+  test('rotation state is scoped per provider', async () => {
+    const cacheService = createCacheService();
+    const first = createRotationService([apiKey('a', 'key-a'), apiKey('b', 'key-b')], cacheService);
+
+    await expect(first.getRotatedApiKey('provider-one')).resolves.toBe('key-a');
+    await expect(first.getRotatedApiKey('provider-two')).resolves.toBe('key-a');
+    await expect(first.getRotatedApiKey('provider-one')).resolves.toBe('key-b');
+  });
+
+  test('deleting a provider resets its rotation state', async () => {
+    const cacheService = createCacheService();
+    const rotation = createRotationService(
+      [apiKey('a', 'key-a'), apiKey('b', 'key-b')],
+      cacheService,
+    );
+
+    await rotation.getRotatedApiKey('custom-provider');
+    expect(cacheService.get('settings.provider.custom-provider.last_used_key_id')).toBe('a');
+
+    const tx = createDeleteTransaction({
+      modelIds: [],
+      presetProviderId: null,
+      providerId: 'custom-provider',
+    });
+    await createService(tx, undefined, cacheService).delete('custom-provider');
+
+    expect(cacheService.get('settings.provider.custom-provider.last_used_key_id')).toBeUndefined();
+    await expect(rotation.getRotatedApiKey('custom-provider')).resolves.toBe('key-a');
+  });
+
   test('rejects deleting registry and canonical preset providers', async () => {
     const registryTx = createDeleteTransaction({
       modelIds: [],
@@ -140,13 +200,48 @@ describe('ProviderService', () => {
   });
 });
 
-function createService(tx: object, pinService?: PinService): ProviderService {
+function createService(
+  tx: object,
+  pinService?: PinService,
+  cacheService?: CacheService,
+): ProviderService {
   return new ProviderService(
     {
       getDb: () => ({}),
       withWriteTx: async (callback: (transaction: object) => Promise<unknown>) => callback(tx),
     } as unknown as DbService,
     pinService ?? createPinServiceStub(),
+    cacheService ?? createCacheService(),
+  );
+}
+
+function createCacheService(): CacheService {
+  return new CacheService(new InMemoryKVStorage());
+}
+
+function apiKey(id: string, key: string, isEnabled = true): ApiKeyEntry {
+  return { id, isEnabled, key };
+}
+
+/** Service whose db always resolves one provider row with the given API keys. */
+function createRotationService(apiKeys: ApiKeyEntry[], cacheService?: CacheService) {
+  const db = {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          limit: jest.fn(async () => [{ apiKeys }]),
+        })),
+      })),
+    })),
+  };
+
+  return new ProviderService(
+    {
+      getDb: () => db,
+      withWriteTx: async () => undefined,
+    } as unknown as DbService,
+    createPinServiceStub(),
+    cacheService ?? createCacheService(),
   );
 }
 

--- a/src/data/services/__tests__/ProviderService.test.ts
+++ b/src/data/services/__tests__/ProviderService.test.ts
@@ -1,4 +1,4 @@
-import { CacheService, InMemoryKVStorage } from '@/data/cache';
+import { CacheService, createInMemoryKvStorage } from '@/data/cache';
 import type { DbService } from '@/data/db/DbService';
 import type { UserProviderRow } from '@/data/db/schemas/userProvider';
 import type { ApiKeyEntry, ProviderSettings } from '@/data/types/provider';
@@ -216,7 +216,7 @@ function createService(
 }
 
 function createCacheService(): CacheService {
-  return new CacheService(new InMemoryKVStorage());
+  return new CacheService(createInMemoryKvStorage());
 }
 
 function apiKey(id: string, key: string, isEnabled = true): ApiKeyEntry {

--- a/src/data/services/createDataServices.ts
+++ b/src/data/services/createDataServices.ts
@@ -1,4 +1,5 @@
 import { AiService } from '@/ai/AiService';
+import { cacheService } from '@/data/cache';
 import type { DbService } from '@/data/db/DbService';
 import { WebSearchService } from '@/services/webSearch/WebSearchService';
 
@@ -18,7 +19,7 @@ export type DataServices = ReturnType<typeof createDataServices>;
 export function createDataServices(dbService: DbService) {
   const preference = new PreferenceService(dbService);
   const pin = new PinService(dbService);
-  const provider = new ProviderService(dbService, pin);
+  const provider = new ProviderService(dbService, pin, cacheService);
   const model = new ModelService(dbService, preference, pin);
   const tag = new TagService(dbService);
   const group = new GroupService(dbService);


### PR DESCRIPTION
Ports the desktop three-tier CacheService to mobile as two tiers — the shared/IPC tier is folded into the memory tier since mobile runs a single JS runtime — with typed template-key schemas, TTL lazy cleanup, hook reference counting, and `useCache`/`usePersistCache` hooks (React 19 `useSyncExternalStore`).

The persist tier is backed by `react-native-mmkv@4.3.2` (one JSON entry per schema key, synchronous write-through with self-healing storage canonicalization, default-relative semantics so `getPersist` never returns undefined). First real consumer: ProviderService API-key round-robin moves off its service-graph-scoped Map onto the typed key `settings.provider.${providerId}.last_used_key_id`, matching the desktop main-process key. Review fixes are included as a follow-up commit: `deepEqual` restricted to plain objects/arrays, `KvStorage` naming + factory, narrowed cache barrel, while desktop-verbatim identifiers (`hasTTL`, `DefaultUseCache`) stay as documented porting exceptions.

⚠️ New native dependency — rebuild the dev-client (`expo run:ios` / `run:android`) after pulling; an old client crashes at Nitro HybridObject creation. Verified with 630 passing tests, typecheck/biome clean, and an on-simulator MMKV persistence probe across process kills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)