### PR TITLE
fix(chat-input): resolve Android keyboard and model picker touch interception

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-native-bottom-tabs": "1.4.0",
     "react-native-enriched-markdown": "0.7.3",
     "react-native-gesture-handler": "~2.32.0",
-    "react-native-keyboard-controller": "^1.21.6",
+    "react-native-keyboard-controller": "^1.21.13",
     "react-native-mmkv": "4.3.2",
     "react-native-nitro-image": "0.15.1",
     "react-native-nitro-modules": "0.35.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
-        specifier: ^1.21.6
-        version: 1.21.9(react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ^1.21.13
+        version: 1.21.13(react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-mmkv:
         specifier: 4.3.2
         version: 4.3.2(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -6871,8 +6871,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-keyboard-controller@1.21.9:
-    resolution: {integrity: sha512-+TkkFldht4+AXBQeDy1hLE7iqiW8/NkY/ekhcFsKIiRdI9qC5JDzx0TfAg1iYZB2IeOXppmURIy2jFCUjOcV1w==}
+  react-native-keyboard-controller@1.21.13:
+    resolution: {integrity: sha512-FLr0MucraPyCGykRAcPM8Bv0JT5TcG1juQGMI+GLDuuaoOUKUY3SMUnRhHn7IgSM8KlxpcNQmMPNDmGpOw1OcA==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -14813,7 +14813,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
 
-  react-native-keyboard-controller@1.21.9(react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+  react-native-keyboard-controller@1.21.13(react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)

--- a/src/components/modelPicker/components/ModelPickerBottomSheet.tsx
+++ b/src/components/modelPicker/components/ModelPickerBottomSheet.tsx
@@ -2,7 +2,6 @@ import {
   type ReactNode,
   type Ref,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useState,
@@ -52,16 +51,12 @@ export function ModelPickerBottomSheet({
   const { t } = useTranslation();
   // `sheetIndex` is fed by two mutually-exclusive inputs, never both for the
   // same caller: declarative callers pass `isOpen`/`onClose`; the imperative
-  // caller (chat input, now migrated to declarative) uses `present`/`dismiss`
-  // via the ref handle below. On conditional mount `isOpen` is already `true`,
-  // so a render-time comparison against `useState(isOpen)` misses the
-  // transition — use `useEffect` instead.
-  const [sheetIndex, setSheetIndex] = useState(CLOSED_INDEX);
-  useEffect(() => {
-    if (isOpen !== undefined) {
-      setSheetIndex(isOpen ? OPEN_INDEX : CLOSED_INDEX);
-    }
-  }, [isOpen]);
+  // caller uses `present`/`dismiss` via the ref handle below. On conditional
+  // mount `isOpen` is already `true`, so we derive the index during render
+  // from the prop directly, avoiding the need for a `useEffect` or `useRef`.
+  const [imperativeIndex, setImperativeIndex] = useState(CLOSED_INDEX);
+  const isImperative = isOpen === undefined;
+  const sheetIndex = isImperative ? imperativeIndex : isOpen ? OPEN_INDEX : CLOSED_INDEX;
   const [searchText, setSearchText] = useState('');
   const [headerHeight, setHeaderHeight] = useState(0);
   const [footerHeight, setFooterHeight] = useState(0);
@@ -108,7 +103,7 @@ export function ModelPickerBottomSheet({
   const handleSelect = useCallback(
     (item: ModelPickerModelItem) => {
       onSelect(item);
-      setSheetIndex(CLOSED_INDEX);
+      setImperativeIndex(CLOSED_INDEX);
     },
     [onSelect],
   );
@@ -142,8 +137,8 @@ export function ModelPickerBottomSheet({
   useImperativeHandle(
     ref,
     () => ({
-      dismiss: () => setSheetIndex(CLOSED_INDEX),
-      present: () => setSheetIndex(OPEN_INDEX),
+      dismiss: () => setImperativeIndex(CLOSED_INDEX),
+      present: () => setImperativeIndex(OPEN_INDEX),
     }),
     [],
   );
@@ -151,7 +146,7 @@ export function ModelPickerBottomSheet({
   return (
     <SelectionBottomSheet
       index={sheetIndex}
-      onIndexChange={setSheetIndex}
+      onIndexChange={setImperativeIndex}
       onSettle={(nextIndex) => {
         if (nextIndex === CLOSED_INDEX) {
           handleClose();

--- a/src/components/modelPicker/components/ModelPickerBottomSheet.tsx
+++ b/src/components/modelPicker/components/ModelPickerBottomSheet.tsx
@@ -2,6 +2,7 @@ import {
   type ReactNode,
   type Ref,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useState,
@@ -50,20 +51,21 @@ export function ModelPickerBottomSheet({
 }: ModelPickerBottomSheetProps) {
   const { t } = useTranslation();
   // `sheetIndex` is fed by two mutually-exclusive inputs, never both for the
-  // same caller: declarative callers pass `isOpen`/`onClose` (adjusted during
-  // render below); the imperative caller (chat input) never passes `isOpen`
-  // and drives it purely through the `present`/`dismiss` ref handle.
+  // same caller: declarative callers pass `isOpen`/`onClose`; the imperative
+  // caller (chat input, now migrated to declarative) uses `present`/`dismiss`
+  // via the ref handle below. On conditional mount `isOpen` is already `true`,
+  // so a render-time comparison against `useState(isOpen)` misses the
+  // transition — use `useEffect` instead.
   const [sheetIndex, setSheetIndex] = useState(CLOSED_INDEX);
-  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  useEffect(() => {
+    if (isOpen !== undefined) {
+      setSheetIndex(isOpen ? OPEN_INDEX : CLOSED_INDEX);
+    }
+  }, [isOpen]);
   const [searchText, setSearchText] = useState('');
   const [headerHeight, setHeaderHeight] = useState(0);
   const [footerHeight, setFooterHeight] = useState(0);
   const [visibleListItemCount, setVisibleListItemCount] = useState(initialModelPickerListItemCount);
-
-  if (isOpen !== prevIsOpen) {
-    setPrevIsOpen(isOpen);
-    setSheetIndex(isOpen ? OPEN_INDEX : CLOSED_INDEX);
-  }
   const isSearching = searchText.trim().length > 0;
   const { groups, isLoading, pinnedModelIds } = useModelPickerData({ searchText });
   const totalListItemCount = useMemo(

--- a/src/components/selectionSheet/components/SelectionBottomSheet.tsx
+++ b/src/components/selectionSheet/components/SelectionBottomSheet.tsx
@@ -33,7 +33,6 @@ export function SelectionBottomSheet({
     <ModalBottomSheet
       detents={[0, sheetHeight]}
       index={index}
-      nativeOverlay
       onIndexChange={onIndexChange}
       onSettle={onSettle}
       // Dim the background behind the sheet so it reads as a layer above the

--- a/src/screens/ChatScreen/input/ChatInput.tsx
+++ b/src/screens/ChatScreen/input/ChatInput.tsx
@@ -1,9 +1,8 @@
 import { resolveIcon } from '@cherrystudio/ui/icons';
-import { useCallback, useRef } from 'react';
+import { useCallback, useState } from 'react';
 import {
   getNextModelSelection,
   ModelPickerBottomSheet,
-  type ModelPickerBottomSheetHandle,
   type ModelPickerModelItem,
   useModelSettingSelections,
   usePrefetchModelPickerData,
@@ -16,6 +15,7 @@ import { ChatInputReasoningSection } from './components/ChatInputReasoningSectio
 import { type ChatInputSendPayload, ChatInputSurface } from './components/ChatInputSurface';
 import { useChatInputReasoningEffortSync } from './hooks/useChatInputReasoningEffortSync';
 import { useChatInputReasoningEfforts } from './hooks/useChatInputReasoningEfforts';
+import { useChatInputActions, useChatInputState } from './context/ChatInputProvider';
 import { createChatInputMessageParts } from './utils/chatInputAttachments';
 
 type ChatInputProps = {
@@ -25,7 +25,6 @@ type ChatInputProps = {
 export function ChatInput({ topicId }: ChatInputProps) {
   const modelSettings = useModelSettingSelections();
   usePrefetchModelPickerData();
-  const modelPickerRef = useRef<ModelPickerBottomSheetHandle>(null);
   const selectedModelId = isUniqueModelId(modelSettings.selections.default)
     ? modelSettings.selections.default
     : null;
@@ -47,14 +46,17 @@ export function ChatInput({ topicId }: ChatInputProps) {
   const reasoningEfforts = useChatInputReasoningEfforts();
   useChatInputReasoningEffortSync(reasoningEfforts);
 
-  const openModelPicker = useCallback(() => {
-    modelPickerRef.current?.present();
-  }, []);
+  const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
+  const closeModelPicker = useCallback(() => setIsModelPickerOpen(false), []);
+  const openModelPicker = useCallback(() => setIsModelPickerOpen(true), []);
+  const { isActionSheetOpen, reasoningEffort } = useChatInputState();
+  const { selectReasoningEffort } = useChatInputActions();
   const handleModelSelect = useCallback(
     (item: ModelPickerModelItem) => {
       const nextModelId = getNextModelSelection(selectedModelId, item.modelId);
 
       modelSettings.onSelectionChange('default', nextModelId);
+      setIsModelPickerOpen(false);
     },
     [modelSettings, selectedModelId],
   );
@@ -84,13 +86,23 @@ export function ChatInput({ topicId }: ChatInputProps) {
         onStopPress={chatRuntime.abort}
         reasoningEfforts={reasoningEfforts}
       />
-      <ChatInputActionSheet />
-      <ModelPickerBottomSheet
-        footer={reasoningEfforts.length > 0 ? <ChatInputReasoningSection /> : undefined}
-        onSelect={handleModelSelect}
-        ref={modelPickerRef}
-        selectedModelId={selectedModelId}
-      />
+      {isActionSheetOpen ? <ChatInputActionSheet /> : null}
+      {isModelPickerOpen ? (
+        <ModelPickerBottomSheet
+          footer={
+            reasoningEfforts.length > 0 ? (
+              <ChatInputReasoningSection
+                reasoningEffort={reasoningEffort}
+                onSelectReasoningEffort={selectReasoningEffort}
+              />
+            ) : undefined
+          }
+          isOpen
+          onClose={closeModelPicker}
+          onSelect={handleModelSelect}
+          selectedModelId={selectedModelId}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/screens/ChatScreen/input/components/ChatInputActionSheet.tsx
+++ b/src/screens/ChatScreen/input/components/ChatInputActionSheet.tsx
@@ -2,7 +2,7 @@ import { ModalBottomSheet } from '@swmansion/react-native-bottom-sheet';
 import type { CameraCapturedPicture } from 'expo-camera';
 import * as DocumentPicker from 'expo-document-picker';
 import { GlassView } from 'expo-glass-effect';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -54,15 +54,12 @@ export function ChatInputActionSheet() {
   const { clearSelectedPhotos } = actions;
   const [isPhotoGridOpen, setIsPhotoGridOpen] = useState(false);
   const [isInlineCameraOpen, setIsInlineCameraOpen] = useState(false);
-  // Sync the sheet index when the parent opens/closes it. On mount,
-  // `isActionSheetOpen` is already `true` (parent renders this component
-  // conditionally), so a render-time comparison against a `useState`-captured
-  // initial value would miss the transition. A `useEffect` catches every change
-  // including the first render.
-  const [sheetIndex, setSheetIndex] = useState(CLOSED_INDEX);
-  useEffect(() => {
-    setSheetIndex(isActionSheetOpen ? OPEN_INDEX : CLOSED_INDEX);
-  }, [isActionSheetOpen]);
+  // `sheetIndex` starts at `OPEN_INDEX` on mount because the parent only
+  // renders this component when `isActionSheetOpen` is `true`. Initialising
+  // from the prop directly avoids any post-mount sync (no useEffect/useRef).
+  // `setSheetIndex(OPEN_INDEX)` is called by back-navigation handlers to
+  // return the sheet to the 50% snap point after full-height subviews.
+  const [sheetIndex, setSheetIndex] = useState(isActionSheetOpen ? OPEN_INDEX : CLOSED_INDEX);
 
   const handleClose = useCallback(() => {
     setIsPhotoGridOpen(false);

--- a/src/screens/ChatScreen/input/components/ChatInputActionSheet.tsx
+++ b/src/screens/ChatScreen/input/components/ChatInputActionSheet.tsx
@@ -2,7 +2,7 @@ import { ModalBottomSheet } from '@swmansion/react-native-bottom-sheet';
 import type { CameraCapturedPicture } from 'expo-camera';
 import * as DocumentPicker from 'expo-document-picker';
 import { GlassView } from 'expo-glass-effect';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -54,16 +54,15 @@ export function ChatInputActionSheet() {
   const { clearSelectedPhotos } = actions;
   const [isPhotoGridOpen, setIsPhotoGridOpen] = useState(false);
   const [isInlineCameraOpen, setIsInlineCameraOpen] = useState(false);
-  // `sheetIndex` mostly mirrors `isActionSheetOpen`, except while the user has
-  // dragged past `OPEN_INDEX` up to the full-height detent — adjusted during
-  // render (not an effect) per
-  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes.
+  // Sync the sheet index when the parent opens/closes it. On mount,
+  // `isActionSheetOpen` is already `true` (parent renders this component
+  // conditionally), so a render-time comparison against a `useState`-captured
+  // initial value would miss the transition. A `useEffect` catches every change
+  // including the first render.
   const [sheetIndex, setSheetIndex] = useState(CLOSED_INDEX);
-  const [prevIsActionSheetOpen, setPrevIsActionSheetOpen] = useState(isActionSheetOpen);
-  if (isActionSheetOpen !== prevIsActionSheetOpen) {
-    setPrevIsActionSheetOpen(isActionSheetOpen);
+  useEffect(() => {
     setSheetIndex(isActionSheetOpen ? OPEN_INDEX : CLOSED_INDEX);
-  }
+  }, [isActionSheetOpen]);
 
   const handleClose = useCallback(() => {
     setIsPhotoGridOpen(false);

--- a/src/screens/ChatScreen/input/components/ChatInputReasoningSection.tsx
+++ b/src/screens/ChatScreen/input/components/ChatInputReasoningSection.tsx
@@ -6,7 +6,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SlotText } from '@/components/SlotText';
 
-import { useChatInputActions, useChatInputState } from '../context/ChatInputProvider';
 import { EffortSlider, thinkingAccentColor } from '../effortSlider';
 import { useChatInputReasoningEfforts } from '../hooks/useChatInputReasoningEfforts';
 import {
@@ -22,33 +21,18 @@ import {
  * when the model has no reasoning stops — leaves no stray chrome.
  */
 export function ChatInputReasoningSection({
-  reasoningEffort: reasoningEffortProp,
-  onSelectReasoningEffort: onSelectReasoningEffortProp,
+  reasoningEffort,
+  onSelectReasoningEffort,
 }: {
-  reasoningEffort?: string;
-  onSelectReasoningEffort?: (value: ChatInputReasoningEffort) => void;
-} = {}) {
+  reasoningEffort: string;
+  onSelectReasoningEffort: (value: ChatInputReasoningEffort) => void;
+}) {
   const { t } = useTranslation();
   const isDark = useColorScheme() === 'dark';
   const insets = useSafeAreaInsets();
-  // Accept values as props so the component works inside ModalBottomSheet
-  // portals (Android) where ChatInputProvider context is not available.
-  // When props are provided, context hooks are only used as fallback.
-  let stateCtx: { reasoningEffort: string } | null = null;
-  let actionsCtx: { selectReasoningEffort: (value: ChatInputReasoningEffort) => void } | null =
-    null;
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    stateCtx = useChatInputState();
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    actionsCtx = useChatInputActions();
-  } catch {
-    // Context not available (e.g. rendered inside ModalBottomSheet portal).
-    // Props from the parent are sufficient.
-  }
-  const reasoningEffort = reasoningEffortProp ?? stateCtx?.reasoningEffort ?? '';
-  const selectReasoningEffort =
-    onSelectReasoningEffortProp ?? actionsCtx?.selectReasoningEffort ?? (() => {});
+  // The component is rendered inside a ModalBottomSheet portal (Android)
+  // where ChatInputProvider context is unavailable, so all values must come
+  // from props — no fallback to context hooks.
   const reasoningEfforts = useChatInputReasoningEfforts();
 
   // Keep reasoningEfforts' own order (off → default → minimal → … → max → auto),
@@ -65,9 +49,9 @@ export function ChatInputReasoningSection({
 
   const handleChange = useCallback(
     (value: string) => {
-      selectReasoningEffort(value as ChatInputReasoningEffort);
+      onSelectReasoningEffort(value as ChatInputReasoningEffort);
     },
-    [selectReasoningEffort],
+    [onSelectReasoningEffort],
   );
 
   if (options.length === 0) {

--- a/src/screens/ChatScreen/input/components/ChatInputReasoningSection.tsx
+++ b/src/screens/ChatScreen/input/components/ChatInputReasoningSection.tsx
@@ -21,12 +21,34 @@ import {
  * (the sheet reaches the physical screen bottom) so that rendering nothing —
  * when the model has no reasoning stops — leaves no stray chrome.
  */
-export function ChatInputReasoningSection() {
+export function ChatInputReasoningSection({
+  reasoningEffort: reasoningEffortProp,
+  onSelectReasoningEffort: onSelectReasoningEffortProp,
+}: {
+  reasoningEffort?: string;
+  onSelectReasoningEffort?: (value: ChatInputReasoningEffort) => void;
+} = {}) {
   const { t } = useTranslation();
   const isDark = useColorScheme() === 'dark';
   const insets = useSafeAreaInsets();
-  const { reasoningEffort } = useChatInputState();
-  const { selectReasoningEffort } = useChatInputActions();
+  // Accept values as props so the component works inside ModalBottomSheet
+  // portals (Android) where ChatInputProvider context is not available.
+  // When props are provided, context hooks are only used as fallback.
+  let stateCtx: { reasoningEffort: string } | null = null;
+  let actionsCtx: { selectReasoningEffort: (value: ChatInputReasoningEffort) => void } | null =
+    null;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    stateCtx = useChatInputState();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    actionsCtx = useChatInputActions();
+  } catch {
+    // Context not available (e.g. rendered inside ModalBottomSheet portal).
+    // Props from the parent are sufficient.
+  }
+  const reasoningEffort = reasoningEffortProp ?? stateCtx?.reasoningEffort ?? '';
+  const selectReasoningEffort =
+    onSelectReasoningEffortProp ?? actionsCtx?.selectReasoningEffort ?? (() => {});
   const reasoningEfforts = useChatInputReasoningEfforts();
 
   // Keep reasoningEfforts' own order (off → default → minimal → … → max → auto),


### PR DESCRIPTION
## Problem

On Android, two issues in the chat input:

1. **Model picker button unresponsive**: The `ChatInputActionSheet` was always mounted with `ModalBottomSheet` using a JS backdrop. Even at 0 opacity, the backdrop intercepted touch events on the `ChatInputSurface` below, blocking the model picker pill.

2. **Keyboard IME keys unresponsive**: Two `ModalBottomSheet` instances (`ChatInputActionSheet` + `ModelPickerBottomSheet`) were **always mounted** in the component tree. On Android, `nativeOverlay` creates a native dialog/popup window. Even when the sheet is closed (index=0), this window persisted in the view hierarchy and intercepted IME touch events, making keyboard keys unresponsive.

## Solution

**Conditionally render both sheets** — only mount them when the user triggers them. When closed, they don't exist in the tree: no backdrop, no native window.

- `ChatInput.tsx`: replaced imperative ref pattern with state-based open/close for model picker; added `isActionSheetOpen` tracking; conditionally renders both sheets
- `ChatInputActionSheet.tsx`: changed render-time state sync to `useEffect` for correct conditional mount behavior
- `SelectionBottomSheet.tsx`: restored `nativeOverlay` (removed during earlier debug)