### PR TITLE
test(profile-settings): name input mock component

### DIFF
--- a/src/screens/SettingsScreen/__tests__/ProfileSettingsScreen.test.tsx
+++ b/src/screens/SettingsScreen/__tests__/ProfileSettingsScreen.test.tsx
@@ -43,11 +43,12 @@ jest.mock('heroui-native/input', () => {
   const { TextInput: MockTextInput } = jest.requireActual('react-native');
 
   return {
-    Input: React.forwardRef(
-      (props: React.ComponentProps<typeof MockTextInput>, ref: React.Ref<typeof MockTextInput>) => (
-        <MockTextInput {...props} ref={ref} />
-      ),
-    ),
+    Input: React.forwardRef(function MockInput(
+      props: React.ComponentProps<typeof MockTextInput>,
+      ref: React.Ref<typeof MockTextInput>,
+    ) {
+      return <MockTextInput {...props} ref={ref} />;
+    }),
   };
 });
 


### PR DESCRIPTION
Name the `React.forwardRef` input mock added in #469 so the `react/display-name` CI rule passes. Tests: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and `pnpm test` (187 suites, 1218 tests).