### PR TITLE
fix(topic-list): Android topics list pin button unresponsive + add pin/unpin reorder animation

### DIFF
--- a/src/screens/TopicListScreen/TopicList.tsx
+++ b/src/screens/TopicListScreen/TopicList.tsx
@@ -1,16 +1,18 @@
-import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
+import { LegendListRenderItemProps } from '@legendapp/list/react-native';
+import { AnimatedLegendList } from '@legendapp/list/reanimated';
 import { useToast } from 'heroui-native/toast';
 import { CheckIcon, PencilIcon, PinIcon, PinOffIcon, Trash2Icon } from 'lucide-uniwind/png';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type AccessibilityActionEvent, Pressable, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector, RectButton } from 'react-native-gesture-handler';
 import ReanimatedSwipeable, {
   type SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import Animated, {
   FadeInLeft,
   FadeOutLeft,
+  LinearTransition,
   runOnJS,
   type SharedValue,
   useAnimatedStyle,
@@ -183,7 +185,7 @@ const TopicListView = memo(function TopicListView() {
 
   return (
     <View className="flex-1">
-      <LegendList
+      <AnimatedLegendList
         className="flex-1 bg-background"
         contentInsetAdjustmentBehavior="never"
         contentContainerStyle={contentContainerStyle}
@@ -193,6 +195,7 @@ const TopicListView = memo(function TopicListView() {
         keyExtractor={topicKeyExtractor}
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
+        itemLayoutAnimation={LinearTransition.duration(280)}
         ListEmptyComponent={listEmptyComponent}
         onEndReached={loadMoreTopics}
         onEndReachedThreshold={0.7}
@@ -518,19 +521,22 @@ function TopicPinAction({ disabled, drag, isPinned, label, onPress }: TopicPinAc
 
   return (
     <Animated.View className="h-full w-16" style={animatedStyle}>
-      <Pressable
+      <RectButton
         accessibilityLabel={label}
         accessibilityRole="button"
-        className="h-full items-center justify-center bg-primary active:opacity-80 disabled:opacity-40"
-        disabled={disabled}
+        activeOpacity={0.8}
+        enabled={!disabled}
         onPress={onPress}
+        style={disabled ? { opacity: 0.4 } : undefined}
       >
-        {isPinned ? (
-          <PinOffIcon className="size-5 text-white" strokeWidth={2} />
-        ) : (
-          <PinIcon className="size-5 text-white" strokeWidth={2} />
-        )}
-      </Pressable>
+        <View className="h-full w-full items-center justify-center bg-primary">
+          {isPinned ? (
+            <PinOffIcon className="size-5 text-white" strokeWidth={2} />
+          ) : (
+            <PinIcon className="size-5 text-white" strokeWidth={2} />
+          )}
+        </View>
+      </RectButton>
     </Animated.View>
   );
 }

--- a/src/screens/TopicListScreen/__tests__/TopicList.test.tsx
+++ b/src/screens/TopicListScreen/__tests__/TopicList.test.tsx
@@ -35,6 +35,27 @@ jest.mock('@legendapp/list/react-native', () => {
   };
 });
 
+jest.mock('@legendapp/list/reanimated', () => {
+  const React = jest.requireActual('react');
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    AnimatedLegendList: ({
+      data,
+      renderItem,
+    }: {
+      data: readonly Topic[];
+      renderItem: (info: { index: number; item: Topic }) => ReactNode;
+    }) => (
+      <MockView testID="topic-list">
+        {data.map((item, index) => (
+          <React.Fragment key={item.id}>{renderItem({ index, item })}</React.Fragment>
+        ))}
+      </MockView>
+    ),
+  };
+});
+
 jest.mock('heroui-native/toast', () => ({
   useToast: () => ({ toast: { show: mockToastShow } }),
 }));
@@ -62,6 +83,41 @@ jest.mock('react-i18next', () => ({
       })[key] ?? key,
   }),
 }));
+
+jest.mock('react-native-gesture-handler', () => {
+  const { TouchableOpacity } = jest.requireActual('react-native');
+
+  return {
+    RectButton: TouchableOpacity,
+    Gesture: {
+      Tap: () => {
+        const tap = {
+          enabled: () => tap,
+          maxDistance: () => tap,
+          onBegin: () => tap,
+          onEnd: () => tap,
+          onFinalize: () => tap,
+        };
+        return tap;
+      },
+      Pan: () => {
+        const pan = {
+          enabled: () => pan,
+          activeOffsetX: () => pan,
+          enableTrackpadTwoFingerGesture: () => pan,
+          hitSlop: () => pan,
+          onStart: () => pan,
+          onUpdate: () => pan,
+          onEnd: () => pan,
+          onFinalize: () => pan,
+        };
+        return pan;
+      },
+    },
+    GestureDetector: ({ children }: { children: ReactNode }) => children,
+    Swipeable: () => null,
+  };
+});
 
 jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   const { View: MockView } = jest.requireActual('react-native');
@@ -91,6 +147,7 @@ jest.mock('react-native-reanimated', () => {
     default: { View: MockView },
     FadeInLeft: { duration: () => undefined },
     FadeOutLeft: { duration: () => undefined },
+    LinearTransition: { duration: () => undefined },
     runOnJS: (callback: (...args: unknown[]) => unknown) => callback,
     useAnimatedStyle: (factory: () => unknown) => factory(),
     useSharedValue: (value: number) => ({ value }),


### PR DESCRIPTION
## Changes

   ### Fix: Pin button on Android (`TopicPinAction`)

   - Replace `Pressable` from `react-native` with `RectButton` from
     `react-native-gesture-handler`. `RectButton` registers a native gesture
     handler that correctly negotiates priority with the parent
     `PanGestureHandler` within the same gesture system, so taps are delivered
     reliably.

   ### Animation: Pin/unpin reorder

   - Switch from `LegendList` (`@legendapp/list/react-native`) to
     `AnimatedLegendList` (`@legendapp/list/reanimated`) — the reanimated
     variant supports `itemLayoutAnimation`.
   - Add `itemLayoutAnimation={LinearTransition.duration(280)}` so pinned
     topics animate smoothly to the top section and unpinned topics animate
     back to the chronological list, with surrounding items easing into their
     new positions.