### PR TITLE
fix(provider-settings): align provider avatar styling

### DIFF
--- a/src/frontend/features/settings/components/ProviderAvatar.tsx
+++ b/src/frontend/features/settings/components/ProviderAvatar.tsx
@@ -6,6 +6,21 @@ import { useUniwind } from 'uniwind';
 import { Image } from '@/frontend/components/nativePrimitives';
 import { useBackendModule } from '@/frontend/data';
 
+import {
+  DEFAULT_PROVIDER_ICON_SCALE,
+  getProviderAvatarFallback,
+  getProviderListIconDisplayConfig,
+} from '../utils/providerAvatarStyles';
+
+const PROVIDER_LIST_AVATAR_SIZE = 26;
+const PROVIDER_LIST_AVATAR_FRAME_CLASS_NAME =
+  'items-center justify-center overflow-hidden border border-border-subtle border-continuous';
+const PROVIDER_LIST_AVATAR_FRAME_STYLE = {
+  borderRadius: 6,
+  height: PROVIDER_LIST_AVATAR_SIZE,
+  width: PROVIDER_LIST_AVATAR_SIZE,
+};
+
 /**
  * Reads a provider's stored custom avatar uri (see `providerAvatarStorage`).
  * The lookup is a synchronous file-system stat, memoized per `providerId`, so
@@ -20,7 +35,6 @@ type ProviderAvatarProps = {
   presetProviderId?: string;
   providerId: string;
   providerName: string;
-  size?: number;
 };
 
 /**
@@ -32,55 +46,65 @@ export function ProviderAvatar({
   presetProviderId,
   providerId,
   providerName,
-  size = 20,
 }: ProviderAvatarProps) {
   const { theme } = useUniwind();
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
   const avatarUri = useProviderAvatar(providerId);
-  const iconSource = resolveProviderIcon(presetProviderId ?? providerId);
-  const initial = providerName.trim().charAt(0).toUpperCase() || 'P';
-  const frameStyle = { borderRadius: size / 2, height: size, width: size };
 
   if (avatarUri) {
     return (
-      <View className="overflow-hidden border-continuous" style={frameStyle}>
+      <View
+        className={PROVIDER_LIST_AVATAR_FRAME_CLASS_NAME}
+        style={PROVIDER_LIST_AVATAR_FRAME_STYLE}
+      >
         <Image
           cachePolicy="memory-disk"
           contentFit="cover"
           recyclingKey={avatarUri}
           source={{ uri: avatarUri }}
-          style={{ height: size, width: size }}
+          style={{ height: PROVIDER_LIST_AVATAR_SIZE, width: PROVIDER_LIST_AVATAR_SIZE }}
         />
       </View>
     );
   }
 
+  const displayIconId = presetProviderId ?? providerId;
+  const iconSource = resolveProviderIcon(displayIconId);
+
   if (iconSource) {
-    const imageSize = Math.round(size * 0.8125);
+    const displayConfig = getProviderListIconDisplayConfig(displayIconId);
+    const imageSize =
+      PROVIDER_LIST_AVATAR_SIZE * (displayConfig?.scale ?? DEFAULT_PROVIDER_ICON_SCALE);
 
     return (
       <View
-        className="items-center justify-center overflow-hidden border-continuous"
-        style={frameStyle}
+        className={PROVIDER_LIST_AVATAR_FRAME_CLASS_NAME}
+        style={PROVIDER_LIST_AVATAR_FRAME_STYLE}
       >
         <Image
           cachePolicy="memory-disk"
           contentFit="contain"
           recyclingKey={providerId}
           source={iconSource[iconTheme]}
-          style={{ height: imageSize, width: imageSize }}
+          style={{
+            borderRadius: displayConfig?.borderRadius,
+            height: imageSize,
+            width: imageSize,
+          }}
         />
       </View>
     );
   }
 
+  const fallback = getProviderAvatarFallback(providerName);
+
   return (
-    <View className="items-center justify-center bg-surface-secondary" style={frameStyle}>
-      <Text
-        className="font-medium text-default-foreground"
-        style={{ fontSize: Math.round(size * 0.5) }}
-      >
-        {initial}
+    <View
+      className={PROVIDER_LIST_AVATAR_FRAME_CLASS_NAME}
+      style={{ ...PROVIDER_LIST_AVATAR_FRAME_STYLE, backgroundColor: fallback.backgroundColor }}
+    >
+      <Text className="font-medium" style={{ color: fallback.color, fontSize: 14 }}>
+        {fallback.initial}
       </Text>
     </View>
   );

--- a/src/frontend/features/settings/components/__tests__/ProviderAvatar.test.tsx
+++ b/src/frontend/features/settings/components/__tests__/ProviderAvatar.test.tsx
@@ -1,0 +1,89 @@
+import { Text, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ProviderAvatar } from '../ProviderAvatar';
+
+const mockResolveProviderIcon = jest.fn();
+const mockResolveAvatar = jest.fn();
+const mockImage = jest.fn((_props: unknown) => null);
+
+jest.mock('@cherrystudio/ui/icons', () => ({
+  resolveProviderIcon: (...args: unknown[]) => mockResolveProviderIcon(...args),
+}));
+
+jest.mock('@/frontend/components/nativePrimitives', () => ({
+  Image: (props: unknown) => mockImage(props),
+}));
+
+jest.mock('@/frontend/data', () => ({
+  useBackendModule: () => ({ resolveAvatar: mockResolveAvatar }),
+}));
+
+jest.mock('uniwind', () => ({
+  useUniwind: () => ({ theme: 'dark' }),
+}));
+
+describe('ProviderAvatar', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveAvatar.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = undefined;
+    }
+  });
+
+  it('renders a contained desktop-style provider logo in the list frame', () => {
+    mockResolveProviderIcon.mockReturnValue({ dark: 'cherryin-dark', light: 'cherryin-light' });
+
+    act(() => {
+      renderer = create(
+        <ProviderAvatar providerId="custom" presetProviderId="cherryin" providerName="CherryIN" />,
+      );
+    });
+
+    expect(renderer?.root.findByType(View).props).toEqual(
+      expect.objectContaining({
+        className:
+          'items-center justify-center overflow-hidden border border-border-subtle border-continuous',
+        style: { borderRadius: 6, height: 26, width: 26 },
+      }),
+    );
+    expect(mockImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'cherryin-dark',
+        style: {
+          borderRadius: 5,
+          height: 26 * (5 / 7),
+          width: 26 * (5 / 7),
+        },
+      }),
+    );
+  });
+
+  it('renders the desktop generated-color fallback when no logo exists', () => {
+    mockResolveProviderIcon.mockReturnValue(undefined);
+
+    act(() => {
+      renderer = create(<ProviderAvatar providerId="codex" providerName="codex" />);
+    });
+
+    expect(renderer?.root.findByType(View).props.style).toEqual({
+      backgroundColor: '#46429b',
+      borderRadius: 6,
+      height: 26,
+      width: 26,
+    });
+    expect(renderer?.root.findByType(Text).props).toEqual(
+      expect.objectContaining({
+        children: 'c',
+        style: { color: '#FFFFFF', fontSize: 14 },
+      }),
+    );
+  });
+});

--- a/src/frontend/features/settings/utils/__tests__/providerAvatarStyles.test.ts
+++ b/src/frontend/features/settings/utils/__tests__/providerAvatarStyles.test.ts
@@ -1,0 +1,41 @@
+import {
+  DEFAULT_PROVIDER_ICON_SCALE,
+  getProviderAvatarFallback,
+  getProviderListIconDisplayConfig,
+} from '../providerAvatarStyles';
+
+describe('provider avatar styles', () => {
+  it.each(['cherryin', 'aihubmix', 'lmstudio', 'anthropic', 'yi', 'groq', 'aws-bedrock'])(
+    'contains the %s logo in the provider list frame',
+    (providerId) => {
+      expect(getProviderListIconDisplayConfig(providerId)).toEqual({
+        borderRadius: 5,
+        scale: 5 / 7,
+      });
+    },
+  );
+
+  it('keeps trimmed provider assets at their native default scale', () => {
+    expect(getProviderListIconDisplayConfig('openai')).toEqual({
+      scale: DEFAULT_PROVIDER_ICON_SCALE,
+    });
+  });
+
+  it('matches the desktop generated fallback colors and Unicode-safe initial', () => {
+    expect(getProviderAvatarFallback('codex')).toEqual({
+      backgroundColor: '#46429b',
+      color: '#FFFFFF',
+      initial: 'c',
+    });
+    expect(getProviderAvatarFallback('E')).toEqual({
+      backgroundColor: '#438910',
+      color: '#000000',
+      initial: 'E',
+    });
+    expect(getProviderAvatarFallback('')).toEqual({
+      backgroundColor: '#448898',
+      color: '#000000',
+      initial: 'P',
+    });
+  });
+});

--- a/src/frontend/features/settings/utils/providerAvatarStyles.ts
+++ b/src/frontend/features/settings/utils/providerAvatarStyles.ts
@@ -1,0 +1,89 @@
+export interface ProviderAvatarDisplayConfig {
+  borderRadius?: number;
+  scale: number;
+}
+
+export const DEFAULT_PROVIDER_ICON_SCALE = 0.8125;
+
+const PROVIDER_LIST_CONTAINED_ICON: Readonly<ProviderAvatarDisplayConfig> = {
+  borderRadius: 5,
+  scale: 5 / 7,
+};
+const PROVIDER_LIST_DEFAULT_ICON: Readonly<ProviderAvatarDisplayConfig> = {
+  // Native provider assets are trimmed during generation, unlike desktop SVGs.
+  scale: DEFAULT_PROVIDER_ICON_SCALE,
+};
+const PROVIDER_LIST_CONTAINED_ICON_IDS = new Set([
+  'aihubmix',
+  'anthropic',
+  'aws-bedrock',
+  'cherryin',
+  'groq',
+  'lmstudio',
+  'yi',
+]);
+
+export function getProviderListIconDisplayConfig(
+  iconId: string | undefined,
+): ProviderAvatarDisplayConfig | undefined {
+  if (!iconId) {
+    return undefined;
+  }
+
+  return PROVIDER_LIST_CONTAINED_ICON_IDS.has(iconId.toLowerCase())
+    ? PROVIDER_LIST_CONTAINED_ICON
+    : PROVIDER_LIST_DEFAULT_ICON;
+}
+
+export function getProviderAvatarFallback(providerName: string) {
+  const initial = getFirstCharacter(providerName) || 'P';
+  const backgroundColor = generateColorFromCharacter(providerName || initial);
+
+  return {
+    backgroundColor,
+    color: getForegroundColor(backgroundColor),
+    initial,
+  };
+}
+
+function generateColorFromCharacter(value: string) {
+  const seed = value.charCodeAt(0);
+  const multiplier = 1664525;
+  const increment = 1013904223;
+  const modulus = 2 ** 32;
+
+  let red = (multiplier * seed + increment) % modulus;
+  let green = (multiplier * red + increment) % modulus;
+  let blue = (multiplier * green + increment) % modulus;
+
+  red = Math.floor((red / modulus) * 256);
+  green = Math.floor((green / modulus) * 256);
+  blue = Math.floor((blue / modulus) * 256);
+
+  return `#${[red, green, blue].map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function getFirstCharacter(value: string) {
+  for (const character of value) {
+    return character;
+  }
+
+  return '';
+}
+
+function getForegroundColor(backgroundColor: string) {
+  const red = Number.parseInt(backgroundColor.slice(1, 3), 16);
+  const green = Number.parseInt(backgroundColor.slice(3, 5), 16);
+  const blue = Number.parseInt(backgroundColor.slice(5, 7), 16);
+  const luminance =
+    0.2126 * normalizeColorChannel(red) +
+    0.7152 * normalizeColorChannel(green) +
+    0.0722 * normalizeColorChannel(blue);
+
+  return luminance > 0.179 ? '#000000' : '#FFFFFF';
+}
+
+function normalizeColorChannel(channel: number) {
+  const normalized = channel / 255;
+  return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+}


### PR DESCRIPTION
Aligns provider list avatars with the desktop 26px frame, continuous radius, and subtle border styling. Adds desktop-equivalent contained sizing for provider logos that need extra inset while preserving the native scale for trimmed mobile assets. Matches the desktop deterministic initial colors and contrast foreground for providers without icons, with Unicode-safe fallback initials. Adds component and utility regression tests; full tests, typecheck, lint, formatting, design checks, and iOS/Android production exports pass.