### PR TITLE
feat: add SlotText roll-transition component and wire it into reasoning label

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -17,6 +17,14 @@ if (expoModules) {
 // undefined), so anything depending on a real id breaks under test.
 jest.mock('expo-crypto', () => ({ randomUUID: mockRandomUUID }));
 
+// expo-glass-effect probes UIKit availability at import time and
+// src/config/constants.ts calls it at module scope, so give Jest a static
+// "no glass" stub.
+jest.mock('expo-glass-effect', () => ({
+  isGlassEffectAPIAvailable: () => false,
+  isLiquidGlassAvailable: () => false,
+}));
+
 // Callstack bottom tabs is a Fabric native view and is unavailable in Jest.
 // Keep its layout context present so tab-owned screens can render normally.
 jest.mock('react-native-bottom-tabs', () => {

--- a/src/components/SlotText/README.md
+++ b/src/components/SlotText/README.md
@@ -1,0 +1,48 @@
+# SlotText
+
+`SlotText` renders tactile roll transitions for short, single-line labels, statuses, and counters.
+It is a controlled React Native component backed by Reanimated; changing `text` rolls each changed
+grapheme from the previous committed value to the latest value.
+
+## Public Interface
+
+Import `SlotText` and its public types from `@/components/SlotText`.
+
+```tsx
+<SlotText
+  text={saved ? 'Saved' : 'Save'}
+  textClassName="font-semibold text-foreground text-sm"
+/>
+```
+
+The component accepts animation timing, stagger, bounce, typography, accessibility, and
+font-scaling props. Defaults tuned for snappy status labels: `200ms` glyph duration, `45ms` stagger,
+`24ms` entry offset, and `0.6` bounce. Glyphs always roll downward, and incoming glyphs land
+tinted with the brand highlight (`slotTextHighlightColor` in `src/config/constants.ts`) before
+fading to the regular text color over `colorFadeDurationMs`.
+
+`skipUnchanged` (default `true`) keeps a grapheme static only when it is unchanged *and* its slot
+offset is stable — the measured widths of all preceding slots sum to the same value before and after
+the transition. Stable prefixes (`Copy` → `Copied`) and same-width digit columns (`12:45` → `12:46`)
+stay put, while coincidental same-index matches (the `p` in `In progress` → `Complete`) roll with
+the rest of the line instead of lingering and drifting sideways during the width change.
+
+Each changed grapheme uses two native faces, following the same slot structure as
+`react-native-slot-numbers`: the outgoing and incoming faces translate vertically while scaling,
+fading, and rotating in depth. Grapheme dimensions are measured in a separate hidden layer so the
+animated slot width never constrains the measurement.
+
+## Usage Boundary
+
+- Keep values to one short line. The default maximum is 32 graphemes; longer values render as one
+  static `Text` node and warn in development.
+- Reduced-motion preferences and invalid numeric animation props also use the static path.
+- `Intl.Segmenter` keeps combining marks and joined emoji together when the runtime provides it;
+  older runtimes fall back to Unicode code points.
+- Per-grapheme rendering intentionally gives up kerning and ligatures. Do not use it for Markdown,
+  paragraphs, streamed chat content, or scripts that require shaping across adjacent characters.
+- `textClassName` and `textStyle` are applied to every grapheme, so they should contain typography
+  and color styles rather than per-element spacing or backgrounds.
+
+The module does not own temporary flash state. Callers should update their own controlled `text`
+value when they need a `Save` to `Saved` to `Save` interaction.

--- a/src/components/SlotText/SlotText.tsx
+++ b/src/components/SlotText/SlotText.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useState } from 'react';
+import { type LayoutChangeEvent, Text, View } from 'react-native';
+import { useReducedMotion } from 'react-native-reanimated';
+
+import { slotTextHighlightColor } from '@/config/constants';
+
+import { SlotGlyph } from './components/SlotGlyph';
+import type { SlotTextProps } from './SlotText.types';
+import {
+  calculateAnimatedSlotFlags,
+  calculateTransitionCompletionMs,
+  calculateTransitionPhaseTiming,
+  resolveSlotTextOptions,
+  segmentTextIntoGraphemes,
+} from './utils/slotText';
+
+const animatedTextContainerStyle = {
+  // Fabric can assert while recomputing Text baselines during Reanimated width commits.
+  alignItems: 'flex-start',
+  flexDirection: 'row',
+  position: 'relative',
+} as const;
+
+const measurementLayerStyle = {
+  flexDirection: 'row',
+  left: 0,
+  opacity: 0,
+  position: 'absolute',
+  top: 0,
+  width: 10_000,
+} as const;
+
+type SegmentMetrics = {
+  height: number;
+  width: number;
+};
+
+type TextTransition = {
+  canAnimate: boolean;
+  fromText: string;
+  id: number;
+  targetText: string;
+};
+
+export function SlotText({
+  accessibilityLabel,
+  allowFontScaling,
+  bounce,
+  colorFadeDurationMs,
+  containerStyle,
+  durationMs,
+  exitOffsetMs,
+  maxFontSizeMultiplier,
+  maxGraphemes,
+  skipUnchanged,
+  staggerMs,
+  testID,
+  text,
+  textClassName,
+  textStyle,
+}: SlotTextProps) {
+  const reducedMotion = useReducedMotion();
+  const resolved = resolveSlotTextOptions({
+    bounce,
+    colorFadeDurationMs,
+    durationMs,
+    exitOffsetMs,
+    maxGraphemes,
+    skipUnchanged,
+    staggerMs,
+  });
+  const targetSegments = segmentTextIntoGraphemes(text);
+  const isOverLimit = resolved.isValid && targetSegments.length > resolved.options.maxGraphemes;
+  const canAnimate = resolved.isValid && !reducedMotion && !isOverLimit;
+  const [transition, setTransition] = useState<TextTransition>(() => ({
+    canAnimate,
+    fromText: text,
+    id: 0,
+    targetText: text,
+  }));
+  const [segmentMetrics, setSegmentMetrics] = useState<ReadonlyMap<string, SegmentMetrics>>(
+    () => new Map(),
+  );
+
+  // Retarget during render (not in an effect): an effect lets React commit one frame
+  // where the new text renders statically at its final pose, which flashes on screen
+  // before the transition state catches up.
+  if (transition.targetText !== text || transition.canAnimate !== canAnimate) {
+    setTransition(
+      !canAnimate || !transition.canAnimate
+        ? { canAnimate, fromText: text, id: transition.id + 1, targetText: text }
+        : {
+            canAnimate,
+            fromText: transition.targetText,
+            id: transition.id + 1,
+            targetText: text,
+          },
+    );
+  }
+
+  useEffect(() => {
+    if (__DEV__ && isOverLimit) {
+      console.warn(
+        `SlotText received ${targetSegments.length} graphemes; ` +
+          `rendering static text because maxGraphemes is ${resolved.options.maxGraphemes}.`,
+      );
+    }
+  }, [isOverLimit, resolved.options.maxGraphemes, targetSegments.length]);
+
+  const hasCurrentTransition = transition.targetText === text && transition.canAnimate;
+  const fromSegments = hasCurrentTransition
+    ? segmentTextIntoGraphemes(transition.fromText)
+    : targetSegments;
+  const shouldAnimateTransition =
+    canAnimate && hasCurrentTransition && transition.fromText !== transition.targetText;
+  const measurementSegments = Array.from(
+    new Set([...fromSegments, ...targetSegments].filter(Boolean)),
+  );
+  const hasFromMetrics = fromSegments.every(
+    (segment) => segment === '' || segmentMetrics.has(segment),
+  );
+  const hasAllMetrics = measurementSegments.every((segment) => segmentMetrics.has(segment));
+  const animatedSlotFlags = calculateAnimatedSlotFlags(
+    fromSegments,
+    targetSegments,
+    resolved.options,
+    (segment) => segmentMetrics.get(segment)?.width ?? 0,
+  );
+  const transitionPhaseTiming = calculateTransitionPhaseTiming(
+    fromSegments,
+    animatedSlotFlags,
+    resolved.options,
+  );
+  const transitionCompletionMs = shouldAnimateTransition
+    ? calculateTransitionCompletionMs(
+        fromSegments,
+        targetSegments,
+        animatedSlotFlags,
+        resolved.options,
+        true,
+      )
+    : 0;
+
+  useEffect(() => {
+    if (!hasAllMetrics || !shouldAnimateTransition) {
+      return;
+    }
+
+    const transitionId = transition.id;
+    const timeout = setTimeout(() => {
+      setTransition((current) => {
+        if (current.id !== transitionId || current.targetText !== text) {
+          return current;
+        }
+
+        return { ...current, fromText: current.targetText };
+      });
+    }, transitionCompletionMs);
+
+    return () => clearTimeout(timeout);
+  }, [hasAllMetrics, shouldAnimateTransition, text, transition.id, transitionCompletionMs]);
+
+  if (!canAnimate) {
+    return (
+      <View
+        accessibilityLabel={accessibilityLabel ?? text}
+        accessibilityRole="text"
+        accessible
+        pointerEvents="none"
+        style={[animatedTextContainerStyle, containerStyle]}
+        testID={testID}
+      >
+        <Text
+          accessible={false}
+          allowFontScaling={allowFontScaling}
+          className={textClassName}
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+          numberOfLines={1}
+          style={textStyle}
+        >
+          {text}
+        </Text>
+      </View>
+    );
+  }
+
+  const slotCount = hasAllMetrics
+    ? Math.max(fromSegments.length, targetSegments.length)
+    : fromSegments.length;
+
+  const handleSegmentLayout = (segment: string, event: LayoutChangeEvent) => {
+    const { height, width } = event.nativeEvent.layout;
+    setSegmentMetrics((current) => {
+      const previous = current.get(segment);
+      if (previous?.height === height && previous.width === width) {
+        return current;
+      }
+
+      const next = new Map(current);
+      next.set(segment, { height, width });
+      return next;
+    });
+  };
+
+  return (
+    <View
+      accessibilityLabel={accessibilityLabel ?? text}
+      accessibilityRole="text"
+      accessible
+      pointerEvents="none"
+      style={[animatedTextContainerStyle, containerStyle]}
+      testID={testID}
+    >
+      {hasFromMetrics ? (
+        Array.from({ length: slotCount }, (_, index) => {
+          const currentSegment = fromSegments[index] ?? '';
+          const requestedTargetSegment = targetSegments[index] ?? '';
+          const targetSegment = hasAllMetrics ? requestedTargetSegment : currentSegment;
+          const currentMetrics = segmentMetrics.get(currentSegment);
+          const targetMetrics = segmentMetrics.get(targetSegment);
+          const height = Math.max(currentMetrics?.height ?? 0, targetMetrics?.height ?? 0);
+          const shouldAnimate =
+            hasAllMetrics && shouldAnimateTransition && animatedSlotFlags[index];
+          const resolvedHighlightColor = targetSegment ? slotTextHighlightColor : undefined;
+
+          return (
+            <SlotGlyph
+              // biome-ignore lint/suspicious/noArrayIndexKey: Slot identity is positional by design.
+              key={index}
+              allowFontScaling={allowFontScaling}
+              currentSegment={currentSegment}
+              currentWidth={currentMetrics?.width ?? 0}
+              entryPhaseStartMs={transitionPhaseTiming.entryPhaseStartMs}
+              exitPhaseDurationMs={transitionPhaseTiming.exitPhaseDurationMs}
+              height={height}
+              highlightColor={resolvedHighlightColor}
+              index={index}
+              maxFontSizeMultiplier={maxFontSizeMultiplier}
+              options={resolved.options}
+              segmentCount={targetSegments.length}
+              shouldAnimate={shouldAnimate}
+              targetSegment={targetSegment}
+              targetWidth={targetMetrics?.width ?? 0}
+              textClassName={textClassName}
+              textStyle={textStyle}
+              transitionId={transition.id}
+            />
+          );
+        })
+      ) : (
+        <Text
+          accessible={false}
+          allowFontScaling={allowFontScaling}
+          className={textClassName}
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+          numberOfLines={1}
+          style={textStyle}
+        >
+          {transition.fromText}
+        </Text>
+      )}
+
+      <View
+        accessibilityElementsHidden
+        accessible={false}
+        importantForAccessibility="no"
+        pointerEvents="none"
+        style={measurementLayerStyle}
+      >
+        {measurementSegments.map((segment) => (
+          <Text
+            accessible={false}
+            allowFontScaling={allowFontScaling}
+            className={textClassName}
+            key={segment}
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
+            numberOfLines={1}
+            onLayout={(event) => handleSegmentLayout(segment, event)}
+            style={textStyle}
+          >
+            {segment === ' ' ? '\u00A0' : segment}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/components/SlotText/SlotText.types.ts
+++ b/src/components/SlotText/SlotText.types.ts
@@ -1,0 +1,32 @@
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+export type SlotTextProps = {
+  accessibilityLabel?: string;
+  allowFontScaling?: boolean;
+  /** Strength of deterministic per-grapheme timing variation and tilt. */
+  bounce?: number;
+  colorFadeDurationMs?: number;
+  containerStyle?: StyleProp<ViewStyle>;
+  durationMs?: number;
+  exitOffsetMs?: number;
+  /** Longer values render as one static Text node instead of grapheme slots. */
+  maxGraphemes?: number;
+  maxFontSizeMultiplier?: number;
+  /** Keep a grapheme static only when it is unchanged and its slot offset will not move. */
+  skipUnchanged?: boolean;
+  staggerMs?: number;
+  testID?: string;
+  text: string;
+  textClassName?: string;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+export type ResolvedSlotTextOptions = {
+  bounce: number;
+  colorFadeDurationMs: number;
+  durationMs: number;
+  exitOffsetMs: number;
+  maxGraphemes: number;
+  skipUnchanged: boolean;
+  staggerMs: number;
+};

--- a/src/components/SlotText/__tests__/SlotText.test.tsx
+++ b/src/components/SlotText/__tests__/SlotText.test.tsx
@@ -1,0 +1,419 @@
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { slotTextHighlightColor } from '@/config/constants';
+
+import { SlotText } from '../SlotText';
+
+const mockCancelAnimation = jest.fn();
+const mockWithTiming = jest.fn(
+  (value: unknown, _config?: unknown, _callback?: (finished?: boolean) => void) => value,
+);
+let mockReducedMotion = false;
+
+const mockCompositeAnimation = {
+  _isUsingNativeDriver: () => false,
+  _startNativeLoop: jest.fn(),
+  reset: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+};
+
+jest.spyOn(Animated, 'timing').mockImplementation(() => mockCompositeAnimation);
+jest.spyOn(Animated, 'parallel').mockImplementation(() => mockCompositeAnimation);
+
+jest.mock('react-native-reanimated', () => {
+  const { View: NativeView } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: { View: NativeView },
+    cancelAnimation: (...args: unknown[]) => mockCancelAnimation(...args),
+    Easing: {
+      bezier: jest.fn(() => (value: number) => value),
+      linear: (value: number) => value,
+    },
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    useReducedMotion: () => mockReducedMotion,
+    useSharedValue: (initialValue: unknown) => {
+      const shared = {
+        value: initialValue,
+        get: () => shared.value,
+        set: (nextValue: unknown) => {
+          shared.value = nextValue;
+        },
+      };
+      return shared;
+    },
+    withDelay: (_delayMs: number, animation: unknown) => animation,
+    withTiming: (value: unknown, config?: unknown, callback?: (finished?: boolean) => void) =>
+      mockWithTiming(value, config, callback),
+  };
+});
+
+describe('SlotText', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockCancelAnimation.mockClear();
+    mockWithTiming.mockClear();
+    mockReducedMotion = false;
+  });
+
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
+  });
+
+  test('renders grapheme slots without animating the initial value', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText testID="slot-text" text="A😀" />);
+    });
+
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+
+    fireTextLayouts(renderer);
+
+    const root = findHostViewByTestId(renderer, 'slot-text');
+    expect(root.props.accessibilityLabel).toBe('A😀');
+    expect(root.props.accessibilityRole).toBe('text');
+    expect(findInternalSlots(renderer)).toHaveLength(2);
+    expect(mockWithTiming).not.toHaveBeenCalled();
+  });
+
+  test('keeps only the latest requested value during rapid updates', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText text="A" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="B" />);
+    });
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="C" />);
+    });
+
+    const internalText = findInternalText(createdRenderer);
+    expect(internalText).toContain('B');
+    expect(internalText).toContain('C');
+    expect(internalText).not.toContain('A');
+  });
+
+  test('does not roll unchanged graphemes by default', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText text="Copy" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="Copied" />);
+    });
+    fireTextLayouts(createdRenderer);
+
+    const slots = findInternalSlots(createdRenderer);
+    const unchangedFirstSlotText = slots[0]
+      .findAllByType(Text)
+      .flatMap((node) => findTextChildren(node));
+    expect(unchangedFirstSlotText.filter((value) => value === 'C')).toHaveLength(1);
+  });
+
+  test('rolls a coincidentally matching grapheme when its slot offset moves', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText text="In progress" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="Complete" />);
+    });
+    fireTextLayouts(createdRenderer);
+
+    // Index 3 is "p" in both texts, but "In " and "Com" have different widths,
+    // so a static "p" would drift sideways while surrounding slots resize.
+    // An animated slot renders outgoing, incoming, and highlight faces.
+    const slotTexts = findInternalSlots(createdRenderer)[3]
+      .findAllByType(Text)
+      .flatMap((node) => findTextChildren(node));
+    expect(slotTexts.filter((value) => value === 'p')).toHaveLength(3);
+  });
+
+  test('grows and shrinks the positional slot set', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText text="Hi" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="Hello" />);
+    });
+    fireTextLayouts(createdRenderer);
+    expect(findInternalSlots(createdRenderer)).toHaveLength(5);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="Yo" />);
+    });
+    fireTextLayouts(createdRenderer);
+    expect(findInternalSlots(createdRenderer)).toHaveLength(5);
+  });
+
+  test('cleans up outgoing faces and removed slots after the transition', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText text="Long" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="Go" />);
+    });
+    fireTextLayouts(createdRenderer);
+    expect(findInternalSlots(createdRenderer)).toHaveLength(4);
+    expect(findInternalText(createdRenderer)).toContain('L');
+
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(findInternalSlots(createdRenderer)).toHaveLength(2);
+    expect(findInternalText(createdRenderer)).not.toContain('L');
+    expect(findInternalText(createdRenderer)).toEqual(expect.arrayContaining(['G', 'o']));
+  });
+
+  test('expands a new slot to its independently measured glyph width', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText text="A" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+    mockWithTiming.mockClear();
+
+    act(() => {
+      createdRenderer.update(<SlotText text="AW" />);
+    });
+    fireTextLayouts(createdRenderer);
+
+    expect(findInternalSlots(createdRenderer)).toHaveLength(2);
+    expect(mockWithTiming).toHaveBeenCalledWith(
+      24,
+      expect.objectContaining({ duration: expect.any(Number) }),
+      undefined,
+    );
+  });
+
+  test('supports an empty initial value without creating slots', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText testID="slot-text" text="" />);
+    });
+
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+
+    expect(findHostViewByTestId(renderer, 'slot-text').props.accessibilityLabel).toBe('');
+    expect(findInternalSlots(renderer)).toHaveLength(0);
+  });
+
+  test('tints incoming glyphs with the fixed brand highlight', () => {
+    let renderer: ReactTestRenderer | undefined;
+    act(() => {
+      renderer = create(<SlotText text="Go" />);
+    });
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    act(() => {
+      createdRenderer.update(<SlotText text="Hi" />);
+    });
+    fireTextLayouts(createdRenderer);
+
+    const highlighted = createdRenderer.root
+      .findAllByType(Text)
+      .filter((node) => StyleSheet.flatten(node.props.style)?.color === slotTextHighlightColor);
+    expect(highlighted).toHaveLength(2);
+  });
+
+  test('renders one static Text node when reduced motion is enabled', () => {
+    mockReducedMotion = true;
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText testID="slot-text" text="Static" />);
+    });
+
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+
+    const root = findHostViewByTestId(renderer, 'slot-text');
+    expect(root.findByType(Text).props.children).toBe('Static');
+    expect(findInternalSlots(renderer)).toHaveLength(0);
+  });
+
+  test('falls back and warns when text exceeds the grapheme limit', () => {
+    const warning = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText maxGraphemes={3} testID="slot-text" text="Long" />);
+    });
+
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    expect(findHostViewByTestId(renderer, 'slot-text').findByType(Text).props.children).toBe(
+      'Long',
+    );
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('received 4 graphemes'));
+    warning.mockRestore();
+  });
+
+  test('falls back without scheduling animation for invalid options', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(<SlotText durationMs={-1} testID="slot-text" text="Invalid" />);
+    });
+
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    expect(findHostViewByTestId(renderer, 'slot-text').findByType(Text).props.children).toBe(
+      'Invalid',
+    );
+    expect(mockWithTiming).not.toHaveBeenCalled();
+  });
+
+  test('hides every animation node from accessibility and cancels on unmount', () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    act(() => {
+      renderer = create(
+        <SlotText accessibilityLabel="Current status" testID="slot-text" text="Ready" />,
+      );
+    });
+
+    if (!renderer) {
+      throw new Error('SlotText test renderer was not created.');
+    }
+    const createdRenderer = renderer;
+    fireTextLayouts(createdRenderer);
+
+    const root = findHostViewByTestId(createdRenderer, 'slot-text');
+    expect(root.props.accessible).toBe(true);
+    expect(root.props.accessibilityLabel).toBe('Current status');
+    expect(
+      findInternalSlots(createdRenderer).every((slot) => slot.props.accessible === false),
+    ).toBe(true);
+    expect(
+      createdRenderer.root
+        .findAllByType(Text)
+        .every((textNode) => textNode.props.accessible === false),
+    ).toBe(true);
+
+    act(() => createdRenderer.unmount());
+    expect(mockCancelAnimation).toHaveBeenCalled();
+  });
+});
+
+function findInternalSlots(renderer: ReactTestRenderer) {
+  return renderer.root
+    .findAllByType(View)
+    .filter((view) => view.props.importantForAccessibility === 'no-hide-descendants');
+}
+
+function findInternalText(renderer: ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByType(Text)
+    .flatMap((node) => findTextChildren(node))
+    .filter((value) => value !== '\u00A0');
+}
+
+function findTextChildren(node: { props: { children?: unknown } }): string[] {
+  const { children } = node.props;
+  if (typeof children === 'string') {
+    return [children];
+  }
+  if (Array.isArray(children)) {
+    return children.filter((child): child is string => typeof child === 'string');
+  }
+  return [];
+}
+
+const MOCK_GLYPH_WIDTHS: Record<string, number> = {
+  ' ': 6,
+  '\u00A0': 6,
+  C: 16,
+  I: 6,
+  m: 20,
+  W: 24,
+};
+
+function fireTextLayouts(renderer: ReactTestRenderer) {
+  act(() => {
+    renderer.root.findAllByType(Text).forEach((node) => {
+      if (typeof node.props.onLayout !== 'function') {
+        return;
+      }
+
+      const text = findTextChildren(node).join('');
+      const width = MOCK_GLYPH_WIDTHS[text] ?? Math.max(8, Array.from(text).length * 8);
+      node.props.onLayout({
+        nativeEvent: {
+          layout: { height: 20, width },
+        },
+      });
+    });
+  });
+}
+
+function findHostViewByTestId(renderer: ReactTestRenderer, testID: string) {
+  const node = renderer.root.findAllByType(View).find((view) => view.props.testID === testID);
+  if (!node) {
+    throw new Error(`Could not find View with testID ${testID}.`);
+  }
+  return node;
+}

