### PR TITLE
feat(chat-input): support pasted image attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "expo-localization": "~57.0.1",
     "expo-location": "~57.0.6",
     "expo-media-library": "~57.0.2",
+    "expo-paste-input": "0.2.2",
     "expo-router": "~57.0.6",
     "expo-screen-corner-radius": "^1.1.0",
     "expo-splash-screen": "~57.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       expo-media-library:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))
+      expo-paste-input:
+        specifier: 0.2.2
+        version: 0.2.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ~57.0.6
         version: 57.0.6(0affca755774a72a3e12455a1156c114)
@@ -5302,6 +5305,13 @@ packages:
   expo-modules-jsi@57.0.3:
     resolution: {integrity: sha512-B+iXJCC5OIXjFKkLLSY2DZ8BGS+hC3PBTrALpV43pHqhXqqZrRH3uTEylZgsoKQO8N8tjmjAua2ucTFHtr1o0w==}
     peerDependencies:
+      react-native: '*'
+
+  expo-paste-input@0.2.2:
+    resolution: {integrity: sha512-uDv5qi+/FRsEYwVF0Y9MJE7k9pxTNpI77jOnNqS1TQDQlqSfj11O5yvd+G8e7Hi8fDVBZx/BhyImG0b9sK/zIQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
       react-native: '*'
 
   expo-router@57.0.6:
@@ -13030,6 +13040,12 @@ snapshots:
 
   expo-modules-jsi@57.0.3(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)):
     dependencies:
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+
+  expo-paste-input@0.2.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      expo: 57.0.6(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.5)(expo-router@57.0.6)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
 
   expo-router@57.0.6(0affca755774a72a3e12455a1156c114):

--- a/src/frontend/features/chat/input/components/ChatInputTextArea.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputTextArea.tsx
@@ -1,5 +1,7 @@
+import { type PasteEventPayload, TextInputWrapper } from 'expo-paste-input';
 import { TextArea } from 'heroui-native/text-area';
 import { cn } from 'heroui-native/utils';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet } from 'react-native';
 
@@ -9,6 +11,7 @@ import {
   useChatInputMeta,
   useChatInputState,
 } from '../context/ChatInputProvider';
+import { createPastedImageAttachmentDraft } from '../utils/chatInputAttachments';
 
 // heroui-native's Input paints the border/outline `accent`-colored on focus
 // (`ios:focus:outline-ring` / `android:focus:border-primary`). `border-0` only
@@ -19,37 +22,50 @@ const transparentInputSurfaceClassName =
 
 export function ChatInputTextArea() {
   const { t } = useTranslation();
-  const { setDraft, setInputFocused } = useChatInputActions();
+  const { addAttachments, setDraft, setInputFocused } = useChatInputActions();
   const { inputRef } = useChatInputMeta();
   const { draft } = useChatInputState();
+  const handlePaste = useCallback(
+    (payload: PasteEventPayload) => {
+      if (payload.type === 'images' && payload.uris.length > 0) {
+        addAttachments(payload.uris.map(createPastedImageAttachmentDraft));
+      }
+    },
+    [addAttachments],
+  );
 
   return (
-    <TextArea
-      ref={inputRef}
-      multiline
-      className={cn(
-        'h-auto min-h-11 flex-1 rounded-3xl pt-3! pr-12! pb-3! pl-3! text-base leading-5',
-        transparentInputSurfaceClassName,
-      )}
-      numberOfLines={6}
-      placeholder={t('chat.inputPlaceholder')}
-      style={[
-        styles.transparentInputSurface,
-        {
-          maxHeight: chatInputMaxTextAreaHeight,
-          minHeight: chatInputMinTextAreaHeight,
-        },
-      ]}
-      textAlignVertical="center"
-      value={draft}
-      onBlur={() => setInputFocused(false)}
-      onChangeText={setDraft}
-      onFocus={() => setInputFocused(true)}
-    />
+    <TextInputWrapper style={styles.pasteInputWrapper} onPaste={handlePaste}>
+      <TextArea
+        ref={inputRef}
+        multiline
+        className={cn(
+          'h-auto min-h-11 flex-1 rounded-3xl pt-3! pr-12! pb-3! pl-3! text-base leading-5',
+          transparentInputSurfaceClassName,
+        )}
+        numberOfLines={6}
+        placeholder={t('chat.inputPlaceholder')}
+        style={[
+          styles.transparentInputSurface,
+          {
+            maxHeight: chatInputMaxTextAreaHeight,
+            minHeight: chatInputMinTextAreaHeight,
+          },
+        ]}
+        textAlignVertical="center"
+        value={draft}
+        onBlur={() => setInputFocused(false)}
+        onChangeText={setDraft}
+        onFocus={() => setInputFocused(true)}
+      />
+    </TextInputWrapper>
   );
 }
 
 const styles = StyleSheet.create({
+  pasteInputWrapper: {
+    alignSelf: 'stretch',
+  },
   transparentInputSurface: {
     backgroundColor: 'transparent',
     borderColor: 'transparent',

--- a/src/frontend/features/chat/input/components/__tests__/ChatInputSurface.test.tsx
+++ b/src/frontend/features/chat/input/components/__tests__/ChatInputSurface.test.tsx
@@ -32,6 +32,24 @@ jest.mock('heroui-native/text-area', () => {
   };
 });
 
+jest.mock('expo-paste-input', () => {
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    TextInputWrapper: ({
+      children,
+      onPaste,
+    }: {
+      children: React.ReactNode;
+      onPaste: (payload: unknown) => void;
+    }) => {
+      const viewProps = { onPaste, testID: 'paste-input-wrapper' };
+
+      return <View {...viewProps}>{children}</View>;
+    },
+  };
+});
+
 jest.mock('heroui-native/utils', () => ({
   cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
 }));
@@ -292,6 +310,42 @@ describe('ChatInputSurface', () => {
         accessibilityLabel: 'chat.input.action.stopGenerating',
       }),
     ).toHaveLength(0);
