### PR TITLE
fix(profile-settings): preserve Chinese IME composition

### DIFF
--- a/src/screens/SettingsScreen/ProfileSettingsScreen.tsx
+++ b/src/screens/SettingsScreen/ProfileSettingsScreen.tsx
@@ -6,7 +6,7 @@ import { useThemeColor } from 'heroui-native/hooks';
 import { Input } from 'heroui-native/input';
 import { useToast } from 'heroui-native/toast';
 import { SaveIcon } from 'lucide-uniwind/png';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { BackHeader, type HeaderToolbarAction } from '@/components/headers';
@@ -27,6 +27,7 @@ export default function ProfileSettingsScreen() {
   const inputRef = useRef<TextInput>(null);
   const [userName, setUserName] = usePreference('app.user.name');
   const [avatar, setAvatar] = usePreference('app.user.avatar');
+  const [nameDraft, setNameDraft] = useState(userName);
   const avatarActions = useMemo<MenuAction[]>(
     () => [
       {
@@ -128,14 +129,11 @@ export default function ProfileSettingsScreen() {
   }, []);
   const finishEditing = useCallback(() => {
     blurInput();
+    if (nameDraft !== userName) {
+      void setUserName(nameDraft, { optimistic: true });
+    }
     router.back();
-  }, [blurInput, router]);
-  const handleNameChange = useCallback(
-    (nextName: string) => {
-      void setUserName(nextName, { optimistic: true });
-    },
-    [setUserName],
-  );
+  }, [blurInput, nameDraft, router, setUserName, userName]);
   const rightActions = useMemo<HeaderToolbarAction[]>(
     () => [
       {
@@ -177,14 +175,14 @@ export default function ProfileSettingsScreen() {
               accessibilityLabel={t('settings.profile.userName')}
               autoCorrect={false}
               className="rounded-2xl px-4 text-base text-foreground leading-5"
-              onChangeText={handleNameChange}
+              onChangeText={setNameDraft}
               onSubmitEditing={blurInput}
               placeholderColorClassName="accent-muted"
               ref={inputRef}
               returnKeyLabel="done"
               returnKeyType="done"
               style={[styles.input, { borderColor }]}
-              value={userName}
+              value={nameDraft}
             />
           </View>
         </View>

--- a/src/screens/SettingsScreen/__tests__/ProfileSettingsScreen.test.tsx
+++ b/src/screens/SettingsScreen/__tests__/ProfileSettingsScreen.test.tsx
@@ -1,0 +1,135 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import ProfileSettingsScreen from '../ProfileSettingsScreen';
+
+type HeaderAction = { key: string; onPress?: () => void };
+
+const mockBack = jest.fn();
+const mockSetAvatar = jest.fn();
+const mockSetUserName = jest.fn();
+let mockRightActions: readonly HeaderAction[] = [];
+
+jest.mock('@expo/ui/community/menu', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    MenuView: ({ children }: { children: React.ReactNode }) => <MockView>{children}</MockView>,
+  };
+});
+
+jest.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ error: jest.fn() }),
+  },
+}));
+
+jest.mock('expo-image-picker', () => ({
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+  requestCameraPermissionsAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+jest.mock('heroui-native/hooks', () => ({
+  useThemeColor: () => '#000000',
+}));
+
+jest.mock('heroui-native/input', () => {
+  const React = jest.requireActual('react');
+  const { TextInput: MockTextInput } = jest.requireActual('react-native');
+
+  return {
+    Input: React.forwardRef(
+      (props: React.ComponentProps<typeof MockTextInput>, ref: React.Ref<typeof MockTextInput>) => (
+        <MockTextInput {...props} ref={ref} />
+      ),
+    ),
+  };
+});
+
+jest.mock('heroui-native/toast', () => ({
+  useToast: () => ({ toast: { show: jest.fn() } }),
+}));
+
+jest.mock('lucide-uniwind/png', () => ({
+  SaveIcon: () => null,
+}));
+
+jest.mock('@/components/headers', () => ({
+  BackHeader: ({ rightActions }: { rightActions?: readonly HeaderAction[] }) => {
+    mockRightActions = rightActions ?? [];
+    return null;
+  },
+}));
+
+jest.mock('@/components/ProfileAvatar', () => ({
+  ProfileAvatarEditBadge: () => null,
+  ProfileAvatarImage: () => null,
+}));
+
+jest.mock('@/data/hooks', () => ({
+  usePreference: (key: string) =>
+    key === 'app.user.name' ? ['Saved name', mockSetUserName] : [null, mockSetAvatar],
+}));
+
+jest.mock('@/services/userAvatarStorage', () => ({
+  replaceUserAvatar: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'chat.media.camera': 'Camera',
+        'chat.media.photos': 'Photos',
+        'common.save': 'Save',
+        'settings.profile.changeAvatar': 'Change avatar',
+        'settings.profile.edit': 'Edit profile',
+        'settings.profile.userName': 'Username',
+      })[key] ?? key,
+  }),
+}));
+
+describe('ProfileSettingsScreen', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRightActions = [];
+  });
+
+  afterEach(async () => {
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('keeps name edits local until the user saves', async () => {
+    await act(async () => {
+      renderer = create(<ProfileSettingsScreen />);
+    });
+
+    const nameInput = renderer?.root.findByProps({ accessibilityLabel: 'Username' });
+
+    await act(async () => {
+      nameInput?.props.onChangeText('槑');
+      nameInput?.props.onChangeText('槑囿');
+      nameInput?.props.onChangeText('槑囿脑袋');
+    });
+
+    expect(mockSetUserName).not.toHaveBeenCalled();
+    expect(renderer?.root.findByProps({ accessibilityLabel: 'Username' }).props.value).toBe(
+      '槑囿脑袋',
+    );
+
+    const saveAction = mockRightActions.find((action) => action.key === 'finish-profile-edit');
+    saveAction?.onPress?.();
+
+    expect(mockSetUserName).toHaveBeenCalledTimes(1);
+    expect(mockSetUserName).toHaveBeenCalledWith('槑囿脑袋', { optimistic: true });
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Prevent profile username edits from writing preferences on every keystroke by keeping the active value in local draft state. Persist the final username only when the user saves, avoiding stale controlled values that interrupt Chinese IME composition. Add a regression test covering incremental Chinese input and final save behavior.

Tests: `pnpm exec jest --runInBand` (187 suites, 1218 tests), `pnpm typecheck`, `pnpm lint`, and Biome checks.