### PR TITLE
feat(onboarding): brand logo draw-on animation (Skia mask reveal)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -66,6 +66,8 @@ jest.mock('@shopify/react-native-skia', () => {
     BlurMask: inert('SkiaBlurMask'),
     RoundedRect: inert('SkiaRoundedRect'),
     Shader: inert('SkiaShader'),
+    Path: inert('SkiaPath'),
+    Mask: inert('SkiaMask'),
     matchFont: () => ({
       getGlyphIDs: (text: string) => Array.from(text).map((_, index) => index),
       getGlyphWidths: (ids: number[]) => ids.map(() => 8),

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -55,6 +55,7 @@ function RootStack() {
       }}
     >
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      <Stack.Screen name="onboarding" options={{ headerShown: false }} />
       <Stack.Screen
         name="topics"
         options={{

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -1,0 +1,1 @@
+export { OnboardingScreen as default } from '@/screens/OnboardingScreen';

--- a/src/screens/OnboardingScreen/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen/OnboardingScreen.tsx
@@ -1,0 +1,98 @@
+import { Button } from 'heroui-native/button';
+import { Slider } from 'heroui-native/slider';
+import { Switch } from 'heroui-native/switch';
+import { Text } from 'heroui-native/text';
+import { useRef, useState } from 'react';
+import { View } from 'react-native';
+import { useSharedValue } from 'react-native-reanimated';
+
+import { LogoDrawAnimation, type LogoDrawAnimationRef } from './logoDraw';
+
+/**
+ * Onboarding entry screen. Currently a skeleton hosting the logo draw
+ * animation; the real onboarding content (copy, pager, actions) lands later.
+ */
+export function OnboardingScreen() {
+  const logoRef = useRef<LogoDrawAnimationRef>(null);
+  const scrub = useSharedValue(0);
+  const [scrubbing, setScrubbing] = useState(false);
+  const [debug, setDebug] = useState(false);
+
+  return (
+    <View className="flex-1 items-center justify-center gap-16 bg-background">
+      <LogoDrawAnimation
+        debug={debug}
+        progress={scrubbing ? scrub : undefined}
+        ref={logoRef}
+        size={180}
+      />
+      {__DEV__ ? (
+        <LogoDrawDevPanel
+          debug={debug}
+          onDebugChange={setDebug}
+          onReplay={() => logoRef.current?.replay()}
+          onScrub={(value) => {
+            scrub.value = value;
+          }}
+          onScrubbingChange={setScrubbing}
+          scrubbing={scrubbing}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+/** Dev-only calibration controls; not part of the future onboarding UI. */
+function LogoDrawDevPanel({
+  debug,
+  onDebugChange,
+  onReplay,
+  onScrub,
+  onScrubbingChange,
+  scrubbing,
+}: {
+  debug: boolean;
+  onDebugChange: (debug: boolean) => void;
+  onReplay: () => void;
+  onScrub: (value: number) => void;
+  onScrubbingChange: (scrubbing: boolean) => void;
+  scrubbing: boolean;
+}) {
+  const [value, setValue] = useState(0);
+
+  return (
+    <View className="w-72 gap-4">
+      <View className="flex-row items-center justify-between">
+        <Text className="text-foreground">Debug centerlines</Text>
+        <Switch isSelected={debug} onSelectedChange={onDebugChange} />
+      </View>
+      <View className="flex-row items-center justify-between">
+        <Text className="text-foreground">Scrub</Text>
+        <Switch isSelected={scrubbing} onSelectedChange={onScrubbingChange} />
+      </View>
+      {scrubbing ? (
+        <Slider
+          maxValue={1}
+          minValue={0}
+          onChange={(next) => {
+            const single = Array.isArray(next) ? (next[0] ?? 0) : next;
+            setValue(single);
+            onScrub(single);
+          }}
+          step={0.005}
+          value={value}
+        >
+          <Slider.Output />
+          <Slider.Track>
+            <Slider.Fill />
+            <Slider.Thumb />
+          </Slider.Track>
+        </Slider>
+      ) : (
+        <Button onPress={onReplay} variant="secondary">
+          <Text className="text-foreground">Replay</Text>
+        </Button>
+      )}
+    </View>
+  );
+}

--- a/src/screens/OnboardingScreen/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen/OnboardingScreen.tsx
@@ -1,98 +1,15 @@
-import { Button } from 'heroui-native/button';
-import { Slider } from 'heroui-native/slider';
-import { Switch } from 'heroui-native/switch';
-import { Text } from 'heroui-native/text';
-import { useRef, useState } from 'react';
 import { View } from 'react-native';
-import { useSharedValue } from 'react-native-reanimated';
 
-import { LogoDrawAnimation, type LogoDrawAnimationRef } from './logoDraw';
+import { LogoDrawAnimation } from './logoDraw';
 
 /**
  * Onboarding entry screen. Currently a skeleton hosting the logo draw
  * animation; the real onboarding content (copy, pager, actions) lands later.
  */
 export function OnboardingScreen() {
-  const logoRef = useRef<LogoDrawAnimationRef>(null);
-  const scrub = useSharedValue(0);
-  const [scrubbing, setScrubbing] = useState(false);
-  const [debug, setDebug] = useState(false);
-
   return (
-    <View className="flex-1 items-center justify-center gap-16 bg-background">
-      <LogoDrawAnimation
-        debug={debug}
-        progress={scrubbing ? scrub : undefined}
-        ref={logoRef}
-        size={180}
-      />
-      {__DEV__ ? (
-        <LogoDrawDevPanel
-          debug={debug}
-          onDebugChange={setDebug}
-          onReplay={() => logoRef.current?.replay()}
-          onScrub={(value) => {
-            scrub.value = value;
-          }}
-          onScrubbingChange={setScrubbing}
-          scrubbing={scrubbing}
-        />
-      ) : null}
-    </View>
-  );
-}
-
-/** Dev-only calibration controls; not part of the future onboarding UI. */
-function LogoDrawDevPanel({
-  debug,
-  onDebugChange,
-  onReplay,
-  onScrub,
-  onScrubbingChange,
-  scrubbing,
-}: {
-  debug: boolean;
-  onDebugChange: (debug: boolean) => void;
-  onReplay: () => void;
-  onScrub: (value: number) => void;
-  onScrubbingChange: (scrubbing: boolean) => void;
-  scrubbing: boolean;
-}) {
-  const [value, setValue] = useState(0);
-
-  return (
-    <View className="w-72 gap-4">
-      <View className="flex-row items-center justify-between">
-        <Text className="text-foreground">Debug centerlines</Text>
-        <Switch isSelected={debug} onSelectedChange={onDebugChange} />
-      </View>
-      <View className="flex-row items-center justify-between">
-        <Text className="text-foreground">Scrub</Text>
-        <Switch isSelected={scrubbing} onSelectedChange={onScrubbingChange} />
-      </View>
-      {scrubbing ? (
-        <Slider
-          maxValue={1}
-          minValue={0}
-          onChange={(next) => {
-            const single = Array.isArray(next) ? (next[0] ?? 0) : next;
-            setValue(single);
-            onScrub(single);
-          }}
-          step={0.005}
-          value={value}
-        >
-          <Slider.Output />
-          <Slider.Track>
-            <Slider.Fill />
-            <Slider.Thumb />
-          </Slider.Track>
-        </Slider>
-      ) : (
-        <Button onPress={onReplay} variant="secondary">
-          <Text className="text-foreground">Replay</Text>
-        </Button>
-      )}
+    <View className="flex-1 items-center justify-center bg-background">
+      <LogoDrawAnimation size={180} />
     </View>
   );
 }

--- a/src/screens/OnboardingScreen/README.md
+++ b/src/screens/OnboardingScreen/README.md
@@ -1,0 +1,62 @@
+# OnboardingScreen
+
+Onboarding entry (route: `/onboarding`, registered headerless in
+`src/app/_layout.tsx`). Currently a skeleton that hosts the brand-logo draw
+animation plus `__DEV__`-only calibration controls (replay / scrub slider /
+debug overlay); the real onboarding content lands later.
+
+## logoDraw
+
+`logoDraw/` is the paint-on reveal of the brand logo: the two orange swirls
+draw first as one continuous gesture, then the green check lands with a
+spring. Public surface is `LogoDrawAnimation` (see `logoDraw/index.ts`).
+
+### How it works
+
+The logo SVG consists of *filled outlines*, not strokes, so a classic
+dash-offset trick cannot draw it. Instead each fill path renders inside an
+alpha `<Mask>` whose content is a thick round-cap stroke growing along a
+hand-reconstructed centerline of the original pen stroke (Skia `Path`
+`end`-trim). The visible pixels always come from the original fill path —
+the mask only controls how much is revealed — so `progress = 1` is
+pixel-identical to the brand SVG. After the internal timeline settles, the
+component swaps to unmasked fills (drops three saveLayers).
+
+A single master `progress` shared value drives everything through
+`useDerivedValue` sub-segment mappings (`LOGO_DRAW_SEGMENTS`), so all
+per-frame work stays on the UI thread via Skia's Reanimated integration.
+
+### Geometry reverse-engineering (logoPaths.ts)
+
+- Both swirls are ~12-unit-thick ring strokes: outer rim r≈17.05, inner
+  edge = an r≈4.94 circular *hole* concentric with each ring center (the
+  small circles are negative space — verified by ray casting, easy to
+  misread as filled discs).
+- Centerlines are radius-11.1 arcs around the ring centers plus a cubic
+  waist for the right swirl; stroke width 12.6 covers the radial band with
+  margin. Builders live in `logoDrawMath.ts` (pure, unit-tested).
+- Each ring is a near-closed hook with a ~6-unit *mouth* at its top (between
+  the interlock lip and the arch that leads to the waist). A round mask nib
+  (half-width 6.3) placed inside a mouth bridges it and reveals the far arch
+  as a sliver detached from the growing blob — it only rejoins ~0.3 later
+  when the sweep comes all the way around, so it reads as a floating extra
+  stroke. The right sweep therefore starts at 231° (`LOWER_RIM_FROM_DEG`),
+  just below the mouth: the start nib covers the interlock lip (and sits 3.6
+  units from the C's bottom lip, so the handoff still reads) yet stays 7.8
+  units from the arch, keeping every revealed frame a single connected blob.
+  There is no separate cap lead-in — that lead-in was what used to drag the
+  nib through the mouth. Verified by an offline rasteriser (flatten the fill
+  polygon, intersect with the trimmed thick stroke, count connected
+  components): 0 detached components across all trims.
+
+### Calibrating after geometry changes
+
+1. Open `/onboarding` (`xcrun simctl openurl booted cherrystudio://onboarding`).
+2. Flip on the dev panel's **Scrub** and **Debug centerlines** switches —
+   debug draws the mask corridors in translucent cyan *with* the same trim,
+   and keeps masks mounted at `progress = 1`.
+3. Walk the slider through ~0.05 steps: no fill may appear outside the cyan
+   corridor's leading edge, and the corridor must fully cover each shape at
+   its segment end. Temporarily rendering a grid of fixed-progress
+   instances (one `useSharedValue(p)` per cell) makes before/after
+   comparison easy in a single screenshot.

--- a/src/screens/OnboardingScreen/README.md
+++ b/src/screens/OnboardingScreen/README.md
@@ -1,9 +1,8 @@
 # OnboardingScreen
 
 Onboarding entry (route: `/onboarding`, registered headerless in
-`src/app/_layout.tsx`). Currently a skeleton that hosts the brand-logo draw
-animation plus `__DEV__`-only calibration controls (replay / scrub slider /
-debug overlay); the real onboarding content lands later.
+`src/app/_layout.tsx`). Currently a skeleton that centers the brand-logo draw
+animation; the real onboarding content lands later.
 
 ## logoDraw
 
@@ -51,12 +50,13 @@ per-frame work stays on the UI thread via Skia's Reanimated integration.
 
 ### Calibrating after geometry changes
 
-1. Open `/onboarding` (`xcrun simctl openurl booted cherrystudio://onboarding`).
-2. Flip on the dev panel's **Scrub** and **Debug centerlines** switches —
-   debug draws the mask corridors in translucent cyan *with* the same trim,
-   and keeps masks mounted at `progress = 1`.
-3. Walk the slider through ~0.05 steps: no fill may appear outside the cyan
-   corridor's leading edge, and the corridor must fully cover each shape at
-   its segment end. Temporarily rendering a grid of fixed-progress
-   instances (one `useSharedValue(p)` per cell) makes before/after
-   comparison easy in a single screenshot.
+`LogoDrawAnimation` takes a controlled `progress` shared value, which is the
+scrubbing seam for recalibration — drive it from a temporary slider (or a
+grid of fixed-progress instances, one `useSharedValue(p)` per cell, for a
+single before/after screenshot) and step through ~0.05 increments. At every
+step no fill may appear outside the growing mask corridor's leading edge, and
+the corridor must fully cover each shape by its segment end. To see the
+corridor itself, temporarily render each centerline as a translucent
+`<Path style="stroke">` with the matching trim next to the masks. The
+deterministic check for detached slivers is the offline rasteriser described
+above (flatten fill polygon ∩ trimmed thick stroke → count components).

--- a/src/screens/OnboardingScreen/index.ts
+++ b/src/screens/OnboardingScreen/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingScreen } from './OnboardingScreen';

--- a/src/screens/OnboardingScreen/logoDraw/components/LogoDrawAnimation.tsx
+++ b/src/screens/OnboardingScreen/logoDraw/components/LogoDrawAnimation.tsx
@@ -1,0 +1,248 @@
+import { Canvas, Group, Mask, Path } from '@shopify/react-native-skia';
+import { type Ref, useCallback, useImperativeHandle, useState } from 'react';
+import {
+  Extrapolation,
+  interpolate,
+  type SharedValue,
+  useDerivedValue,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+import { useLogoDrawProgress } from '../hooks/useLogoDrawProgress';
+import {
+  CHECK_MASK_STROKE_WIDTH,
+  CHECK_OVERSHOOT_RANGE,
+  CHECK_OVERSHOOT_SCALE,
+  LOGO_ASPECT_RATIO,
+  LOGO_DRAW_SEGMENTS,
+  LOGO_VIEWBOX_HEIGHT,
+  LOGO_VIEWBOX_INSET,
+  SWIRL_MASK_STROKE_WIDTH,
+} from '../utils/constants';
+import { segmentProgress } from '../utils/logoDrawMath';
+import {
+  CHECK_CENTERLINE,
+  CHECK_FILL,
+  CHECK_PIVOT,
+  SWIRL_LEFT_CENTERLINE,
+  SWIRL_LEFT_FILL,
+  SWIRL_RIGHT_CENTERLINE,
+  SWIRL_RIGHT_FILL,
+} from '../utils/logoPaths';
+import { centerlineDebugColor, logoBrandColors } from '../utils/logoPalette';
+
+export type LogoDrawAnimationRef = {
+  /** (Re)start the draw animation from the beginning. */
+  play: () => void;
+  /** Alias of play; reads better at call sites restarting a finished run. */
+  replay: () => void;
+};
+
+export type LogoDrawAnimationProps = {
+  /** Rendered logo height in dp; width follows the logo aspect ratio. */
+  size: number;
+  /** Play the draw animation on mount. Ignored when `progress` is supplied. */
+  autoPlay?: boolean;
+  /**
+   * External progress (0→1) for scrubbing or pager-driven reveals. Supplying
+   * it disables the internal timeline and the at-rest unmasked fast path.
+   */
+  progress?: SharedValue<number>;
+  /** Called on the JS thread once the draw reaches the end. */
+  onFinish?: () => void;
+  /** Overlay the mask centerlines and keep masks mounted at rest (calibration). */
+  debug?: boolean;
+  /** Imperative play/replay handle. */
+  ref?: Ref<LogoDrawAnimationRef>;
+};
+
+/**
+ * Paint-on reveal of the brand logo: the two orange swirls draw first as one
+ * continuous gesture (their pen caps interlock), then the green check lands
+ * with a spring. Each fill path is revealed through an alpha mask whose
+ * content is a thick round-cap stroke growing along the reconstructed pen
+ * centerline (`utils/logoPaths.ts`); all per-frame work stays on the UI
+ * thread via Skia's Reanimated integration.
+ */
+export function LogoDrawAnimation({
+  size,
+  autoPlay = true,
+  progress,
+  onFinish,
+  debug = false,
+  ref,
+}: LogoDrawAnimationProps) {
+  const internalProgress = useSharedValue(0);
+  const controlled = progress !== undefined;
+  const master = progress ?? internalProgress;
+  const [finished, setFinished] = useState(false);
+
+  const handleSettle = useCallback(() => {
+    // Controlled progress can scrub back below 1, so the unmasked fast path
+    // only engages for the internal timeline.
+    if (!controlled) {
+      setFinished(true);
+    }
+    onFinish?.();
+  }, [controlled, onFinish]);
+
+  const play = useLogoDrawProgress({
+    progress: master,
+    controlled,
+    autoPlay,
+    onSettle: handleSettle,
+  });
+
+  const replay = useCallback(() => {
+    setFinished(false);
+    play();
+  }, [play]);
+
+  useImperativeHandle(ref, () => ({ play: replay, replay }), [replay]);
+
+  const leftTrim = useDerivedValue(
+    () =>
+      segmentProgress(
+        master.value,
+        LOGO_DRAW_SEGMENTS.swirlLeft.from,
+        LOGO_DRAW_SEGMENTS.swirlLeft.to,
+      ),
+    [master],
+  );
+  const rightTrim = useDerivedValue(
+    () =>
+      segmentProgress(
+        master.value,
+        LOGO_DRAW_SEGMENTS.swirlRight.from,
+        LOGO_DRAW_SEGMENTS.swirlRight.to,
+      ),
+    [master],
+  );
+  const checkTrim = useDerivedValue(
+    () => segmentProgress(master.value, LOGO_DRAW_SEGMENTS.check.from, LOGO_DRAW_SEGMENTS.check.to),
+    [master],
+  );
+  // The landing spring overshoots past 1; the check group converts that tail
+  // into a small scale rebound around the tick's center.
+  const checkTransform = useDerivedValue(() => {
+    const scale = interpolate(
+      master.value,
+      [1, 1 + CHECK_OVERSHOOT_RANGE],
+      [1, CHECK_OVERSHOOT_SCALE],
+      Extrapolation.CLAMP,
+    );
+    return [
+      { translateX: CHECK_PIVOT.x },
+      { translateY: CHECK_PIVOT.y },
+      { scale },
+      { translateX: -CHECK_PIVOT.x },
+      { translateY: -CHECK_PIVOT.y },
+    ];
+  }, [master]);
+
+  const height = size;
+  const width = size * LOGO_ASPECT_RATIO;
+  const fitTransform = [
+    { scale: height / LOGO_VIEWBOX_HEIGHT },
+    { translateX: LOGO_VIEWBOX_INSET },
+    { translateY: LOGO_VIEWBOX_INSET },
+  ];
+
+  return (
+    <Canvas pointerEvents="none" style={{ height, width }}>
+      <Group transform={fitTransform}>
+        {finished && !debug ? (
+          <>
+            <Path color={logoBrandColors.swirl} path={SWIRL_LEFT_FILL} />
+            <Path color={logoBrandColors.swirl} path={SWIRL_RIGHT_FILL} />
+            <Path color={logoBrandColors.check} path={CHECK_FILL} />
+          </>
+        ) : (
+          <>
+            <Mask
+              mask={
+                <Path
+                  color="white"
+                  end={leftTrim}
+                  path={SWIRL_LEFT_CENTERLINE}
+                  strokeCap="round"
+                  strokeJoin="round"
+                  strokeWidth={SWIRL_MASK_STROKE_WIDTH}
+                  style="stroke"
+                />
+              }
+              mode="alpha"
+            >
+              <Path color={logoBrandColors.swirl} path={SWIRL_LEFT_FILL} />
+            </Mask>
+            <Mask
+              mask={
+                <Path
+                  color="white"
+                  end={rightTrim}
+                  path={SWIRL_RIGHT_CENTERLINE}
+                  strokeCap="round"
+                  strokeJoin="round"
+                  strokeWidth={SWIRL_MASK_STROKE_WIDTH}
+                  style="stroke"
+                />
+              }
+              mode="alpha"
+            >
+              <Path color={logoBrandColors.swirl} path={SWIRL_RIGHT_FILL} />
+            </Mask>
+            <Group transform={checkTransform}>
+              <Mask
+                mask={
+                  <Path
+                    color="white"
+                    end={checkTrim}
+                    path={CHECK_CENTERLINE}
+                    strokeCap="round"
+                    strokeJoin="round"
+                    strokeWidth={CHECK_MASK_STROKE_WIDTH}
+                    style="stroke"
+                  />
+                }
+                mode="alpha"
+              >
+                <Path color={logoBrandColors.check} path={CHECK_FILL} />
+              </Mask>
+            </Group>
+          </>
+        )}
+        {debug ? (
+          <>
+            <Path
+              color={centerlineDebugColor}
+              end={leftTrim}
+              path={SWIRL_LEFT_CENTERLINE}
+              strokeCap="round"
+              strokeJoin="round"
+              strokeWidth={SWIRL_MASK_STROKE_WIDTH}
+              style="stroke"
+            />
+            <Path
+              color={centerlineDebugColor}
+              end={rightTrim}
+              path={SWIRL_RIGHT_CENTERLINE}
+              strokeCap="round"
+              strokeJoin="round"
+              strokeWidth={SWIRL_MASK_STROKE_WIDTH}
+              style="stroke"
+            />
+            <Path
+              color={centerlineDebugColor}
+              end={checkTrim}
+              path={CHECK_CENTERLINE}
+              strokeCap="round"
+              strokeJoin="round"
+              strokeWidth={CHECK_MASK_STROKE_WIDTH}
+              style="stroke"
+            />
+          </>
+        ) : null}
+      </Group>
+    </Canvas>
+  );
+}

--- a/src/screens/OnboardingScreen/logoDraw/components/LogoDrawAnimation.tsx
+++ b/src/screens/OnboardingScreen/logoDraw/components/LogoDrawAnimation.tsx
@@ -29,7 +29,7 @@ import {
   SWIRL_RIGHT_CENTERLINE,
   SWIRL_RIGHT_FILL,
 } from '../utils/logoPaths';
-import { centerlineDebugColor, logoBrandColors } from '../utils/logoPalette';
+import { logoBrandColors } from '../utils/logoPalette';
 
 export type LogoDrawAnimationRef = {
   /** (Re)start the draw animation from the beginning. */
@@ -50,8 +50,6 @@ export type LogoDrawAnimationProps = {
   progress?: SharedValue<number>;
   /** Called on the JS thread once the draw reaches the end. */
   onFinish?: () => void;
-  /** Overlay the mask centerlines and keep masks mounted at rest (calibration). */
-  debug?: boolean;
   /** Imperative play/replay handle. */
   ref?: Ref<LogoDrawAnimationRef>;
 };
@@ -69,7 +67,6 @@ export function LogoDrawAnimation({
   autoPlay = true,
   progress,
   onFinish,
-  debug = false,
   ref,
 }: LogoDrawAnimationProps) {
   const internalProgress = useSharedValue(0);
@@ -151,7 +148,7 @@ export function LogoDrawAnimation({
   return (
     <Canvas pointerEvents="none" style={{ height, width }}>
       <Group transform={fitTransform}>
-        {finished && !debug ? (
+        {finished ? (
           <>
             <Path color={logoBrandColors.swirl} path={SWIRL_LEFT_FILL} />
             <Path color={logoBrandColors.swirl} path={SWIRL_RIGHT_FILL} />
@@ -211,37 +208,6 @@ export function LogoDrawAnimation({
             </Group>
           </>
         )}
-        {debug ? (
-          <>
-            <Path
-              color={centerlineDebugColor}
-              end={leftTrim}
-              path={SWIRL_LEFT_CENTERLINE}
-              strokeCap="round"
-              strokeJoin="round"
-              strokeWidth={SWIRL_MASK_STROKE_WIDTH}
-              style="stroke"
-            />
-            <Path
-              color={centerlineDebugColor}
-              end={rightTrim}
-              path={SWIRL_RIGHT_CENTERLINE}
-              strokeCap="round"
-              strokeJoin="round"
-              strokeWidth={SWIRL_MASK_STROKE_WIDTH}
-              style="stroke"
-            />
-            <Path
-              color={centerlineDebugColor}
-              end={checkTrim}
-              path={CHECK_CENTERLINE}
-              strokeCap="round"
-              strokeJoin="round"
-              strokeWidth={CHECK_MASK_STROKE_WIDTH}
-              style="stroke"
-            />
-          </>
-        ) : null}
       </Group>
     </Canvas>
   );

--- a/src/screens/OnboardingScreen/logoDraw/hooks/useLogoDrawProgress.ts
+++ b/src/screens/OnboardingScreen/logoDraw/hooks/useLogoDrawProgress.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  cancelAnimation,
+  runOnJS,
+  type SharedValue,
+  useAnimatedReaction,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { checkSpringConfig, LOGO_DRAW_SEGMENTS, logoDrawTiming } from '../utils/constants';
+
+type UseLogoDrawProgressOptions = {
+  /** Master progress the timeline drives (or only observes when controlled). */
+  progress: SharedValue<number>;
+  /** True when the caller supplies an external progress value. */
+  controlled: boolean;
+  /** Start the timeline on mount (uncontrolled mode only). */
+  autoPlay: boolean;
+  /** Fires once on the JS thread when the draw reaches the end. */
+  onSettle: () => void;
+};
+
+/**
+ * Drives the master progress: the orange phase is one ease-in-out ramp up to
+ * the check segment, then a spring lands (and slightly overshoots) the green
+ * check. Returns `play`, which (re)starts the timeline from zero.
+ *
+ * In controlled mode nothing is driven; `onSettle` fires each time the
+ * external progress crosses 1 from below.
+ */
+export function useLogoDrawProgress({
+  progress,
+  controlled,
+  autoPlay,
+  onSettle,
+}: UseLogoDrawProgressOptions): () => void {
+  // Keep the settle callback identity-stable so play() and the animated
+  // reaction never rebuild when the caller passes a fresh closure.
+  const settleRef = useRef(onSettle);
+  useEffect(() => {
+    settleRef.current = onSettle;
+  }, [onSettle]);
+  const settle = useCallback(() => settleRef.current(), []);
+
+  const play = useCallback(() => {
+    if (controlled) {
+      return;
+    }
+    cancelAnimation(progress);
+    progress.value = 0;
+    progress.value = withSequence(
+      withTiming(LOGO_DRAW_SEGMENTS.check.from, logoDrawTiming),
+      withSpring(1, checkSpringConfig, (settled) => {
+        if (settled) {
+          runOnJS(settle)();
+        }
+      }),
+    );
+  }, [controlled, progress, settle]);
+
+  useEffect(() => {
+    if (autoPlay && !controlled) {
+      play();
+    }
+  }, [autoPlay, controlled, play]);
+
+  useAnimatedReaction(
+    () => progress.value >= 1,
+    (atEnd, previous) => {
+      if (controlled && atEnd && previous === false) {
+        runOnJS(settle)();
+      }
+    },
+    [controlled, progress],
+  );
+
+  return play;
+}

--- a/src/screens/OnboardingScreen/logoDraw/index.ts
+++ b/src/screens/OnboardingScreen/logoDraw/index.ts
@@ -1,0 +1,2 @@
+export { LogoDrawAnimation } from './components/LogoDrawAnimation';
+export type { LogoDrawAnimationProps, LogoDrawAnimationRef } from './components/LogoDrawAnimation';

--- a/src/screens/OnboardingScreen/logoDraw/utils/__tests__/logoDrawMath.test.ts
+++ b/src/screens/OnboardingScreen/logoDraw/utils/__tests__/logoDrawMath.test.ts
@@ -1,0 +1,105 @@
+import { arcPoint, buildArcSweep, segmentProgress } from '../logoDrawMath';
+import { CHECK_CENTERLINE, SWIRL_LEFT_CENTERLINE, SWIRL_RIGHT_CENTERLINE } from '../logoPaths';
+
+describe('arcPoint', () => {
+  it('matches the fill-path anchors of the left swirl outer rim', () => {
+    // Top of the left swirl: (16.72, 17.11) in the source SVG.
+    const top = arcPoint(16.72, 34.16, 17.05, -90);
+    expect(top.x).toBeCloseTo(16.72, 2);
+    expect(top.y).toBeCloseTo(17.11, 2);
+
+    // Left of the left swirl: (0, 34.16) — rim radius is ~16.7–17.05.
+    const left = arcPoint(16.72, 34.16, 17.05, 180);
+    expect(left.x).toBeCloseTo(-0.33, 2);
+    expect(left.y).toBeCloseTo(34.16, 2);
+  });
+
+  it('is y-down: positive angles go below the center', () => {
+    const below = arcPoint(0, 0, 10, 90);
+    expect(below.x).toBeCloseTo(0);
+    expect(below.y).toBeCloseTo(10);
+  });
+});
+
+describe('buildArcSweep', () => {
+  it('splits long sweeps into ≤90° segments with the backward sweep flag', () => {
+    const d = buildArcSweep(0, 0, 10, 0, -293);
+    const segments = d.match(/A /g);
+    expect(segments).toHaveLength(4);
+    expect(d).toContain('A 10 10 0 0 0 ');
+  });
+
+  it('uses the forward sweep flag when angles increase', () => {
+    const d = buildArcSweep(0, 0, 10, 0, 90);
+    expect(d).toBe('A 10 10 0 0 1 0 10');
+  });
+
+  it('lands exactly on the target angle point', () => {
+    const d = buildArcSweep(16.72, 34.16, 11.1, -33.35, -326.65);
+    const end = arcPoint(16.72, 34.16, 11.1, -326.65);
+    const lastPair = d.trim().split(' ').slice(-2).map(Number);
+    expect(lastPair[0]).toBeCloseTo(end.x, 2);
+    expect(lastPair[1]).toBeCloseTo(end.y, 2);
+  });
+});
+
+describe('segmentProgress', () => {
+  it('maps the segment linearly onto [0, 1]', () => {
+    expect(segmentProgress(0.3, 0.3, 0.8)).toBe(0);
+    expect(segmentProgress(0.55, 0.3, 0.8)).toBeCloseTo(0.5);
+    expect(segmentProgress(0.8, 0.3, 0.8)).toBe(1);
+  });
+
+  it('clamps outside the segment, including spring overshoot past 1', () => {
+    expect(segmentProgress(0.1, 0.3, 0.8)).toBe(0);
+    expect(segmentProgress(0.95, 0.3, 0.8)).toBe(1);
+    expect(segmentProgress(1.06, 0.84, 1)).toBe(1);
+  });
+
+  it('treats a degenerate segment as a step', () => {
+    expect(segmentProgress(0.49, 0.5, 0.5)).toBe(0);
+    expect(segmentProgress(0.5, 0.5, 0.5)).toBe(1);
+  });
+});
+
+describe('centerlines', () => {
+  // Guard the hand-reconstructed geometry: each centerline must start and
+  // end at its pen-stroke cap center so the growing mask covers the round
+  // caps from the first and last frames.
+  const firstMove = (d: string) =>
+    d
+      .match(/^M ([\d.-]+) ([\d.-]+)/)!
+      .slice(1, 3)
+      .map(Number);
+  const lastLine = (d: string) =>
+    d
+      .match(/L ([\d.-]+) ([\d.-]+)$/)!
+      .slice(1, 3)
+      .map(Number);
+
+  it('left swirl runs from the top cap to the bottom cap', () => {
+    expect(firstMove(SWIRL_LEFT_CENTERLINE)).toEqual([28.54, 26.38]);
+    expect(lastLine(SWIRL_LEFT_CENTERLINE)).toEqual([28.54, 41.92]);
+  });
+
+  it('right swirl starts on the lower ring at 231° and ends at the end cap', () => {
+    // Start sits on the r=11.1 arc at 231° (no cap lead-in), just below the
+    // ring's mouth so the nib never bridges it; see LOWER_RIM_FROM_DEG.
+    const start = arcPoint(32.05, 49.68, 11.1, 231);
+    const [sx, sy] = firstMove(SWIRL_RIGHT_CENTERLINE);
+    expect(sx).toBeCloseTo(start.x, 1);
+    expect(sy).toBeCloseTo(start.y, 1);
+    expect(lastLine(SWIRL_RIGHT_CENTERLINE)).toEqual([50.81, 41.93]);
+  });
+
+  it('check runs left to right across the tick', () => {
+    expect(firstMove(CHECK_CENTERLINE)).toEqual([24.87, 7.26]);
+    expect(lastLine(CHECK_CENTERLINE)).toEqual([39.72, 3.71]);
+  });
+
+  it('contains no NaN coordinates', () => {
+    for (const d of [SWIRL_LEFT_CENTERLINE, SWIRL_RIGHT_CENTERLINE, CHECK_CENTERLINE]) {
+      expect(d).not.toMatch(/NaN/);
+    }
+  });
+});

--- a/src/screens/OnboardingScreen/logoDraw/utils/constants.ts
+++ b/src/screens/OnboardingScreen/logoDraw/utils/constants.ts
@@ -1,0 +1,64 @@
+import { Easing } from 'react-native-reanimated';
+
+/**
+ * Tuning constants for the logo draw animation. The mask centerline
+ * geometry itself lives in `logoPaths.ts`; the values here are stroke
+ * widths, the master-progress timeline, and the reanimated configs.
+ */
+
+/**
+ * Logo bounds in source-SVG user units. The ink spans x ∈ [-0.33, 64.44]
+ * (left rim curve → upper-ring right rim) and y ∈ [-0.2, 66.73] (check
+ * curve bulge → lower-ring bottom); a 0.5-unit inset on every side keeps
+ * those sub-unit overshoots inside the Canvas, which clips at its bounds.
+ */
+export const LOGO_VIEWBOX_INSET = 0.5;
+export const LOGO_VIEWBOX_WIDTH = 64.44 + 2 * LOGO_VIEWBOX_INSET;
+export const LOGO_VIEWBOX_HEIGHT = 66.73 + 2 * LOGO_VIEWBOX_INSET;
+
+/** Width-over-height aspect ratio of the logo drawing area. */
+export const LOGO_ASPECT_RATIO = LOGO_VIEWBOX_WIDTH / LOGO_VIEWBOX_HEIGHT;
+
+/**
+ * Mask stroke widths in viewBox units. The swirl stroke spans the radial
+ * band [4.94, 17.05] (hole edge → outer rim) around a radius-11.1
+ * centerline, so 12.6 covers it with margin on both sides; wider would be
+ * safer against gaps but the right swirl's start nib must stay clear of
+ * the nearby waist band (see RIGHT_STROKE_START in logoPaths.ts). The
+ * check stroke covers the 7.42-wide tick with ~0.8 margin per side.
+ */
+export const SWIRL_MASK_STROKE_WIDTH = 12.6;
+export const CHECK_MASK_STROKE_WIDTH = 9;
+
+/**
+ * Master-progress sub-segments, sized roughly by centerline arc length
+ * (left swirl ≈ 63 units, right swirl ≈ 114) so the pen speed stays even.
+ * The [0.80, 0.84] gap is a deliberate beat before the green check lands.
+ */
+export const LOGO_DRAW_SEGMENTS = {
+  swirlLeft: { from: 0, to: 0.3 },
+  swirlRight: { from: 0.3, to: 0.8 },
+  check: { from: 0.84, to: 1 },
+} as const;
+
+/** Timing for the orange phase: progress 0 → check.from, ease-in-out. */
+export const logoDrawTiming = {
+  duration: 1300,
+  easing: Easing.inOut(Easing.cubic),
+} as const;
+
+/**
+ * Spring that lands the green check. Its overshoot past progress=1 is safe:
+ * every trim interpolation clamps, and the check group scale consumes the
+ * overshoot as a small rebound instead.
+ */
+export const checkSpringConfig = {
+  damping: 14,
+  stiffness: 180,
+} as const;
+
+/** Peak extra scale the check group reaches while the spring overshoots. */
+export const CHECK_OVERSHOOT_SCALE = 1.04;
+
+/** Progress overshoot (past 1) that maps onto the peak check scale. */
+export const CHECK_OVERSHOOT_RANGE = 0.06;

--- a/src/screens/OnboardingScreen/logoDraw/utils/logoDrawMath.ts
+++ b/src/screens/OnboardingScreen/logoDraw/utils/logoDrawMath.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure geometry helpers for the logo draw animation. No Skia or React
+ * dependencies so everything here is unit-testable in plain jest.
+ *
+ * Angle convention: SVG user space is y-down, so 0° points right (+x) and
+ * angles grow toward +y (visually clockwise on screen). `arcPoint(…, -90)`
+ * is the top of the circle.
+ */
+
+export type Point = { x: number; y: number };
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/** Point on the circle centered at (cx, cy) with radius r at `deg` degrees. */
+export function arcPoint(cx: number, cy: number, r: number, deg: number): Point {
+  const rad = deg * DEG_TO_RAD;
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+const fmt = (n: number): string => String(Number(n.toFixed(2)));
+
+/** `x y` pair formatted for an SVG path string. */
+export function fmtPoint(p: Point): string {
+  return `${fmt(p.x)} ${fmt(p.y)}`;
+}
+
+/**
+ * SVG arc commands sweeping the circle centered at (cx, cy) from `fromDeg`
+ * to `toDeg`. The sweep may exceed 180° and may run backwards (toDeg <
+ * fromDeg); it is split into ≤90° `A` segments so the large-arc flag stays
+ * unambiguous. Returns the command string *without* a leading move — callers
+ * chain it onto a subpath already positioned at the `fromDeg` point.
+ */
+export function buildArcSweep(
+  cx: number,
+  cy: number,
+  r: number,
+  fromDeg: number,
+  toDeg: number,
+): string {
+  const total = toDeg - fromDeg;
+  const segments = Math.max(1, Math.ceil(Math.abs(total) / 90));
+  const sweepFlag = total >= 0 ? 1 : 0;
+  const parts: string[] = [];
+  for (let i = 1; i <= segments; i++) {
+    const p = arcPoint(cx, cy, r, fromDeg + (total * i) / segments);
+    parts.push(`A ${fmt(r)} ${fmt(r)} 0 0 ${sweepFlag} ${fmtPoint(p)}`);
+  }
+  return parts.join(' ');
+}
+
+/**
+ * Maps master progress onto a [from, to] sub-segment, clamped to [0, 1].
+ * Runs inside useDerivedValue, hence the worklet directive. A degenerate
+ * segment (to <= from) acts as a step at `to`.
+ */
+export function segmentProgress(progress: number, from: number, to: number): number {
+  'worklet';
+  if (to <= from) {
+    return progress >= to ? 1 : 0;
+  }
+  const t = (progress - from) / (to - from);
+  return t < 0 ? 0 : t > 1 ? 1 : t;
+}

--- a/src/screens/OnboardingScreen/logoDraw/utils/logoPalette.ts
+++ b/src/screens/OnboardingScreen/logoDraw/utils/logoPalette.ts
@@ -10,6 +10,3 @@ export const logoBrandColors = {
   /** Check mark — the cherry stem (`.cls-2`). */
   check: '#23af69',
 } as const;
-
-/** Debug-only overlay color for the mask centerlines (40% cyan). */
-export const centerlineDebugColor = 'rgba(0, 200, 255, 0.4)';

--- a/src/screens/OnboardingScreen/logoDraw/utils/logoPalette.ts
+++ b/src/screens/OnboardingScreen/logoDraw/utils/logoPalette.ts
@@ -1,0 +1,15 @@
+/**
+ * Brand colors for the animated logo, copied verbatim from the logo SVG
+ * source (`资源 2svg版.svg`). These are fixed brand-asset colors and
+ * intentionally do not follow the app theme — the logo reads the same in
+ * light and dark mode.
+ */
+export const logoBrandColors = {
+  /** Swirl strokes (`.cls-1` in the source SVG). */
+  swirl: '#ea5e5d',
+  /** Check mark — the cherry stem (`.cls-2`). */
+  check: '#23af69',
+} as const;
+
+/** Debug-only overlay color for the mask centerlines (40% cyan). */
+export const centerlineDebugColor = 'rgba(0, 200, 255, 0.4)';

--- a/src/screens/OnboardingScreen/logoDraw/utils/logoPaths.ts
+++ b/src/screens/OnboardingScreen/logoDraw/utils/logoPaths.ts
@@ -1,0 +1,117 @@
+import { arcPoint, buildArcSweep, fmtPoint } from './logoDrawMath';
+
+/**
+ * Logo geometry. All coordinates are in the source-SVG user space
+ * (viewBox `0 0 64.44 66.73`, y-down).
+ *
+ * The three fill paths are copied verbatim from the brand SVG
+ * (`资源 2svg版.svg`). They are filled outlines, not strokes, so the draw
+ * animation reveals them through masks: each mask is a thick round-cap
+ * stroke that grows along a hand-reconstructed *centerline* of the original
+ * pen stroke (Skia `Path` end-trim). Reverse-engineering notes:
+ *
+ * - Both swirls are ~12-unit-thick ring strokes: outer rim r≈17.05, inner
+ *   edge = a small r≈4.94 circular *hole* concentric with each ring center
+ *   (verified by ray casting — the small circles are negative space, not
+ *   filled discs). A radius-11.1 arc centerline with a stroke width of 13
+ *   therefore covers the whole band.
+ * - Round end caps (r≈4.28) sit where each pen stroke starts/ends; the
+ *   centerlines begin/end at those cap centers so the growing mask covers
+ *   the caps from the first frame.
+ * - The right swirl is one continuous S-stroke: lower ring (center O2) →
+ *   waist → upper ring (center O3). Its start cap nearly coincides with the
+ *   left swirl's bottom cap (the two shapes interlock there), which makes
+ *   the left→right handoff read as one continuous gesture.
+ */
+
+/** Left swirl fill (`.cls-1` #1 in the source SVG). */
+export const SWIRL_LEFT_FILL =
+  'M16.72,51.21c-4.45,0-8.64-1.78-11.81-5.01-3.17-3.23-4.91-7.51-4.91-12.04s1.74-8.81,4.91-12.04,7.36-5.01,11.81-5.01,8.71,1.82,11.82,4.99c2.32,2.36,2.32,6.2,0,8.56-2.32,2.36-6.08,2.36-8.4,0-.9-.92-2.15-1.45-3.43-1.45-2.63,0-4.85,2.26-4.85,4.94s2.22,4.94,4.85,4.94c1.28,0,2.52-.53,3.43-1.45,2.32-2.36,6.08-2.36,8.4,0,2.32,2.36,2.32,6.2,0,8.56-3.11,3.17-7.42,4.99-11.82,4.99Z';
+
+/** Right swirl fill (`.cls-1` #2). */
+export const SWIRL_RIGHT_FILL =
+  'M32.05,66.73c-4.45,0-8.64-1.78-11.81-5.01s-4.91-7.51-4.91-12.04,1.79-8.88,4.9-12.06c2.32-2.36,6.08-2.36,8.4,0,2.32,2.36,2.32,6.2,0,8.56-.9.92-1.42,2.19-1.42,3.49,0,2.68,2.22,4.94,4.85,4.94s4.85-2.26,4.85-4.94c0-.95-.23-2.31-1.32-3.43-3.13-3.19-4.92-7.6-4.92-12.09s1.74-8.81,4.91-12.04,7.36-5.01,11.81-5.01,8.64,1.78,11.81,5.01,4.91,7.51,4.91,12.04-1.79,8.88-4.9,12.06c-2.32,2.36-6.08,2.36-8.4,0-2.32-2.36-2.32-6.2,0-8.56.9-.92,1.42-2.19,1.42-3.49,0-2.68-2.22-4.94-4.85-4.94s-4.85,2.26-4.85,4.94c0,1.31.53,2.6,1.45,3.53,3.1,3.16,4.8,7.42,4.8,11.99s-1.74,8.81-4.91,12.04c-3.17,3.23-7.36,5.01-11.81,5.01Z';
+
+/** Check mark fill (`.cls-2`). */
+export const CHECK_FILL =
+  'M32.05,19.09l-9.72-9.12c-1.5-1.4-1.57-3.75-.17-5.25,1.4-1.49,3.75-1.57,5.25-.17l3.89,3.65,5.53-6.83c1.29-1.59,3.63-1.84,5.22-.55,1.59,1.29,1.84,3.63.55,5.22l-10.56,13.05Z';
+
+/** Ring centers of the left swirl (O1), lower-right ring (O2), upper-right ring (O3). */
+export const SWIRL_LEFT_CENTER = { x: 16.72, y: 34.16 };
+export const SWIRL_LOWER_CENTER = { x: 32.05, y: 49.68 };
+export const SWIRL_UPPER_CENTER = { x: 47.39, y: 34.15 };
+
+/** Centerline arc radius — midway across the [4.94, 17.05] ring band. */
+const ARC_RADIUS = 11.1;
+
+/** Pen-stroke end-cap centers (round caps, r≈4.28). */
+const LEFT_CAP_TOP = { x: 28.54, y: 26.38 };
+const LEFT_CAP_BOTTOM = { x: 28.54, y: 41.92 };
+const RIGHT_CAP_END = { x: 50.81, y: 41.93 };
+
+/** Angular positions (deg) where lips/rims meet, from the fill-path anchors. */
+const LEFT_LIP_DEG = 33.35;
+/**
+ * Where the lower-ring sweep starts. The lower ring is a near-closed hook
+ * with a ~6-unit mouth at its top between the interlock lip (~246°) and the
+ * arch that leads to the waist (~270°). A round mask nib (half-width 6.3)
+ * placed inside that mouth bridges it and reveals the far arch as a sliver
+ * detached from the growing outer-rim blob (it only rejoins once the sweep
+ * comes all the way around ~0.3 later). Starting the sweep at 231° — just
+ * below the mouth, so the start nib covers the interlock lip yet stays 7.8
+ * units from the arch (> 6.3) — keeps every revealed frame a single
+ * connected blob. The nib still sits 3.6 units from the C's bottom lip
+ * (< 6.3), so the handoff from the left swirl still reads as continuous.
+ */
+const LOWER_RIM_FROM_DEG = 231;
+const UPPER_RIM_TO_DEG = 405.6;
+
+/**
+ * Left swirl centerline: short radial lead-in from the top cap center,
+ * a 293° arc around O1 (top → left → bottom, i.e. counter-clockwise on
+ * screen), then a radial lead-out onto the bottom cap center.
+ */
+function buildSwirlLeftCenterline(): string {
+  const c = SWIRL_LEFT_CENTER;
+  const start = arcPoint(c.x, c.y, ARC_RADIUS, -LEFT_LIP_DEG);
+  const sweep = buildArcSweep(c.x, c.y, ARC_RADIUS, -LEFT_LIP_DEG, -(360 - LEFT_LIP_DEG));
+  return `M ${fmtPoint(LEFT_CAP_TOP)} L ${fmtPoint(start)} ${sweep} L ${fmtPoint(LEFT_CAP_BOTTOM)}`;
+}
+
+/**
+ * Right swirl centerline, one continuous S-stroke: it starts on the lower
+ * ring at 231° (see LOWER_RIM_FROM_DEG — no separate cap lead-in, which is
+ * what used to bridge the mouth), sweeps the lower-ring arc (231° → 0°
+ * through the bottom), runs a waist cubic whose tangents point straight up
+ * on both ends, sweeps the upper-ring arc (180° → 405.6° over the top), and
+ * leads out onto the end cap.
+ */
+function buildSwirlRightCenterline(): string {
+  const lo = SWIRL_LOWER_CENTER;
+  const up = SWIRL_UPPER_CENTER;
+  const lowerStart = arcPoint(lo.x, lo.y, ARC_RADIUS, LOWER_RIM_FROM_DEG);
+  const lowerSweep = buildArcSweep(lo.x, lo.y, ARC_RADIUS, LOWER_RIM_FROM_DEG, 0);
+  const lowerEnd = arcPoint(lo.x, lo.y, ARC_RADIUS, 0);
+  const upperStart = arcPoint(up.x, up.y, ARC_RADIUS, 180);
+  const upperSweep = buildArcSweep(up.x, up.y, ARC_RADIUS, 180, UPPER_RIM_TO_DEG);
+  const waistPull = 5.5;
+  const waist =
+    `C ${fmtPoint({ x: lowerEnd.x, y: lowerEnd.y - waistPull })} ` +
+    `${fmtPoint({ x: upperStart.x, y: upperStart.y + waistPull })} ${fmtPoint(upperStart)}`;
+  return (
+    `M ${fmtPoint(lowerStart)} ${lowerSweep} ` +
+    `${waist} ${upperSweep} L ${fmtPoint(RIGHT_CAP_END)}`
+  );
+}
+
+/** Check centerline: two straight strokes through the tick, left to right. */
+function buildCheckCenterline(): string {
+  return 'M 24.87 7.26 L 31.68 13.65 L 39.72 3.71';
+}
+
+export const SWIRL_LEFT_CENTERLINE = buildSwirlLeftCenterline();
+export const SWIRL_RIGHT_CENTERLINE = buildSwirlRightCenterline();
+export const CHECK_CENTERLINE = buildCheckCenterline();
+
+/** Center of the check's bounding box — pivot for the landing rebound scale. */
+export const CHECK_PIVOT = { x: 32.3, y: 9.3 };


### PR DESCRIPTION
Adds a standalone `OnboardingScreen` skeleton and a headerless `/onboarding` route, hosting a self-contained `logoDraw` module that paints the brand logo on: the two orange swirls draw first as one continuous gesture, then the green check lands with a spring. Because the logo is filled outlines rather than strokes, each fill path renders inside a Skia alpha `<Mask>` whose content is a thick round-cap stroke growing along a hand-reconstructed pen centerline (Skia `Path` `end`-trim), so the visible pixels are always the real fill and `progress = 1` is pixel-identical to the source SVG. A single master `progress` shared value drives every sub-segment via `useDerivedValue`, keeping all per-frame work on the UI thread, and the component swaps to unmasked fills once settled. Ships pure, unit-tested geometry helpers (arc/segment math + centerline guards), a Skia `Path`/`Mask` jest mock, and a README documenting the reverse-engineered geometry (including the 231° right-sweep start that avoids a detached-sliver artifact) and the controlled-`progress` recalibration seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)