--- a/src/components/SlotText/components/SlotGlyph.tsx
+++ b/src/components/SlotText/components/SlotGlyph.tsx
@@ -1,0 +1,325 @@
+import { useLayoutEffect, useMemo } from 'react';
+import { Animated, Easing, type StyleProp, Text, type TextStyle, View } from 'react-native';
+import Reanimated, {
+  cancelAnimation,
+  Easing as ReanimatedEasing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+
+import type { ResolvedSlotTextOptions } from '../SlotText.types';
+import { calculateSlotTransitionTiming, getVisibleSegmentText } from '../utils/slotText';
+
+const faceEasing = Easing.bezier(0.23, 0, 0.23, 0.99);
+const widthEasing = ReanimatedEasing.bezier(0.2, 0, 0, 1);
+
+const slotStyle = {
+  flexShrink: 0,
+  overflow: 'hidden',
+  position: 'relative',
+} as const;
+
+const faceStyle = {
+  alignItems: 'center',
+  bottom: 0,
+  justifyContent: 'center',
+  left: 0,
+  position: 'absolute',
+  right: 0,
+  top: 0,
+} as const;
+
+type SlotGlyphProps = {
+  allowFontScaling?: boolean;
+  currentSegment: string;
+  currentWidth: number;
+  entryPhaseStartMs: number;
+  exitPhaseDurationMs: number;
+  height: number;
+  highlightColor?: string;
+  index: number;
+  maxFontSizeMultiplier?: number;
+  options: ResolvedSlotTextOptions;
+  segmentCount: number;
+  shouldAnimate: boolean;
+  targetSegment: string;
+  targetWidth: number;
+  textClassName?: string;
+  textStyle?: StyleProp<TextStyle>;
+  transitionId: number;
+};
+
+type GlyphTextProps = Pick<
+  SlotGlyphProps,
+  'allowFontScaling' | 'maxFontSizeMultiplier' | 'textClassName' | 'textStyle'
+> & {
+  color?: string;
+  segment: string;
+};
+
+export function SlotGlyph({
+  allowFontScaling,
+  currentSegment,
+  currentWidth,
+  entryPhaseStartMs,
+  exitPhaseDurationMs,
+  height,
+  highlightColor,
+  index,
+  maxFontSizeMultiplier,
+  options,
+  segmentCount,
+  shouldAnimate,
+  targetSegment,
+  targetWidth,
+  textClassName,
+  textStyle,
+  transitionId,
+}: SlotGlyphProps) {
+  const slotWidth = useSharedValue(currentWidth);
+
+  const transitionSignature = `${transitionId}:${currentSegment.length}:${currentSegment}:${targetSegment}`;
+  // Faces must mount already posed at their transition start values; seeding them only in
+  // the layout effect can paint one native frame at the final pose first, which shows the
+  // incoming glyph overlapping the outgoing one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Poses re-seed per transition; geometry changes re-seed in the layout effect below.
+  const faces = useMemo(
+    () => ({
+      highlightOpacity: new Animated.Value(shouldAnimate && highlightColor ? 1 : 0),
+      incomingY: new Animated.Value(shouldAnimate ? -height : 0),
+      outgoingY: new Animated.Value(0),
+    }),
+    [transitionSignature],
+  );
+  const { highlightOpacity, incomingY, outgoingY } = faces;
+  const slotTiming = calculateSlotTransitionTiming(
+    index,
+    segmentCount,
+    currentSegment,
+    targetSegment,
+    options,
+    { entryPhaseStartMs, exitPhaseDurationMs },
+    Boolean(highlightColor),
+  );
+  const glyphTiming = slotTiming.entry;
+  const widthTiming = slotTiming.width;
+  const rotationDegrees = 30 + options.bounce * 25 + glyphTiming.startingTiltDegrees;
+  const minimumScale = 0.25 + (1 - options.bounce) * 0.2;
+
+  useLayoutEffect(() => {
+    void transitionSignature;
+    cancelAnimation(slotWidth);
+    outgoingY.stopAnimation();
+    incomingY.stopAnimation();
+    highlightOpacity.stopAnimation();
+
+    if (!shouldAnimate) {
+      slotWidth.set(targetWidth);
+      outgoingY.setValue(0);
+      incomingY.setValue(0);
+      highlightOpacity.setValue(0);
+      return;
+    }
+
+    slotWidth.set(currentWidth);
+    slotWidth.set(
+      withDelay(
+        widthTiming.startDelayMs,
+        withTiming(targetWidth, {
+          duration: widthTiming.durationMs,
+          easing: widthEasing,
+        }),
+      ),
+    );
+
+    outgoingY.setValue(0);
+    incomingY.setValue(-height);
+    highlightOpacity.setValue(highlightColor ? 1 : 0);
+
+    const animations = [
+      Animated.timing(outgoingY, {
+        duration: slotTiming.exitDurationMs,
+        easing: faceEasing,
+        toValue: height,
+        useNativeDriver: true,
+      }),
+      Animated.timing(incomingY, {
+        delay: glyphTiming.startDelayMs,
+        duration: glyphTiming.durationMs,
+        easing: faceEasing,
+        toValue: 0,
+        useNativeDriver: true,
+      }),
+    ];
+
+    if (highlightColor) {
+      animations.push(
+        Animated.timing(highlightOpacity, {
+          delay: glyphTiming.startDelayMs + glyphTiming.durationMs,
+          duration: options.colorFadeDurationMs,
+          easing: Easing.linear,
+          toValue: 0,
+          useNativeDriver: true,
+        }),
+      );
+    }
+
+    Animated.parallel(animations).start();
+
+    return () => {
+      outgoingY.stopAnimation();
+      incomingY.stopAnimation();
+      highlightOpacity.stopAnimation();
+      cancelAnimation(slotWidth);
+    };
+  }, [
+    currentWidth,
+    glyphTiming.durationMs,
+    glyphTiming.startDelayMs,
+    height,
+    highlightColor,
+    highlightOpacity,
+    incomingY,
+    options.colorFadeDurationMs,
+    outgoingY,
+    shouldAnimate,
+    slotTiming.exitDurationMs,
+    slotWidth,
+    targetWidth,
+    transitionSignature,
+    widthTiming.durationMs,
+    widthTiming.startDelayMs,
+  ]);
+
+  const animatedSlotStyle = useAnimatedStyle(() => ({
+    width: Math.max(0, slotWidth.get()),
+  }));
+  const outgoingStyle = createFaceAnimationStyle(outgoingY, height, minimumScale, rotationDegrees);
+  const incomingStyle = createFaceAnimationStyle(incomingY, height, minimumScale, rotationDegrees);
+  const highlightIncomingStyle = createFaceAnimationStyle(
+    incomingY,
+    height,
+    minimumScale,
+    rotationDegrees,
+  );
+
+  return (
+    <Reanimated.View
+      accessibilityElementsHidden
+      accessible={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      style={[slotStyle, { height }, animatedSlotStyle]}
+    >
+      {shouldAnimate ? (
+        <>
+          {currentSegment ? (
+            <Animated.View style={[faceStyle, outgoingStyle]}>
+              <GlyphText
+                allowFontScaling={allowFontScaling}
+                maxFontSizeMultiplier={maxFontSizeMultiplier}
+                segment={currentSegment}
+                textClassName={textClassName}
+                textStyle={textStyle}
+              />
+            </Animated.View>
+          ) : null}
+          {targetSegment ? (
+            <>
+              <Animated.View style={[faceStyle, incomingStyle]}>
+                <GlyphText
+                  allowFontScaling={allowFontScaling}
+                  maxFontSizeMultiplier={maxFontSizeMultiplier}
+                  segment={targetSegment}
+                  textClassName={textClassName}
+                  textStyle={textStyle}
+                />
+              </Animated.View>
+              {highlightColor ? (
+                <Animated.View
+                  style={[faceStyle, highlightIncomingStyle, { opacity: highlightOpacity }]}
+                >
+                  <GlyphText
+                    allowFontScaling={allowFontScaling}
+                    color={highlightColor}
+                    maxFontSizeMultiplier={maxFontSizeMultiplier}
+                    segment={targetSegment}
+                    textClassName={textClassName}
+                    textStyle={textStyle}
+                  />
+                </Animated.View>
+              ) : null}
+            </>
+          ) : null}
+        </>
+      ) : (
+        <View style={faceStyle}>
+          <GlyphText
+            allowFontScaling={allowFontScaling}
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
+            segment={targetSegment}
+            textClassName={textClassName}
+            textStyle={textStyle}
+          />
+        </View>
+      )}
+    </Reanimated.View>
+  );
+}
+
+function createFaceAnimationStyle(
+  translateY: Animated.Value,
+  height: number,
+  minimumScale: number,
+  rotationDegrees: number,
+) {
+  const safeHeight = Math.max(1, height);
+  return {
+    opacity: translateY.interpolate({
+      extrapolate: 'clamp',
+      inputRange: [-safeHeight, 0, safeHeight],
+      outputRange: [0, 1, 0],
+    }),
+    transform: [
+      { translateY },
+      {
+        scale: translateY.interpolate({
+          extrapolate: 'clamp',
+          inputRange: [-safeHeight, 0, safeHeight],
+          outputRange: [minimumScale, 1, minimumScale],
+        }),
+      },
+      {
+        rotateX: translateY.interpolate({
+          extrapolate: 'clamp',
+          inputRange: [-safeHeight, 0, safeHeight],
+          outputRange: [`${rotationDegrees}deg`, '0deg', `${-rotationDegrees}deg`],
+        }),
+      },
+    ],
+  };
+}
+
+function GlyphText({
+  allowFontScaling,
+  color,
+  maxFontSizeMultiplier,
+  segment,
+  textClassName,
+  textStyle,
+}: GlyphTextProps) {
+  return (
+    <Text
+      accessible={false}
+      allowFontScaling={allowFontScaling}
+      className={textClassName}
+      maxFontSizeMultiplier={maxFontSizeMultiplier}
+      numberOfLines={1}
+      style={[textStyle, color ? { color } : undefined]}
+    >
+      {getVisibleSegmentText(segment)}
+    </Text>
+  );
+}

--- a/src/components/SlotText/index.ts
+++ b/src/components/SlotText/index.ts
@@ -1,0 +1,2 @@
+export { SlotText } from './SlotText';
+export type { SlotTextProps } from './SlotText.types';

--- a/src/components/SlotText/utils/__tests__/slotText.test.ts
+++ b/src/components/SlotText/utils/__tests__/slotText.test.ts
@@ -1,0 +1,193 @@
+import {
+  calculateAnimatedSlotFlags,
+  calculateGlyphTiming,
+  calculateSlotCompletionMs,
+  calculateSlotTransitionTiming,
+  calculateTransitionCompletionMs,
+  calculateTransitionPhaseTiming,
+  calculateWidthTiming,
+  getVisibleSegmentText,
+  resolveSlotTextOptions,
+  segmentTextIntoGraphemes,
+} from '../slotText';
+
+const uniformWidth = () => 10;
+
+function widthFromTable(widths: Record<string, number>) {
+  return (segment: string) => widths[segment] ?? 10;
+}
+
+describe('slotText utilities', () => {
+  test.each([
+    ['astral emoji', '😀'],
+    ['joined emoji', '👨‍👩‍👧'],
+    ['combining marks', 'e\u0301'],
+  ])('keeps %s in one grapheme slot', (_name, value) => {
+    expect(segmentTextIntoGraphemes(value)).toEqual([value]);
+  });
+
+  test('preserves spaces inside independently measured slots', () => {
+    expect(getVisibleSegmentText(' ')).toBe('\u00A0');
+    expect(getVisibleSegmentText('A')).toBe('A');
+  });
+
+  test('resolves the public defaults', () => {
+    expect(resolveSlotTextOptions({})).toEqual({
+      isValid: true,
+      options: {
+        bounce: 0.6,
+        colorFadeDurationMs: 280,
+        durationMs: 200,
+        exitOffsetMs: 24,
+        maxGraphemes: 32,
+        skipUnchanged: true,
+        staggerMs: 45,
+      },
+    });
+  });
+
+  test('clamps finite bounce values and floors the grapheme limit', () => {
+    expect(resolveSlotTextOptions({ bounce: 2, maxGraphemes: 12.8 }).options).toMatchObject({
+      bounce: 1,
+      maxGraphemes: 12,
+    });
+    expect(resolveSlotTextOptions({ bounce: -1 }).options.bounce).toBe(0);
+  });
+
+  test.each([
+    { durationMs: -1 },
+    { staggerMs: Number.NaN },
+    { exitOffsetMs: Number.POSITIVE_INFINITY },
+    { colorFadeDurationMs: -1 },
+    { bounce: Number.NaN },
+    { maxGraphemes: 0 },
+  ])('marks invalid numeric options for static fallback', (props) => {
+    expect(resolveSlotTextOptions(props)).toMatchObject({ isValid: false });
+  });
+
+  test('calculates deterministic timing without variation when bounce is zero', () => {
+    expect(
+      calculateGlyphTiming(2, 5, false, {
+        bounce: 0,
+        durationMs: 300,
+        staggerMs: 45,
+      }),
+    ).toEqual({
+      durationMs: 300,
+      startDelayMs: 90,
+      startingTiltDegrees: 0,
+    });
+  });
+
+  test('shortens and groups trailing slot timing', () => {
+    expect(
+      calculateGlyphTiming(4, 2, true, {
+        bounce: 0,
+        durationMs: 300,
+        staggerMs: 40,
+      }),
+    ).toEqual({
+      durationMs: 225,
+      startDelayMs: 60,
+      startingTiltDegrees: 0,
+    });
+  });
+
+  test('expands new slots and delays removed-slot collapse', () => {
+    const glyphTiming = { durationMs: 300, startDelayMs: 90, startingTiltDegrees: 0 };
+
+    expect(calculateWidthTiming('', 'A', glyphTiming)).toEqual({
+      durationMs: 140,
+      startDelayMs: 90,
+    });
+    expect(calculateWidthTiming('A', '', glyphTiming)).toEqual({
+      durationMs: 180,
+      startDelayMs: 255,
+    });
+  });
+
+  test('waits for width and optional color animations before settling', () => {
+    const glyphTiming = { durationMs: 300, startDelayMs: 90, startingTiltDegrees: 0 };
+    const widthTiming = { durationMs: 180, startDelayMs: 255 };
+
+    expect(calculateSlotCompletionMs(glyphTiming, widthTiming, 50, 280, false)).toBe(440);
+    expect(calculateSlotCompletionMs(glyphTiming, widthTiming, 50, 280, true)).toBe(720);
+  });
+
+  test('skips unchanged slots only while their horizontal offset stays put', () => {
+    const options = resolveSlotTextOptions({}).options;
+
+    expect(
+      calculateAnimatedSlotFlags(
+        segmentTextIntoGraphemes('12:45'),
+        segmentTextIntoGraphemes('12:46'),
+        options,
+        uniformWidth,
+      ),
+    ).toEqual([false, false, false, false, true]);
+    expect(
+      calculateAnimatedSlotFlags(
+        segmentTextIntoGraphemes('Copy'),
+        segmentTextIntoGraphemes('Copied'),
+        options,
+        widthFromTable({ d: 12, e: 9, i: 4, y: 9 }),
+      ),
+    ).toEqual([false, false, false, true, true, true]);
+  });
+
+  test('rolls coincidentally matching graphemes once earlier widths diverge', () => {
+    const options = resolveSlotTextOptions({}).options;
+    const flags = calculateAnimatedSlotFlags(
+      segmentTextIntoGraphemes('In progress'),
+      segmentTextIntoGraphemes('Complete'),
+      options,
+      widthFromTable({ ' ': 6, C: 16, I: 6, m: 20 }),
+    );
+
+    // Index 3 "p" matches by coincidence, but "In " (24) and "Com" (46) shift its slot.
+    expect(flags).toEqual(Array.from({ length: 11 }, () => true));
+  });
+
+  test('rolls every slot when skipUnchanged is disabled', () => {
+    const options = resolveSlotTextOptions({ skipUnchanged: false }).options;
+
+    expect(calculateAnimatedSlotFlags(['A', 'B'], ['A', 'B'], options, uniformWidth)).toEqual([
+      true,
+      true,
+    ]);
+  });
+
+  test('settles after the longest changed slot and ignores skipped slots', () => {
+    const options = resolveSlotTextOptions({ bounce: 0 }).options;
+
+    expect(
+      calculateTransitionCompletionMs(['A', 'B'], ['A', 'C'], [false, true], options, false),
+    ).toBe(399);
+    expect(calculateTransitionCompletionMs(['A'], ['A'], [false], options, true)).toBe(0);
+    expect(calculateTransitionCompletionMs(['A'], ['A'], [true], options, true)).toBe(634);
+  });
+
+  test('finishes the outgoing phase before changing widths or entering new glyphs', () => {
+    const options = resolveSlotTextOptions({ bounce: 0 }).options;
+    const phaseTiming = calculateTransitionPhaseTiming(['A', 'B'], [true, true], options);
+    const firstSlot = calculateSlotTransitionTiming(0, 2, 'A', 'C', options, phaseTiming, false);
+    const secondSlot = calculateSlotTransitionTiming(1, 2, 'B', 'D', options, phaseTiming, false);
+
+    expect(phaseTiming).toEqual({ entryPhaseStartMs: 154, exitPhaseDurationMs: 130 });
+    expect(firstSlot.exitDurationMs).toBe(130);
+    expect(secondSlot.exitDurationMs).toBe(130);
+    expect(firstSlot.entry.startDelayMs).toBe(154);
+    expect(firstSlot.width.startDelayMs).toBe(154);
+    expect(secondSlot.entry.startDelayMs).toBe(199);
+    expect(secondSlot.width.startDelayMs).toBe(199);
+  });
+
+  test('starts entry immediately when a transition only adds slots', () => {
+    const options = resolveSlotTextOptions({ bounce: 0 }).options;
+
+    expect(calculateTransitionPhaseTiming(['A'], [false, true], options)).toEqual({
+      entryPhaseStartMs: 0,
+      exitPhaseDurationMs: 0,
+    });
+  });
+});

--- a/src/components/SlotText/utils/slotText.ts
+++ b/src/components/SlotText/utils/slotText.ts
@@ -1,0 +1,338 @@
+import type { ResolvedSlotTextOptions, SlotTextProps } from '../SlotText.types';
+
+const DEFAULT_OPTIONS: ResolvedSlotTextOptions = {
+  bounce: 0.6,
+  colorFadeDurationMs: 280,
+  durationMs: 200,
+  exitOffsetMs: 24,
+  maxGraphemes: 32,
+  skipUnchanged: true,
+  staggerMs: 45,
+};
+
+const MINIMUM_WIDTH_DURATION_MS = 140;
+const NBSP = '\u00A0';
+const EXIT_PHASE_DURATION_MULTIPLIER = 0.65;
+// Sub-pixel tolerance for treating a slot's horizontal start offset as unmoved.
+const POSITION_STABILITY_TOLERANCE = 0.5;
+
+type SegmentData = { segment: string };
+type GraphemeSegmenter = { segment: (text: string) => Iterable<SegmentData> };
+type GraphemeSegmenterConstructor = new (
+  locales?: string | string[],
+  options?: { granularity: 'grapheme' },
+) => GraphemeSegmenter;
+
+const Segmenter = (Intl as typeof Intl & { Segmenter?: GraphemeSegmenterConstructor }).Segmenter;
+const graphemeSegmenter = Segmenter
+  ? new Segmenter(undefined, { granularity: 'grapheme' })
+  : undefined;
+
+export type GlyphTiming = {
+  durationMs: number;
+  startDelayMs: number;
+  startingTiltDegrees: number;
+};
+
+export type WidthTiming = {
+  durationMs: number;
+  startDelayMs: number;
+};
+
+export type TransitionPhaseTiming = {
+  entryPhaseStartMs: number;
+  exitPhaseDurationMs: number;
+};
+
+export type SlotTransitionTiming = {
+  completionMs: number;
+  entry: GlyphTiming;
+  exitDurationMs: number;
+  width: WidthTiming;
+};
+
+export type ResolvedSlotTextOptionsResult = {
+  isValid: boolean;
+  options: ResolvedSlotTextOptions;
+};
+
+export function segmentTextIntoGraphemes(text: string): string[] {
+  if (!graphemeSegmenter) {
+    return Array.from(text);
+  }
+
+  return Array.from(graphemeSegmenter.segment(text), ({ segment }) => segment);
+}
+
+export function getVisibleSegmentText(segment: string): string {
+  return segment === ' ' ? NBSP : segment;
+}
+
+export function resolveSlotTextOptions(
+  props: Pick<
+    SlotTextProps,
+    | 'bounce'
+    | 'colorFadeDurationMs'
+    | 'durationMs'
+    | 'exitOffsetMs'
+    | 'maxGraphemes'
+    | 'skipUnchanged'
+    | 'staggerMs'
+  >,
+): ResolvedSlotTextOptionsResult {
+  const isValid =
+    isFiniteNonNegative(props.durationMs) &&
+    isFiniteNonNegative(props.staggerMs) &&
+    isFiniteNonNegative(props.exitOffsetMs) &&
+    isFiniteNonNegative(props.colorFadeDurationMs) &&
+    isFiniteNumber(props.bounce) &&
+    isValidMaximum(props.maxGraphemes);
+
+  return {
+    isValid,
+    options: {
+      bounce: clamp(props.bounce ?? DEFAULT_OPTIONS.bounce, 0, 1),
+      colorFadeDurationMs: props.colorFadeDurationMs ?? DEFAULT_OPTIONS.colorFadeDurationMs,
+      durationMs: props.durationMs ?? DEFAULT_OPTIONS.durationMs,
+      exitOffsetMs: props.exitOffsetMs ?? DEFAULT_OPTIONS.exitOffsetMs,
+      maxGraphemes: Math.floor(props.maxGraphemes ?? DEFAULT_OPTIONS.maxGraphemes),
+      skipUnchanged: props.skipUnchanged ?? DEFAULT_OPTIONS.skipUnchanged,
+      staggerMs: props.staggerMs ?? DEFAULT_OPTIONS.staggerMs,
+    },
+  };
+}
+
+export function calculateGlyphTiming(
+  segmentIndex: number,
+  targetSegmentCount: number,
+  isTrailingSlot: boolean,
+  options: Pick<ResolvedSlotTextOptions, 'bounce' | 'durationMs' | 'staggerMs'>,
+): GlyphTiming {
+  const durationVariation = 1 + options.bounce * 0.18 * deterministicVariation(segmentIndex, 0);
+  const staggerVariation = 1 + options.bounce * 0.12 * deterministicVariation(segmentIndex, 1);
+  const staggerPosition = isTrailingSlot
+    ? targetSegmentCount * 0.5 + (segmentIndex - targetSegmentCount) * 0.25
+    : segmentIndex;
+  const trailingDurationMultiplier = isTrailingSlot ? 0.75 : 1;
+
+  return {
+    durationMs: Math.max(
+      0,
+      Math.round(options.durationMs * trailingDurationMultiplier * durationVariation),
+    ),
+    startDelayMs: Math.max(0, Math.round(staggerPosition * options.staggerMs * staggerVariation)),
+    startingTiltDegrees: roundToTwoDecimals(
+      options.bounce * 5 * deterministicVariation(segmentIndex, 2),
+    ),
+  };
+}
+
+export function calculateWidthTiming(
+  currentSegment: string,
+  targetSegment: string,
+  glyphTiming: GlyphTiming,
+): WidthTiming {
+  if (glyphTiming.durationMs === 0) {
+    return { durationMs: 0, startDelayMs: glyphTiming.startDelayMs };
+  }
+
+  if (targetSegment === '') {
+    return {
+      durationMs: scaledWidthDuration(glyphTiming.durationMs, 0.6),
+      startDelayMs: glyphTiming.startDelayMs + Math.round(glyphTiming.durationMs * 0.55),
+    };
+  }
+
+  if (currentSegment === '') {
+    return {
+      durationMs: scaledWidthDuration(glyphTiming.durationMs, 0.45),
+      startDelayMs: glyphTiming.startDelayMs,
+    };
+  }
+
+  return {
+    durationMs: glyphTiming.durationMs,
+    startDelayMs: glyphTiming.startDelayMs,
+  };
+}
+
+export function calculateSlotCompletionMs(
+  glyphTiming: GlyphTiming,
+  widthTiming: WidthTiming,
+  exitOffsetMs: number,
+  colorFadeDurationMs: number,
+  hasHighlightColor: boolean,
+): number {
+  const glyphCompletionMs =
+    glyphTiming.startDelayMs +
+    exitOffsetMs +
+    glyphTiming.durationMs +
+    (hasHighlightColor ? colorFadeDurationMs : 0);
+  const widthCompletionMs = widthTiming.startDelayMs + widthTiming.durationMs;
+
+  return Math.max(glyphCompletionMs, widthCompletionMs);
+}
+
+export function calculateAnimatedSlotFlags(
+  fromSegments: readonly string[],
+  targetSegments: readonly string[],
+  options: Pick<ResolvedSlotTextOptions, 'skipUnchanged'>,
+  getSegmentWidth: (segment: string) => number,
+): boolean[] {
+  const slotCount = Math.max(fromSegments.length, targetSegments.length);
+  const flags: boolean[] = [];
+  let currentOffset = 0;
+  let targetOffset = 0;
+
+  for (let index = 0; index < slotCount; index += 1) {
+    const currentSegment = fromSegments[index] ?? '';
+    const targetSegment = targetSegments[index] ?? '';
+    const isPositionStable = Math.abs(currentOffset - targetOffset) <= POSITION_STABILITY_TOLERANCE;
+    flags.push(!options.skipUnchanged || currentSegment !== targetSegment || !isPositionStable);
+    currentOffset += currentSegment === '' ? 0 : getSegmentWidth(currentSegment);
+    targetOffset += targetSegment === '' ? 0 : getSegmentWidth(targetSegment);
+  }
+
+  return flags;
+}
+
+export function calculateTransitionPhaseTiming(
+  fromSegments: readonly string[],
+  animatedSlotFlags: readonly boolean[],
+  options: Pick<ResolvedSlotTextOptions, 'durationMs' | 'exitOffsetMs'>,
+): TransitionPhaseTiming {
+  const hasOutgoingSegment = fromSegments.some(
+    (currentSegment, index) => currentSegment !== '' && animatedSlotFlags[index],
+  );
+  if (!hasOutgoingSegment) {
+    return { entryPhaseStartMs: 0, exitPhaseDurationMs: 0 };
+  }
+
+  const exitPhaseDurationMs = Math.max(
+    0,
+    Math.round(options.durationMs * EXIT_PHASE_DURATION_MULTIPLIER),
+  );
+
+  return {
+    entryPhaseStartMs: exitPhaseDurationMs + options.exitOffsetMs,
+    exitPhaseDurationMs,
+  };
+}
+
+export function calculateSlotTransitionTiming(
+  segmentIndex: number,
+  targetSegmentCount: number,
+  currentSegment: string,
+  targetSegment: string,
+  options: Pick<
+    ResolvedSlotTextOptions,
+    'bounce' | 'colorFadeDurationMs' | 'durationMs' | 'staggerMs'
+  >,
+  phaseTiming: TransitionPhaseTiming,
+  hasHighlightColor: boolean,
+): SlotTransitionTiming {
+  const baseEntryTiming = calculateGlyphTiming(
+    segmentIndex,
+    targetSegmentCount,
+    targetSegment === '',
+    options,
+  );
+  const entry = {
+    ...baseEntryTiming,
+    startDelayMs: phaseTiming.entryPhaseStartMs + baseEntryTiming.startDelayMs,
+  };
+  const baseWidthTiming = calculateWidthTiming(currentSegment, targetSegment, baseEntryTiming);
+  const width = {
+    ...baseWidthTiming,
+    startDelayMs:
+      targetSegment === ''
+        ? phaseTiming.entryPhaseStartMs
+        : phaseTiming.entryPhaseStartMs + baseWidthTiming.startDelayMs,
+  };
+  const exitDurationMs = currentSegment ? phaseTiming.exitPhaseDurationMs : 0;
+  const entryCompletionMs = targetSegment
+    ? entry.startDelayMs + entry.durationMs + (hasHighlightColor ? options.colorFadeDurationMs : 0)
+    : 0;
+
+  return {
+    completionMs: Math.max(
+      exitDurationMs,
+      entryCompletionMs,
+      width.startDelayMs + width.durationMs,
+    ),
+    entry,
+    exitDurationMs,
+    width,
+  };
+}
+
+export function calculateTransitionCompletionMs(
+  fromSegments: readonly string[],
+  targetSegments: readonly string[],
+  animatedSlotFlags: readonly boolean[],
+  options: Pick<
+    ResolvedSlotTextOptions,
+    'bounce' | 'colorFadeDurationMs' | 'durationMs' | 'exitOffsetMs' | 'staggerMs'
+  >,
+  hasHighlightColor: boolean,
+): number {
+  const phaseTiming = calculateTransitionPhaseTiming(fromSegments, animatedSlotFlags, options);
+  const slotCount = Math.max(fromSegments.length, targetSegments.length);
+  let completionMs = 0;
+
+  for (let index = 0; index < slotCount; index += 1) {
+    const currentSegment = fromSegments[index] ?? '';
+    const targetSegment = targetSegments[index] ?? '';
+    if (!animatedSlotFlags[index]) {
+      continue;
+    }
+
+    const slotTiming = calculateSlotTransitionTiming(
+      index,
+      targetSegments.length,
+      currentSegment,
+      targetSegment,
+      options,
+      phaseTiming,
+      hasHighlightColor && targetSegment !== '',
+    );
+    completionMs = Math.max(completionMs, slotTiming.completionMs);
+  }
+
+  return completionMs;
+}
+
+function isFiniteNonNegative(value: number | undefined): boolean {
+  return value === undefined || (Number.isFinite(value) && value >= 0);
+}
+
+function isFiniteNumber(value: number | undefined): boolean {
+  return value === undefined || Number.isFinite(value);
+}
+
+function isValidMaximum(value: number | undefined): boolean {
+  return value === undefined || (Number.isFinite(value) && value >= 1);
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function scaledWidthDuration(durationMs: number, multiplier: number): number {
+  return Math.max(MINIMUM_WIDTH_DURATION_MS, Math.round(durationMs * multiplier));
+}
+
+function deterministicVariation(segmentIndex: number, channel: number): number {
+  let seed = Math.imul(segmentIndex + 1, 0x45d9f3b) ^ Math.imul(channel + 1, 0x27d4eb2d);
+  seed ^= seed >>> 16;
+  seed = Math.imul(seed, 0x45d9f3b);
+  seed ^= seed >>> 16;
+  const zeroToOne = (seed >>> 0) / 0xffffffff;
+
+  return zeroToOne * 2 - 1;
+}
+
+function roundToTwoDecimals(value: number): number {
+  const rounded = Math.round(value * 100) / 100;
+  return Object.is(rounded, -0) ? 0 : rounded;
+}

--- a/src/components/modelPicker/components/ModelPickerBottomSheet.tsx
+++ b/src/components/modelPicker/components/ModelPickerBottomSheet.tsx
@@ -15,7 +15,7 @@ import { buildModelPickerListItems } from '../utils/modelPickerListItems';
 import { ModelPickerSheetContent } from './ModelPickerSheetContent';
 
 const defaultModelPickerHeaderHeight = 64;
-const initialModelPickerListItemCount = 12;
+const initialModelPickerListItemCount = 24;
 const modelPickerListItemBatchSize = 24;
 // Detent indices for the underlying `SelectionBottomSheet`: 0 closed, 1 open.
 const CLOSED_INDEX = 0;
@@ -157,8 +157,11 @@ export function ModelPickerBottomSheet({
       }}
     >
       {({ sheetHeight }) => {
+        // footerHeight only grows from onLayout; drop it when the slot is empty so
+        // a removed footer stops reserving its old band.
+        const effectiveFooterHeight = footer ? footerHeight : 0;
         const modelListHeight = Math.max(
-          sheetHeight - (headerHeight || defaultModelPickerHeaderHeight) - footerHeight,
+          sheetHeight - (headerHeight || defaultModelPickerHeaderHeight) - effectiveFooterHeight,
           120,
         );
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -12,6 +12,10 @@ export const isLiquidGlassAvailable = isSystemLiquidGlassAvailable() && isGlassE
 // the background behind them consistently. Single source of truth — tune here.
 export const sheetScrimColor = 'rgba(0, 0, 0, 0.4)';
 
+// Brand accent (ui.theme_user.color_primary default). SlotText tints freshly
+// landed glyphs with it before they fade to the regular text color.
+export const slotTextHighlightColor = '#00b96b';
+
 // Gap kept between the keyboard and the focused input inside scrollable forms.
 export const keyboardBottomOffset = 16;
 

--- a/src/screens/ChatScreen/input/ChatInput.tsx
+++ b/src/screens/ChatScreen/input/ChatInput.tsx
@@ -86,7 +86,7 @@ export function ChatInput({ topicId }: ChatInputProps) {
       />
       <ChatInputActionSheet />
       <ModelPickerBottomSheet
-        footer={<ChatInputReasoningSection />}
+        footer={reasoningEfforts.length > 0 ? <ChatInputReasoningSection /> : undefined}
         onSelect={handleModelSelect}
         ref={modelPickerRef}
         selectedModelId={selectedModelId}

--- a/src/screens/ChatScreen/input/components/ChatInputReasoningSection.tsx
+++ b/src/screens/ChatScreen/input/components/ChatInputReasoningSection.tsx
@@ -3,6 +3,9 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, useColorScheme, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { SlotText } from '@/components/SlotText';
+
 import { useChatInputActions, useChatInputState } from '../context/ChatInputProvider';
 import { EffortSlider, thinkingAccentColor } from '../effortSlider';
 import { useChatInputReasoningEfforts } from '../hooks/useChatInputReasoningEfforts';
@@ -58,16 +61,15 @@ export function ChatInputReasoningSection() {
       style={{ paddingBottom: Math.max(insets.bottom, 16) }}
       testID="chat-input-reasoning-section"
     >
-      <View className="flex-row items-baseline gap-1.5">
+      <View className="flex-row items-center gap-1.5">
         <Text className="font-medium text-base text-foreground">{t('chat.reasoning.title')}</Text>
-        <Text
-          className="font-semibold text-base text-foreground"
-          style={
+        <SlotText
+          text={currentOption ? t(currentOption.labelKey) : ''}
+          textClassName="font-semibold text-base text-foreground"
+          textStyle={
             isMaxEffort ? { color: thinkingAccentColor[isDark ? 'dark' : 'light'] } : undefined
           }
-        >
-          {currentOption ? t(currentOption.labelKey) : ''}
-        </Text>
+        />
       </View>
       <View className="mt-3 flex-row items-center justify-between">
         <Text className="text-accent text-sm">{t('chat.reasoning.faster')}</Text>


### PR DESCRIPTION
Adds a controlled `SlotText` component that rolls each changed grapheme from the previous value to the latest (per-grapheme slots, two native faces, hidden measurement layer), with latest-wins updates, reduced-motion / over-limit static fallbacks, and a fixed brand highlight. Wires it into the reasoning-effort label so the value animates as the slider crosses stops. Fixes the model picker sheet reserving an empty footer band when the selected model has no reasoning stops, and bumps the initial model-list load (12 → 24) so the taller viewport fills on open. Also adds a `slotTextHighlightColor` constant and an `expo-glass-effect` Jest stub; the SlotText component and its timing utilities are fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
