### PR TITLE
Hide bottom tabs on secondary screens; iOS message-edit & settings fixes

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -5,10 +5,12 @@ import {
 } from '@bottom-tabs/react-navigation';
 import { withLayoutContext } from 'expo-router';
 import type { ParamListBase, TabNavigationState } from 'expo-router/react-navigation';
+import { useNavigationState } from 'expo-router/react-navigation';
 import { useThemeColor } from 'heroui-native/hooks';
 import { useTranslation } from 'react-i18next';
 
 import { BottomTabBarVisibilityProvider, useBottomTabBarHidden } from '@/components/navigation';
+import { selectIsNestedTabScreen } from '@/components/navigation/tabBarVisibility';
 import { isAndroid } from '@/config/constants';
 import {
   SearchScopeProvider,
@@ -72,6 +74,7 @@ function TabNavigator() {
   const accentColor = useThemeColor('accent');
   const [tabBarColor] = useThemeColor(['background-secondary']);
   const isBottomTabBarHidden = useBottomTabBarHidden();
+  const isNestedScreen = useNavigationState(selectIsNestedTabScreen);
   const setScope = useSetSearchScope();
   const androidTabProps = isAndroid
     ? {
@@ -86,7 +89,7 @@ function TabNavigator() {
       {...androidTabProps}
       backBehavior="history"
       initialRouteName="(messages)"
-      tabBarHidden={isBottomTabBarHidden}
+      tabBarHidden={isBottomTabBarHidden || isNestedScreen}
       screenOptions={{
         sceneStyle,
         // freezeOnBlur 会让冻结中的 tab 错过 uniwind 的免重渲染主题 patch，

--- a/src/components/messageTabs/index.ts
+++ b/src/components/messageTabs/index.ts
@@ -16,3 +16,4 @@ export {
 } from './scope';
 export { areAllSelected, toggleSelection } from './selection';
 export { selectionToolbarGap, selectionToolbarHeight } from './selectionToolbarLayout';
+export { useMessageListBottomInset } from './useMessageListBottomInset';

--- a/src/components/messageTabs/useMessageListBottomInset.ts
+++ b/src/components/messageTabs/useMessageListBottomInset.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useBottomTabBarHeight } from 'react-native-bottom-tabs';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { selectionToolbarGap, selectionToolbarHeight } from './selectionToolbarLayout';
+
+// The message-tab lists (topics + drawings) sit above two mutually-exclusive
+// bottom bars: the app tab bar at rest, and the selection toolbar in edit mode.
+// Entering/leaving edit mode hides the tab bar and shows the toolbar (or vice
+// versa). While the tab bar is hidden the native side re-measures its height to
+// 0 (it becomes GONE on Android; iOS stops reporting), so if the list's bottom
+// inset tracked `tabBarHeight` directly it would collapse on every edit⇄done and
+// the content container would resize — a reflow that reads as a flash.
+//
+// We return ONE inset that clears whichever bar is showing and never changes
+// across the toggle, so the list content stays put:
+//   - `tabBarHeight` is latched to its last non-zero reading, so the transient 0
+//     while the bar is hidden can't shrink the inset;
+//   - we take the max of that and the toolbar's footprint so the same value
+//     covers both states.
+// Both terms are independent of `isEditing`, so callers can drop it from their
+// contentContainerStyle memo and keep a stable style reference.
+export function useMessageListBottomInset(): number {
+  const rawTabBarHeight = useBottomTabBarHeight();
+  const insets = useSafeAreaInsets();
+  const [tabBarHeight, setTabBarHeight] = useState(rawTabBarHeight);
+
+  // Latch during render (React's "adjusting state when a prop changes" pattern):
+  // only track real, non-zero heights, ignoring the transient 0 while hidden.
+  if (rawTabBarHeight > 0 && rawTabBarHeight !== tabBarHeight) {
+    setTabBarHeight(rawTabBarHeight);
+  }
+
+  const selectionToolbarInset = insets.bottom + selectionToolbarHeight + selectionToolbarGap * 2;
+
+  return Math.max(tabBarHeight, selectionToolbarInset);
+}

--- a/src/components/navigation/__tests__/tabBarVisibility.test.ts
+++ b/src/components/navigation/__tests__/tabBarVisibility.test.ts
@@ -1,0 +1,61 @@
+import type { NavigationState } from 'expo-router/react-navigation';
+
+import { selectIsNestedTabScreen } from '../tabBarVisibility';
+
+// Minimal navigation-tree factory: root stack → focused tab group → focused tab
+// stack. `tabDepth` is the focused tab's stack index (0 = tab root).
+function makeState({
+  rootRouteName = '(tabs)',
+  tabInitialized = true,
+  tabDepth = 0,
+}: {
+  rootRouteName?: string;
+  tabInitialized?: boolean;
+  tabDepth?: number | null;
+} = {}): NavigationState {
+  return {
+    index: 0,
+    routes: [
+      {
+        key: 'root',
+        name: rootRouteName,
+        state: tabInitialized
+          ? {
+              index: 1,
+              routes: [
+                { key: 'home', name: 'home' },
+                {
+                  key: 'settings',
+                  name: 'settings',
+                  state: tabDepth == null ? undefined : { index: tabDepth, routes: [] },
+                },
+              ],
+            }
+          : undefined,
+      },
+    ],
+  } as unknown as NavigationState;
+}
+
+describe('selectIsNestedTabScreen', () => {
+  it('keeps the tab bar on a tab root (stack depth 0)', () => {
+    expect(selectIsNestedTabScreen(makeState({ tabDepth: 0 }))).toBe(false);
+  });
+
+  it('hides the tab bar once the focused tab pushes a secondary screen', () => {
+    expect(selectIsNestedTabScreen(makeState({ tabDepth: 1 }))).toBe(true);
+    expect(selectIsNestedTabScreen(makeState({ tabDepth: 3 }))).toBe(true);
+  });
+
+  it('keeps the tab bar when the active root route is not the tabs group', () => {
+    // A pushed root screen (topics/paintings) already covers the tabs.
+    expect(selectIsNestedTabScreen(makeState({ rootRouteName: 'topics', tabDepth: 2 }))).toBe(
+      false,
+    );
+  });
+
+  it('treats an uninitialized tab tree as a root (no crash)', () => {
+    expect(selectIsNestedTabScreen(makeState({ tabInitialized: false }))).toBe(false);
+    expect(selectIsNestedTabScreen(makeState({ tabDepth: null }))).toBe(false);
+  });
+});

--- a/src/components/navigation/tabBarVisibility.ts
+++ b/src/components/navigation/tabBarVisibility.ts
@@ -1,0 +1,25 @@
+import type { NavigationState } from 'expo-router/react-navigation';
+
+// The native bottom tab bar belongs to each tab's root. As soon as a tab pushes a
+// secondary screen (settings → provider, assistants → edit, …) the bar should go
+// away — matching iOS's hidesBottomBarWhenPushed — so every stack behaves the
+// same without each screen opting in.
+//
+// This runs against the ROOT stack's state (the navigator that hosts the `(tabs)`
+// group), so we walk root → `(tabs)` → focused tab and report whether the focused
+// tab's own stack sits past its root (index > 0). When the active root route is
+// not `(tabs)` (onboarding, a pushed `topics`/`paintings` screen) the tab bar is
+// already covered, so there is nothing to hide.
+export function selectIsNestedTabScreen(state: NavigationState): boolean {
+  const tabsRoute = state.routes[state.index];
+
+  if (tabsRoute?.name !== '(tabs)') {
+    return false;
+  }
+
+  const tabsState = tabsRoute.state;
+  const focusedTab = tabsState?.index != null ? tabsState.routes[tabsState.index] : undefined;
+  const stackIndex = focusedTab?.state?.index;
+
+  return stackIndex != null && stackIndex > 0;
+}

--- a/src/i18n/locales/en-us.json
+++ b/src/i18n/locales/en-us.json
@@ -237,6 +237,7 @@
   "settings.profile.avatarSaveError": "Failed to save avatar",
   "settings.profile.changeAvatar": "Change avatar",
   "settings.profile.edit": "Edit profile",
+  "settings.profile.setPrompt": "Tap to set avatar and name",
   "settings.profile.toggleAvatar": "Expand or collapse avatar",
   "settings.profile.userName": "User Name",
   "settings.provider.disabled.title": "Disabled model services",

--- a/src/i18n/locales/zh-cn.json
+++ b/src/i18n/locales/zh-cn.json
@@ -237,6 +237,7 @@
   "settings.profile.avatarSaveError": "头像保存失败",
   "settings.profile.changeAvatar": "更换头像",
   "settings.profile.edit": "编辑个人资料",
+  "settings.profile.setPrompt": "点击设置头像和用户名",
   "settings.profile.toggleAvatar": "放大或还原头像",
   "settings.profile.userName": "用户名",
   "settings.provider.disabled.title": "未开启服务商",

--- a/src/screens/MessagesScreen/MessagesScreen/MessagesScreen.ios.tsx
+++ b/src/screens/MessagesScreen/MessagesScreen/MessagesScreen.ios.tsx
@@ -10,7 +10,6 @@ import {
   useMessageSelectionActions,
   useMessageSelectionState,
 } from '@/components/messageTabs';
-import { useSetBottomTabBarHidden } from '@/components/navigation';
 import { isLiquidGlassAvailable } from '@/config/constants';
 
 import { MessagePager } from '../components/MessagePager';
@@ -57,30 +56,33 @@ export function MessagesScreen() {
           {t(isEditing ? 'common.done' : 'common.edit')}
         </Stack.Toolbar.Button>
       </Stack.Toolbar>
-      <Stack.Toolbar placement="right">
-        <Stack.Toolbar.Menu
-          accessibilityLabel={t('navigation.new')}
-          hidden={isEditing}
-          icon="square.and.pencil"
-        >
-          <Stack.Toolbar.MenuAction icon="message" onPress={() => router.push('/topics')}>
-            {t('navigation.newChat')}
-          </Stack.Toolbar.MenuAction>
-          <Stack.Toolbar.MenuAction icon="paintbrush" onPress={() => router.push('/paintings')}>
-            {t('navigation.newPainting')}
-          </Stack.Toolbar.MenuAction>
-        </Stack.Toolbar.Menu>
-      </Stack.Toolbar>
+      {/* While editing, the selection actions own the header's right slot (see
+          SelectionToolbar.ios). expo-router lets the last-rendered toolbar of a
+          placement win, so we render the compose menu only when NOT editing to keep a
+          single, unambiguous owner of the right slot. */}
+      {isEditing ? null : (
+        <Stack.Toolbar placement="right">
+          <Stack.Toolbar.Menu accessibilityLabel={t('navigation.new')} icon="square.and.pencil">
+            <Stack.Toolbar.MenuAction icon="message" onPress={() => router.push('/topics')}>
+              {t('navigation.newChat')}
+            </Stack.Toolbar.MenuAction>
+            <Stack.Toolbar.MenuAction icon="paintbrush" onPress={() => router.push('/paintings')}>
+              {t('navigation.newPainting')}
+            </Stack.Toolbar.MenuAction>
+          </Stack.Toolbar.Menu>
+        </Stack.Toolbar>
+      )}
     </>
   );
 }
 
 export function MessagesRoute() {
-  const setBottomTabBarHidden = useSetBottomTabBarHidden();
-
+  // iOS keeps the native tab bar visible during editing — the selection actions live
+  // in the header (see SelectionToolbar.ios), so there is no need to hide the tab bar.
+  // Toggling it per edit⇄done flashes and can freeze the scene under rapid taps.
   return (
     <MessageScopeProvider>
-      <MessageSelectionProvider onEditingChange={setBottomTabBarHidden}>
+      <MessageSelectionProvider>
         <MessagesScreen />
       </MessageSelectionProvider>
     </MessageScopeProvider>

--- a/src/screens/MessagesScreen/components/SelectionControls.tsx
+++ b/src/screens/MessagesScreen/components/SelectionControls.tsx
@@ -77,9 +77,14 @@ export function SelectionControls() {
           <Dialog.Overlay isCloseOnPress={!isDeleting} />
           <Dialog.Content className="gap-5 rounded-3xl bg-overlay p-5" isSwipeable={false}>
             <View className="gap-1.5">
-              <Dialog.Title>{t(source?.copy.deleteTitle ?? '')}</Dialog.Title>
+              {/* `source` is registered by the active list on mount, so it can be
+                  undefined on the first frames / right after a scope switch. Guard the
+                  copy lookups so we never call `t('')` (which warns about the missing
+                  empty key and its plural forms). The dialog can only be opened once a
+                  source exists, so this never blanks a visible dialog. */}
+              <Dialog.Title>{source ? t(source.copy.deleteTitle) : null}</Dialog.Title>
               <Dialog.Description>
-                {t(source?.copy.deleteMessage ?? '', { count: selectedCount })}
+                {source ? t(source.copy.deleteMessage, { count: selectedCount }) : null}
               </Dialog.Description>
             </View>
             <View className="flex-row justify-end gap-3">

--- a/src/screens/MessagesScreen/components/SelectionToolbar/SelectionToolbar.ios.tsx
+++ b/src/screens/MessagesScreen/components/SelectionToolbar/SelectionToolbar.ios.tsx
@@ -3,34 +3,22 @@ import { useTranslation } from 'react-i18next';
 
 import type { SelectionToolbarProps } from './types';
 
-export function SelectionToolbar({
-  isDeleting,
-  onDelete,
-  onToggleAll,
-  selectedCount,
-}: SelectionToolbarProps) {
+// iOS surfaces the selection actions in the native header (right side) rather than a
+// bottom toolbar. A bottom `Stack.Toolbar` is z-covered by the tab bar, so it would
+// require hiding the tab bar to be visible — and toggling the native tab bar on every
+// edit⇄done flashes (an interrupted SwiftUI transition) and can even freeze the scene
+// under rapid toggling. Keeping the tab bar untouched and moving the actions to the
+// header sidesteps both. Android keeps the bottom overlay (see the `.android` variant),
+// where hiding the tab bar is an instant, safe layout change.
+export function SelectionToolbar({ isDeleting, onDelete, selectedCount }: SelectionToolbarProps) {
   const { t } = useTranslation();
-  const selectionLabel =
-    selectedCount === 0
-      ? t('topic.selection.selectAll')
-      : t('topic.selection.count', { count: selectedCount });
 
   return (
-    <Stack.Toolbar placement="bottom">
-      <Stack.Toolbar.Button
-        accessibilityLabel={selectionLabel}
-        disabled={isDeleting}
-        onPress={onToggleAll}
-        separateBackground
-      >
-        {selectionLabel}
-      </Stack.Toolbar.Button>
-      <Stack.Toolbar.Spacer />
+    <Stack.Toolbar placement="right">
       <Stack.Toolbar.Button
         accessibilityLabel={t('common.delete')}
         disabled={selectedCount === 0 || isDeleting}
         onPress={onDelete}
-        separateBackground
         tintColor={Color.ios.systemRed}
       >
         {t('common.delete')}

--- a/src/screens/PaintingScreen/DrawingList.tsx
+++ b/src/screens/PaintingScreen/DrawingList.tsx
@@ -13,12 +13,9 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native';
-import { useBottomTabBarHeight } from 'react-native-bottom-tabs';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-  selectionToolbarGap,
-  selectionToolbarHeight,
+  useMessageListBottomInset,
   useMessageScope,
   useMessageSelectionActions,
   useMessageSelectionState,
@@ -57,8 +54,7 @@ export function DrawingList() {
   const { toggleId } = useMessageSelectionActions();
   const selectionSource = usePaintingSelectionSource(isEditing && scope === 'drawings');
   useRegisterSelectionSource('drawings', selectionSource);
-  const tabBarHeight = useBottomTabBarHeight();
-  const insets = useSafeAreaInsets();
+  const bottomInset = useMessageListBottomInset();
   const { width: windowWidth } = useWindowDimensions();
   const recentPhotos = useRecentPaintingPhotos(scope === 'drawings');
   const paintings = usePaintings();
@@ -143,11 +139,9 @@ export function DrawingList() {
   return (
     <ScrollView
       className="flex-1 bg-background"
-      contentContainerStyle={{
-        paddingBottom: isEditing
-          ? insets.bottom + selectionToolbarHeight + selectionToolbarGap * 2
-          : tabBarHeight + 24,
-      }}
+      // Stable across the edit⇄done flip (see useMessageListBottomInset) so the
+      // gallery never reflows on toggle.
+      contentContainerStyle={{ paddingBottom: bottomInset }}
       onScroll={({ nativeEvent }) => {
         const distanceToEnd =
           nativeEvent.contentSize.height -

--- a/src/screens/PaintingScreen/__tests__/DrawingList.test.tsx
+++ b/src/screens/PaintingScreen/__tests__/DrawingList.test.tsx
@@ -118,6 +118,7 @@ jest.mock('@/screens/PaintingScreen/utils/paintingDraftHandoff', () => ({
 }));
 
 jest.mock('@/components/messageTabs', () => ({
+  useMessageListBottomInset: () => 0,
   useMessageScope: () => ({ scope: 'drawings' }),
   useMessageSelectionActions: () => ({ toggleId: mockToggleId }),
   useMessageSelectionState: () => ({ isEditing: mockIsEditing, selectedIds: mockSelectedIds }),

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -38,6 +38,11 @@ export default function SettingsScreen() {
     router.push('/settings/profile');
   }, [router]);
 
+  // With no name set yet, the hero is a call to action: tapping it (avatar or the
+  // prompt) opens profile settings instead of toggling the expand/collapse lock.
+  const hasUserName = userName.trim().length > 0;
+  const onHeroPress = hasUserName ? toggleHeroLock : openProfileSettings;
+
   // Own the insets explicitly: `never` keeps the scroll-offset zero point stable
   // (so scrollY reads 0 at rest and negative on iOS overscroll), which the hero
   // animation depends on. No top padding: the hero box is pinned to content y=0
@@ -56,7 +61,7 @@ export default function SettingsScreen() {
       >
         <ProfileHero
           lockProgress={lockProgress}
-          onPress={toggleHeroLock}
+          onPress={onHeroPress}
           scrollY={scrollY}
           userName={userName}
         />

--- a/src/screens/SettingsScreen/profileHero/ProfileHero.tsx
+++ b/src/screens/SettingsScreen/profileHero/ProfileHero.tsx
@@ -1,7 +1,7 @@
 import { useThemeColor } from 'heroui-native/hooks';
 import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type LayoutChangeEvent, Pressable, useWindowDimensions } from 'react-native';
+import { type LayoutChangeEvent, Pressable, Text, useWindowDimensions } from 'react-native';
 import Animated, {
   Extrapolation,
   interpolate,
@@ -47,6 +47,7 @@ export function ProfileHero({ lockProgress, onPress, scrollY, userName }: Profil
   const restingHeight = profileHero.restingHeight;
   const expandedHeight = Math.round(screenHeight * profileHero.expandedHeightRatio);
   const avatarRestLeft = (screenWidth - profileHero.avatarSize) / 2;
+  const hasUserName = userName.trim().length > 0;
 
   const handleNameLayout = useCallback(
     (event: LayoutChangeEvent) => {
@@ -141,24 +142,43 @@ export function ProfileHero({ lockProgress, onPress, scrollY, userName }: Profil
       </Animated.View>
       <Animated.View
         className="absolute right-0 bottom-0 left-0 items-center"
-        pointerEvents="none"
+        pointerEvents={hasUserName ? 'none' : 'box-none'}
         style={{ paddingBottom: profileHero.nameRestPaddingBottom }}
       >
-        <Animated.Text
-          className="font-semibold"
-          numberOfLines={1}
-          onLayout={handleNameLayout}
-          style={[
-            nameStyle,
-            {
-              fontSize: profileHero.nameBaseFontSize,
-              lineHeight: profileHero.nameLineHeight,
-              maxWidth: screenWidth - 2 * profileHero.nameOverlayInsetX,
-            },
-          ]}
-        >
-          {userName}
-        </Animated.Text>
+        {hasUserName ? (
+          <Animated.Text
+            className="font-semibold"
+            numberOfLines={1}
+            onLayout={handleNameLayout}
+            style={[
+              nameStyle,
+              {
+                fontSize: profileHero.nameBaseFontSize,
+                lineHeight: profileHero.nameLineHeight,
+                maxWidth: screenWidth - 2 * profileHero.nameOverlayInsetX,
+              },
+            ]}
+          >
+            {userName}
+          </Animated.Text>
+        ) : (
+          // No name yet: show a tappable prompt in the name slot. Tapping it (or
+          // the avatar) opens profile settings instead of toggling the expand
+          // lock — `onPress` is wired to that by the parent when the name is empty.
+          <Pressable
+            accessibilityRole="button"
+            hitSlop={12}
+            onPress={onPress}
+            style={{ maxWidth: screenWidth - 2 * profileHero.nameOverlayInsetX }}
+          >
+            <Text
+              className="text-center font-medium text-base text-foreground-secondary"
+              numberOfLines={1}
+            >
+              {t('settings.profile.setPrompt')}
+            </Text>
+          </Pressable>
+        )}
       </Animated.View>
     </Animated.View>
   );

--- a/src/screens/SettingsScreen/profileHero/ProfileStickyBar.tsx
+++ b/src/screens/SettingsScreen/profileHero/ProfileStickyBar.tsx
@@ -1,4 +1,5 @@
 import { useThemeColor } from 'heroui-native/hooks';
+import { useTranslation } from 'react-i18next';
 import { StyleSheet, View } from 'react-native';
 import Animated, {
   Extrapolation,
@@ -30,7 +31,10 @@ type ProfileStickyBarProps = {
  * hero underneath always receives taps (a tap on it toggles the expand).
  */
 export function ProfileStickyBar({ scrollY, topInset, userName }: ProfileStickyBarProps) {
+  const { t } = useTranslation();
   const separatorColor = useThemeColor('separator');
+  // Mirror the hero's name slot: fall back to the set-profile prompt when empty.
+  const title = userName.trim().length > 0 ? userName : t('settings.profile.setPrompt');
 
   const backgroundStyle = useAnimatedStyle(() => ({
     opacity: interpolate(scrollY.value, fadeInput, [0, 0, 1], Extrapolation.CLAMP),
@@ -58,7 +62,7 @@ export function ProfileStickyBar({ scrollY, topInset, userName }: ProfileStickyB
             numberOfLines={1}
             style={titleStyle}
           >
-            {userName}
+            {title}
           </Animated.Text>
         </View>
       </View>

--- a/src/screens/TopicListScreen/TopicList.tsx
+++ b/src/screens/TopicListScreen/TopicList.tsx
@@ -4,7 +4,6 @@ import { CheckIcon, PencilIcon, PinIcon, PinOffIcon, Trash2Icon } from 'lucide-u
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type AccessibilityActionEvent, Pressable, Text, View } from 'react-native';
-import { useBottomTabBarHeight } from 'react-native-bottom-tabs';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import ReanimatedSwipeable, {
   type SwipeableMethods,
@@ -17,11 +16,9 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
-  selectionToolbarGap,
-  selectionToolbarHeight,
+  useMessageListBottomInset,
   useMessageSelectionActions,
   useMessageSelectionState,
   useRegisterSelectionSource,
@@ -101,8 +98,7 @@ function formatTopicUpdatedAt(updatedAt: string, locale: string | undefined, yes
 const TopicListView = memo(function TopicListView() {
   const { t } = useTranslation();
   const { toast } = useToast();
-  const tabBarHeight = useBottomTabBarHeight();
-  const insets = useSafeAreaInsets();
+  const bottomInset = useMessageListBottomInset();
   const { isPinActionDisabled, isTopicListLoading, pinnedTopicIds, topics } = useTopicListTopics();
   const { loadMoreTopics, openTopic, toggleTopicPin } = useTopicListActions();
   const { assistants } = useAssistantsApi();
@@ -112,14 +108,11 @@ const TopicListView = memo(function TopicListView() {
   useRegisterSelectionSource('conversations', selectionSource);
   const { dialogs, requestDelete, requestRename } = useTopicActionDialogs();
   const { notifyClose, notifyWillOpen } = useExclusiveSwipeable();
+  // Bottom inset is stable across the edit⇄done flip (see useMessageListBottomInset),
+  // so this style reference stays put and the list never reflows on toggle.
   const contentContainerStyle = useMemo(
-    () => ({
-      paddingBottom: isEditing
-        ? insets.bottom + selectionToolbarHeight + selectionToolbarGap * 2
-        : tabBarHeight,
-      paddingHorizontal: 8,
-    }),
-    [insets.bottom, isEditing, tabBarHeight],
+    () => ({ paddingBottom: bottomInset, paddingHorizontal: 8 }),
+    [bottomInset],
   );
   const listExtraData = useMemo(
     () => ({ isEditing, isPinActionDisabled, pinnedTopicIds, selectedIds }),

--- a/src/screens/TopicListScreen/__tests__/TopicList.test.tsx
+++ b/src/screens/TopicListScreen/__tests__/TopicList.test.tsx
@@ -125,6 +125,7 @@ jest.mock('../context/TopicListProvider', () => ({
 }));
 
 jest.mock('@/components/messageTabs', () => ({
+  useMessageListBottomInset: () => 0,
   useMessageSelectionActions: () => ({ toggleId: jest.fn() }),
   useMessageSelectionState: () => ({ isEditing: false, selectedIds: new Set() }),
   useRegisterSelectionSource: () => undefined,


### PR DESCRIPTION
Hide the native bottom tab bar on any pushed/secondary screen (e.g. Settings → provider) via a nested-screen selector driven by the navigation state, so tabs only show on tab roots. On iOS, move the message edit-mode selection actions into the native header and stop toggling the tab bar while editing — this fixes a flash on every edit⇄done and a scene freeze (black screen) under rapid taps, since toggling `react-native-bottom-tabs`' `tabBarHidden` interrupts a native transition; Android keeps its instant-hide bottom overlay. In Settings, when no username is set, the profile area now shows a "tap to set avatar and name" prompt that opens the profile screen. Also stabilizes the topic/drawing list bottom inset and stops passing an empty i18n key in the delete dialog while the selection source is still registering (which logged missing-key warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)