+  });
+
+  test('adds pasted images to the attachment strip', async () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(async () => {
+      renderer = create(
+        <ChatInputProvider>
+          <ChatInputSurface
+            isSendEnabled
+            isStreaming={false}
+            modelLabel="Model"
+            onModelPickerPress={jest.fn()}
+            onSendPress={jest.fn()}
+            onStopPress={jest.fn()}
+          />
+        </ChatInputProvider>,
+      );
+    });
+
+    if (!renderer) {
+      throw new Error('ChatInputSurface test renderer was not created.');
+    }
+
+    const pasteInputWrapper = renderer.root.findByProps({ testID: 'paste-input-wrapper' });
+    await act(async () => {
+      pasteInputWrapper.props.onPaste({
+        type: 'images',
+        uris: ['file:///tmp/Pasted%20Sticker.GIF'],
+      });
+    });
+
+    expect(
+      renderer.root.findAllByProps({ accessibilityLabel: 'Pasted Sticker.GIF' }).length,
+    ).toBeGreaterThan(0);
+    expect(getTextInputValue(renderer)).toBe('');
   });
 
   test('can send an empty payload when the caller explicitly allows it', async () => {

--- a/src/frontend/features/chat/input/utils/__tests__/chatInputAttachments.test.ts
+++ b/src/frontend/features/chat/input/utils/__tests__/chatInputAttachments.test.ts
@@ -6,6 +6,7 @@ import {
   createCameraAttachmentDraft,
   createChatInputMessageParts,
   createDocumentAttachmentDraft,
+  createPastedImageAttachmentDraft,
   createPhotoAttachmentDraft,
   hasChatInputSendableContent,
   isChatInputImageFileName,
@@ -66,6 +67,16 @@ describe('chat input attachments', () => {
       mediaType: 'image/heic',
       name: 'camera-shot.HEIC',
       uri: 'file://photo-a.heic',
+    });
+  });
+
+  test('creates pasted image attachments from local file URIs', () => {
+    expect(createPastedImageAttachmentDraft('file:///tmp/Pasted%20Sticker.GIF')).toMatchObject({
+      id: 'photo:file:///tmp/Pasted%20Sticker.GIF',
+      kind: 'image',
+      mediaType: 'image/gif',
+      name: 'Pasted Sticker.GIF',
+      uri: 'file:///tmp/Pasted%20Sticker.GIF',
     });
   });
 

--- a/src/frontend/features/chat/input/utils/chatInputAttachments.ts
+++ b/src/frontend/features/chat/input/utils/chatInputAttachments.ts
@@ -75,6 +75,13 @@ export function createPhotoAttachmentDraft(photo: PhotoAttachmentInput): ChatInp
   };
 }
 
+export function createPastedImageAttachmentDraft(uri: string): ChatInputAttachmentDraft {
+  const pathname = new URL(uri).pathname;
+  const fileName = decodeURIComponent(pathname.slice(pathname.lastIndexOf('/') + 1));
+
+  return createPhotoAttachmentDraft({ fileName, id: uri, uri });
+}
+
 type CameraPhotoInput = {
   uri: string;
 };


### PR DESCRIPTION
## Summary

- Add `expo-paste-input` to the chat text area for native image, sticker, and GIF paste events.
- Route pasted media through the existing attachment and file-persistence flow while leaving native text paste behavior unchanged.
- Add attachment conversion and chat-surface regression coverage.

## Validation

- `pnpm typecheck`
- Focused Jest suite: 23 tests passed
- iOS Metro export and native simulator build succeeded