### PR TITLE
feat(user-avatar): sync mobile avatar persistence

### DIFF
--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -1,43 +1,39 @@
-import type { ImageSource } from 'expo-image';
 import { useThemeColor } from 'heroui-native/hooks';
 import { CameraIcon, PencilIcon } from 'lucide-uniwind/png';
 import { View } from 'react-native';
 
 import { Image } from '@/components/nativePrimitives';
-
-const avatarSource = require('@/assets/icon.png');
+import { useAvatar } from '@/hooks/useAvatar';
 
 export type ProfileAvatarEditIcon = 'camera' | 'pencil';
 
 type ProfileEditableAvatarProps = {
   icon: ProfileAvatarEditIcon;
-  imageSource?: ImageSource | number;
   size: number;
 };
 
-export function ProfileEditableAvatar({ icon, imageSource, size }: ProfileEditableAvatarProps) {
+export function ProfileEditableAvatar({ icon, size }: ProfileEditableAvatarProps) {
   return (
     <View style={{ height: size, width: size }}>
-      <ProfileAvatarImage imageSource={imageSource} size={size} />
+      <ProfileAvatarImage size={size} />
       <ProfileAvatarEditBadge icon={icon} size={size} />
     </View>
   );
 }
 
 type ProfileAvatarImageProps = {
-  imageSource?: ImageSource | number;
   size: number;
 };
 
-export function ProfileAvatarImage({ imageSource, size }: ProfileAvatarImageProps) {
-  const source = imageSource ?? avatarSource;
+export function ProfileAvatarImage({ size }: ProfileAvatarImageProps) {
+  const avatarSource = useAvatar();
 
   return (
     <Image
       accessibilityIgnoresInvertColors
       cachePolicy="memory-disk"
       className="rounded-full"
-      source={source}
+      source={avatarSource}
       style={{ borderRadius: size / 2, height: size, width: size }}
     />
   );

--- a/src/data/preference/__tests__/preferenceUtils.test.ts
+++ b/src/data/preference/__tests__/preferenceUtils.test.ts
@@ -9,12 +9,13 @@ import {
 describe('preference defaults', () => {
   test('keeps the desktop preference key surface aligned', () => {
     expect(getPreferenceKeys()).toEqual(Object.keys(DefaultPreferences.default));
-    expect(getPreferenceKeys()).toHaveLength(229);
+    expect(getPreferenceKeys()).toHaveLength(230);
 
     expect(getPreferenceKeys()).toEqual(
       expect.arrayContaining([
         'app.developer_mode.enabled',
         'app.language',
+        'app.user.avatar',
         'chat.default_model_id',
         'chat.input.send_message_shortcut',
         'feature.quick_assistant.model_id',
@@ -29,6 +30,7 @@ describe('preference defaults', () => {
 
   test('returns desktop-aligned default values', () => {
     expect(getDefaultValue('app.language')).toBeNull();
+    expect(getDefaultValue('app.user.avatar')).toBe('');
     expect(getDefaultValue('app.user.id')).toBe('uuid()');
     expect(getDefaultValue('app.user.name')).toBe('');
     expect(getDefaultValue('app.dist.auto_update.enabled')).toBe(true);
@@ -62,6 +64,6 @@ describe('preference defaults', () => {
     expect(isPreferenceKey('chat.web_search.max_results')).toBe(true);
     expect(isPreferenceKey('feature.translate.model_prompt')).toBe(true);
     expect(isPreferenceKey('BootConfig.example')).toBe(false);
-    expect(Object.keys(DefaultPreferences.default)).toHaveLength(229);
+    expect(Object.keys(DefaultPreferences.default)).toHaveLength(230);
   });
 });

--- a/src/data/preference/preferenceSchemas.ts
+++ b/src/data/preference/preferenceSchemas.ts
@@ -76,6 +76,8 @@ export interface PreferenceSchemas {
     'app.tray.on_launch': boolean;
     // redux/settings/useSystemTitleBar
     'app.use_system_title_bar': boolean;
+    // redux/settings/userAvatar
+    'app.user.avatar': string;
     // redux/settings/userId
     'app.user.id': string;
     // redux/settings/userName
@@ -521,6 +523,7 @@ export const DefaultPreferences: PreferenceSchemas = {
     'app.tray.on_close': true,
     'app.tray.on_launch': false,
     'app.use_system_title_bar': false,
+    'app.user.avatar': '',
     'app.user.id': 'uuid()',
     'app.user.name': '',
     'app.zoom_factor': 1,

--- a/src/hooks/useAvatar.ts
+++ b/src/hooks/useAvatar.ts
@@ -1,0 +1,11 @@
+import { usePreference } from '@/data/hooks';
+import { resolveUserAvatarUri } from '@/services/userAvatarStorage';
+
+const defaultAvatarSource = require('@/assets/icon.png');
+
+/** The user avatar as an Expo Image source, with the bundled icon as fallback. */
+export function useAvatar(): string | number {
+  const [avatar] = usePreference('app.user.avatar');
+
+  return resolveUserAvatarUri(avatar) ?? defaultAvatarSource;
+}

--- a/src/i18n/locales/en-us.json
+++ b/src/i18n/locales/en-us.json
@@ -229,6 +229,7 @@
   "settings.pages.websearch.placeholder": "Web search settings are coming soon.",
   "settings.pages.websearch.title": "Web search",
   "settings.plugin.title": "Plugins",
+  "settings.profile.avatarSaveError": "Failed to save avatar",
   "settings.profile.changeAvatar": "Change avatar",
   "settings.profile.edit": "Edit profile",
   "settings.profile.userName": "User Name",

--- a/src/i18n/locales/zh-cn.json
+++ b/src/i18n/locales/zh-cn.json
@@ -229,6 +229,7 @@
   "settings.pages.websearch.placeholder": "网络搜索相关设置即将推出。",
   "settings.pages.websearch.title": "网络搜索",
   "settings.plugin.title": "插件",
+  "settings.profile.avatarSaveError": "头像保存失败",
   "settings.profile.changeAvatar": "更换头像",
   "settings.profile.edit": "编辑个人资料",
   "settings.profile.userName": "用户名",

--- a/src/screens/HomeScreen/components/HomeProfileHero.tsx
+++ b/src/screens/HomeScreen/components/HomeProfileHero.tsx
@@ -13,8 +13,7 @@ import Animated, {
 import { Image } from '@/components/nativePrimitives';
 import { ProfileAvatarEditBadge } from '@/components/ProfileAvatar';
 import { homeHeader } from '@/config/constants';
-
-const avatarSource = require('@/assets/icon.png');
+import { useAvatar } from '@/hooks/useAvatar';
 
 const heroHeight = homeHeader.heroContainerHeight;
 // Clip trick from the reference header: the box's bounds extend far above its
@@ -64,6 +63,7 @@ export function HomeProfileHero({
 }: HomeProfileHeroProps) {
   const { t } = useTranslation();
   const { width: screenWidth } = useWindowDimensions();
+  const avatarSource = useAvatar();
   const nameWidth = useSharedValue(0);
   const measuredNameRef = useRef<string | null>(null);
 

--- a/src/screens/SettingsScreen/ProfileSettingsScreen.tsx
+++ b/src/screens/SettingsScreen/ProfileSettingsScreen.tsx
@@ -1,28 +1,32 @@
 import { type MenuAction, MenuView, type NativeActionEvent } from '@expo/ui/community/menu';
-import type { ImageSource } from 'expo-image';
+import { loggerService } from '@logger';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 import { useThemeColor } from 'heroui-native/hooks';
 import { Input } from 'heroui-native/input';
+import { useToast } from 'heroui-native/toast';
 import { SaveIcon } from 'lucide-uniwind/png';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { BackHeader, type HeaderToolbarAction } from '@/components/headers';
 import { ProfileAvatarEditBadge, ProfileAvatarImage } from '@/components/ProfileAvatar';
 import { usePreference } from '@/data/hooks';
+import { replaceUserAvatar } from '@/services/userAvatarStorage';
 
 const profileAvatarSize = 104;
+const logger = loggerService.withContext('ProfileSettingsScreen');
 
 type AvatarSourceValue = 'camera' | 'photos';
 
 export default function ProfileSettingsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
+  const { toast } = useToast();
   const borderColor = useThemeColor('border');
   const inputRef = useRef<TextInput>(null);
   const [userName, setUserName] = usePreference('app.user.name');
-  const [draftAvatarUri, setDraftAvatarUri] = useState<string | null>(null);
+  const [avatar, setAvatar] = usePreference('app.user.avatar');
   const avatarActions = useMemo<MenuAction[]>(
     () => [
       {
@@ -39,46 +43,69 @@ export default function ProfileSettingsScreen() {
     [t],
   );
 
+  const persistSelectedAvatar = useCallback(
+    (sourceUri: string) =>
+      replaceUserAvatar(sourceUri, avatar, (nextAvatar) =>
+        setAvatar(nextAvatar, { optimistic: true }),
+      ),
+    [avatar, setAvatar],
+  );
+  const reportAvatarSaveError = useCallback(
+    (error: unknown) => {
+      logger.error('Failed to save user avatar', error as Error);
+      toast.show({ label: t('settings.profile.avatarSaveError'), variant: 'danger' });
+    },
+    [t, toast],
+  );
+
   const selectAvatarFromCamera = useCallback(async () => {
-    const permission = await ImagePicker.requestCameraPermissionsAsync();
+    try {
+      const permission = await ImagePicker.requestCameraPermissionsAsync();
 
-    if (!permission.granted) {
-      return;
+      if (!permission.granted) {
+        return;
+      }
+
+      const result = await ImagePicker.launchCameraAsync({
+        allowsEditing: true,
+        aspect: [1, 1],
+        mediaTypes: ['images'],
+        quality: 1,
+      });
+
+      const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
+      if (assetUri) {
+        await persistSelectedAvatar(assetUri);
+      }
+    } catch (error) {
+      reportAvatarSaveError(error);
     }
-
-    const result = await ImagePicker.launchCameraAsync({
-      allowsEditing: true,
-      aspect: [1, 1],
-      mediaTypes: ['images'],
-      quality: 1,
-    });
-
-    const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
-    if (assetUri) {
-      setDraftAvatarUri(assetUri);
-    }
-  }, []);
+  }, [persistSelectedAvatar, reportAvatarSaveError]);
 
   const selectAvatarFromPhotoLibrary = useCallback(async () => {
-    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
 
-    if (!permission.granted) {
-      return;
+      if (!permission.granted) {
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        allowsEditing: true,
+        aspect: [1, 1],
+        mediaTypes: ['images'],
+        quality: 1,
+        selectionLimit: 1,
+      });
+
+      const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
+      if (assetUri) {
+        await persistSelectedAvatar(assetUri);
+      }
+    } catch (error) {
+      reportAvatarSaveError(error);
     }
-
-    const result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,
-      aspect: [1, 1],
-      mediaTypes: ['images'],
-      quality: 1,
-      selectionLimit: 1,
-    });
-
-    const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
-    if (assetUri) {
-      setDraftAvatarUri(assetUri);
-    }
-  }, []);
+  }, [persistSelectedAvatar, reportAvatarSaveError]);
 
   const handleAvatarSourceChange = useCallback(
     (event: NativeActionEvent) => {
@@ -137,7 +164,6 @@ export default function ProfileSettingsScreen() {
             <MenuAvatarTrigger
               actions={avatarActions}
               accessibilityLabel={t('settings.profile.changeAvatar')}
-              imageSource={draftAvatarUri ? { uri: draftAvatarUri } : undefined}
               onPress={blurInput}
               onPressAction={handleAvatarSourceChange}
               size={profileAvatarSize}
@@ -170,7 +196,6 @@ export default function ProfileSettingsScreen() {
 type MenuAvatarTriggerProps = {
   accessibilityLabel: string;
   actions: MenuAction[];
-  imageSource?: ImageSource | number;
   onPress: () => void;
   onPressAction: (event: NativeActionEvent) => void;
   size: number;
@@ -179,7 +204,6 @@ type MenuAvatarTriggerProps = {
 function MenuAvatarTrigger({
   accessibilityLabel,
   actions,
-  imageSource,
   onPress,
   onPressAction,
   size,
@@ -192,7 +216,7 @@ function MenuAvatarTrigger({
       }}
       style={{ height: size, width: size }}
     >
-      <ProfileAvatarImage imageSource={imageSource} size={size} />
+      <ProfileAvatarImage size={size} />
       <MenuView actions={actions} onPressAction={onPressAction} style={styles.avatarMenuTrigger}>
         <View
           accessibilityLabel={accessibilityLabel}

--- a/src/services/__tests__/userAvatarStorage.test.ts
+++ b/src/services/__tests__/userAvatarStorage.test.ts
@@ -1,0 +1,142 @@
+import { replaceUserAvatar, resolveUserAvatarUri } from '../userAvatarStorage';
+
+jest.mock('expo-file-system', () => {
+  const directories = new Set<string>();
+  const files = new Set<string>();
+  const copies: { destination: string; source: string }[] = [];
+  const joinUri = (parts: (string | { uri: string })[], isDirectory: boolean) => {
+    const [first, ...rest] = parts.map((part) => (typeof part === 'string' ? part : part.uri));
+    let uri = first?.replace(/\/+$/, '') ?? '';
+
+    for (const part of rest) {
+      uri += `/${part.replace(/^\/+|\/+$/g, '')}`;
+    }
+
+    return isDirectory ? `${uri}/` : uri;
+  };
+
+  class MockDirectory {
+    readonly uri: string;
+
+    constructor(...parts: (string | { uri: string })[]) {
+      this.uri = joinUri(parts, true);
+    }
+
+    get exists() {
+      return directories.has(this.uri);
+    }
+
+    create() {
+      directories.add(this.uri);
+    }
+  }
+
+  class MockFile {
+    readonly uri: string;
+
+    constructor(...parts: (string | { uri: string })[]) {
+      this.uri = joinUri(parts, false);
+    }
+
+    get exists() {
+      return files.has(this.uri);
+    }
+
+    async copy(destination: MockFile) {
+      copies.push({ destination: destination.uri, source: this.uri });
+      files.add(destination.uri);
+    }
+
+    delete() {
+      files.delete(this.uri);
+    }
+  }
+
+  return {
+    Directory: MockDirectory,
+    File: MockFile,
+    Paths: { document: { uri: 'file:///documents/' } },
+    testState: { copies, directories, files },
+  };
+});
+
+type FileSystemTestState = {
+  copies: { destination: string; source: string }[];
+  directories: Set<string>;
+  files: Set<string>;
+};
+
+const { testState } = jest.requireMock<{ testState: FileSystemTestState }>('expo-file-system');
+
+describe('userAvatarStorage', () => {
+  beforeEach(() => {
+    testState.copies.length = 0;
+    testState.directories.clear();
+    testState.files.clear();
+  });
+
+  it('stores a picked image behind a path-resilient file reference', async () => {
+    let avatar = '';
+
+    await replaceUserAvatar('file:///picker/avatar.jpg', '', async (nextAvatar) => {
+      avatar = nextAvatar;
+    });
+
+    expect(avatar).toMatch(
+      /^file:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(testState.copies).toEqual([
+      {
+        destination: `file:///documents/user-avatars/${avatar.slice('file:'.length)}`,
+        source: 'file:///picker/avatar.jpg',
+      },
+    ]);
+    expect(resolveUserAvatarUri(avatar)).toBe(
+      `file:///documents/user-avatars/${avatar.slice('file:'.length)}`,
+    );
+  });
+
+  it('deletes the previous managed file only after persisting its replacement', async () => {
+    let previousAvatar = '';
+    await replaceUserAvatar('file:///picker/first.jpg', '', async (nextAvatar) => {
+      previousAvatar = nextAvatar;
+    });
+
+    let nextAvatar = '';
+    await replaceUserAvatar('file:///picker/second.jpg', previousAvatar, async (value) => {
+      nextAvatar = value;
+      expect(resolveUserAvatarUri(previousAvatar)).toBeDefined();
+    });
+
+    expect(resolveUserAvatarUri(previousAvatar)).toBeUndefined();
+    expect(resolveUserAvatarUri(nextAvatar)).toBeDefined();
+  });
+
+  it('compensates the new file and preserves the previous avatar when persistence fails', async () => {
+    let previousAvatar = '';
+    await replaceUserAvatar('file:///picker/first.jpg', '', async (nextAvatar) => {
+      previousAvatar = nextAvatar;
+    });
+
+    let rejectedAvatar = '';
+    await expect(
+      replaceUserAvatar('file:///picker/second.jpg', previousAvatar, async (nextAvatar) => {
+        rejectedAvatar = nextAvatar;
+        throw new Error('preference write failed');
+      }),
+    ).rejects.toThrow('preference write failed');
+
+    expect(resolveUserAvatarUri(previousAvatar)).toBeDefined();
+    expect(resolveUserAvatarUri(rejectedAvatar)).toBeUndefined();
+  });
+
+  it('keeps legacy image URIs and rejects non-image or unresolved values', () => {
+    expect(resolveUserAvatarUri('https://example.com/avatar.png')).toBe(
+      'https://example.com/avatar.png',
+    );
+    expect(resolveUserAvatarUri('data:image/png;base64,abc')).toBe('data:image/png;base64,abc');
+    expect(resolveUserAvatarUri('file:///legacy/avatar.png')).toBe('file:///legacy/avatar.png');
+    expect(resolveUserAvatarUri('😀')).toBeUndefined();
+    expect(resolveUserAvatarUri('file:00000000-0000-4000-8000-000000000000')).toBeUndefined();
+  });
+});

--- a/src/services/userAvatarStorage.ts
+++ b/src/services/userAvatarStorage.ts
@@ -1,0 +1,109 @@
+import { loggerService } from '@logger';
+import { randomUUID } from 'expo-crypto';
+import { Directory, File, Paths } from 'expo-file-system';
+
+const logger = loggerService.withContext('UserAvatarStorage');
+const AVATAR_DIRECTORY_NAME = 'user-avatars';
+const STORED_FILE_REF_PREFIX = 'file:';
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_IMAGE_URI_PATTERN = /^(?:blob:|content:\/\/|data:image\/|file:\/\/|https?:\/\/)/i;
+
+type PersistAvatar = (avatar: string) => Promise<void>;
+
+function avatarDirectory(): Directory {
+  return new Directory(Paths.document, AVATAR_DIRECTORY_NAME);
+}
+
+function ensureAvatarDirectory(): Directory {
+  const directory = avatarDirectory();
+
+  if (!directory.exists) {
+    directory.create({ intermediates: true });
+  }
+
+  return directory;
+}
+
+function avatarFile(fileId: string): File {
+  return new File(avatarDirectory(), fileId);
+}
+
+function storedFileId(avatar: string): string | undefined {
+  if (!avatar.startsWith(STORED_FILE_REF_PREFIX) || avatar.startsWith('file://')) {
+    return undefined;
+  }
+
+  const fileId = avatar.slice(STORED_FILE_REF_PREFIX.length);
+  return UUID_PATTERN.test(fileId) ? fileId : undefined;
+}
+
+function deleteStoredAvatar(avatar: string): void {
+  const fileId = storedFileId(avatar);
+
+  if (!fileId) {
+    return;
+  }
+
+  try {
+    const file = avatarFile(fileId);
+
+    if (file.exists) {
+      file.delete();
+    }
+  } catch (error) {
+    logger.warn('Failed to delete stored user avatar', error as Error, { avatar });
+  }
+}
+
+/**
+ * Resolve the preference value into an image URI for this device. New avatars
+ * use a path-resilient `file:<uuid>` reference; legacy image URIs still render.
+ */
+export function resolveUserAvatarUri(avatar: string): string | undefined {
+  const fileId = storedFileId(avatar);
+
+  if (fileId) {
+    const file = avatarFile(fileId);
+    return file.exists ? file.uri : undefined;
+  }
+
+  return LEGACY_IMAGE_URI_PATTERN.test(avatar) ? avatar : undefined;
+}
+
+async function storeUserAvatar(sourceUri: string): Promise<string> {
+  ensureAvatarDirectory();
+
+  const fileId = randomUUID();
+  const destination = avatarFile(fileId);
+
+  try {
+    await new File(sourceUri).copy(destination);
+  } catch (error) {
+    deleteStoredAvatar(`${STORED_FILE_REF_PREFIX}${fileId}`);
+    throw error;
+  }
+
+  return `${STORED_FILE_REF_PREFIX}${fileId}`;
+}
+
+/**
+ * Replace the stored avatar without exposing a temporary picker URI. The new
+ * file is compensated if the preference write fails; the old file is removed
+ * only after the new preference value is durable.
+ */
+export async function replaceUserAvatar(
+  sourceUri: string,
+  previousAvatar: string,
+  persistAvatar: PersistAvatar,
+): Promise<void> {
+  const nextAvatar = await storeUserAvatar(sourceUri);
+
+  try {
+    await persistAvatar(nextAvatar);
+  } catch (error) {
+    deleteStoredAvatar(nextAvatar);
+    throw error;
+  }
+
+  deleteStoredAvatar(previousAvatar);
+}


### PR DESCRIPTION
## Summary

- Add the app.user.avatar preference and managed Expo FileSystem persistence with path-resilient references.
- Update profile, home header, and settings consumers to use the shared persisted avatar with a bundled fallback.
- Handle storage rollback, old-file cleanup, localized save errors, and legacy URI compatibility.

## Verification

- pnpm typecheck; pnpm format:check; pnpm lint; full Jest suite (691 tests); iOS Metro bundle.