### PR TITLE
feat: persist mobile avatars and chat attachments

### DIFF
--- a/migrations/sqlite-drizzle/0002_melted_odin.sql
+++ b/migrations/sqlite-drizzle/0002_melted_odin.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `chat_message_file_ref` (
+	`id` text PRIMARY KEY NOT NULL,
+	`file_entry_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`role` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`file_entry_id`) REFERENCES `file_entry`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`source_id`) REFERENCES `message`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "cmfr_role_check" CHECK("chat_message_file_ref"."role" IN ('attachment'))
+);
+--> statement-breakpoint
+CREATE INDEX `cmfr_entry_id_idx` ON `chat_message_file_ref` (`file_entry_id`);--> statement-breakpoint
+CREATE INDEX `cmfr_source_id_idx` ON `chat_message_file_ref` (`source_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `cmfr_unique_idx` ON `chat_message_file_ref` (`file_entry_id`,`source_id`,`role`);--> statement-breakpoint
+CREATE TABLE `file_entry` (
+	`id` text PRIMARY KEY NOT NULL,
+	`origin` text NOT NULL,
+	`name` text NOT NULL,
+	`ext` text,
+	`size` integer,
+	`external_path` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`deleted_at` integer,
+	CONSTRAINT "fe_origin_check" CHECK("file_entry"."origin" IN ('internal', 'external')),
+	CONSTRAINT "fe_origin_consistency" CHECK(("file_entry"."origin" = 'internal' AND "file_entry"."external_path" IS NULL) OR ("file_entry"."origin" = 'external' AND "file_entry"."external_path" IS NOT NULL)),
+	CONSTRAINT "fe_external_no_delete" CHECK("file_entry"."origin" != 'external' OR "file_entry"."deleted_at" IS NULL),
+	CONSTRAINT "fe_size_internal_only" CHECK(("file_entry"."origin" = 'internal' AND "file_entry"."size" IS NOT NULL AND "file_entry"."size" >= 0) OR ("file_entry"."origin" = 'external' AND "file_entry"."size" IS NULL))
+);
+--> statement-breakpoint
+CREATE INDEX `fe_deleted_at_idx` ON `file_entry` (`deleted_at`);--> statement-breakpoint
+CREATE INDEX `fe_created_at_idx` ON `file_entry` (`created_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `fe_external_path_lower_unique_idx` ON `file_entry` (lower("external_path"));--> statement-breakpoint
+CREATE INDEX `fe_external_path_idx` ON `file_entry` (`external_path`);

--- a/migrations/sqlite-drizzle/meta/0002_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1504 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a550ead9-0981-425b-824c-442a23660820",
+  "prevId": "3ce7175e-f99d-44d2-805c-6e2bbf6633be",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": ["assistant_id", "knowledge_base_id"],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": ["assistant_id", "mcp_server_id"],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "assistant_order_key_idx": {
+          "name": "assistant_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_message_file_ref": {
+      "name": "chat_message_file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cmfr_entry_id_idx": {
+          "name": "cmfr_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "cmfr_source_id_idx": {
+          "name": "cmfr_source_id_idx",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "cmfr_unique_idx": {
+          "name": "cmfr_unique_idx",
+          "columns": ["file_entry_id", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_message_file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "chat_message_file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "chat_message_file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_message_file_ref_source_id_message_id_fk": {
+          "name": "chat_message_file_ref_source_id_message_id_fk",
+          "tableFrom": "chat_message_file_ref",
+          "tableTo": "message",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cmfr_role_check": {
+          "name": "cmfr_role_check",
+          "value": "\"chat_message_file_ref\".\"role\" IN ('attachment')"
+        }
+      }
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_path": {
+          "name": "external_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fe_deleted_at_idx": {
+          "name": "fe_deleted_at_idx",
+          "columns": ["deleted_at"],
+          "isUnique": false
+        },
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "fe_external_path_lower_unique_idx": {
+          "name": "fe_external_path_lower_unique_idx",
+          "columns": ["lower(\"external_path\")"],
+          "isUnique": true
+        },
+        "fe_external_path_idx": {
+          "name": "fe_external_path_idx",
+          "columns": ["external_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "fe_origin_check": {
+          "name": "fe_origin_check",
+          "value": "\"file_entry\".\"origin\" IN ('internal', 'external')"
+        },
+        "fe_origin_consistency": {
+          "name": "fe_origin_consistency",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"external_path\" IS NULL) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"external_path\" IS NOT NULL)"
+        },
+        "fe_external_no_delete": {
+          "name": "fe_external_no_delete",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"deleted_at\" IS NULL"
+        },
+        "fe_size_internal_only": {
+          "name": "fe_size_internal_only",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"size\" IS NOT NULL AND \"file_entry\".\"size\" >= 0) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"size\" IS NULL)"
+        }
+      }
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_status_idx": {
+          "name": "message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "message_fts_rowid_uniq": {
+          "name": "message_fts_rowid_uniq",
+          "columns": ["fts_rowid"],
+          "isUnique": true
+        },
+        "message_topic_root_uniq": {
+          "name": "message_topic_root_uniq",
+          "columns": ["topic_id"],
+          "isUnique": true,
+          "where": "\"message\".\"parent_id\" is null and \"message\".\"deleted_at\" is null"
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system', 'root')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        },
+        "message_root_parent_check": {
+          "name": "message_root_parent_check",
+          "value": "(\"message\".\"role\" = 'root') = (\"message\".\"parent_id\" is null)"
+        }
+      }
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt": {
+      "name": "prompt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_order_key_idx": {
+          "name": "prompt_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_group_id_order_key_idx": {
+          "name": "topic_group_id_order_key_idx",
+          "columns": ["group_id", "order_key"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_endpoint_url": {
+          "name": "custom_endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_overrides": {
+          "name": "user_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "fe_external_path_lower_unique_idx": {
+        "columns": {
+          "lower(\"external_path\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783754760843,
       "tag": "0001_message-status-index",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1784546033106,
+      "tag": "0002_melted_odin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/AiService.ts
+++ b/src/ai/AiService.ts
@@ -15,6 +15,7 @@ import {
   type UIMessageChunk,
 } from 'ai';
 import type { AssistantService } from '@/data/services/AssistantService';
+import type { FileEntryService } from '@/data/services/FileEntryService';
 import type { ModelService } from '@/data/services/ModelService';
 import type { PreferenceService } from '@/data/services/PreferenceService';
 import type { ProviderService } from '@/data/services/ProviderService';
@@ -101,6 +102,7 @@ export interface AiImageResult {
 
 export interface AiServiceDependencies {
   assistant: AssistantService;
+  fileEntry: Pick<FileEntryService, 'resolveUri'>;
   model: ModelService;
   preference: PreferenceService;
   provider: ProviderService;
@@ -135,7 +137,9 @@ export class AiService {
     const [{ sdkConfig, model, system, tools, plugins, options }, preparedMessages] =
       await Promise.all([
         this.buildAgentParamsFor(request, { shouldIncludeExternalTools: true }),
-        resolveUIMessageFileUrls(request.messages ?? []),
+        resolveUIMessageFileUrls(request.messages ?? [], (fileEntryId) =>
+          this.services.fileEntry.resolveUri(fileEntryId),
+        ),
       ]);
 
     const agent = new Agent({

--- a/src/ai/__tests__/AiService.test.ts
+++ b/src/ai/__tests__/AiService.test.ts
@@ -444,6 +444,9 @@ function createServices({
     assistant: {
       getById: jest.fn(async () => assistant),
     },
+    fileEntry: {
+      resolveUri: jest.fn(async () => undefined),
+    },
     model: {
       getById: jest.fn(async (id: UniqueModelId) => modelsById.get(id)),
     },

--- a/src/ai/messages/__tests__/messageConverter.test.ts
+++ b/src/ai/messages/__tests__/messageConverter.test.ts
@@ -49,7 +49,7 @@ describe('resolveUIMessageFileUrls', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  test('prefers a managed file URI over the persisted fallback URL', async () => {
+  test('uses a managed file URI without reading the persisted URL', async () => {
     testState.contents.set('file:///new-sandbox/files/entry.png', {
       base64: 'managed',
       type: 'image/png',
@@ -68,7 +68,7 @@ describe('resolveUIMessageFileUrls', () => {
     expect(testState.reads).toEqual(['file:///new-sandbox/files/entry.png']);
   });
 
-  test('falls back to the wire URL when the entry cannot be resolved', async () => {
+  test('drops a managed attachment when its entry cannot be resolved', async () => {
     testState.contents.set('file:///legacy/brief.pdf', { base64: 'legacy', type: '' });
 
     const [message] = await resolveUIMessageFileUrls(
@@ -76,12 +76,8 @@ describe('resolveUIMessageFileUrls', () => {
       async () => undefined,
     );
 
-    expect(message.parts[0]).toEqual(
-      expect.objectContaining({
-        mediaType: 'application/pdf',
-        url: 'data:application/pdf;base64,legacy',
-      }),
-    );
+    expect(message.parts).toEqual([]);
+    expect(testState.reads).toEqual([]);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
@@ -90,7 +86,7 @@ describe('resolveUIMessageFileUrls', () => {
     );
   });
 
-  test('uses the fallback URL after a managed file read fails', async () => {
+  test('does not read the persisted URL after a managed file read fails', async () => {
     testState.contents.set('file:///legacy/brief.pdf', { base64: 'legacy', type: '' });
 
     const [message] = await resolveUIMessageFileUrls(
@@ -98,16 +94,11 @@ describe('resolveUIMessageFileUrls', () => {
       async () => 'file:///new-sandbox/files/missing.pdf',
     );
 
-    expect(message.parts[0]).toEqual(
-      expect.objectContaining({ url: 'data:application/pdf;base64,legacy' }),
-    );
-    expect(testState.reads).toEqual([
-      'file:///new-sandbox/files/missing.pdf',
-      'file:///legacy/brief.pdf',
-    ]);
+    expect(message.parts).toEqual([]);
+    expect(testState.reads).toEqual(['file:///new-sandbox/files/missing.pdf']);
   });
 
-  test('drops only attachments whose managed and fallback files are both unreadable', async () => {
+  test('drops only unreadable managed attachments', async () => {
     const message = createMessage([
       { text: 'keep me', type: 'text' },
       filePart('file:///legacy/missing.pdf', 'entry-1'),
@@ -128,7 +119,7 @@ describe('resolveUIMessageFileUrls', () => {
       { text: 'keep me', type: 'text' },
       expect.objectContaining({ url: 'https://example.com/remote.pdf' }),
     ]);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/ai/messages/__tests__/messageConverter.test.ts
+++ b/src/ai/messages/__tests__/messageConverter.test.ts
@@ -1,0 +1,147 @@
+import type { UIMessage } from 'ai';
+import { resolveUIMessageFileUrls } from '../messageConverter';
+
+jest.mock('expo-file-system', () => {
+  const contents = new Map<string, { base64: string; type: string }>();
+  const reads: string[] = [];
+
+  class MockFile {
+    readonly uri: string;
+
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+
+    get type() {
+      return contents.get(this.uri)?.type ?? '';
+    }
+
+    async base64() {
+      reads.push(this.uri);
+      const content = contents.get(this.uri);
+      if (!content) {
+        throw new Error(`missing file: ${this.uri}`);
+      }
+      return content.base64;
+    }
+  }
+
+  return { File: MockFile, testState: { contents, reads } };
+});
+
+type FileSystemTestState = {
+  contents: Map<string, { base64: string; type: string }>;
+  reads: string[];
+};
+
+const { testState } = jest.requireMock<{ testState: FileSystemTestState }>('expo-file-system');
+
+describe('resolveUIMessageFileUrls', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    testState.contents.clear();
+    testState.reads.length = 0;
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('prefers a managed file URI over the persisted fallback URL', async () => {
+    testState.contents.set('file:///new-sandbox/files/entry.png', {
+      base64: 'managed',
+      type: 'image/png',
+    });
+    const resolveFileEntryUri = jest.fn(async () => 'file:///new-sandbox/files/entry.png');
+
+    const [message] = await resolveUIMessageFileUrls(
+      [createMessage([filePart('file:///old-sandbox/image.jpg', 'entry-1')])],
+      resolveFileEntryUri,
+    );
+
+    expect(resolveFileEntryUri).toHaveBeenCalledWith('entry-1');
+    expect(message.parts[0]).toEqual(
+      expect.objectContaining({ mediaType: 'image/png', url: 'data:image/png;base64,managed' }),
+    );
+    expect(testState.reads).toEqual(['file:///new-sandbox/files/entry.png']);
+  });
+
+  test('falls back to the wire URL when the entry cannot be resolved', async () => {
+    testState.contents.set('file:///legacy/brief.pdf', { base64: 'legacy', type: '' });
+
+    const [message] = await resolveUIMessageFileUrls(
+      [createMessage([filePart('file:///legacy/brief.pdf', 'entry-1')])],
+      async () => undefined,
+    );
+
+    expect(message.parts[0]).toEqual(
+      expect.objectContaining({
+        mediaType: 'application/pdf',
+        url: 'data:application/pdf;base64,legacy',
+      }),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      '[fileProcessor] Managed file entry is unavailable',
+      { fileEntryId: 'entry-1' },
+    );
+  });
+
+  test('uses the fallback URL after a managed file read fails', async () => {
+    testState.contents.set('file:///legacy/brief.pdf', { base64: 'legacy', type: '' });
+
+    const [message] = await resolveUIMessageFileUrls(
+      [createMessage([filePart('file:///legacy/brief.pdf', 'entry-1')])],
+      async () => 'file:///new-sandbox/files/missing.pdf',
+    );
+
+    expect(message.parts[0]).toEqual(
+      expect.objectContaining({ url: 'data:application/pdf;base64,legacy' }),
+    );
+    expect(testState.reads).toEqual([
+      'file:///new-sandbox/files/missing.pdf',
+      'file:///legacy/brief.pdf',
+    ]);
+  });
+
+  test('drops only attachments whose managed and fallback files are both unreadable', async () => {
+    const message = createMessage([
+      { text: 'keep me', type: 'text' },
+      filePart('file:///legacy/missing.pdf', 'entry-1'),
+      {
+        filename: 'remote.pdf',
+        mediaType: 'application/pdf',
+        type: 'file',
+        url: 'https://example.com/remote.pdf',
+      },
+    ]);
+
+    const [resolved] = await resolveUIMessageFileUrls(
+      [message],
+      async () => 'file:///new-sandbox/files/missing.pdf',
+    );
+
+    expect(resolved.parts).toEqual([
+      { text: 'keep me', type: 'text' },
+      expect.objectContaining({ url: 'https://example.com/remote.pdf' }),
+    ]);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createMessage(parts: UIMessage['parts']): UIMessage {
+  return { id: 'message-1', parts, role: 'user' };
+}
+
+function filePart(url: string, fileEntryId: string): UIMessage['parts'][number] {
+  return {
+    filename: 'brief.pdf',
+    mediaType: 'application/pdf',
+    providerMetadata: { cherry: { fileEntryId } },
+    type: 'file',
+    url,
+  };
+}

--- a/src/ai/messages/fileProcessor.ts
+++ b/src/ai/messages/fileProcessor.ts
@@ -18,7 +18,7 @@ const logger = loggerService.withContext('fileProcessor');
 export type ResolveFileEntryUri = (fileEntryId: string) => Promise<string | undefined>;
 
 /**
- * Resolve a managed file before falling back to the wire URL. Local files are
+ * Resolve managed files exclusively by entry ID. Unmanaged local files are
  * rewritten to data URLs because the AI SDK cannot fetch device-only URIs.
  */
 export async function resolveFileUIPart(
@@ -26,41 +26,40 @@ export async function resolveFileUIPart(
   resolveFileEntryUri?: ResolveFileEntryUri,
 ): Promise<FileUIPart | null> {
   const fileEntryId = readCherryMeta(part)?.fileEntryId;
-  let managedUri: string | undefined;
 
-  if (fileEntryId && resolveFileEntryUri) {
+  if (fileEntryId) {
+    if (!resolveFileEntryUri) {
+      logger.warn('Managed file resolver is unavailable', { fileEntryId });
+      return null;
+    }
+
+    let managedUri: string | undefined;
     try {
       managedUri = await resolveFileEntryUri(fileEntryId);
     } catch (error) {
       logger.warn('Failed to resolve managed file entry', toError(error), { fileEntryId });
+      return null;
     }
 
     if (!managedUri) {
       logger.warn('Managed file entry is unavailable', { fileEntryId });
-    } else {
-      const resolved = await readLocalFilePart(part, managedUri, fileEntryId, 'managed');
-      if (resolved) {
-        return resolved;
-      }
+      return null;
     }
-  }
 
-  if (part.url === managedUri) {
-    return null;
+    return readLocalFilePart(part, managedUri, fileEntryId);
   }
 
   if (!isLocalFileUri(part.url)) {
     return part;
   }
 
-  return readLocalFilePart(part, part.url, fileEntryId, 'fallback');
+  return readLocalFilePart(part, part.url);
 }
 
 async function readLocalFilePart(
   part: FileUIPart,
   uri: string,
-  fileEntryId: string | undefined,
-  source: 'fallback' | 'managed',
+  fileEntryId?: string,
 ): Promise<FileUIPart | null> {
   try {
     const file = new File(uri);
@@ -70,7 +69,6 @@ async function readLocalFilePart(
   } catch (error) {
     logger.warn('Failed to read attachment for AI request', toError(error), {
       fileEntryId,
-      source,
     });
     return null;
   }

--- a/src/ai/messages/fileProcessor.ts
+++ b/src/ai/messages/fileProcessor.ts
@@ -6,33 +6,80 @@
  * rewrites those with Node fs; mobile uses Expo FileSystem to produce data URLs.
  */
 
-import * as FileSystem from 'expo-file-system';
+import { File } from 'expo-file-system';
 
+import { loggerService } from '@/core/logger/LoggerService';
 import type { FileUIPart } from '@/data/types/message';
+import { readCherryMeta } from '@/data/types/uiParts';
 
 const FALLBACK_MEDIA_TYPE = 'application/octet-stream';
+const logger = loggerService.withContext('fileProcessor');
+
+export type ResolveFileEntryUri = (fileEntryId: string) => Promise<string | undefined>;
 
 /**
- * Rewrite any `file://` URLs in a `FileUIPart` to base64 data URLs. Leaves
- * `data:` / `https:` / `http:` URLs untouched. If the file can't be read,
- * returns `null` to signal the caller should drop the part.
+ * Resolve a managed file before falling back to the wire URL. Local files are
+ * rewritten to data URLs because the AI SDK cannot fetch device-only URIs.
  */
-export async function resolveFileUIPart(part: FileUIPart): Promise<FileUIPart | null> {
-  const url = part.url;
-  if (!url) return part;
-  if (!url.startsWith('file://')) return part;
+export async function resolveFileUIPart(
+  part: FileUIPart,
+  resolveFileEntryUri?: ResolveFileEntryUri,
+): Promise<FileUIPart | null> {
+  const fileEntryId = readCherryMeta(part)?.fileEntryId;
+  let managedUri: string | undefined;
 
-  try {
-    const base64 = await FileSystem.readAsStringAsync(url, {
-      encoding: FileSystem.EncodingType.Base64,
-    });
-    const mediaType = part.mediaType || FALLBACK_MEDIA_TYPE;
-    return {
-      ...part,
-      mediaType,
-      url: `data:${mediaType};base64,${base64}`,
-    };
-  } catch {
+  if (fileEntryId && resolveFileEntryUri) {
+    try {
+      managedUri = await resolveFileEntryUri(fileEntryId);
+    } catch (error) {
+      logger.warn('Failed to resolve managed file entry', toError(error), { fileEntryId });
+    }
+
+    if (!managedUri) {
+      logger.warn('Managed file entry is unavailable', { fileEntryId });
+    } else {
+      const resolved = await readLocalFilePart(part, managedUri, fileEntryId, 'managed');
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  if (part.url === managedUri) {
     return null;
   }
+
+  if (!isLocalFileUri(part.url)) {
+    return part;
+  }
+
+  return readLocalFilePart(part, part.url, fileEntryId, 'fallback');
+}
+
+async function readLocalFilePart(
+  part: FileUIPart,
+  uri: string,
+  fileEntryId: string | undefined,
+  source: 'fallback' | 'managed',
+): Promise<FileUIPart | null> {
+  try {
+    const file = new File(uri);
+    const base64 = await file.base64();
+    const mediaType = file.type || part.mediaType || FALLBACK_MEDIA_TYPE;
+    return { ...part, mediaType, url: `data:${mediaType};base64,${base64}` };
+  } catch (error) {
+    logger.warn('Failed to read attachment for AI request', toError(error), {
+      fileEntryId,
+      source,
+    });
+    return null;
+  }
+}
+
+function isLocalFileUri(uri: string): boolean {
+  return uri.startsWith('file://') || uri.startsWith('content://');
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/src/ai/messages/messageConverter.ts
+++ b/src/ai/messages/messageConverter.ts
@@ -1,12 +1,9 @@
-/**
- * `Message` -> AI SDK `UIMessage`, with unresolved `file://` URLs dropped
- * until the mobile file resolver is wired to Expo FileSystem.
- */
+/** `Message` -> AI SDK `UIMessage`. */
 
 import type { UIMessage } from 'ai';
 import type { CherryMessagePart, CherryUIMessage, Message } from '@/data/types/message';
 
-import { resolveFileUIPart } from './fileProcessor';
+import { type ResolveFileEntryUri, resolveFileUIPart } from './fileProcessor';
 
 export function toCherryUIMessage(message: Message): CherryUIMessage {
   const parts: CherryMessagePart[] = message.data?.parts ?? [];
@@ -18,13 +15,16 @@ export function toCherryUIMessage(message: Message): CherryUIMessage {
 }
 
 /** Unresolvable file parts are dropped with a warning. */
-async function resolveMessageParts<T extends UIMessage>(message: T): Promise<T> {
+async function resolveMessageParts<T extends UIMessage>(
+  message: T,
+  resolveFileEntryUri?: ResolveFileEntryUri,
+): Promise<T> {
   if (!message.parts?.length) return message;
 
   const resolved: UIMessage['parts'] = [];
   for (const part of message.parts) {
     if (part.type === 'file') {
-      const next = await resolveFileUIPart(part);
+      const next = await resolveFileUIPart(part, resolveFileEntryUri);
       if (next) resolved.push(next as UIMessage['parts'][number]);
       continue;
     }
@@ -37,6 +37,7 @@ async function resolveMessageParts<T extends UIMessage>(message: T): Promise<T> 
 /** Idempotent for non-file parts and non-`file://` URLs. */
 export async function resolveUIMessageFileUrls<T extends UIMessage = UIMessage>(
   messages: T[],
+  resolveFileEntryUri?: ResolveFileEntryUri,
 ): Promise<T[]> {
-  return Promise.all(messages.map(resolveMessageParts));
+  return Promise.all(messages.map((message) => resolveMessageParts(message, resolveFileEntryUri)));
 }

--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -1,43 +1,39 @@
-import type { ImageSource } from 'expo-image';
 import { useThemeColor } from 'heroui-native/hooks';
 import { CameraIcon, PencilIcon } from 'lucide-uniwind/png';
 import { View } from 'react-native';
 
 import { Image } from '@/components/nativePrimitives';
-
-const avatarSource = require('@/assets/icon.png');
+import { useAvatar } from '@/hooks/useAvatar';
 
 export type ProfileAvatarEditIcon = 'camera' | 'pencil';
 
 type ProfileEditableAvatarProps = {
   icon: ProfileAvatarEditIcon;
-  imageSource?: ImageSource | number;
   size: number;
 };
 
-export function ProfileEditableAvatar({ icon, imageSource, size }: ProfileEditableAvatarProps) {
+export function ProfileEditableAvatar({ icon, size }: ProfileEditableAvatarProps) {
   return (
     <View style={{ height: size, width: size }}>
-      <ProfileAvatarImage imageSource={imageSource} size={size} />
+      <ProfileAvatarImage size={size} />
       <ProfileAvatarEditBadge icon={icon} size={size} />
     </View>
   );
 }
 
 type ProfileAvatarImageProps = {
-  imageSource?: ImageSource | number;
   size: number;
 };
 
-export function ProfileAvatarImage({ imageSource, size }: ProfileAvatarImageProps) {
-  const source = imageSource ?? avatarSource;
+export function ProfileAvatarImage({ size }: ProfileAvatarImageProps) {
+  const avatarSource = useAvatar();
 
   return (
     <Image
       accessibilityIgnoresInvertColors
       cachePolicy="memory-disk"
       className="rounded-full"
-      source={source}
+      source={avatarSource}
       style={{ borderRadius: size / 2, height: size, width: size }}
     />
   );

--- a/src/data/db/__tests__/migrations.test.ts
+++ b/src/data/db/__tests__/migrations.test.ts
@@ -29,6 +29,12 @@ describe('bundled SQLite migrations', () => {
       const messageColumns = database.prepare("PRAGMA table_info('message')").all() as {
         name: string;
       }[];
+      const fileEntryColumns = database.prepare("PRAGMA table_info('file_entry')").all() as {
+        name: string;
+      }[];
+      const chatMessageFileRefColumns = database
+        .prepare("PRAGMA table_info('chat_message_file_ref')")
+        .all() as { name: string }[];
       const modelColumns = database.prepare("PRAGMA table_info('user_model')").all() as {
         name: string;
       }[];
@@ -42,18 +48,46 @@ describe('bundled SQLite migrations', () => {
       const modelIndexes = database.prepare("PRAGMA index_list('user_model')").all() as {
         name: string;
       }[];
+      const fileEntryIndexes = database.prepare("PRAGMA index_list('file_entry')").all() as {
+        name: string;
+      }[];
+      const chatMessageFileRefIndexes = database
+        .prepare("PRAGMA index_list('chat_message_file_ref')")
+        .all() as { name: string; unique: number }[];
       const tables = database
         .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
         .all() as { name: string }[];
       const messageTableSql = getSchemaSql(database, 'table', 'message');
+      const fileEntryTableSql = getSchemaSql(database, 'table', 'file_entry');
+      const chatMessageFileRefTableSql = getSchemaSql(database, 'table', 'chat_message_file_ref');
       const rootIndexSql = getSchemaSql(database, 'index', 'message_topic_root_uniq');
       const assistantKnowledgeBaseFks = getForeignKeys(database, 'assistant_knowledge_base');
       const assistantMcpServerFks = getForeignKeys(database, 'assistant_mcp_server');
       const messageFks = getForeignKeys(database, 'message');
+      const chatMessageFileRefFks = getForeignKeys(database, 'chat_message_file_ref');
 
       expect(topicColumns.map((column) => column.name)).toContain('trace_id');
       expect(messageColumns.map((column) => column.name)).not.toContain('trace_id');
       expect(modelColumns.map((column) => column.name)).not.toContain('owned_by');
+      expect(fileEntryColumns.map((column) => column.name)).toEqual([
+        'id',
+        'origin',
+        'name',
+        'ext',
+        'size',
+        'external_path',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+      ]);
+      expect(chatMessageFileRefColumns.map((column) => column.name)).toEqual([
+        'id',
+        'file_entry_id',
+        'source_id',
+        'role',
+        'created_at',
+        'updated_at',
+      ]);
       expect(messageIndexes.map((index) => index.name)).not.toContain('message_trace_id_idx');
       expect(messageIndexes).toEqual(
         expect.arrayContaining([
@@ -79,7 +113,27 @@ describe('bundled SQLite migrations', () => {
           'user_model_provider_model_unique',
         ]),
       );
+      expect(fileEntryIndexes.map((index) => index.name)).toEqual(
+        expect.arrayContaining([
+          'fe_created_at_idx',
+          'fe_deleted_at_idx',
+          'fe_external_path_idx',
+          'fe_external_path_lower_unique_idx',
+        ]),
+      );
+      expect(chatMessageFileRefIndexes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'cmfr_entry_id_idx', unique: 0 }),
+          expect.objectContaining({ name: 'cmfr_source_id_idx', unique: 0 }),
+          expect.objectContaining({ name: 'cmfr_unique_idx', unique: 1 }),
+        ]),
+      );
       expect(messageTableSql).toContain('message_root_parent_check');
+      expect(fileEntryTableSql).toEqual(expect.stringContaining('fe_origin_check'));
+      expect(fileEntryTableSql).toEqual(expect.stringContaining('fe_origin_consistency'));
+      expect(fileEntryTableSql).toEqual(expect.stringContaining('fe_external_no_delete'));
+      expect(fileEntryTableSql).toEqual(expect.stringContaining('fe_size_internal_only'));
+      expect(chatMessageFileRefTableSql).toContain('cmfr_role_check');
       expect(rootIndexSql).toContain('"deleted_at" is null');
       expect(assistantKnowledgeBaseFks).toContainEqual(
         expect.objectContaining({ from: 'assistant_id', on_delete: 'CASCADE', table: 'assistant' }),
@@ -93,8 +147,27 @@ describe('bundled SQLite migrations', () => {
           expect.objectContaining({ from: 'topic_id', on_delete: 'CASCADE', table: 'topic' }),
         ]),
       );
+      expect(chatMessageFileRefFks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            from: 'file_entry_id',
+            on_delete: 'CASCADE',
+            table: 'file_entry',
+          }),
+          expect.objectContaining({
+            from: 'source_id',
+            on_delete: 'CASCADE',
+            table: 'message',
+          }),
+        ]),
+      );
       expect(tables.map((table) => table.name)).toEqual(
-        expect.arrayContaining(['assistant_knowledge_base', 'assistant_mcp_server']),
+        expect.arrayContaining([
+          'assistant_knowledge_base',
+          'assistant_mcp_server',
+          'chat_message_file_ref',
+          'file_entry',
+        ]),
       );
     } finally {
       database.close();

--- a/src/data/db/migrations.ts
+++ b/src/data/db/migrations.ts
@@ -1,5 +1,6 @@
 import m0000 from '../../../migrations/sqlite-drizzle/0000_release_baseline.sql';
 import m0001 from '../../../migrations/sqlite-drizzle/0001_message-status-index.sql';
+import m0002 from '../../../migrations/sqlite-drizzle/0002_melted_odin.sql';
 import journal from '../../../migrations/sqlite-drizzle/meta/_journal.json';
 
 // Expo SQLite migrations must be bundled into JS; unlike the desktop main
@@ -11,5 +12,6 @@ export const migrations = {
   migrations: {
     m0000,
     m0001,
+    m0002,
   },
 };

--- a/src/data/db/schemas/_columnHelpers.ts
+++ b/src/data/db/schemas/_columnHelpers.ts
@@ -73,10 +73,9 @@ export const uuidPrimaryKey = () => text().primaryKey().$defaultFn(createRandomU
  * UUID v7 primary key with auto-generation (time-ordered).
  * Use for tables with large datasets that benefit from sequential inserts.
  */
-export const uuidPrimaryKeyOrdered = () =>
-  text()
-    .primaryKey()
-    .$defaultFn(() => uuidv7({ rng: createUuidBytes }));
+export const createOrderedUuid = () => uuidv7({ rng: createUuidBytes });
+
+export const uuidPrimaryKeyOrdered = () => text().primaryKey().$defaultFn(createOrderedUuid);
 
 export const createUpdateTimestamps = {
   createdAt: integer().notNull().$defaultFn(createTimestamp),

--- a/src/data/db/schemas/file.ts
+++ b/src/data/db/schemas/file.ts
@@ -1,0 +1,39 @@
+import { sql } from 'drizzle-orm';
+import { check, index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+
+import { createUpdateDeleteTimestamps, uuidPrimaryKeyOrdered } from './_columnHelpers';
+
+export const fileEntryTable = sqliteTable(
+  'file_entry',
+  {
+    id: uuidPrimaryKeyOrdered(),
+    origin: text().notNull(),
+    name: text().notNull(),
+    ext: text(),
+    size: integer(),
+    externalPath: text(),
+    ...createUpdateDeleteTimestamps,
+  },
+  (table) => [
+    index('fe_deleted_at_idx').on(table.deletedAt),
+    index('fe_created_at_idx').on(table.createdAt),
+    uniqueIndex('fe_external_path_lower_unique_idx').on(sql`lower(${table.externalPath})`),
+    index('fe_external_path_idx').on(table.externalPath),
+    check('fe_origin_check', sql`${table.origin} IN ('internal', 'external')`),
+    check(
+      'fe_origin_consistency',
+      sql`(${table.origin} = 'internal' AND ${table.externalPath} IS NULL) OR (${table.origin} = 'external' AND ${table.externalPath} IS NOT NULL)`,
+    ),
+    check(
+      'fe_external_no_delete',
+      sql`${table.origin} != 'external' OR ${table.deletedAt} IS NULL`,
+    ),
+    check(
+      'fe_size_internal_only',
+      sql`(${table.origin} = 'internal' AND ${table.size} IS NOT NULL AND ${table.size} >= 0) OR (${table.origin} = 'external' AND ${table.size} IS NULL)`,
+    ),
+  ],
+);
+
+export type FileEntryRow = typeof fileEntryTable.$inferSelect;
+export type InsertFileEntryRow = typeof fileEntryTable.$inferInsert;

--- a/src/data/db/schemas/fileRelations.ts
+++ b/src/data/db/schemas/fileRelations.ts
@@ -1,0 +1,40 @@
+import { type SQLWrapper, sql } from 'drizzle-orm';
+import { check, index, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+
+import { chatMessageRoles } from '@/data/types/file';
+
+import { createUpdateTimestamps, uuidPrimaryKey } from './_columnHelpers';
+import { fileEntryTable } from './file';
+import { messageTable } from './message';
+
+function sqlStringList(values: readonly string[]) {
+  return sql.raw(values.map((value) => `'${value.replaceAll("'", "''")}'`).join(', '));
+}
+
+function roleCheck(column: SQLWrapper, roles: readonly string[]) {
+  return sql`${column} IN (${sqlStringList(roles)})`;
+}
+
+export const chatMessageFileRefTable = sqliteTable(
+  'chat_message_file_ref',
+  {
+    id: uuidPrimaryKey(),
+    fileEntryId: text()
+      .notNull()
+      .references(() => fileEntryTable.id, { onDelete: 'cascade' }),
+    sourceId: text()
+      .notNull()
+      .references(() => messageTable.id, { onDelete: 'cascade' }),
+    role: text().notNull().$type<(typeof chatMessageRoles)[number]>(),
+    ...createUpdateTimestamps,
+  },
+  (table) => [
+    index('cmfr_entry_id_idx').on(table.fileEntryId),
+    index('cmfr_source_id_idx').on(table.sourceId),
+    uniqueIndex('cmfr_unique_idx').on(table.fileEntryId, table.sourceId, table.role),
+    check('cmfr_role_check', roleCheck(table.role, chatMessageRoles)),
+  ],
+);
+
+export type ChatMessageFileRefRow = typeof chatMessageFileRefTable.$inferSelect;
+export type InsertChatMessageFileRefRow = typeof chatMessageFileRefTable.$inferInsert;

--- a/src/data/db/schemas/index.ts
+++ b/src/data/db/schemas/index.ts
@@ -1,6 +1,8 @@
 import { appStateTable } from './appState';
 import { assistantTable } from './assistant';
 import { assistantKnowledgeBaseTable, assistantMcpServerTable } from './assistantRelations';
+import { fileEntryTable } from './file';
+import { chatMessageFileRefTable } from './fileRelations';
 import { groupTable } from './group';
 import { messageTable } from './message';
 import { pinTable } from './pin';
@@ -25,6 +27,10 @@ export {
   assistantKnowledgeBaseTable,
   assistantMcpServerTable,
 } from './assistantRelations';
+export type { FileEntryRow, InsertFileEntryRow } from './file';
+export { fileEntryTable } from './file';
+export type { ChatMessageFileRefRow, InsertChatMessageFileRefRow } from './fileRelations';
+export { chatMessageFileRefTable } from './fileRelations';
 export type { GroupRow, InsertGroupRow } from './group';
 export { groupTable } from './group';
 export type { InsertMessageRow, MessageRow } from './message';
@@ -54,6 +60,8 @@ export const schema = {
   assistantMcpServerTable,
   assistantTable,
   appStateTable,
+  chatMessageFileRefTable,
+  fileEntryTable,
   groupTable,
   messageTable,
   pinTable,

--- a/src/data/preference/__tests__/preferenceUtils.test.ts
+++ b/src/data/preference/__tests__/preferenceUtils.test.ts
@@ -9,12 +9,13 @@ import {
 describe('preference defaults', () => {
   test('keeps the desktop preference key surface aligned', () => {
     expect(getPreferenceKeys()).toEqual(Object.keys(DefaultPreferences.default));
-    expect(getPreferenceKeys()).toHaveLength(229);
+    expect(getPreferenceKeys()).toHaveLength(230);
 
     expect(getPreferenceKeys()).toEqual(
       expect.arrayContaining([
         'app.developer_mode.enabled',
         'app.language',
+        'app.user.avatar',
         'chat.default_model_id',
         'chat.input.send_message_shortcut',
         'feature.quick_assistant.model_id',
@@ -29,6 +30,7 @@ describe('preference defaults', () => {
 
   test('returns desktop-aligned default values', () => {
     expect(getDefaultValue('app.language')).toBeNull();
+    expect(getDefaultValue('app.user.avatar')).toBe('');
     expect(getDefaultValue('app.user.id')).toBe('uuid()');
     expect(getDefaultValue('app.user.name')).toBe('');
     expect(getDefaultValue('app.dist.auto_update.enabled')).toBe(true);
@@ -62,6 +64,6 @@ describe('preference defaults', () => {
     expect(isPreferenceKey('chat.web_search.max_results')).toBe(true);
     expect(isPreferenceKey('feature.translate.model_prompt')).toBe(true);
     expect(isPreferenceKey('BootConfig.example')).toBe(false);
-    expect(Object.keys(DefaultPreferences.default)).toHaveLength(229);
+    expect(Object.keys(DefaultPreferences.default)).toHaveLength(230);
   });
 });

--- a/src/data/preference/preferenceSchemas.ts
+++ b/src/data/preference/preferenceSchemas.ts
@@ -76,6 +76,8 @@ export interface PreferenceSchemas {
     'app.tray.on_launch': boolean;
     // redux/settings/useSystemTitleBar
     'app.use_system_title_bar': boolean;
+    // redux/settings/userAvatar
+    'app.user.avatar': string;
     // redux/settings/userId
     'app.user.id': string;
     // redux/settings/userName
@@ -521,6 +523,7 @@ export const DefaultPreferences: PreferenceSchemas = {
     'app.tray.on_close': true,
     'app.tray.on_launch': false,
     'app.use_system_title_bar': false,
+    'app.user.avatar': '',
     'app.user.id': 'uuid()',
     'app.user.name': '',
     'app.zoom_factor': 1,

--- a/src/data/services/FileEntryService.ts
+++ b/src/data/services/FileEntryService.ts
@@ -1,0 +1,81 @@
+import { eq } from 'drizzle-orm';
+
+import type { Database, DbService } from '@/data/db/DbService';
+import { type FileEntryRow, fileEntryTable } from '@/data/db/schemas';
+import {
+  type FileEntry,
+  type FileEntryId,
+  FileEntrySchema,
+  type PreparedInternalFile,
+} from '@/data/types/file';
+
+import { resolveInternalFileUri } from './fileStorage';
+
+export class FileEntryService {
+  constructor(private readonly dbService: DbService) {}
+
+  private get db() {
+    return this.dbService.getDb();
+  }
+
+  async findById(id: FileEntryId): Promise<FileEntry | null> {
+    const [row] = await this.db
+      .select()
+      .from(fileEntryTable)
+      .where(eq(fileEntryTable.id, id))
+      .limit(1);
+    return row ? rowToFileEntry(row) : null;
+  }
+
+  async createPreparedEntriesTx(
+    tx: Database,
+    files: readonly PreparedInternalFile[],
+  ): Promise<void> {
+    if (files.length === 0) {
+      return;
+    }
+
+    await tx.insert(fileEntryTable).values(
+      files.map(({ ext, id, name, size }) => ({
+        ext,
+        id,
+        name,
+        origin: 'internal',
+        size,
+      })),
+    );
+  }
+
+  async resolveUri(id: FileEntryId): Promise<string | undefined> {
+    const entry = await this.findById(id);
+    if (!entry || entry.origin !== 'internal') {
+      return undefined;
+    }
+    return resolveInternalFileUri(entry);
+  }
+}
+
+function rowToFileEntry(row: FileEntryRow): FileEntry {
+  if (row.origin === 'internal') {
+    return FileEntrySchema.parse({
+      createdAt: row.createdAt,
+      ...(row.deletedAt !== null ? { deletedAt: row.deletedAt } : {}),
+      ext: row.ext,
+      id: row.id,
+      name: row.name,
+      origin: 'internal',
+      size: row.size,
+      updatedAt: row.updatedAt,
+    });
+  }
+
+  return FileEntrySchema.parse({
+    createdAt: row.createdAt,
+    ext: row.ext,
+    externalPath: row.externalPath,
+    id: row.id,
+    name: row.name,
+    origin: 'external',
+    updatedAt: row.updatedAt,
+  });
+}

--- a/src/data/services/MessageService.ts
+++ b/src/data/services/MessageService.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 
+import { loggerService } from '@/core/logger/LoggerService';
 import type {
   ActiveNodeStrategy,
   CreateMessageDto,
@@ -7,6 +8,7 @@ import type {
   UpdateMessageDto,
 } from '@/data/api/schemas/messages';
 import { DataApiErrorFactory } from '@/data/types/apiTypes';
+import type { PreparedInternalFile } from '@/data/types/file';
 import type {
   BranchMessage,
   BranchMessagesResponse,
@@ -17,14 +19,25 @@ import type {
   TreeResponse,
 } from '@/data/types/message';
 import type { UniqueModelId } from '@/data/types/model';
+import { readCherryMeta } from '@/data/types/uiParts';
 
-import type { DbService } from '../db/DbService';
-import { type MessageRow, messageTable, topicTable } from '../db/schemas';
+import type { Database, DbService } from '../db/DbService';
+import {
+  chatMessageFileRefTable,
+  fileEntryTable,
+  type MessageRow,
+  messageTable,
+  topicTable,
+} from '../db/schemas';
+import type { FileEntryService } from './FileEntryService';
 import type { TopicService } from './TopicService';
 import { timestampToISO } from './utils/rowMappers';
 
 const previewLength = 50;
 const defaultLimit = 20;
+const sqliteInArrayChunk = 500;
+const sqliteInsertChunk = 100;
+const logger = loggerService.withContext('MessageService');
 
 export type BranchMessagesParams = {
   cursor?: string;
@@ -40,6 +53,7 @@ export interface AssistantPlaceholder
 
 export interface CreateUserMessageWithPlaceholdersInput {
   placeholders: AssistantPlaceholder[];
+  preparedFiles?: readonly PreparedInternalFile[];
   siblingsGroupId?: number;
   topicId: string;
   userMessage: { dto: CreateMessageDto; mode: 'create' } | { id: string; mode: 'existing' };
@@ -54,10 +68,81 @@ export type ReserveAssistantTurnPlaceholder = AssistantPlaceholder;
 export type ReserveAssistantTurnInput = CreateUserMessageWithPlaceholdersInput;
 export type ReserveAssistantTurnResult = CreateUserMessageWithPlaceholdersResult;
 
+function extractChatMessageFileEntryIds(data: MessageData | null | undefined): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  for (const part of data?.parts ?? []) {
+    if (part.type !== 'file') {
+      continue;
+    }
+
+    const fileEntryId = readCherryMeta(part)?.fileEntryId;
+    if (!fileEntryId || seen.has(fileEntryId)) {
+      continue;
+    }
+
+    seen.add(fileEntryId);
+    ids.push(fileEntryId);
+  }
+
+  return ids;
+}
+
+async function selectExistingFileEntryIdsTx(
+  tx: Database,
+  ids: readonly string[],
+): Promise<Set<string>> {
+  const existing = new Set<string>();
+
+  for (let index = 0; index < ids.length; index += sqliteInArrayChunk) {
+    const rows = await tx
+      .select({ id: fileEntryTable.id })
+      .from(fileEntryTable)
+      .where(inArray(fileEntryTable.id, ids.slice(index, index + sqliteInArrayChunk)));
+    for (const row of rows) {
+      existing.add(row.id);
+    }
+  }
+
+  return existing;
+}
+
+async function replaceChatMessageFileRefsTx(
+  tx: Database,
+  messageId: string,
+  data: MessageData,
+): Promise<void> {
+  await tx.delete(chatMessageFileRefTable).where(eq(chatMessageFileRefTable.sourceId, messageId));
+
+  const fileEntryIds = extractChatMessageFileEntryIds(data);
+  if (fileEntryIds.length === 0) {
+    return;
+  }
+
+  const existingIds = await selectExistingFileEntryIdsTx(tx, fileEntryIds);
+  const rows = fileEntryIds
+    .filter((fileEntryId) => existingIds.has(fileEntryId))
+    .map((fileEntryId) => ({ fileEntryId, role: 'attachment' as const, sourceId: messageId }));
+
+  if (rows.length !== fileEntryIds.length) {
+    logger.warn('Dropped chat message file refs without matching file_entry', {
+      dropped: fileEntryIds.length - rows.length,
+      messageId,
+      total: fileEntryIds.length,
+    });
+  }
+
+  for (let index = 0; index < rows.length; index += sqliteInsertChunk) {
+    await tx.insert(chatMessageFileRefTable).values(rows.slice(index, index + sqliteInsertChunk));
+  }
+}
+
 export class MessageService {
   constructor(
     private readonly dbService: DbService,
     private readonly topicService: TopicService,
+    private readonly fileEntryService: FileEntryService,
   ) {}
 
   private get db() {
@@ -408,6 +493,7 @@ export class MessageService {
         })
         .returning();
 
+      await replaceChatMessageFileRefsTx(tx, row.id, data);
       await this.topicService.setActiveNodeTx(tx, source.topicId, row.id, { assumeValid: true });
       return rowToMessage(row);
     });
@@ -448,6 +534,7 @@ export class MessageService {
         })
         .returning();
 
+      await replaceChatMessageFileRefsTx(tx, row.id, dto.data);
       if (dto.setAsActive !== false) {
         await this.topicService.setActiveNodeTx(tx, topicId, row.id, { assumeValid: true });
       }
@@ -470,6 +557,13 @@ export class MessageService {
         throw DataApiErrorFactory.notFound('Topic', input.topicId);
       }
 
+      if (input.preparedFiles?.length && input.userMessage.mode !== 'create') {
+        throw DataApiErrorFactory.invalidOperation(
+          'prepare files for an existing message',
+          'prepared files require a newly created user message',
+        );
+      }
+
       let userMessage: Message;
       if (input.userMessage.mode === 'create') {
         const dto = input.userMessage.dto;
@@ -477,6 +571,7 @@ export class MessageService {
           dto.parentId === undefined || dto.parentId === null
             ? await getRootMessageIdTx(tx, input.topicId)
             : await validateParent(tx, input.topicId, dto.parentId);
+        await this.fileEntryService.createPreparedEntriesTx(tx, input.preparedFiles ?? []);
         const [row] = await tx
           .insert(messageTable)
           .values({
@@ -491,6 +586,7 @@ export class MessageService {
             topicId: input.topicId,
           })
           .returning();
+        await replaceChatMessageFileRefsTx(tx, row.id, dto.data);
         userMessage = rowToMessage(row);
       } else {
         const [row] = await tx
@@ -537,6 +633,7 @@ export class MessageService {
             topicId: input.topicId,
           })
           .returning();
+        await replaceChatMessageFileRefsTx(tx, row.id, placeholder.data);
         placeholders.push(rowToMessage(row));
       }
 
@@ -605,6 +702,10 @@ export class MessageService {
         .returning();
       if (!row) {
         throw DataApiErrorFactory.notFound('Message', id);
+      }
+
+      if (dto.data !== undefined) {
+        await replaceChatMessageFileRefsTx(tx, id, dto.data);
       }
 
       return rowToMessage(row);

--- a/src/data/services/__tests__/FileEntryService.test.ts
+++ b/src/data/services/__tests__/FileEntryService.test.ts
@@ -1,0 +1,100 @@
+import type { Database, DbService } from '@/data/db/DbService';
+import { FileEntryService } from '../FileEntryService';
+
+jest.mock('uuid', () => ({
+  v7: jest.fn(() => '00000000-0000-7000-8000-000000000000'),
+}));
+
+jest.mock('../fileStorage', () => ({
+  resolveInternalFileUri: jest.fn(() => 'file:///documents/files/entry.txt'),
+}));
+
+describe('FileEntryService', () => {
+  test.each([
+    [
+      {
+        createdAt: 1,
+        deletedAt: null,
+        ext: 'txt',
+        externalPath: null,
+        id: '00000000-0000-7000-8000-000000000001',
+        name: 'brief',
+        origin: 'internal',
+        size: 12,
+        updatedAt: 2,
+      },
+      {
+        createdAt: 1,
+        ext: 'txt',
+        id: '00000000-0000-7000-8000-000000000001',
+        name: 'brief',
+        origin: 'internal',
+        size: 12,
+        updatedAt: 2,
+      },
+    ],
+    [
+      {
+        createdAt: 1,
+        deletedAt: null,
+        ext: null,
+        externalPath: '/tmp/brief',
+        id: '00000000-0000-7000-8000-000000000002',
+        name: 'brief',
+        origin: 'external',
+        size: null,
+        updatedAt: 2,
+      },
+      {
+        createdAt: 1,
+        ext: null,
+        externalPath: '/tmp/brief',
+        id: '00000000-0000-7000-8000-000000000002',
+        name: 'brief',
+        origin: 'external',
+        updatedAt: 2,
+      },
+    ],
+  ])('maps %s database rows to file entries', async (row, expected) => {
+    const service = createServiceWithRows([row]);
+
+    await expect(service.findById(row.id)).resolves.toEqual(expected);
+  });
+
+  test('inserts prepared entries into the caller transaction', async () => {
+    const values = jest.fn(async () => undefined);
+    const tx = { insert: jest.fn(() => ({ values })) } as unknown as Database;
+    const service = new FileEntryService({} as DbService);
+
+    await service.createPreparedEntriesTx(tx, [
+      {
+        ext: 'txt',
+        id: '00000000-0000-7000-8000-000000000001',
+        name: 'brief',
+        size: 12,
+        uri: 'file:///documents/files/entry.txt',
+      },
+    ]);
+
+    expect(values).toHaveBeenCalledWith([
+      {
+        ext: 'txt',
+        id: '00000000-0000-7000-8000-000000000001',
+        name: 'brief',
+        origin: 'internal',
+        size: 12,
+      },
+    ]);
+  });
+});
+
+function createServiceWithRows(rows: unknown[]) {
+  const db = {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({ limit: jest.fn(async () => rows) })),
+      })),
+    })),
+  };
+  return new FileEntryService({ getDb: () => db } as unknown as DbService);
+}

--- a/src/data/services/__tests__/MessageService.test.ts
+++ b/src/data/services/__tests__/MessageService.test.ts
@@ -1,8 +1,16 @@
 import type { DbService } from '@/data/db/DbService';
-import type { Message } from '@/data/types/message';
+import { chatMessageFileRefTable, messageTable } from '@/data/db/schemas';
+import type { Message, MessageData } from '@/data/types/message';
 import { MessageService } from '../MessageService';
 
 jest.mock('@/data/db/schemas', () => ({
+  chatMessageFileRefTable: {
+    fileEntryId: 'chatMessageFileRef.fileEntryId',
+    sourceId: 'chatMessageFileRef.sourceId',
+  },
+  fileEntryTable: {
+    id: 'fileEntry.id',
+  },
   messageTable: {
     deletedAt: 'message.deletedAt',
     id: 'message.id',
@@ -19,7 +27,7 @@ jest.mock('@/data/db/schemas', () => ({
 
 describe('MessageService', () => {
   test('reserveAssistantTurn delegates to createUserMessageWithPlaceholders', async () => {
-    const service = new MessageService({} as never, {} as never);
+    const service = new MessageService({} as never, {} as never, {} as never);
     const result = {
       placeholders: [createMessage('650e8400-e29b-41d4-a716-446655440000', 'assistant')],
       userMessage: createMessage('550e8400-e29b-41d4-a716-446655440000', 'user'),
@@ -59,7 +67,7 @@ describe('MessageService', () => {
         }),
       }),
     } as unknown as DbService;
-    const service = new MessageService(dbService, {} as never);
+    const service = new MessageService(dbService, {} as never, {} as never);
 
     await expect(service.findPendingAssistantMessageIds()).resolves.toEqual(['a', 'b']);
   });
@@ -80,7 +88,7 @@ describe('MessageService', () => {
       callback(tx),
     );
     const dbService = { withWriteTx } as unknown as DbService;
-    const service = new MessageService(dbService, {} as never);
+    const service = new MessageService(dbService, {} as never, {} as never);
 
     await service.markMessagesError(['a', 'b']);
 
@@ -91,7 +99,7 @@ describe('MessageService', () => {
   test('markMessagesError is a no-op for an empty id list', async () => {
     const withWriteTx = jest.fn();
     const dbService = { withWriteTx } as unknown as DbService;
-    const service = new MessageService(dbService, {} as never);
+    const service = new MessageService(dbService, {} as never, {} as never);
 
     await service.markMessagesError([]);
 
@@ -133,7 +141,7 @@ describe('MessageService', () => {
       ),
     } as unknown as DbService;
     const topicService = { setActiveNodeTx: jest.fn() };
-    const service = new MessageService(dbService, topicService as never);
+    const service = new MessageService(dbService, topicService as never, {} as never);
     jest.spyOn(service, 'getById').mockResolvedValue(message);
 
     await expect(service.delete(message.id, true, 'parent')).resolves.toEqual({
@@ -188,7 +196,7 @@ describe('MessageService', () => {
       ),
     } as unknown as DbService;
     const topicService = { setActiveNodeTx: jest.fn() };
-    const service = new MessageService(dbService, topicService as never);
+    const service = new MessageService(dbService, topicService as never, {} as never);
     jest.spyOn(service, 'getById').mockResolvedValue(message);
 
     await expect(service.delete(message.id, false, 'parent')).resolves.toEqual({
@@ -227,6 +235,7 @@ describe('MessageService', () => {
     };
     const insertedValues: Record<string, unknown>[] = [];
     const tx = {
+      delete: jest.fn(() => ({ where: jest.fn(async () => undefined) })),
       insert: jest.fn(() => ({
         values: jest.fn((values: Record<string, unknown>) => {
           insertedValues.push(values);
@@ -245,7 +254,7 @@ describe('MessageService', () => {
       ),
     } as unknown as DbService;
     const topicService = { setActiveNodeTx: jest.fn() };
-    const service = new MessageService(dbService, topicService as never);
+    const service = new MessageService(dbService, topicService as never, {} as never);
 
     const sibling = await service.createSibling('source-1', { parts: [] });
 
@@ -253,6 +262,124 @@ describe('MessageService', () => {
     expect(sibling.status).toBe(expectedStatus);
     expect(topicService.setActiveNodeTx).toHaveBeenCalledWith(tx, topicId, 'sibling-1', {
       assumeValid: true,
+    });
+  });
+
+  test('atomically creates prepared entries, messages, and deduplicated refs', async () => {
+    const firstId = '00000000-0000-7000-8000-000000000001';
+    const secondId = '00000000-0000-7000-8000-000000000002';
+    const unknownId = '00000000-0000-7000-8000-000000000003';
+    const userData = {
+      parts: [filePart(firstId), filePart(firstId), filePart(unknownId)],
+    } satisfies MessageData;
+    const placeholderData = { parts: [filePart(secondId)] } satisfies MessageData;
+    const userRow = createMessageRow('user-1', 'user', userData, 'root-1');
+    const placeholderRow = createMessageRow('assistant-1', 'assistant', placeholderData, 'user-1');
+    const { insertCalls, tx } = createWriteTx({
+      insertRows: [userRow, placeholderRow],
+      selectResults: [
+        [{ id: 'topic-1' }],
+        [{ id: 'root-1' }],
+        [{ id: firstId }],
+        [{ id: secondId }],
+      ],
+    });
+    const dbService = {
+      withWriteTx: jest.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+        callback(tx),
+      ),
+    } as unknown as DbService;
+    const topicService = { setActiveNodeTx: jest.fn(async () => undefined) };
+    const createPreparedEntriesTx = jest.fn(async () => undefined);
+    const service = new MessageService(
+      dbService,
+      topicService as never,
+      { createPreparedEntriesTx } as never,
+    );
+    const preparedFiles = [
+      {
+        ext: 'txt',
+        id: firstId,
+        name: 'brief',
+        size: 12,
+        uri: 'file:///documents/files/brief.txt',
+      },
+    ];
+
+    await service.createUserMessageWithPlaceholders({
+      placeholders: [{ data: placeholderData, role: 'assistant' }],
+      preparedFiles,
+      topicId: 'topic-1',
+      userMessage: { dto: { data: userData, role: 'user' }, mode: 'create' },
+    });
+
+    expect(createPreparedEntriesTx).toHaveBeenCalledWith(tx, preparedFiles);
+    expect(createPreparedEntriesTx.mock.invocationCallOrder[0]).toBeLessThan(
+      (tx.insert as jest.Mock).mock.invocationCallOrder[0],
+    );
+    expect(insertCalls.filter((call) => call.table === messageTable)).toHaveLength(2);
+    expect(insertCalls.filter((call) => call.table === chatMessageFileRefTable)).toEqual([
+      {
+        table: chatMessageFileRefTable,
+        values: [{ fileEntryId: firstId, role: 'attachment', sourceId: 'user-1' }],
+      },
+      {
+        table: chatMessageFileRefTable,
+        values: [{ fileEntryId: secondId, role: 'attachment', sourceId: 'assistant-1' }],
+      },
+    ]);
+  });
+
+  test('creates refs from the general create and createSibling entry points', async () => {
+    const fileEntryId = '00000000-0000-7000-8000-000000000001';
+    const data = { parts: [filePart(fileEntryId)] } satisfies MessageData;
+    const createdRow = createMessageRow('message-1', 'user', data, 'active-1');
+    const createTx = createWriteTx({
+      insertRows: [createdRow],
+      selectResults: [[{ activeNodeId: 'active-1', id: 'topic-1' }], [{ id: fileEntryId }]],
+    });
+    const createService = createMessageService(createTx.tx);
+
+    await createService.create('topic-1', { data, role: 'user' });
+
+    expect(createTx.insertCalls).toContainEqual({
+      table: chatMessageFileRefTable,
+      values: [{ fileEntryId, role: 'attachment', sourceId: 'message-1' }],
+    });
+
+    const sourceRow = createMessageRow('source-1', 'user', { parts: [] }, 'root-1');
+    const siblingRow = createMessageRow('sibling-1', 'user', data, 'root-1');
+    const siblingTx = createWriteTx({
+      insertRows: [siblingRow],
+      selectResults: [[sourceRow], [{ id: fileEntryId }]],
+    });
+    const siblingService = createMessageService(siblingTx.tx);
+
+    await siblingService.createSibling('source-1', data);
+
+    expect(siblingTx.insertCalls).toContainEqual({
+      table: chatMessageFileRefTable,
+      values: [{ fileEntryId, role: 'attachment', sourceId: 'sibling-1' }],
+    });
+  });
+
+  test('replaces refs when message data is updated', async () => {
+    const fileEntryId = '00000000-0000-7000-8000-000000000002';
+    const previous = createMessageRow('message-1', 'user', { parts: [] }, 'root-1');
+    const data = { parts: [filePart(fileEntryId)] } satisfies MessageData;
+    const updated = { ...previous, data };
+    const { deleteCalls, insertCalls, tx } = createWriteTx({
+      selectResults: [[previous], [{ id: fileEntryId }]],
+      updateRows: [updated],
+    });
+    const service = createMessageService(tx);
+
+    await service.update('message-1', { data });
+
+    expect(deleteCalls).toContain(chatMessageFileRefTable);
+    expect(insertCalls).toContainEqual({
+      table: chatMessageFileRefTable,
+      values: [{ fileEntryId, role: 'attachment', sourceId: 'message-1' }],
     });
   });
 });
@@ -272,4 +399,102 @@ function createMessage(id: string, role: Message['role']): Message {
     topicId: '750e8400-e29b-41d4-a716-446655440000',
     updatedAt: now,
   };
+}
+
+function filePart(fileEntryId: string) {
+  return {
+    filename: 'brief.txt',
+    mediaType: 'text/plain',
+    providerMetadata: { cherry: { fileEntryId } },
+    type: 'file' as const,
+    url: 'file:///old-sandbox/brief.txt',
+  };
+}
+
+function createMessageRow(
+  id: string,
+  role: Message['role'],
+  data: MessageData,
+  parentId: string | null,
+) {
+  return {
+    createdAt: 1747267200000,
+    data,
+    deletedAt: null,
+    ftsRowid: 1,
+    id,
+    modelId: null,
+    modelSnapshot: null,
+    parentId,
+    role,
+    searchableText: '',
+    siblingsGroupId: 0,
+    stats: null,
+    status: role === 'assistant' ? 'pending' : 'success',
+    topicId: 'topic-1',
+    updatedAt: 1747267200000,
+  };
+}
+
+function createMessageService(tx: ReturnType<typeof createWriteTx>['tx']) {
+  return new MessageService(
+    {
+      getDb: () => ({ all: jest.fn(async () => []) }),
+      withWriteTx: jest.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+        callback(tx),
+      ),
+    } as unknown as DbService,
+    { setActiveNodeTx: jest.fn(async () => undefined) } as never,
+    { createPreparedEntriesTx: jest.fn(async () => undefined) } as never,
+  );
+}
+
+function createWriteTx({
+  insertRows = [],
+  selectResults = [],
+  updateRows = [],
+}: {
+  insertRows?: unknown[];
+  selectResults?: unknown[][];
+  updateRows?: unknown[];
+}) {
+  const deleteCalls: unknown[] = [];
+  const insertCalls: { table: unknown; values: unknown }[] = [];
+  const nextSelect = () => selectResults.shift() ?? [];
+  const tx = {
+    delete: jest.fn((table: unknown) => ({
+      where: jest.fn(async () => {
+        deleteCalls.push(table);
+      }),
+    })),
+    insert: jest.fn((table: unknown) => ({
+      values: jest.fn((values: unknown) => {
+        insertCalls.push({ table, values });
+        return Object.assign(Promise.resolve(undefined), {
+          returning: jest.fn(async () =>
+            table === messageTable ? [insertRows.shift()].filter(Boolean) : [],
+          ),
+        });
+      }),
+    })),
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => {
+          const rows = nextSelect();
+          return Object.assign(Promise.resolve(rows), {
+            limit: jest.fn(async () => rows),
+          });
+        }),
+      })),
+    })),
+    update: jest.fn(() => ({
+      set: jest.fn(() => ({
+        where: jest.fn(() => ({
+          returning: jest.fn(async () => [updateRows.shift()].filter(Boolean)),
+        })),
+      })),
+    })),
+  };
+
+  return { deleteCalls, insertCalls, tx };
 }

--- a/src/data/services/__tests__/fileStorage.test.ts
+++ b/src/data/services/__tests__/fileStorage.test.ts
@@ -1,0 +1,201 @@
+import type { CherryMessagePart } from '@/data/types/message';
+import { readCherryMeta } from '@/data/types/uiParts';
+
+import { prepareMessageParts, resolveInternalFileUri } from '../fileStorage';
+
+jest.mock('uuid', () => ({
+  v7: jest.fn(() => '00000000-0000-7000-8000-000000000001'),
+}));
+
+jest.mock('expo-file-system', () => {
+  const directories = new Set<string>();
+  const files = new Map<string, number>();
+  const copies: { destination: string; source: string }[] = [];
+  const failures = new Set<string>();
+  const paths = { document: { uri: 'file:///documents/' } };
+  const joinUri = (parts: (string | { uri: string })[], isDirectory: boolean) => {
+    const [first, ...rest] = parts.map((part) => (typeof part === 'string' ? part : part.uri));
+    let uri = first?.replace(/\/+$/, '') ?? '';
+
+    for (const part of rest) {
+      uri += `/${part.replace(/^\/+|\/+$/g, '')}`;
+    }
+
+    return isDirectory ? `${uri}/` : uri;
+  };
+
+  class MockDirectory {
+    readonly uri: string;
+
+    constructor(...parts: (string | { uri: string })[]) {
+      this.uri = joinUri(parts, true);
+    }
+
+    get exists() {
+      return directories.has(this.uri);
+    }
+
+    create() {
+      directories.add(this.uri);
+    }
+  }
+
+  class MockFile {
+    readonly uri: string;
+
+    constructor(...parts: (string | { uri: string })[]) {
+      this.uri = joinUri(parts, false);
+    }
+
+    get exists() {
+      return files.has(this.uri);
+    }
+
+    get name() {
+      return this.uri.split('/').pop() ?? '';
+    }
+
+    get size() {
+      return files.get(this.uri) ?? 0;
+    }
+
+    async copy(destination: MockFile) {
+      copies.push({ destination: destination.uri, source: this.uri });
+      files.set(destination.uri, files.get(this.uri) ?? 0);
+      if (failures.has(this.uri)) {
+        throw new Error(`copy failed: ${this.uri}`);
+      }
+    }
+
+    delete() {
+      files.delete(this.uri);
+    }
+  }
+
+  return {
+    Directory: MockDirectory,
+    File: MockFile,
+    Paths: paths,
+    testState: { copies, directories, failures, files, paths },
+  };
+});
+
+type FileSystemTestState = {
+  copies: { destination: string; source: string }[];
+  directories: Set<string>;
+  failures: Set<string>;
+  files: Map<string, number>;
+  paths: { document: { uri: string } };
+};
+
+const { testState } = jest.requireMock<{ testState: FileSystemTestState }>('expo-file-system');
+
+describe('fileStorage', () => {
+  beforeEach(() => {
+    testState.copies.length = 0;
+    testState.directories.clear();
+    testState.failures.clear();
+    testState.files.clear();
+    testState.paths.document.uri = 'file:///documents/';
+  });
+
+  test('copies files with a normalized extension and records their actual size', async () => {
+    testState.files.set('file:///picker/brief.PDF', 42);
+
+    const prepared = await prepareMessageParts([
+      createFilePart('file:///picker/brief.PDF', 'Quarterly Brief.PDF'),
+    ]);
+
+    expect(prepared.files).toEqual([
+      {
+        ext: 'pdf',
+        id: '00000000-0000-7000-8000-000000000001',
+        name: 'Quarterly Brief',
+        size: 42,
+        uri: 'file:///documents/files/00000000-0000-7000-8000-000000000001.pdf',
+      },
+    ]);
+    expect(prepared.parts[0]).toEqual(
+      expect.objectContaining({
+        url: 'file:///documents/files/00000000-0000-7000-8000-000000000001.pdf',
+      }),
+    );
+    const preparedPart = prepared.parts[0];
+    expect(preparedPart.type).toBe('file');
+    if (preparedPart.type !== 'file') {
+      throw new Error('Expected a prepared file part');
+    }
+    expect(readCherryMeta(preparedPart)?.fileEntryId).toBe('00000000-0000-7000-8000-000000000001');
+  });
+
+  test('stores extensionless files without a trailing dot', async () => {
+    testState.files.set('file:///picker/README', 7);
+
+    const prepared = await prepareMessageParts([createFilePart('file:///picker/README', 'README')]);
+
+    expect(prepared.files[0]).toEqual(
+      expect.objectContaining({
+        ext: null,
+        name: 'README',
+        uri: 'file:///documents/files/00000000-0000-7000-8000-000000000001',
+      }),
+    );
+  });
+
+  test('uses the source extension when a camera display name has none', async () => {
+    testState.files.set('file:///camera/IMG_0001.JPG', 128);
+
+    const prepared = await prepareMessageParts([
+      createFilePart('file:///camera/IMG_0001.JPG', 'Photo'),
+    ]);
+
+    expect(prepared.files[0]).toEqual(expect.objectContaining({ ext: 'jpg', name: 'Photo' }));
+  });
+
+  test('rebuilds managed paths from the current document directory', () => {
+    const entry = {
+      ext: 'png',
+      id: '00000000-0000-7000-8000-000000000001',
+    } as const;
+    testState.files.set('file:///documents/files/00000000-0000-7000-8000-000000000001.png', 10);
+    expect(resolveInternalFileUri(entry)).toBe(
+      'file:///documents/files/00000000-0000-7000-8000-000000000001.png',
+    );
+
+    testState.paths.document.uri = 'file:///new-sandbox/Documents/';
+    testState.files.set(
+      'file:///new-sandbox/Documents/files/00000000-0000-7000-8000-000000000001.png',
+      10,
+    );
+    expect(resolveInternalFileUri(entry)).toBe(
+      'file:///new-sandbox/Documents/files/00000000-0000-7000-8000-000000000001.png',
+    );
+  });
+
+  test('removes every copied destination when a later copy fails partially', async () => {
+    testState.files.set('file:///picker/first.txt', 1);
+    testState.files.set('file:///picker/second.txt', 2);
+    testState.failures.add('file:///picker/second.txt');
+
+    await expect(
+      prepareMessageParts([
+        createFilePart('file:///picker/first.txt', 'first.txt'),
+        createFilePart('file:///picker/second.txt', 'second.txt'),
+      ]),
+    ).rejects.toThrow('copy failed');
+
+    expect([...testState.files.keys()]).toEqual([
+      'file:///picker/first.txt',
+      'file:///picker/second.txt',
+    ]);
+  });
+});
+
+function createFilePart(url: string, filename: string): CherryMessagePart {
+  return {
+    filename,
+    mediaType: 'application/octet-stream',
+    type: 'file',
+    url,
+  };
+}

--- a/src/data/services/createDataServices.ts
+++ b/src/data/services/createDataServices.ts
@@ -4,6 +4,7 @@ import type { DbService } from '@/data/db/DbService';
 import { WebSearchService } from '@/services/webSearch/WebSearchService';
 
 import { AssistantService } from './AssistantService';
+import { FileEntryService } from './FileEntryService';
 import { GroupService } from './GroupService';
 import { MessageService } from './MessageService';
 import { ModelService } from './ModelService';
@@ -24,15 +25,17 @@ export function createDataServices(dbService: DbService) {
   const tag = new TagService(dbService);
   const group = new GroupService(dbService);
   const prompt = new PromptService(dbService);
+  const fileEntry = new FileEntryService(dbService);
   const assistant = new AssistantService(dbService, model, preference, tag, pin);
   const topic = new TopicService(dbService, pin, tag);
-  const message = new MessageService(dbService, topic);
+  const message = new MessageService(dbService, topic, fileEntry);
   const webSearch = new WebSearchService(preference);
   const ai = new AiService({ assistant, model, preference, provider, webSearch });
 
   return {
     ai,
     assistant,
+    fileEntry,
     group,
     message,
     model,

--- a/src/data/services/createDataServices.ts
+++ b/src/data/services/createDataServices.ts
@@ -30,7 +30,7 @@ export function createDataServices(dbService: DbService) {
   const topic = new TopicService(dbService, pin, tag);
   const message = new MessageService(dbService, topic, fileEntry);
   const webSearch = new WebSearchService(preference);
-  const ai = new AiService({ assistant, model, preference, provider, webSearch });
+  const ai = new AiService({ assistant, fileEntry, model, preference, provider, webSearch });
 
   return {
     ai,

--- a/src/data/services/fileStorage.ts
+++ b/src/data/services/fileStorage.ts
@@ -1,0 +1,137 @@
+import { Directory, File, Paths } from 'expo-file-system';
+
+import { loggerService } from '@/core/logger/LoggerService';
+import { createOrderedUuid } from '@/data/db/schemas/_columnHelpers';
+import {
+  type FileEntryId,
+  type InternalFileEntry,
+  type PreparedInternalFile,
+  SafeFileExtensionSchema,
+  SafeFileNameSchema,
+} from '@/data/types/file';
+import type { CherryMessagePart } from '@/data/types/message';
+import { readCherryMeta, withCherryMeta } from '@/data/types/uiParts';
+
+const FILE_DIRECTORY_NAME = 'files';
+const logger = loggerService.withContext('fileStorage');
+
+function fileDirectory(): Directory {
+  return new Directory(Paths.document, FILE_DIRECTORY_NAME);
+}
+
+function ensureFileDirectory(): Directory {
+  const directory = fileDirectory();
+  if (!directory.exists) {
+    directory.create({ intermediates: true });
+  }
+  return directory;
+}
+
+function managedFile(id: FileEntryId, ext: string | null): File {
+  return new File(fileDirectory(), `${id}${ext ? `.${ext}` : ''}`);
+}
+
+function projectFileName(displayFilename: string, sourceFilename: string) {
+  const displayBase =
+    basenameForProjection(displayFilename) || basenameForProjection(sourceFilename);
+  const displayDot = displayBase.lastIndexOf('.');
+  const sourceBase = basenameForProjection(sourceFilename);
+  const sourceDot = sourceBase.lastIndexOf('.');
+  const name = displayDot > 0 ? displayBase.slice(0, displayDot) : displayBase;
+  const ext =
+    displayDot > 0
+      ? displayBase.slice(displayDot + 1).toLowerCase()
+      : sourceDot > 0
+        ? sourceBase.slice(sourceDot + 1).toLowerCase()
+        : null;
+
+  return {
+    ext: ext ? SafeFileExtensionSchema.parse(ext) : null,
+    name: SafeFileNameSchema.parse(name),
+  };
+}
+
+function basenameForProjection(value: string): string {
+  return (value.split(/[\\/]/).pop() ?? value).replace(/[\s.]+$/, '');
+}
+
+async function prepareFilePart(
+  part: Extract<CherryMessagePart, { type: 'file' }>,
+): Promise<{ file: PreparedInternalFile; part: CherryMessagePart }> {
+  const source = new File(part.url);
+  const { ext, name } = projectFileName(part.filename ?? source.name, source.name);
+  const id = createOrderedUuid();
+  const destination = new File(ensureFileDirectory(), `${id}${ext ? `.${ext}` : ''}`);
+
+  try {
+    await source.copy(destination);
+
+    if (!destination.exists) {
+      throw new Error(`Prepared file does not exist after copy: ${destination.uri}`);
+    }
+
+    const size = destination.size;
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new Error(`Prepared file has an invalid size: ${destination.uri}`);
+    }
+
+    return {
+      file: { ext, id, name, size, uri: destination.uri },
+      part: withCherryMeta({ ...part, url: destination.uri }, { fileEntryId: id }),
+    };
+  } catch (error) {
+    try {
+      if (destination.exists) {
+        destination.delete();
+      }
+    } catch (cleanupError) {
+      logger.warn('Failed to discard partially prepared file', cleanupError as Error, { id });
+    }
+    throw error;
+  }
+}
+
+export async function prepareMessageParts(
+  parts: readonly CherryMessagePart[],
+): Promise<{ files: PreparedInternalFile[]; parts: CherryMessagePart[] }> {
+  const files: PreparedInternalFile[] = [];
+  const preparedParts: CherryMessagePart[] = [];
+
+  try {
+    for (const part of parts) {
+      if (part.type !== 'file' || readCherryMeta(part)?.fileEntryId) {
+        preparedParts.push(part);
+        continue;
+      }
+
+      const prepared = await prepareFilePart(part);
+      files.push(prepared.file);
+      preparedParts.push(prepared.part);
+    }
+  } catch (error) {
+    discardPreparedFiles(files);
+    throw error;
+  }
+
+  return { files, parts: preparedParts };
+}
+
+export function discardPreparedFiles(files: readonly PreparedInternalFile[]): void {
+  for (const prepared of files) {
+    try {
+      const file = new File(prepared.uri);
+      if (file.exists) {
+        file.delete();
+      }
+    } catch (error) {
+      logger.warn('Failed to discard prepared file', error as Error, { id: prepared.id });
+    }
+  }
+}
+
+export function resolveInternalFileUri(
+  entry: Pick<InternalFileEntry, 'ext' | 'id'>,
+): string | undefined {
+  const file = managedFile(entry.id, entry.ext);
+  return file.exists ? file.uri : undefined;
+}

--- a/src/data/services/index.ts
+++ b/src/data/services/index.ts
@@ -1,4 +1,5 @@
 export { AssistantService } from './AssistantService';
+export { FileEntryService } from './FileEntryService';
 export { GroupService } from './GroupService';
 export { MessageService } from './MessageService';
 export { ModelService } from './ModelService';

--- a/src/data/types/__tests__/uiParts.test.ts
+++ b/src/data/types/__tests__/uiParts.test.ts
@@ -14,6 +14,18 @@ function reasoningPart(
   };
 }
 
+function filePart(
+  providerMetadata?: ProviderMetadata,
+): Extract<CherryMessagePart, { type: 'file' }> {
+  return {
+    type: 'file',
+    filename: 'notes.pdf',
+    mediaType: 'application/pdf',
+    url: 'file:///notes.pdf',
+    ...(providerMetadata && { providerMetadata }),
+  };
+}
+
 describe('readCherryMeta', () => {
   test('returns undefined when providerMetadata.cherry is missing', () => {
     expect(readCherryMeta(reasoningPart())).toBeUndefined();
@@ -27,6 +39,28 @@ describe('readCherryMeta', () => {
 
   test('returns undefined for a malformed payload instead of throwing', () => {
     const part = reasoningPart({ cherry: { thinkingMs: 'not-a-number' } });
+
+    expect(readCherryMeta(part)).toBeUndefined();
+  });
+
+  test('parses the complete desktop-compatible file metadata shape', () => {
+    const part = filePart({
+      cherry: {
+        composerFileKind: 'pasted-text',
+        fileEntryId: 'file-entry-1',
+        fileTokenSourceId: 'composer-source-1',
+      },
+    });
+
+    expect(readCherryMeta(part)).toEqual({
+      composerFileKind: 'pasted-text',
+      fileEntryId: 'file-entry-1',
+      fileTokenSourceId: 'composer-source-1',
+    });
+  });
+
+  test('rejects malformed file metadata without throwing', () => {
+    const part = filePart({ cherry: { composerFileKind: 'upload' } });
 
     expect(readCherryMeta(part)).toBeUndefined();
   });
@@ -47,5 +81,16 @@ describe('withCherryMeta', () => {
     const patched = withCherryMeta(part, { thinkingMs: 500 });
 
     expect(readCherryMeta(patched)).toEqual({ startedAt: 42, thinkingMs: 500 });
+  });
+
+  test('merges file identity without replacing composer metadata', () => {
+    const part = filePart({ cherry: { fileTokenSourceId: 'composer-source-1' } });
+
+    const patched = withCherryMeta(part, { fileEntryId: 'file-entry-1' });
+
+    expect(readCherryMeta(patched)).toEqual({
+      fileEntryId: 'file-entry-1',
+      fileTokenSourceId: 'composer-source-1',
+    });
   });
 });

--- a/src/data/types/file.ts
+++ b/src/data/types/file.ts
@@ -1,0 +1,73 @@
+import * as z from 'zod';
+
+export const TimestampSchema = z.int().nonnegative();
+
+export const SafeFileNameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine((value) => !value.includes('\0'), 'Name must not contain null bytes')
+  .refine((value) => !/[/\\]/.test(value), 'Name must not contain path separators')
+  .refine((value) => !/^\.\.?$/.test(value), 'Name must not be . or ..')
+  .refine((value) => value.trim().length > 0, 'Name must not be all whitespace');
+
+export const SafeFileExtensionSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine((value) => !/[.\s/\\\0]/.test(value), 'Extension contains unsafe characters');
+
+export const FileEntryIdSchema = z.uuid();
+export type FileEntryId = z.infer<typeof FileEntryIdSchema>;
+
+export const FileEntryOriginSchema = z.enum(['internal', 'external']);
+export type FileEntryOrigin = z.infer<typeof FileEntryOriginSchema>;
+
+export const AbsoluteFilePathSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !value.includes('\0'), 'externalPath must not contain null bytes')
+  .refine(
+    (value) => value.startsWith('/') || /^[A-Za-z]:\\/.test(value),
+    'externalPath must be an absolute filesystem path',
+  );
+
+const commonFileEntryFields = {
+  createdAt: TimestampSchema,
+  ext: SafeFileExtensionSchema.nullable(),
+  id: FileEntryIdSchema,
+  name: SafeFileNameSchema,
+  updatedAt: TimestampSchema,
+} as const;
+
+export const InternalFileEntrySchema = z.strictObject({
+  ...commonFileEntryFields,
+  deletedAt: TimestampSchema.optional(),
+  origin: z.literal('internal'),
+  size: z.int().nonnegative(),
+});
+
+export const ExternalFileEntrySchema = z.strictObject({
+  ...commonFileEntryFields,
+  externalPath: AbsoluteFilePathSchema,
+  origin: z.literal('external'),
+});
+
+export const FileEntrySchema = z
+  .discriminatedUnion('origin', [InternalFileEntrySchema, ExternalFileEntrySchema])
+  .brand<'FileEntry'>();
+
+export type FileEntry = z.infer<typeof FileEntrySchema>;
+export type InternalFileEntry = z.infer<typeof InternalFileEntrySchema>;
+export type ExternalFileEntry = z.infer<typeof ExternalFileEntrySchema>;
+
+export const chatMessageRoles = ['attachment'] as const;
+export type ChatMessageFileRole = (typeof chatMessageRoles)[number];
+
+export type PreparedInternalFile = {
+  ext: string | null;
+  id: FileEntryId;
+  name: string;
+  size: number;
+  uri: string;
+};

--- a/src/data/types/index.ts
+++ b/src/data/types/index.ts
@@ -1,6 +1,7 @@
 export * from './apiTypes';
 export * from './assistant';
 export * from './entityType';
+export * from './file';
 export * from './group';
 export * from './message';
 export * from './model';

--- a/src/data/types/uiParts.ts
+++ b/src/data/types/uiParts.ts
@@ -91,6 +91,16 @@ export interface CherryToolMeta {
   };
 }
 
+/** Cherry metadata on a FileUIPart. */
+export interface CherryFileMeta {
+  /** Stable identity of an internal Cherry-managed file. */
+  fileEntryId?: string;
+  /** Composer file token association identity. */
+  fileTokenSourceId?: string;
+  /** Safe composer-only source marker used to restore sent-message token previews. */
+  composerFileKind?: 'pasted-text';
+}
+
 /**
  * Conditional mapping from a part's `type` literal to its cherry-meta shape.
  * Parts without a registered shape have no cherry meta — represented as `Record<string, never>`.
@@ -101,7 +111,9 @@ export type CherryMetaForPartType<T extends string> = T extends 'text'
     ? CherryReasoningMeta
     : T extends `tool-${string}` | 'dynamic-tool'
       ? CherryToolMeta
-      : Record<string, never>;
+      : T extends 'file'
+        ? CherryFileMeta
+        : Record<string, never>;
 
 // ============================================================================
 // Zod schemas — runtime validation at the read boundary
@@ -128,11 +140,18 @@ export const CherryToolMetaSchema: z.ZodType<CherryToolMeta> = z.object({
     .optional(),
 });
 
+export const CherryFileMetaSchema: z.ZodType<CherryFileMeta> = z.object({
+  fileEntryId: z.string().optional(),
+  fileTokenSourceId: z.string().optional(),
+  composerFileKind: z.literal('pasted-text').optional(),
+});
+
 // Table-driven dispatch — part `type` → schema. First match wins.
 const SCHEMA_BY_PART_TYPE: ReadonlyArray<readonly [(t: string) => boolean, z.ZodTypeAny]> = [
   [(t) => t === 'text', CherryTextMetaSchema],
   [(t) => t === 'reasoning', CherryReasoningMetaSchema],
   [(t) => t === 'dynamic-tool' || t.startsWith('tool-'), CherryToolMetaSchema],
+  [(t) => t === 'file', CherryFileMetaSchema],
 ];
 
 function schemaForPartType(type: string): z.ZodTypeAny | null {

--- a/src/data/types/uiParts.ts
+++ b/src/data/types/uiParts.ts
@@ -147,7 +147,7 @@ export const CherryFileMetaSchema: z.ZodType<CherryFileMeta> = z.object({
 });
 
 // Table-driven dispatch — part `type` → schema. First match wins.
-const SCHEMA_BY_PART_TYPE: ReadonlyArray<readonly [(t: string) => boolean, z.ZodTypeAny]> = [
+const SCHEMA_BY_PART_TYPE: readonly (readonly [(t: string) => boolean, z.ZodTypeAny])[] = [
   [(t) => t === 'text', CherryTextMetaSchema],
   [(t) => t === 'reasoning', CherryReasoningMetaSchema],
   [(t) => t === 'dynamic-tool' || t.startsWith('tool-'), CherryToolMetaSchema],

--- a/src/hooks/useAvatar.ts
+++ b/src/hooks/useAvatar.ts
@@ -1,0 +1,11 @@
+import { usePreference } from '@/data/hooks';
+import { resolveUserAvatarUri } from '@/services/userAvatarStorage';
+
+const defaultAvatarSource = require('@/assets/icon.png');
+
+/** The user avatar as an Expo Image source, with the bundled icon as fallback. */
+export function useAvatar(): string | number {
+  const [avatar] = usePreference('app.user.avatar');
+
+  return resolveUserAvatarUri(avatar) ?? defaultAvatarSource;
+}

--- a/src/i18n/locales/en-us.json
+++ b/src/i18n/locales/en-us.json
@@ -76,6 +76,8 @@
   "chat.media.openSettings": "Open Settings",
   "chat.media.takePhoto": "Take photo",
   "chat.media.file": "File",
+  "chat.media.fileUnavailable": "{{name}} is unavailable",
+  "chat.media.unavailable": "Unavailable",
   "chat.media.limitedPhotoAccess": "Limited photo access",
   "chat.media.noPhotos": "No photos available",
   "chat.media.photoPermissionDescription": "Allow Cherry Studio to access photos you want to add to chat.",

--- a/src/i18n/locales/en-us.json
+++ b/src/i18n/locales/en-us.json
@@ -229,6 +229,7 @@
   "settings.pages.websearch.placeholder": "Web search settings are coming soon.",
   "settings.pages.websearch.title": "Web search",
   "settings.plugin.title": "Plugins",
+  "settings.profile.avatarSaveError": "Failed to save avatar",
   "settings.profile.changeAvatar": "Change avatar",
   "settings.profile.edit": "Edit profile",
   "settings.profile.userName": "User Name",

--- a/src/i18n/locales/zh-cn.json
+++ b/src/i18n/locales/zh-cn.json
@@ -229,6 +229,7 @@
   "settings.pages.websearch.placeholder": "网络搜索相关设置即将推出。",
   "settings.pages.websearch.title": "网络搜索",
   "settings.plugin.title": "插件",
+  "settings.profile.avatarSaveError": "头像保存失败",
   "settings.profile.changeAvatar": "更换头像",
   "settings.profile.edit": "编辑个人资料",
   "settings.profile.userName": "用户名",

--- a/src/i18n/locales/zh-cn.json
+++ b/src/i18n/locales/zh-cn.json
@@ -76,6 +76,8 @@
   "chat.media.openSettings": "打开设置",
   "chat.media.takePhoto": "拍照",
   "chat.media.file": "文件",
+  "chat.media.fileUnavailable": "{{name}} 不可用",
+  "chat.media.unavailable": "不可用",
   "chat.media.limitedPhotoAccess": "有限的照片访问权限",
   "chat.media.noPhotos": "暂无可用照片",
   "chat.media.photoPermissionDescription": "请允许 Cherry Studio 访问你想添加到聊天的照片。",

--- a/src/screens/ChatScreen/mediaTile/components/FileTile.tsx
+++ b/src/screens/ChatScreen/mediaTile/components/FileTile.tsx
@@ -1,15 +1,24 @@
 import { cn } from 'heroui-native/utils';
-import { Pressable, Text, View } from 'react-native';
+import { type AccessibilityState, Pressable, Text, View } from 'react-native';
 import { getFileBaseName, getFileExtension } from '../utils/getFileExtension';
 
 type FileTileProps = {
   accessibilityLabel?: string;
+  accessibilityState?: AccessibilityState;
   className?: string;
   name: string;
   onPress?: () => void;
+  statusLabel?: string;
 };
 
-export function FileTile({ accessibilityLabel, className, name, onPress }: FileTileProps) {
+export function FileTile({
+  accessibilityLabel,
+  accessibilityState,
+  className,
+  name,
+  onPress,
+  statusLabel,
+}: FileTileProps) {
   const extension = getFileExtension(name);
   const baseName = getFileBaseName(name);
   const containerClassName = cn(
@@ -19,7 +28,11 @@ export function FileTile({ accessibilityLabel, className, name, onPress }: FileT
   );
   const content = (
     <>
-      {extension ? (
+      {statusLabel ? (
+        <Text className="font-medium text-danger text-xs" numberOfLines={2}>
+          {statusLabel}
+        </Text>
+      ) : extension ? (
         <View className="rounded-md border border-border px-1.5 py-0.5">
           <Text className="font-semibold text-default-foreground text-xs">{extension}</Text>
         </View>
@@ -33,13 +46,23 @@ export function FileTile({ accessibilityLabel, className, name, onPress }: FileT
   );
 
   if (!onPress) {
-    return <View className={containerClassName}>{content}</View>;
+    return (
+      <View
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={accessibilityState}
+        accessible={Boolean(accessibilityLabel)}
+        className={containerClassName}
+      >
+        {content}
+      </View>
+    );
   }
 
   return (
     <Pressable
       accessibilityLabel={accessibilityLabel ?? name}
       accessibilityRole="button"
+      accessibilityState={accessibilityState}
       className={containerClassName}
       onPress={onPress}
     >

--- a/src/screens/ChatScreen/messageContent/components/FilePart.tsx
+++ b/src/screens/ChatScreen/messageContent/components/FilePart.tsx
@@ -1,14 +1,47 @@
+import ExpoQuickLook from '@magrinj/expo-quick-look';
+import { useTranslation } from 'react-i18next';
+
+import { loggerService } from '@/core/logger/LoggerService';
 import type { CherryMessagePart } from '@/data/types/message';
 import { FileTile, ImageTile } from '../../mediaTile';
+import { useFilePartUri } from '../hooks/useFilePartUri';
+
+const logger = loggerService.withContext('FilePart');
 
 type FilePartProps = {
   part: Extract<CherryMessagePart, { type: 'file' }>;
 };
 
 export function FilePart({ part }: FilePartProps) {
-  if (part.mediaType.startsWith('image/')) {
-    return <ImageTile accessibilityLabel={part.filename ?? 'Image'} uri={part.url} />;
+  const { t } = useTranslation();
+  const { isLoading, uri } = useFilePartUri(part);
+  const name = part.filename ?? part.mediaType;
+  const handlePreview = () => {
+    if (!uri) {
+      return;
+    }
+    void ExpoQuickLook.previewFile({ editingMode: 'disabled', uri }).catch((error) => {
+      logger.warn('Failed to preview message attachment', toError(error));
+    });
+  };
+
+  if (part.mediaType.startsWith('image/') && uri) {
+    return <ImageTile accessibilityLabel={name} onPress={handlePreview} uri={uri} />;
   }
 
-  return <FileTile name={part.filename ?? part.mediaType} />;
+  const isUnavailable = !isLoading && !uri;
+  return (
+    <FileTile
+      accessibilityLabel={isUnavailable ? t('chat.media.fileUnavailable', { name }) : name}
+      accessibilityState={isUnavailable ? { disabled: true } : undefined}
+      className={!uri ? 'opacity-60' : undefined}
+      name={name}
+      onPress={uri ? handlePreview : undefined}
+      statusLabel={isUnavailable ? t('chat.media.unavailable') : undefined}
+    />
+  );
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/src/screens/ChatScreen/messageContent/components/__tests__/FilePart.test.tsx
+++ b/src/screens/ChatScreen/messageContent/components/__tests__/FilePart.test.tsx
@@ -1,0 +1,108 @@
+import type { ReactElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/data/types/message';
+import { FilePart } from '../FilePart';
+
+const mockPreviewFile = jest.fn(async (_input: unknown) => undefined);
+const mockUseFilePartUri = jest.fn();
+
+jest.mock('@magrinj/expo-quick-look', () => ({
+  __esModule: true,
+  default: { previewFile: (input: unknown) => mockPreviewFile(input) },
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { name?: string }) =>
+      key === 'chat.media.fileUnavailable' ? `${values?.name} unavailable` : 'Unavailable',
+  }),
+}));
+
+jest.mock('../../hooks/useFilePartUri', () => ({
+  useFilePartUri: (part: unknown) => mockUseFilePartUri(part),
+}));
+
+jest.mock('../../../mediaTile', () => {
+  const { createElement } = jest.requireActual('react');
+  return {
+    FileTile: (props: object) => createElement('FileTile', props),
+    ImageTile: (props: object) => createElement('ImageTile', props),
+  };
+});
+
+describe('FilePart', () => {
+  beforeEach(() => {
+    mockPreviewFile.mockClear();
+    mockUseFilePartUri.mockReset();
+  });
+
+  test('renders and previews an image with the resolved URI', async () => {
+    mockUseFilePartUri.mockReturnValue({
+      isLoading: false,
+      uri: 'file:///new-sandbox/files/image.png',
+    });
+    const renderer = render(<FilePart part={filePart('image/png')} />);
+    const imageTile = renderer.root.findByType('ImageTile');
+
+    await act(async () => imageTile.props.onPress());
+
+    expect(imageTile.props.uri).toBe('file:///new-sandbox/files/image.png');
+    expect(mockPreviewFile).toHaveBeenCalledWith({
+      editingMode: 'disabled',
+      uri: 'file:///new-sandbox/files/image.png',
+    });
+  });
+
+  test('previews a non-image file with the same resolved URI', async () => {
+    mockUseFilePartUri.mockReturnValue({
+      isLoading: false,
+      uri: 'file:///new-sandbox/files/brief.pdf',
+    });
+    const renderer = render(<FilePart part={filePart('application/pdf')} />);
+    const fileTile = renderer.root.findByType('FileTile');
+
+    await act(async () => fileTile.props.onPress());
+
+    expect(mockPreviewFile).toHaveBeenCalledWith({
+      editingMode: 'disabled',
+      uri: 'file:///new-sandbox/files/brief.pdf',
+    });
+  });
+
+  test('renders a disabled unavailable tile without mounting an image', () => {
+    mockUseFilePartUri.mockReturnValue({ isLoading: false, uri: undefined });
+    const renderer = render(<FilePart part={filePart('image/png')} />);
+    const fileTile = renderer.root.findByType('FileTile');
+
+    expect(renderer.root.findAllByType('ImageTile')).toHaveLength(0);
+    expect(fileTile.props).toEqual(
+      expect.objectContaining({
+        accessibilityLabel: 'brief.pdf unavailable',
+        accessibilityState: { disabled: true },
+        onPress: undefined,
+        statusLabel: 'Unavailable',
+      }),
+    );
+  });
+});
+
+function render(element: ReactElement): ReactTestRenderer {
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(element);
+  });
+  if (!renderer) {
+    throw new Error('Renderer was not created');
+  }
+  return renderer;
+}
+
+function filePart(mediaType: string): Extract<CherryMessagePart, { type: 'file' }> {
+  return {
+    filename: 'brief.pdf',
+    mediaType,
+    type: 'file',
+    url: 'file:///old-sandbox/brief.pdf',
+  };
+}

--- a/src/screens/ChatScreen/messageContent/hooks/__tests__/useFilePartUri.test.ts
+++ b/src/screens/ChatScreen/messageContent/hooks/__tests__/useFilePartUri.test.ts
@@ -1,0 +1,69 @@
+import type { FileUIPart } from '@/data/types/message';
+import { resolveFilePartUri } from '../useFilePartUri';
+
+jest.mock('@/data/hooks', () => ({ useDataQuery: jest.fn() }));
+
+jest.mock('expo-file-system', () => {
+  const files = new Set<string>();
+
+  class MockFile {
+    readonly uri: string;
+
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+
+    get exists() {
+      return files.has(this.uri);
+    }
+  }
+
+  return { File: MockFile, testState: { files } };
+});
+
+const { testState } = jest.requireMock<{ testState: { files: Set<string> } }>('expo-file-system');
+
+describe('resolveFilePartUri', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    testState.files.clear();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('prefers the URI rebuilt from a managed file entry', async () => {
+    const resolver = jest.fn(async () => 'file:///new-sandbox/files/entry.png');
+
+    await expect(
+      resolveFilePartUri(filePart('file:///old-sandbox/image.png'), resolver),
+    ).resolves.toBe('file:///new-sandbox/files/entry.png');
+  });
+
+  test('uses a readable local fallback when the managed entry is unavailable', async () => {
+    testState.files.add('file:///legacy/image.png');
+
+    await expect(
+      resolveFilePartUri(filePart('file:///legacy/image.png'), async () => undefined),
+    ).resolves.toBe('file:///legacy/image.png');
+  });
+
+  test('returns undefined instead of forwarding an unreadable local URI', async () => {
+    await expect(
+      resolveFilePartUri(filePart('file:///legacy/missing.png'), async () => undefined),
+    ).resolves.toBeUndefined();
+  });
+});
+
+function filePart(url: string): FileUIPart {
+  return {
+    filename: 'image.png',
+    mediaType: 'image/png',
+    providerMetadata: { cherry: { fileEntryId: 'entry-1' } },
+    type: 'file',
+    url,
+  };
+}

--- a/src/screens/ChatScreen/messageContent/hooks/__tests__/useFilePartUri.test.ts
+++ b/src/screens/ChatScreen/messageContent/hooks/__tests__/useFilePartUri.test.ts
@@ -43,17 +43,19 @@ describe('resolveFilePartUri', () => {
     ).resolves.toBe('file:///new-sandbox/files/entry.png');
   });
 
-  test('uses a readable local fallback when the managed entry is unavailable', async () => {
+  test('does not use the persisted URL when the managed entry is unavailable', async () => {
     testState.files.add('file:///legacy/image.png');
 
     await expect(
       resolveFilePartUri(filePart('file:///legacy/image.png'), async () => undefined),
-    ).resolves.toBe('file:///legacy/image.png');
+    ).resolves.toBeUndefined();
   });
 
-  test('returns undefined instead of forwarding an unreadable local URI', async () => {
+  test('returns undefined when the managed entry resolver fails', async () => {
     await expect(
-      resolveFilePartUri(filePart('file:///legacy/missing.png'), async () => undefined),
+      resolveFilePartUri(filePart('file:///legacy/image.png'), async () => {
+        throw new Error('database unavailable');
+      }),
     ).resolves.toBeUndefined();
   });
 });

--- a/src/screens/ChatScreen/messageContent/hooks/useFilePartUri.ts
+++ b/src/screens/ChatScreen/messageContent/hooks/useFilePartUri.ts
@@ -40,6 +40,8 @@ export async function resolveFilePartUri(
     } catch (error) {
       logger.warn('Failed to resolve managed file entry', toError(error), { fileEntryId });
     }
+
+    return undefined;
   }
 
   if (!isLocalFileUri(part.url)) {
@@ -49,7 +51,7 @@ export async function resolveFilePartUri(
   try {
     return new File(part.url).exists ? part.url : undefined;
   } catch (error) {
-    logger.warn('Failed to inspect fallback file URI', toError(error), { fileEntryId });
+    logger.warn('Failed to inspect file URI', toError(error));
     return undefined;
   }
 }

--- a/src/screens/ChatScreen/messageContent/hooks/useFilePartUri.ts
+++ b/src/screens/ChatScreen/messageContent/hooks/useFilePartUri.ts
@@ -1,0 +1,63 @@
+import { File } from 'expo-file-system';
+
+import { loggerService } from '@/core/logger/LoggerService';
+import { useDataQuery } from '@/data/hooks';
+import type { FileUIPart } from '@/data/types/message';
+import { readCherryMeta } from '@/data/types/uiParts';
+
+const logger = loggerService.withContext('useFilePartUri');
+
+type ResolveFileEntryUri = (fileEntryId: string) => Promise<string | undefined>;
+
+export function useFilePartUri(part: FileUIPart) {
+  const fileEntryId = readCherryMeta(part)?.fileEntryId;
+  const requiresLookup = Boolean(fileEntryId) || isLocalFileUri(part.url);
+  const query = useDataQuery({
+    enabled: requiresLookup,
+    queryFn: (services) => resolveFilePartUri(part, (id) => services.fileEntry.resolveUri(id)),
+    queryKey: ['file-part-uri', fileEntryId ?? null, part.url],
+  });
+
+  return {
+    isLoading: requiresLookup && query.isPending,
+    uri: requiresLookup ? query.data : part.url,
+  };
+}
+
+export async function resolveFilePartUri(
+  part: FileUIPart,
+  resolveFileEntryUri: ResolveFileEntryUri,
+): Promise<string | undefined> {
+  const fileEntryId = readCherryMeta(part)?.fileEntryId;
+
+  if (fileEntryId) {
+    try {
+      const managedUri = await resolveFileEntryUri(fileEntryId);
+      if (managedUri) {
+        return managedUri;
+      }
+      logger.warn('Managed file entry is unavailable', { fileEntryId });
+    } catch (error) {
+      logger.warn('Failed to resolve managed file entry', toError(error), { fileEntryId });
+    }
+  }
+
+  if (!isLocalFileUri(part.url)) {
+    return part.url;
+  }
+
+  try {
+    return new File(part.url).exists ? part.url : undefined;
+  } catch (error) {
+    logger.warn('Failed to inspect fallback file URI', toError(error), { fileEntryId });
+    return undefined;
+  }
+}
+
+function isLocalFileUri(uri: string): boolean {
+  return uri.startsWith('file://') || uri.startsWith('content://');
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/src/screens/ChatScreen/runtime/ChatRuntime.ts
+++ b/src/screens/ChatScreen/runtime/ChatRuntime.ts
@@ -4,6 +4,7 @@ import { toCherryUIMessage } from '@/ai/messages/messageConverter';
 import { serializeError } from '@/ai/utils/serializeError';
 import { loggerService } from '@/core/logger/LoggerService';
 import type { DataServices } from '@/data/services/createDataServices';
+import { discardPreparedFiles, prepareMessageParts } from '@/data/services/fileStorage';
 import type {
   CherryMessagePart,
   CherryUIMessage,
@@ -233,17 +234,24 @@ export class ChatRuntime {
     let assistantPlaceholder: Message | undefined;
     let latestAssistantMessage: CherryUIMessage | undefined;
     let terminalAssistantMessage: Message | undefined;
+    let preparedFilesCommitted = false;
+    let preparedFiles: Awaited<ReturnType<typeof prepareMessageParts>>['files'] = [];
+    let turnParts = [...parts];
 
     try {
+      const prepared = await prepareMessageParts(parts);
+      preparedFiles = prepared.files;
+      turnParts = prepared.parts;
       const modelSnapshot = toModelSnapshot(model);
       throwIfAborted(abortController.signal);
       const reservedTurn =
         await this.dependencies.services.message.createUserMessageWithPlaceholders({
+          ...(preparedFiles.length > 0 ? { preparedFiles } : {}),
           topicId,
           userMessage: {
             mode: 'create',
             dto: {
-              data: { parts: parts as CherryMessagePart[] },
+              data: { parts: turnParts },
               modelId: model.id,
               modelSnapshot,
               parentId: topic.activeNodeId ?? null,
@@ -261,6 +269,7 @@ export class ChatRuntime {
             },
           ],
         });
+      preparedFilesCommitted = true;
       if (abortController.signal.aborted) {
         await this.cancelReservedTurn({
           topicId,
@@ -326,7 +335,7 @@ export class ChatRuntime {
           assistantParts: (latestAssistantMessage?.parts ?? []) as CherryMessagePart[],
           defaultModelId: model.id,
           topicId,
-          userParts: parts,
+          userParts: turnParts,
         });
       }
     } catch (error) {
@@ -345,6 +354,10 @@ export class ChatRuntime {
         logger.warn('Chat stream failed', toError(error));
       }
     } finally {
+      if (!preparedFilesCommitted) {
+        discardPreparedFiles(preparedFiles);
+      }
+
       if (terminalAssistantMessage) {
         this.setTurnSnapshot(topicId, {
           overlayMessage: terminalAssistantMessage,

--- a/src/screens/ChatScreen/runtime/__tests__/ChatRuntime.test.ts
+++ b/src/screens/ChatScreen/runtime/__tests__/ChatRuntime.test.ts
@@ -1,20 +1,41 @@
 import type { AiStreamRequest } from '@/ai/types/requests';
 import type { DataServices } from '@/data/services/createDataServices';
 import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/data/types/assistant';
+import type { PreparedInternalFile } from '@/data/types/file';
 import type { CherryMessagePart, CherryUIMessage, Message } from '@/data/types/message';
 import type { Model, UniqueModelId } from '@/data/types/model';
 
 import { ChatRuntime, newTopicRuntimeId } from '../ChatRuntime';
 
 const mockReadUIMessageStream = jest.fn();
+const mockPrepareMessageParts = jest.fn(
+  async (
+    parts: readonly CherryMessagePart[],
+  ): Promise<{ files: PreparedInternalFile[]; parts: CherryMessagePart[] }> => ({
+    files: [],
+    parts: [...parts],
+  }),
+);
+const mockDiscardPreparedFiles = jest.fn();
 
 jest.mock('ai', () => ({
   readUIMessageStream: (...args: unknown[]) => mockReadUIMessageStream(...args),
 }));
 
+jest.mock('@/data/services/fileStorage', () => ({
+  discardPreparedFiles: (...args: unknown[]) => mockDiscardPreparedFiles(...args),
+  prepareMessageParts: (parts: readonly CherryMessagePart[]) => mockPrepareMessageParts(parts),
+}));
+
 describe('ChatRuntime', () => {
   beforeEach(() => {
     mockReadUIMessageStream.mockReset();
+    mockPrepareMessageParts.mockClear();
+    mockPrepareMessageParts.mockImplementation(async (parts: readonly CherryMessagePart[]) => ({
+      files: [],
+      parts: [...parts],
+    }));
+    mockDiscardPreparedFiles.mockReset();
   });
 
   test('reserves user and assistant messages before streaming and persists terminal assistant parts', async () => {
@@ -325,13 +346,25 @@ describe('ChatRuntime', () => {
     const services = createServices();
     const runtime = createRuntime({ services });
     const partialChunk = createUiMessage('assistant-1', 'partial');
+    const preparedFile = {
+      ext: 'pdf',
+      id: '00000000-0000-7000-8000-000000000001',
+      name: 'brief',
+      size: 12,
+      uri: 'file:///documents/files/00000000-0000-7000-8000-000000000001.pdf',
+    };
+    mockPrepareMessageParts.mockResolvedValueOnce({
+      files: [preparedFile],
+      parts: [createFilePart(preparedFile.uri)],
+    });
     mockReadUIMessageStream.mockReturnValue(
       asyncIterableWithFailure([partialChunk], new Error('stream failed')),
     );
 
     await runtime.sendText({
+      parts: [createFilePart('file://brief.pdf')],
       selectedModelId: 'provider::model' as UniqueModelId,
-      text: 'hi',
+      text: '',
       topicId: 'topic-1',
     });
 
@@ -347,6 +380,7 @@ describe('ChatRuntime', () => {
       },
       status: 'error',
     });
+    expect(mockDiscardPreparedFiles).not.toHaveBeenCalled();
   });
 
   test('finalizes a lingering streaming reasoning part when the stream fails after partial output', async () => {
@@ -494,10 +528,29 @@ describe('ChatRuntime', () => {
     const services = createServices();
     const runtime = createRuntime({ services });
     const assistantChunk = createUiMessage('assistant-1', 'hello');
+    const sourcePart = createFilePart('file://brief.pdf');
+    const managedPart = {
+      ...sourcePart,
+      providerMetadata: {
+        cherry: { fileEntryId: '00000000-0000-7000-8000-000000000001' },
+      },
+      url: 'file:///documents/files/00000000-0000-7000-8000-000000000001.pdf',
+    } as CherryMessagePart;
+    const preparedFile = {
+      ext: 'pdf',
+      id: '00000000-0000-7000-8000-000000000001',
+      name: 'brief',
+      size: 12,
+      uri: 'file:///documents/files/00000000-0000-7000-8000-000000000001.pdf',
+    };
+    mockPrepareMessageParts.mockResolvedValueOnce({
+      files: [preparedFile],
+      parts: [managedPart],
+    });
     mockReadUIMessageStream.mockReturnValue(asyncIterable([assistantChunk]));
 
     await runtime.sendNewTopicText({
-      parts: [createFilePart('file://brief.pdf')],
+      parts: [sourcePart],
       selectedModelId: 'provider::model' as UniqueModelId,
       text: '',
     });
@@ -507,13 +560,15 @@ describe('ChatRuntime', () => {
     });
     expect(services.message.createUserMessageWithPlaceholders).toHaveBeenCalledWith(
       expect.objectContaining({
+        preparedFiles: [preparedFile],
         userMessage: expect.objectContaining({
           dto: expect.objectContaining({
-            data: { parts: [createFilePart('file://brief.pdf')] },
+            data: { parts: [managedPart] },
           }),
         }),
       }),
     );
+    expect(mockDiscardPreparedFiles).not.toHaveBeenCalled();
   });
 
   test('rejects and does not reserve messages when context resolution fails', async () => {
@@ -535,6 +590,17 @@ describe('ChatRuntime', () => {
 
   test('rejects and restores the topic snapshot when reservation fails', async () => {
     const services = createServices();
+    const preparedFile = {
+      ext: 'pdf',
+      id: '00000000-0000-7000-8000-000000000001',
+      name: 'brief',
+      size: 12,
+      uri: 'file:///documents/files/00000000-0000-7000-8000-000000000001.pdf',
+    };
+    mockPrepareMessageParts.mockResolvedValueOnce({
+      files: [preparedFile],
+      parts: [createFilePart(preparedFile.uri)],
+    });
     services.message.createUserMessageWithPlaceholders = jest.fn(async () => {
       throw new Error('reservation failed');
     });
@@ -542,13 +608,15 @@ describe('ChatRuntime', () => {
 
     await expect(
       runtime.sendText({
+        parts: [createFilePart('file://brief.pdf')],
         selectedModelId: 'provider::model' as UniqueModelId,
-        text: 'hi',
+        text: '',
         topicId: 'topic-1',
       }),
     ).rejects.toThrow('reservation failed');
 
     expect(services.ai.streamText).not.toHaveBeenCalled();
+    expect(mockDiscardPreparedFiles).toHaveBeenCalledWith([preparedFile]);
     expect(runtime.getTopicSnapshot('topic-1').status).toBe('idle');
   });
 

--- a/src/screens/HomeScreen/components/HomeProfileHero.tsx
+++ b/src/screens/HomeScreen/components/HomeProfileHero.tsx
@@ -13,8 +13,7 @@ import Animated, {
 import { Image } from '@/components/nativePrimitives';
 import { ProfileAvatarEditBadge } from '@/components/ProfileAvatar';
 import { homeHeader } from '@/config/constants';
-
-const avatarSource = require('@/assets/icon.png');
+import { useAvatar } from '@/hooks/useAvatar';
 
 const heroHeight = homeHeader.heroContainerHeight;
 // Clip trick from the reference header: the box's bounds extend far above its
@@ -64,6 +63,7 @@ export function HomeProfileHero({
 }: HomeProfileHeroProps) {
   const { t } = useTranslation();
   const { width: screenWidth } = useWindowDimensions();
+  const avatarSource = useAvatar();
   const nameWidth = useSharedValue(0);
   const measuredNameRef = useRef<string | null>(null);
 

--- a/src/screens/SettingsScreen/ProfileSettingsScreen.tsx
+++ b/src/screens/SettingsScreen/ProfileSettingsScreen.tsx
@@ -1,28 +1,32 @@
 import { type MenuAction, MenuView, type NativeActionEvent } from '@expo/ui/community/menu';
-import type { ImageSource } from 'expo-image';
+import { loggerService } from '@logger';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 import { useThemeColor } from 'heroui-native/hooks';
 import { Input } from 'heroui-native/input';
+import { useToast } from 'heroui-native/toast';
 import { SaveIcon } from 'lucide-uniwind/png';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { BackHeader, type HeaderToolbarAction } from '@/components/headers';
 import { ProfileAvatarEditBadge, ProfileAvatarImage } from '@/components/ProfileAvatar';
 import { usePreference } from '@/data/hooks';
+import { replaceUserAvatar } from '@/services/userAvatarStorage';
 
 const profileAvatarSize = 104;
+const logger = loggerService.withContext('ProfileSettingsScreen');
 
 type AvatarSourceValue = 'camera' | 'photos';
 
 export default function ProfileSettingsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
+  const { toast } = useToast();
   const borderColor = useThemeColor('border');
   const inputRef = useRef<TextInput>(null);
   const [userName, setUserName] = usePreference('app.user.name');
-  const [draftAvatarUri, setDraftAvatarUri] = useState<string | null>(null);
+  const [avatar, setAvatar] = usePreference('app.user.avatar');
   const avatarActions = useMemo<MenuAction[]>(
     () => [
       {
@@ -39,46 +43,69 @@ export default function ProfileSettingsScreen() {
     [t],
   );
 
+  const persistSelectedAvatar = useCallback(
+    (sourceUri: string) =>
+      replaceUserAvatar(sourceUri, avatar, (nextAvatar) =>
+        setAvatar(nextAvatar, { optimistic: true }),
+      ),
+    [avatar, setAvatar],
+  );
+  const reportAvatarSaveError = useCallback(
+    (error: unknown) => {
+      logger.error('Failed to save user avatar', error as Error);
+      toast.show({ label: t('settings.profile.avatarSaveError'), variant: 'danger' });
+    },
+    [t, toast],
+  );
+
   const selectAvatarFromCamera = useCallback(async () => {
-    const permission = await ImagePicker.requestCameraPermissionsAsync();
+    try {
+      const permission = await ImagePicker.requestCameraPermissionsAsync();
 
-    if (!permission.granted) {
-      return;
+      if (!permission.granted) {
+        return;
+      }
+
+      const result = await ImagePicker.launchCameraAsync({
+        allowsEditing: true,
+        aspect: [1, 1],
+        mediaTypes: ['images'],
+        quality: 1,
+      });
+
+      const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
+      if (assetUri) {
+        await persistSelectedAvatar(assetUri);
+      }
+    } catch (error) {
+      reportAvatarSaveError(error);
     }
-
-    const result = await ImagePicker.launchCameraAsync({
-      allowsEditing: true,
-      aspect: [1, 1],
-      mediaTypes: ['images'],
-      quality: 1,
-    });
-
-    const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
-    if (assetUri) {
-      setDraftAvatarUri(assetUri);
-    }
-  }, []);
+  }, [persistSelectedAvatar, reportAvatarSaveError]);
 
   const selectAvatarFromPhotoLibrary = useCallback(async () => {
-    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
 
-    if (!permission.granted) {
-      return;
+      if (!permission.granted) {
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        allowsEditing: true,
+        aspect: [1, 1],
+        mediaTypes: ['images'],
+        quality: 1,
+        selectionLimit: 1,
+      });
+
+      const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
+      if (assetUri) {
+        await persistSelectedAvatar(assetUri);
+      }
+    } catch (error) {
+      reportAvatarSaveError(error);
     }
-
-    const result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,
-      aspect: [1, 1],
-      mediaTypes: ['images'],
-      quality: 1,
-      selectionLimit: 1,
-    });
-
-    const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
-    if (assetUri) {
-      setDraftAvatarUri(assetUri);
-    }
-  }, []);
+  }, [persistSelectedAvatar, reportAvatarSaveError]);
 
   const handleAvatarSourceChange = useCallback(
     (event: NativeActionEvent) => {
@@ -137,7 +164,6 @@ export default function ProfileSettingsScreen() {
             <MenuAvatarTrigger
               actions={avatarActions}
               accessibilityLabel={t('settings.profile.changeAvatar')}
-              imageSource={draftAvatarUri ? { uri: draftAvatarUri } : undefined}
               onPress={blurInput}
               onPressAction={handleAvatarSourceChange}
               size={profileAvatarSize}
@@ -170,7 +196,6 @@ export default function ProfileSettingsScreen() {
 type MenuAvatarTriggerProps = {
   accessibilityLabel: string;
   actions: MenuAction[];
-  imageSource?: ImageSource | number;
   onPress: () => void;
   onPressAction: (event: NativeActionEvent) => void;
   size: number;
@@ -179,7 +204,6 @@ type MenuAvatarTriggerProps = {
 function MenuAvatarTrigger({
   accessibilityLabel,
   actions,
-  imageSource,
   onPress,
   onPressAction,
   size,
@@ -192,7 +216,7 @@ function MenuAvatarTrigger({
       }}
       style={{ height: size, width: size }}
     >
-      <ProfileAvatarImage imageSource={imageSource} size={size} />
+      <ProfileAvatarImage size={size} />
       <MenuView actions={actions} onPressAction={onPressAction} style={styles.avatarMenuTrigger}>
         <View
           accessibilityLabel={accessibilityLabel}

--- a/src/services/__tests__/userAvatarStorage.test.ts
+++ b/src/services/__tests__/userAvatarStorage.test.ts
@@ -1,0 +1,142 @@
+import { replaceUserAvatar, resolveUserAvatarUri } from '../userAvatarStorage';
+
+jest.mock('expo-file-system', () => {
+  const directories = new Set<string>();
+  const files = new Set<string>();
+  const copies: { destination: string; source: string }[] = [];
+  const joinUri = (parts: (string | { uri: string })[], isDirectory: boolean) => {
+    const [first, ...rest] = parts.map((part) => (typeof part === 'string' ? part : part.uri));
+    let uri = first?.replace(/\/+$/, '') ?? '';
+
+    for (const part of rest) {
+      uri += `/${part.replace(/^\/+|\/+$/g, '')}`;
+    }
+
+    return isDirectory ? `${uri}/` : uri;
+  };
+
+  class MockDirectory {
+    readonly uri: string;
+
+    constructor(...parts: (string | { uri: string })[]) {
+      this.uri = joinUri(parts, true);
+    }
+
+    get exists() {
+      return directories.has(this.uri);
+    }
+
+    create() {
+      directories.add(this.uri);
+    }
+  }
+
+  class MockFile {
+    readonly uri: string;
+
+    constructor(...parts: (string | { uri: string })[]) {
+      this.uri = joinUri(parts, false);
+    }
+
+    get exists() {
+      return files.has(this.uri);
+    }
+
+    async copy(destination: MockFile) {
+      copies.push({ destination: destination.uri, source: this.uri });
+      files.add(destination.uri);
+    }
+
+    delete() {
+      files.delete(this.uri);
+    }
+  }
+
+  return {
+    Directory: MockDirectory,
+    File: MockFile,
+    Paths: { document: { uri: 'file:///documents/' } },
+    testState: { copies, directories, files },
+  };
+});
+
+type FileSystemTestState = {
+  copies: { destination: string; source: string }[];
+  directories: Set<string>;
+  files: Set<string>;
+};
+
+const { testState } = jest.requireMock<{ testState: FileSystemTestState }>('expo-file-system');
+
+describe('userAvatarStorage', () => {
+  beforeEach(() => {
+    testState.copies.length = 0;
+    testState.directories.clear();
+    testState.files.clear();
+  });
+
+  it('stores a picked image behind a path-resilient file reference', async () => {
+    let avatar = '';
+
+    await replaceUserAvatar('file:///picker/avatar.jpg', '', async (nextAvatar) => {
+      avatar = nextAvatar;
+    });
+
+    expect(avatar).toMatch(
+      /^file:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(testState.copies).toEqual([
+      {
+        destination: `file:///documents/user-avatars/${avatar.slice('file:'.length)}`,
+        source: 'file:///picker/avatar.jpg',
+      },
+    ]);
+    expect(resolveUserAvatarUri(avatar)).toBe(
+      `file:///documents/user-avatars/${avatar.slice('file:'.length)}`,
+    );
+  });
+
+  it('deletes the previous managed file only after persisting its replacement', async () => {
+    let previousAvatar = '';
+    await replaceUserAvatar('file:///picker/first.jpg', '', async (nextAvatar) => {
+      previousAvatar = nextAvatar;
+    });
+
+    let nextAvatar = '';
+    await replaceUserAvatar('file:///picker/second.jpg', previousAvatar, async (value) => {
+      nextAvatar = value;
+      expect(resolveUserAvatarUri(previousAvatar)).toBeDefined();
+    });
+
+    expect(resolveUserAvatarUri(previousAvatar)).toBeUndefined();
+    expect(resolveUserAvatarUri(nextAvatar)).toBeDefined();
+  });
+
+  it('compensates the new file and preserves the previous avatar when persistence fails', async () => {
+    let previousAvatar = '';
+    await replaceUserAvatar('file:///picker/first.jpg', '', async (nextAvatar) => {
+      previousAvatar = nextAvatar;
+    });
+
+    let rejectedAvatar = '';
+    await expect(
+      replaceUserAvatar('file:///picker/second.jpg', previousAvatar, async (nextAvatar) => {
+        rejectedAvatar = nextAvatar;
+        throw new Error('preference write failed');
+      }),
+    ).rejects.toThrow('preference write failed');
+
+    expect(resolveUserAvatarUri(previousAvatar)).toBeDefined();
+    expect(resolveUserAvatarUri(rejectedAvatar)).toBeUndefined();
+  });
+
+  it('keeps legacy image URIs and rejects non-image or unresolved values', () => {
+    expect(resolveUserAvatarUri('https://example.com/avatar.png')).toBe(
+      'https://example.com/avatar.png',
+    );
+    expect(resolveUserAvatarUri('data:image/png;base64,abc')).toBe('data:image/png;base64,abc');
+    expect(resolveUserAvatarUri('file:///legacy/avatar.png')).toBe('file:///legacy/avatar.png');
+    expect(resolveUserAvatarUri('😀')).toBeUndefined();
+    expect(resolveUserAvatarUri('file:00000000-0000-4000-8000-000000000000')).toBeUndefined();
+  });
+});

--- a/src/services/userAvatarStorage.ts
+++ b/src/services/userAvatarStorage.ts
@@ -1,0 +1,109 @@
+import { loggerService } from '@logger';
+import { randomUUID } from 'expo-crypto';
+import { Directory, File, Paths } from 'expo-file-system';
+
+const logger = loggerService.withContext('UserAvatarStorage');
+const AVATAR_DIRECTORY_NAME = 'user-avatars';
+const STORED_FILE_REF_PREFIX = 'file:';
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_IMAGE_URI_PATTERN = /^(?:blob:|content:\/\/|data:image\/|file:\/\/|https?:\/\/)/i;
+
+type PersistAvatar = (avatar: string) => Promise<void>;
+
+function avatarDirectory(): Directory {
+  return new Directory(Paths.document, AVATAR_DIRECTORY_NAME);
+}
+
+function ensureAvatarDirectory(): Directory {
+  const directory = avatarDirectory();
+
+  if (!directory.exists) {
+    directory.create({ intermediates: true });
+  }
+
+  return directory;
+}
+
+function avatarFile(fileId: string): File {
+  return new File(avatarDirectory(), fileId);
+}
+
+function storedFileId(avatar: string): string | undefined {
+  if (!avatar.startsWith(STORED_FILE_REF_PREFIX) || avatar.startsWith('file://')) {
+    return undefined;
+  }
+
+  const fileId = avatar.slice(STORED_FILE_REF_PREFIX.length);
+  return UUID_PATTERN.test(fileId) ? fileId : undefined;
+}
+
+function deleteStoredAvatar(avatar: string): void {
+  const fileId = storedFileId(avatar);
+
+  if (!fileId) {
+    return;
+  }
+
+  try {
+    const file = avatarFile(fileId);
+
+    if (file.exists) {
+      file.delete();
+    }
+  } catch (error) {
+    logger.warn('Failed to delete stored user avatar', error as Error, { avatar });
+  }
+}
+
+/**
+ * Resolve the preference value into an image URI for this device. New avatars
+ * use a path-resilient `file:<uuid>` reference; legacy image URIs still render.
+ */
+export function resolveUserAvatarUri(avatar: string): string | undefined {
+  const fileId = storedFileId(avatar);
+
+  if (fileId) {
+    const file = avatarFile(fileId);
+    return file.exists ? file.uri : undefined;
+  }
+
+  return LEGACY_IMAGE_URI_PATTERN.test(avatar) ? avatar : undefined;
+}
+
+async function storeUserAvatar(sourceUri: string): Promise<string> {
+  ensureAvatarDirectory();
+
+  const fileId = randomUUID();
+  const destination = avatarFile(fileId);
+
+  try {
+    await new File(sourceUri).copy(destination);
+  } catch (error) {
+    deleteStoredAvatar(`${STORED_FILE_REF_PREFIX}${fileId}`);
+    throw error;
+  }
+
+  return `${STORED_FILE_REF_PREFIX}${fileId}`;
+}
+
+/**
+ * Replace the stored avatar without exposing a temporary picker URI. The new
+ * file is compensated if the preference write fails; the old file is removed
+ * only after the new preference value is durable.
+ */
+export async function replaceUserAvatar(
+  sourceUri: string,
+  previousAvatar: string,
+  persistAvatar: PersistAvatar,
+): Promise<void> {
+  const nextAvatar = await storeUserAvatar(sourceUri);
+
+  try {
+    await persistAvatar(nextAvatar);
+  } catch (error) {
+    deleteStoredAvatar(nextAvatar);
+    throw error;
+  }
+
+  deleteStoredAvatar(previousAvatar);
+}


### PR DESCRIPTION
## Summary

- Persist selected user avatars in app-owned storage and resolve them through preferences across profile surfaces.
- Align mobile managed-file schemas and `CherryFileMeta` with desktop, including migration constraints, indexes, and chat attachment references.
- Import outgoing attachments into persistent storage transactionally, then resolve AI inputs and previews exclusively through `fileEntryId` with unavailable-state degradation.

## Validation

- `pnpm test --runInBand` (108 suites, 715 tests)
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)