### PR TITLE
feat(bottom-sheet): concentric bottom corners, 4pt inset, template sheet layout

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -25,6 +25,11 @@ jest.mock('expo-glass-effect', () => ({
   isLiquidGlassAvailable: () => false,
 }));
 
+// expo-screen-corner-radius resolves its native module at import time, so any
+// suite reaching BottomSheet throws without this. `null` is the library's own
+// "display radius unknown" answer, which every caller already handles.
+jest.mock('expo-screen-corner-radius', () => ({ getCornerRadiusSync: () => null }));
+
 // Callstack bottom tabs is a Fabric native view and is unavailable in Jest.
 // Keep its layout context present so tab-owned screens can render normally.
 jest.mock('react-native-bottom-tabs', () => {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "expo-localization": "~57.0.1",
     "expo-media-library": "~57.0.2",
     "expo-router": "~57.0.6",
+    "expo-screen-corner-radius": "^1.1.0",
     "expo-splash-screen": "~57.0.4",
     "expo-sqlite": "~57.0.1",
     "expo-status-bar": "~57.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       expo-router:
         specifier: ~57.0.6
         version: 57.0.6(0affca755774a72a3e12455a1156c114)
+      expo-screen-corner-radius:
+        specifier: ^1.1.0
+        version: 1.1.0(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       expo-splash-screen:
         specifier: ~57.0.4
         version: 57.0.4(expo@57.0.6)(typescript@6.0.3)
@@ -5062,6 +5065,13 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-screen-corner-radius@1.1.0:
+    resolution: {integrity: sha512-haF5BW/c72WKINNwtjW8OT9MoVIHQci9jrTBAqG/Omrr8DqCXnPg1RuhsVblRpeUXFCEuTC0NQlY+qS0taaYLA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-server@57.0.1:
     resolution: {integrity: sha512-sBfVDH6dmKVHZxqUxbfkzS00PZELMZt1IpnHKxcOTMZtR/t7CtRAFrbXcisG+EyzeqHSVDacZT+1tbYfZt5D8w==}
@@ -12742,6 +12752,12 @@ snapshots:
       - expo-font
       - react-native-worklets
       - supports-color
+
+  expo-screen-corner-radius@1.1.0(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      expo: 57.0.6(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.5)(expo-router@57.0.6)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
 
   expo-server@57.0.1: {}
 

--- a/src/components/bottomSheet/README.md
+++ b/src/components/bottomSheet/README.md
@@ -1,12 +1,32 @@
 # bottomSheet
 
 Shared "floating card" bottom sheet — the single styled frame every sheet in the
-app uses so they share one silhouette: inset from the screen edges, a concentric
-bottom corner radius that curves around the home indicator, a circular close
-button nested into the top-left corner, a centered title, and a liquid-glass (or
-solid) surface. Built on `@swmansion/react-native-bottom-sheet`'s
-`ModalBottomSheet`. Chrome constants live in `src/config/constants.ts`
-(`bottomSheet`, `sheetScrimColor`, `isLiquidGlassAvailable`).
+app uses so they share one silhouette: inset from the screen edges, bottom
+corners concentric with the display's own corners, a circular close button
+nested into the top-left corner, a centered title, and a liquid-glass (or solid)
+surface. Built on `@swmansion/react-native-bottom-sheet`'s `ModalBottomSheet`.
+Chrome constants live in `src/config/constants.ts` (`bottomSheet`,
+`sheetScrimColor`, `isLiquidGlassAvailable`).
+
+## Concentric bottom corners
+
+The card is inset by `bottomSheet.outerInset` from the left, right and bottom
+screen edges alike, so its bottom corners share a center with the display's
+corners at `screenCornerRadius - outerInset` — the two curves stay parallel
+instead of drifting. The screen radius comes from `@/modules/screenCornerRadius`,
+a thin wrapper over `expo-screen-corner-radius` (device-model lookup on iOS, the
+public `WindowInsets.getRoundedCorner` API on Android 12+).
+
+Anything that can't name a radius — web, Android < 31, an iPhone newer than the
+library's model table, a square-cornered display — arrives as `0` and clamps to
+`bottomSheet.cornerRadius`. There is no approximation in between, by design:
+without the display's radius no value is more concentric than another, so
+anything but the resting radius would only fake the alignment.
+
+The top corners touch no screen edge, so they are simply
+`bottomSheet.cornerRadius` on every device — the close button nested into them
+(`headerInset = topCornerRadius - headerSideWidth / 2`) then sits concentric with
+the card, and neither moves when the display or the navigation mode changes.
 
 ## Usage
 

--- a/src/components/bottomSheet/__tests__/BottomSheet.test.tsx
+++ b/src/components/bottomSheet/__tests__/BottomSheet.test.tsx
@@ -30,13 +30,19 @@ jest.mock('lucide-uniwind/png', () => {
 });
 
 jest.mock('@/config/constants', () => ({
-  bottomSheet: { cornerRadius: 28, headerHeight: 60, headerSideWidth: 44, outerInset: 8 },
+  bottomSheet: { cornerRadius: 28, headerHeight: 60, headerSideWidth: 44, outerInset: 4 },
   isLiquidGlassAvailable: false,
   sheetScrimColor: '#00000066',
 }));
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 59 }),
+}));
+
+let mockScreenCornerRadius = 0;
+
+jest.mock('@/modules/screenCornerRadius', () => ({
+  useScreenCornerRadius: () => mockScreenCornerRadius,
 }));
 
 function BodyCloseButton({ reason }: { reason?: string }) {
@@ -54,6 +60,7 @@ describe('BottomSheet', () => {
 
   beforeEach(() => {
     mockBottomSheetProps = {};
+    mockScreenCornerRadius = 0;
   });
 
   afterEach(() => {
@@ -151,5 +158,42 @@ describe('BottomSheet', () => {
     act(() => (mockBottomSheetProps.onSettle as (index: number) => void)(0));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledWith('use');
+  });
+
+  // The card is inset 4pt from the left, right and bottom screen edges, so it is
+  // concentric with the display at `screenCornerRadius - 4`.
+  test.each([
+    { expected: 51, label: 'a 55pt display (iPhone 15 / 16)', screenCornerRadius: 55 },
+    { expected: 58, label: 'a 62pt display (iPhone 16 Pro)', screenCornerRadius: 62 },
+    {
+      expected: 28,
+      label: 'a squarer display, clamped to the resting radius',
+      screenCornerRadius: 30,
+    },
+    {
+      expected: 28,
+      label: 'a display that reports no radius, resting rather than guessing',
+      screenCornerRadius: 0,
+    },
+  ])('rounds the bottom corners to $expected on $label', ({ expected, screenCornerRadius }) => {
+    mockScreenCornerRadius = screenCornerRadius;
+    act(() => {
+      renderer = create(
+        <BottomSheet onClose={jest.fn()} testID="test-sheet">
+          <Text>body</Text>
+        </BottomSheet>,
+      );
+    });
+
+    expect(renderer?.root.findByProps({ testID: 'test-sheet-sheet' }).props.style).toContainEqual(
+      expect.objectContaining({
+        borderBottomLeftRadius: expected,
+        borderBottomRightRadius: expected,
+        // The top corners touch no screen edge, so they stay at the resting
+        // radius no matter how round the display is.
+        borderTopLeftRadius: 28,
+        borderTopRightRadius: 28,
+      }),
+    );
   });
 });

--- a/src/components/bottomSheet/components/BottomSheet.tsx
+++ b/src/components/bottomSheet/components/BottomSheet.tsx
@@ -6,6 +6,7 @@ import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-na
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { bottomSheet, isLiquidGlassAvailable, sheetScrimColor } from '@/config/constants';
+import { useScreenCornerRadius } from '@/modules/screenCornerRadius';
 
 import { type BottomSheetCloseReason, BottomSheetContext } from '../hooks/useBottomSheet';
 
@@ -17,6 +18,18 @@ const OPEN_INDEX = 1;
 // passes extra detents above it (e.g. `[0, medium, 'content']` for a drag-to-expand
 // sheet — the sheet opens at `medium` and can be dragged up to `content`).
 const DEFAULT_DETENTS: Detent[] = [0, 'content'];
+
+// The card's top corners touch no screen edge, so there is nothing for them to
+// be concentric with — they are simply the resting radius. Deriving them from
+// anything device-shaped is what made them wander before: off the safe-area
+// inset they jumped 28 -> 48 when an Android user switched from gesture to
+// three-button navigation, dragging the close button and header height with
+// them; off `bottomCornerRadius` a 62pt display would do the same.
+const TOP_CORNER_RADIUS = bottomSheet.cornerRadius;
+
+// Nudge the round close button into the card's rounded top corner so the two
+// curves sit concentric.
+const HEADER_INSET = Math.max(0, TOP_CORNER_RADIUS - bottomSheet.headerSideWidth / 2);
 
 type BottomSheetProps = {
   children: ReactNode;
@@ -63,6 +76,7 @@ export function BottomSheet({
 }: BottomSheetProps) {
   const insets = useSafeAreaInsets();
   const { width: windowWidth } = useWindowDimensions();
+  const screenCornerRadius = useScreenCornerRadius();
   const [index, setIndex] = useState(isOpen ? OPEN_INDEX : CLOSED_INDEX);
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   const reasonRef = useRef<BottomSheetCloseReason>('dismiss');
@@ -87,27 +101,26 @@ export function BottomSheet({
   }, [isOpen]);
 
   const sheetWidth = Math.max(0, windowWidth - bottomSheet.outerInset * 2);
+  // The card is inset by `outerInset` from the left, right and bottom screen
+  // edges alike (left/right via `sheetWidth`, bottom via the gap rendered below
+  // the card — the sheet host itself sits flush with the screen bottom). That
+  // uniform inset is what makes the corners concentric: subtracting it from the
+  // display's own radius puts both curves on the same center, so the card's
+  // bottom corners stay parallel to the screen's.
+  //
+  // A display that can't name a radius reports 0, and the clamp resolves that
+  // to the resting radius. There is deliberately no approximation in between:
+  // on a square screen — or one whose radius we simply don't know — no value is
+  // more concentric than another, so guessing one only fakes the alignment.
   const bottomCornerRadius = Math.max(
     bottomSheet.cornerRadius,
-    insets.bottom + bottomSheet.outerInset,
-  );
-  const topCornerRadius = Math.max(
-    bottomSheet.cornerRadius,
-    bottomCornerRadius - bottomSheet.outerInset,
+    screenCornerRadius - bottomSheet.outerInset,
   );
   const cornerStyle = {
     borderBottomLeftRadius: bottomCornerRadius,
     borderBottomRightRadius: bottomCornerRadius,
-    borderTopLeftRadius: topCornerRadius,
-    borderTopRightRadius: topCornerRadius,
-  };
-  // Nudge the round close button into the sheet's rounded top corner so the two
-  // curves sit concentric.
-  const headerInset = Math.max(0, topCornerRadius - bottomSheet.headerSideWidth / 2);
-  const headerStyle = {
-    height: Math.max(bottomSheet.headerHeight, headerInset + bottomSheet.headerSideWidth),
-    paddingHorizontal: headerInset,
-    paddingTop: headerInset,
+    borderTopLeftRadius: TOP_CORNER_RADIUS,
+    borderTopRightRadius: TOP_CORNER_RADIUS,
   };
 
   const requestClose = useCallback(
@@ -150,11 +163,16 @@ export function BottomSheet({
 
   const contextValue = useMemo(
     () => ({
-      geometry: { bottomCornerRadius, insets, sheetWidth, topCornerRadius },
+      geometry: {
+        bottomCornerRadius,
+        insets,
+        sheetWidth,
+        topCornerRadius: TOP_CORNER_RADIUS,
+      },
       isClosing,
       requestClose,
     }),
-    [bottomCornerRadius, insets, isClosing, requestClose, sheetWidth, topCornerRadius],
+    [bottomCornerRadius, insets, isClosing, requestClose, sheetWidth],
   );
 
   const closeButton = (
@@ -203,7 +221,7 @@ export function BottomSheet({
 
             <View
               className="flex-row items-center"
-              style={headerStyle}
+              style={styles.header}
               testID={testID ? `${testID}-header` : undefined}
             >
               {isLiquidGlassAvailable ? (
@@ -281,6 +299,11 @@ const styles = StyleSheet.create({
     height: bottomSheet.headerSideWidth,
     overflow: 'hidden',
     width: bottomSheet.headerSideWidth,
+  },
+  header: {
+    height: Math.max(bottomSheet.headerHeight, HEADER_INSET + bottomSheet.headerSideWidth),
+    paddingHorizontal: HEADER_INSET,
+    paddingTop: HEADER_INSET,
   },
   headerSide: { height: bottomSheet.headerSideWidth, width: bottomSheet.headerSideWidth },
   // Pin the wrapper to the true window width so `alignItems: 'center'` centers

--- a/src/components/bottomSheet/hooks/useBottomSheet.ts
+++ b/src/components/bottomSheet/hooks/useBottomSheet.ts
@@ -7,12 +7,15 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 export type BottomSheetCloseReason = 'dismiss' | (string & {});
 
 export type BottomSheetGeometry = {
-  // Concentric bottom corner radius of the floating card (grows with the bottom
-  // safe-area inset); bodies align their own bottom panels to it.
+  // Bottom corner radius of the floating card, concentric with the display's
+  // own corner; bodies align their own bottom panels to it by subtracting their
+  // inset from the card (`bottomCornerRadius - inset`).
   bottomCornerRadius: number;
   insets: EdgeInsets;
   // Card width = window width minus the outer inset on both sides.
   sheetWidth: number;
+  // Top corner radius of the floating card — the resting radius on every
+  // device, since the top corners touch no screen edge.
   topCornerRadius: number;
 };
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -16,8 +16,11 @@ export const sheetScrimColor = 'rgba(0, 0, 0, 0.4)';
 // Every sheet derives its inset width, bottom gap, concentric corner radius, and
 // header placement from these values — single source of truth, tune here.
 export const bottomSheet = {
-  outerInset: 8, // gap between the floating card and the screen edges / home indicator
-  cornerRadius: 28, // resting top/bottom corner radius (grows with the bottom safe-area inset)
+  // Gap between the floating card and the screen edges, uniform on the left,
+  // right and bottom — that uniformity is what lets the bottom corners be
+  // concentric with the display's own corners.
+  outerInset: 4,
+  cornerRadius: 28, // the top corners exactly; a floor for the concentric bottom ones
   headerHeight: 60, // minimum header row height
   headerSideWidth: 44, // close button + right-slot square size
 } as const;

--- a/src/modules/screenCornerRadius/index.ts
+++ b/src/modules/screenCornerRadius/index.ts
@@ -1,0 +1,32 @@
+import { getCornerRadiusSync } from 'expo-screen-corner-radius';
+import { useWindowDimensions } from 'react-native';
+
+/**
+ * Hardware corner radius of the display, in points / dp — `0` when unknown.
+ *
+ * Use it to keep a rounded rect concentric with the screen: an element inset by
+ * `n` from every screen edge shares the display's corner center at radius
+ * `screenCornerRadius - n`. Always handle the `0` case with a fallback.
+ *
+ * Backed by `expo-screen-corner-radius`, which looks the radius up by device
+ * model on iOS (so a phone newer than the library's table reports `null`, not a
+ * wrong number) and reads the public `WindowInsets.getRoundedCorner` API on
+ * Android 12+. Every "don't know" — an unlisted model, Android < 31, web —
+ * arrives here as `null` and is normalized to `0`.
+ */
+export function getScreenCornerRadius(): number {
+  return getCornerRadiusSync() ?? 0;
+}
+
+/**
+ * Hook form of {@link getScreenCornerRadius}.
+ *
+ * The radius is a hardware constant, but a foldable that unfolds swaps to a
+ * different display — subscribing to the window metrics re-renders the caller
+ * so the value is re-read on that switch.
+ */
+export function useScreenCornerRadius(): number {
+  useWindowDimensions();
+
+  return getScreenCornerRadius();
+}

--- a/src/screens/PaintingScreen/components/__tests__/PaintingSettingsBottomSheet.test.tsx
+++ b/src/screens/PaintingScreen/components/__tests__/PaintingSettingsBottomSheet.test.tsx
@@ -91,7 +91,7 @@ jest.mock('@/components/SlotText', () => {
 });
 
 jest.mock('@/config/constants', () => ({
-  bottomSheet: { cornerRadius: 28, headerHeight: 60, headerSideWidth: 44, outerInset: 8 },
+  bottomSheet: { cornerRadius: 28, headerHeight: 60, headerSideWidth: 44, outerInset: 4 },
   isLiquidGlassAvailable: false,
   sheetScrimColor: '#00000066',
 }));
@@ -163,17 +163,17 @@ describe('PaintingSettingsBottomSheet', () => {
       StyleSheet.flatten(
         renderer.root.findByProps({ testID: 'painting-settings-sheet' }).props.style,
       ),
-    ).toMatchObject({ borderBottomLeftRadius: 42, borderTopLeftRadius: 34 });
+    ).toMatchObject({ borderBottomLeftRadius: 28, borderTopLeftRadius: 28 });
     expect(
       StyleSheet.flatten(
         renderer.root.findByProps({ testID: 'painting-settings-sheet-bottom-gap' }).props.style,
       ).height,
-    ).toBe(8);
+    ).toBe(4);
     expect(
       StyleSheet.flatten(
         renderer.root.findByProps({ testID: 'painting-settings-header' }).props.style,
       ),
-    ).toMatchObject({ height: 60, paddingHorizontal: 12, paddingTop: 12 });
+    ).toMatchObject({ height: 60, paddingHorizontal: 6, paddingTop: 6 });
 
     act(() =>
       renderer?.root

--- a/src/screens/PaintingScreen/templates/PaintingTemplateBottomSheet.tsx
+++ b/src/screens/PaintingScreen/templates/PaintingTemplateBottomSheet.tsx
@@ -72,14 +72,19 @@ function PaintingTemplateSheetBody({ template }: { template: PaintingTemplate })
     0,
     Math.min(windowWidth * 0.5, geometry.sheetWidth - SHEET_CONTENT_INSET * 2, 220),
   );
-  const promptPanelBottomPadding = Math.max(
+  // The button is the last thing in the card, so this padding is what keeps it
+  // clear of the home indicator: `insets.bottom` measured from the screen's
+  // bottom, minus the gap the card already leaves there.
+  const bodyBottomPadding = Math.max(
     SHEET_CONTENT_INSET,
-    geometry.insets.bottom - bottomSheet.outerInset - SHEET_CONTENT_INSET,
+    geometry.insets.bottom - bottomSheet.outerInset,
   );
-  const promptPanelRadius = geometry.bottomCornerRadius - SHEET_CONTENT_INSET;
 
   return (
-    <View style={styles.bodyContent} testID="painting-template-sheet-body">
+    <View
+      style={[styles.bodyContent, { paddingBottom: bodyBottomPadding }]}
+      testID="painting-template-sheet-body"
+    >
       <View style={[styles.preview, { height: (previewWidth * 4) / 3, width: previewWidth }]}>
         <Image
           accessibilityLabel={template.title}
@@ -92,12 +97,12 @@ function PaintingTemplateSheetBody({ template }: { template: PaintingTemplate })
         />
       </View>
 
+      {/* The panel floats between the preview and the button, touching no card
+          edge, so it has nothing to be concentric with and takes a flat radius
+          on all four corners rather than tracking the card's. */}
       <View
-        className="w-full gap-4 bg-surface-secondary px-4 pt-4"
-        style={[
-          styles.promptPanel,
-          { borderRadius: promptPanelRadius, paddingBottom: promptPanelBottomPadding },
-        ]}
+        className="w-full rounded-xl bg-surface-secondary p-4"
+        style={styles.promptPanel}
         testID="painting-template-prompt-panel"
       >
         <Text
@@ -109,19 +114,24 @@ function PaintingTemplateSheetBody({ template }: { template: PaintingTemplate })
         >
           {template.prompt}
         </Text>
-        <Button
-          accessibilityLabel={t('painting.templates.try')}
-          className="w-full rounded-full"
-          isDisabled={isClosing}
-          onPress={() => requestClose('use')}
-          size="sm"
-          testID="painting-template-try"
-        >
-          <Button.Label className="font-semibold text-base">
-            {t('painting.templates.try')}
-          </Button.Label>
-        </Button>
       </View>
+
+      {/* Stretch-minus-margin rather than `w-full`: the margin has to come off
+          the width, and `w-full` would resolve to the body's full content box
+          and overflow by exactly the margin. The 16 matches the panel's own
+          padding, so the button's edges line up with the prompt text above it. */}
+      <Button
+        accessibilityLabel={t('painting.templates.try')}
+        className="mx-4 self-stretch rounded-full"
+        isDisabled={isClosing}
+        onPress={() => requestClose('use')}
+        size="sm"
+        testID="painting-template-try"
+      >
+        <Button.Label className="font-semibold text-base">
+          {t('painting.templates.try')}
+        </Button.Label>
+      </Button>
     </View>
   );
 }
@@ -130,7 +140,6 @@ const styles = StyleSheet.create({
   bodyContent: {
     alignItems: 'center',
     gap: 24,
-    paddingBottom: SHEET_CONTENT_INSET,
     paddingHorizontal: SHEET_CONTENT_INSET,
     paddingTop: 12,
   },

--- a/src/screens/PaintingScreen/templates/__tests__/PaintingTemplateRow.test.tsx
+++ b/src/screens/PaintingScreen/templates/__tests__/PaintingTemplateRow.test.tsx
@@ -74,7 +74,7 @@ jest.mock('@/components/nativePrimitives', () => {
 });
 
 jest.mock('@/config/constants', () => ({
-  bottomSheet: { cornerRadius: 28, headerHeight: 60, headerSideWidth: 44, outerInset: 8 },
+  bottomSheet: { cornerRadius: 28, headerHeight: 60, headerSideWidth: 44, outerInset: 4 },
   isLiquidGlassAvailable: true,
   sheetScrimColor: '#00000066',
 }));
@@ -144,48 +144,55 @@ describe('PaintingTemplateRow', () => {
     expect(renderer?.root.findByProps({ testID: 'painting-template-try' })).toBeTruthy();
 
     const surface = renderer?.root.findByProps({ testID: 'painting-template-sheet-surface' });
+    // No native screen radius under jest, so both corner pairs rest at 28 — the
+    // concentric bottom radius is covered in the BottomSheet suite itself.
     expect(StyleSheet.flatten(surface?.props.style)).toMatchObject({
-      borderBottomLeftRadius: 42,
-      borderBottomRightRadius: 42,
-      borderTopLeftRadius: 34,
-      borderTopRightRadius: 34,
+      borderBottomLeftRadius: 28,
+      borderBottomRightRadius: 28,
+      borderTopLeftRadius: 28,
+      borderTopRightRadius: 28,
       bottom: 0,
       left: 0,
       right: 0,
     });
     const sheet = renderer?.root.findByProps({ testID: 'painting-template-sheet' });
     expect(StyleSheet.flatten(sheet?.props.style)).toMatchObject({
-      borderBottomLeftRadius: 42,
-      borderBottomRightRadius: 42,
-      borderTopLeftRadius: 34,
-      borderTopRightRadius: 34,
+      borderBottomLeftRadius: 28,
+      borderBottomRightRadius: 28,
+      borderTopLeftRadius: 28,
+      borderTopRightRadius: 28,
       overflow: 'hidden',
-      width: Dimensions.get('window').width - 16,
+      width: Dimensions.get('window').width - 8,
     });
     const bottomGap = renderer?.root.findByProps({ testID: 'painting-template-sheet-bottom-gap' });
-    expect(StyleSheet.flatten(bottomGap?.props.style).height).toBe(8);
+    expect(StyleSheet.flatten(bottomGap?.props.style).height).toBe(4);
 
     const header = renderer?.root.findByProps({ testID: 'painting-template-header' });
     expect(StyleSheet.flatten(header?.props.style)).toMatchObject({
       height: 60,
-      paddingHorizontal: 12,
-      paddingTop: 12,
+      paddingHorizontal: 6,
+      paddingTop: 6,
     });
   });
 
-  test('truncates the prompt and keeps equal outer panel spacing above the safe area', () => {
+  test('truncates the prompt and keeps the button clear of the safe area', () => {
     openSheet();
 
     const prompt = renderer?.root.findByProps({ testID: 'painting-template-prompt' });
     expect(prompt?.props.ellipsizeMode).toBe('tail');
     expect(prompt?.props.numberOfLines).toBe(2);
 
+    // The button now sits below the panel, so the body's own bottom padding is
+    // what lifts it off the home indicator: insets.bottom (34) - outerInset (4).
     const body = renderer?.root.findByProps({ testID: 'painting-template-sheet-body' });
-    expect(StyleSheet.flatten(body?.props.style).paddingBottom).toBe(8);
+    expect(StyleSheet.flatten(body?.props.style).paddingBottom).toBe(30);
 
+    // The panel touches no card edge, so its radius is a flat utility class
+    // rather than anything derived from the card — asserted on className
+    // because uniwind does not resolve classes to styles under jest.
     const panel = renderer?.root.findByProps({ testID: 'painting-template-prompt-panel' });
-    expect(StyleSheet.flatten(panel?.props.style).borderRadius).toBe(34);
-    expect(StyleSheet.flatten(panel?.props.style).paddingBottom).toBe(18);
+    expect(panel?.props.className).toContain('rounded-xl');
+    expect(StyleSheet.flatten(panel?.props.style).borderRadius).toBeUndefined();
   });
 
   test('dismisses with the close button after the sheet settles', () => {


### PR DESCRIPTION
The card's bottom radius was `insets.bottom + outerInset`, which encodes nothing about the screen's curvature — 34pt is constant across every iPhone with a home indicator while display radii range from 47 to 62 — so it now reads the hardware value via `expo-screen-corner-radius` and subtracts the outer inset, putting both curves on one center (a display that can't name its radius reports 0 and clamps to the resting 28 rather than guessing). The top corners are pinned to that resting radius instead of being derived from the safe area, which fixes them jumping 28 → 48 (dragging the close button and header height along) when an Android user switches from gesture to three-button navigation.

`bottomSheet.outerInset` also narrows 8 → 4, and in the painting template sheet the "try" button moves out of the prompt panel — the panel now floats between preview and button, concentric with nothing, so it takes a flat `rounded-xl` on all four corners while the button's own bottom padding keeps it clear of the home indicator.

Verified on an iPhone 17 Pro simulator by fitting the rendered edges: card insets 4.0pt, bottom radius r=58 (= 62 − 4, residual < 0.25pt), panel and button geometry as intended. Full suite passes (147 files / 879 tests), typecheck and biome clean; this includes fixing two painting suites that were already red against the new geometry and adding a global jest mock for `expo-screen-corner-radius`, which throws at import time under jest and otherwise takes down every suite reaching `BottomSheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)