### PR TITLE
feat(ai-usage): enrich Home usage summary

### DIFF
--- a/src/frontend/features/home/aiUsage/components/AiUsageCalendar.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageCalendar.tsx
@@ -33,6 +33,7 @@ export function AiUsageCalendar({
   const { theme } = useUniwind();
   const levelColors = aiUsageCalendar.levelColors[theme === 'dark' ? 'dark' : 'light'];
   const weeks = useMemo(() => buildAiUsageCalendarWeeks(data), [data]);
+  const activeDayCount = Object.values(data).filter((level) => level > 0).length;
   const monthLabelKeys = useMemo(() => getAiUsageMonthLabelKeys(weeks), [weeks]);
   const monthFormatter = useMemo(
     () => new Intl.DateTimeFormat(i18n.resolvedLanguage ?? i18n.language, { month: 'short' }),
@@ -150,7 +151,53 @@ export function AiUsageCalendar({
           {calendarGrid}
         </ScrollView>
       ) : (
-        calendarGrid
+        <>
+          {calendarGrid}
+          <View
+            className="mt-3 flex-row items-center justify-between gap-3"
+            testID="ai-usage-calendar-summary"
+          >
+            <Text
+              selectable
+              className="min-w-0 shrink text-muted-foreground text-xs"
+              maxFontSizeMultiplier={1.2}
+              numberOfLines={1}
+              style={styles.summaryText}
+              testID="ai-usage-active-days"
+            >
+              {t('aiUsage.activeDays', { count: activeDayCount })}
+            </Text>
+            <View
+              className="shrink-0 flex-row items-center gap-1.5"
+              testID="ai-usage-calendar-legend"
+            >
+              <Text
+                className="text-muted-foreground text-xs"
+                maxFontSizeMultiplier={1.2}
+                numberOfLines={1}
+              >
+                {t('aiUsage.less')}
+              </Text>
+              <View accessible={false} className="flex-row gap-1">
+                {levelColors.map((color, level) => (
+                  <View
+                    className="size-3"
+                    key={color}
+                    style={{ backgroundColor: color }}
+                    testID={`ai-usage-legend-level-${level}`}
+                  />
+                ))}
+              </View>
+              <Text
+                className="text-muted-foreground text-xs"
+                maxFontSizeMultiplier={1.2}
+                numberOfLines={1}
+              >
+                {t('aiUsage.more')}
+              </Text>
+            </View>
+          </View>
+        </>
       )}
     </View>
   );
@@ -169,6 +216,9 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     minWidth: '100%',
+  },
+  summaryText: {
+    fontVariant: ['tabular-nums'],
   },
   weekColumn: {
     flexShrink: 0,

--- a/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
@@ -1,4 +1,7 @@
-import type { AiUsageRecordCostTotal } from '@cherrystudio/universal/data/api/schemas/aiUsageRecords';
+import type {
+  AiUsageRecordCostTotal,
+  AiUsageRecordTimelineBucket,
+} from '@cherrystudio/universal/data/api/schemas/aiUsageRecords';
 import { Link } from 'expo-router';
 import { ChevronRightIcon, RefreshCwIcon } from 'lucide-uniwind/png';
 import { useTranslation } from 'react-i18next';
@@ -17,10 +20,9 @@ export function AiUsageSummaryCard() {
   const isInitialLoading = isLoading && !hasData;
   const showInitialError = isError && !hasData;
   const animationStartDateKey = getFirstAiUsageDateKey(calendarData);
-  const formattedCost = formatCostTotals(
-    data?.costTotals ?? [],
-    i18n.resolvedLanguage ?? i18n.language,
-  );
+  const locale = i18n.resolvedLanguage ?? i18n.language;
+  const formattedTokens = formatTotalTokens(data?.buckets, locale);
+  const formattedCost = formatCostTotals(data?.costTotals ?? [], locale);
 
   return (
     <View className="w-full rounded-2xl bg-surface p-4" style={styles.card}>
@@ -97,21 +99,39 @@ export function AiUsageSummaryCard() {
             isLoading={isInitialLoading}
             layout="fit"
           />
-          <View className="mt-4 gap-0.5" testID="ai-usage-summary-cost">
-            <Text
-              selectable
-              adjustsFontSizeToFit
-              className="min-w-0 font-semibold text-default-foreground text-lg"
-              maxFontSizeMultiplier={1.2}
-              minimumFontScale={0.75}
-              numberOfLines={1}
-              style={styles.costValue}
-            >
-              {formattedCost}
-            </Text>
-            <Text className="text-muted-foreground text-sm" maxFontSizeMultiplier={1.2}>
-              {t('aiUsage.cost')}
-            </Text>
+          <View className="mt-4 flex-row gap-6" testID="ai-usage-summary-metrics">
+            <View className="min-w-0 flex-1 gap-0.5" testID="ai-usage-summary-tokens">
+              <Text
+                selectable
+                adjustsFontSizeToFit
+                className="min-w-0 font-semibold text-default-foreground text-lg"
+                maxFontSizeMultiplier={1.2}
+                minimumFontScale={0.65}
+                numberOfLines={1}
+                style={styles.metricValue}
+              >
+                {formattedTokens}
+              </Text>
+              <Text className="text-muted-foreground text-sm" maxFontSizeMultiplier={1.2}>
+                {t('aiUsage.tokens')}
+              </Text>
+            </View>
+            <View className="min-w-0 flex-1 gap-0.5" testID="ai-usage-summary-cost">
+              <Text
+                selectable
+                adjustsFontSizeToFit
+                className="min-w-0 font-semibold text-default-foreground text-lg"
+                maxFontSizeMultiplier={1.2}
+                minimumFontScale={0.65}
+                numberOfLines={1}
+                style={styles.metricValue}
+              >
+                {formattedCost}
+              </Text>
+              <Text className="text-muted-foreground text-sm" maxFontSizeMultiplier={1.2}>
+                {t('aiUsage.cost')}
+              </Text>
+            </View>
           </View>
         </View>
       )}
@@ -127,13 +147,23 @@ const styles = StyleSheet.create({
   continuousCorners: {
     borderCurve: 'continuous',
   },
-  costValue: {
+  metricValue: {
     fontVariant: ['tabular-nums'],
   },
   stateContent: {
     minHeight: 104,
   },
 });
+
+function formatTotalTokens(
+  buckets: readonly AiUsageRecordTimelineBucket[] | undefined,
+  locale: string,
+): string {
+  if (!buckets) return '--';
+
+  const totalTokens = buckets.reduce((total, bucket) => total + bucket.totalTokens, 0);
+  return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(totalTokens);
+}
 
 function formatCostTotals(costTotals: readonly AiUsageRecordCostTotal[], locale: string): string {
   if (costTotals.length === 0) return '--';

--- a/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
@@ -13,6 +13,11 @@ import { useAiUsageOverview } from '../hooks/useAiUsageOverview';
 import { getFirstAiUsageDateKey } from '../utils/aiUsageOverview';
 import { AiUsageCalendar } from './AiUsageCalendar';
 
+const costSymbols = {
+  CNY: '\u00a5',
+  USD: '$',
+} satisfies Record<AiUsageRecordCostTotal['currency'], string>;
+
 export function AiUsageSummaryCard() {
   const { i18n, t } = useTranslation();
   const { calendarData, data, hasData, isError, isLoading, isRefreshing, refetch } =
@@ -168,15 +173,12 @@ function formatTotalTokens(
 function formatCostTotals(costTotals: readonly AiUsageRecordCostTotal[], locale: string): string {
   if (costTotals.length === 0) return '--';
 
+  const numberFormatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+
   return costTotals
-    .map(({ currency, total }) =>
-      new Intl.NumberFormat(locale, {
-        currency,
-        currencyDisplay: 'narrowSymbol',
-        maximumFractionDigits: 2,
-        minimumFractionDigits: 2,
-        style: 'currency',
-      }).format(total),
-    )
+    .map(({ currency, total }) => `${costSymbols[currency]}${numberFormatter.format(total)}`)
     .join(' · ');
 }

--- a/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
@@ -1,3 +1,4 @@
+import type { AiUsageRecordCostTotal } from '@cherrystudio/universal/data/api/schemas/aiUsageRecords';
 import { Link } from 'expo-router';
 import { ChevronRightIcon, RefreshCwIcon } from 'lucide-uniwind/png';
 import { useTranslation } from 'react-i18next';
@@ -10,11 +11,16 @@ import { getFirstAiUsageDateKey } from '../utils/aiUsageOverview';
 import { AiUsageCalendar } from './AiUsageCalendar';
 
 export function AiUsageSummaryCard() {
-  const { t } = useTranslation();
-  const { calendarData, hasData, isError, isLoading, isRefreshing, refetch } = useAiUsageOverview();
+  const { i18n, t } = useTranslation();
+  const { calendarData, data, hasData, isError, isLoading, isRefreshing, refetch } =
+    useAiUsageOverview();
   const isInitialLoading = isLoading && !hasData;
   const showInitialError = isError && !hasData;
   const animationStartDateKey = getFirstAiUsageDateKey(calendarData);
+  const formattedCost = formatCostTotals(
+    data?.costTotals ?? [],
+    i18n.resolvedLanguage ?? i18n.language,
+  );
 
   return (
     <View className="w-full rounded-2xl bg-surface p-4" style={styles.card}>
@@ -91,6 +97,22 @@ export function AiUsageSummaryCard() {
             isLoading={isInitialLoading}
             layout="fit"
           />
+          <View className="mt-4 gap-0.5" testID="ai-usage-summary-cost">
+            <Text
+              selectable
+              adjustsFontSizeToFit
+              className="min-w-0 font-semibold text-default-foreground text-lg"
+              maxFontSizeMultiplier={1.2}
+              minimumFontScale={0.75}
+              numberOfLines={1}
+              style={styles.costValue}
+            >
+              {formattedCost}
+            </Text>
+            <Text className="text-muted-foreground text-sm" maxFontSizeMultiplier={1.2}>
+              {t('aiUsage.cost')}
+            </Text>
+          </View>
         </View>
       )}
     </View>
@@ -105,7 +127,26 @@ const styles = StyleSheet.create({
   continuousCorners: {
     borderCurve: 'continuous',
   },
+  costValue: {
+    fontVariant: ['tabular-nums'],
+  },
   stateContent: {
     minHeight: 104,
   },
 });
+
+function formatCostTotals(costTotals: readonly AiUsageRecordCostTotal[], locale: string): string {
+  if (costTotals.length === 0) return '--';
+
+  return costTotals
+    .map(({ currency, total }) =>
+      new Intl.NumberFormat(locale, {
+        currency,
+        currencyDisplay: 'narrowSymbol',
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+        style: 'currency',
+      }).format(total),
+    )
+    .join(' · ');
+}

--- a/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
@@ -1,3 +1,4 @@
+import { resolveProviderIcon } from '@cherrystudio/ui/icons';
 import type {
   AiUsageRecordCostTotal,
   AiUsageRecordTimelineBucket,
@@ -6,7 +7,9 @@ import { Link } from 'expo-router';
 import { ChevronRightIcon, RefreshCwIcon } from 'lucide-uniwind/png';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useUniwind } from 'uniwind';
 
+import { BrandAvatar, BrandAvatarIcon } from '@/frontend/components/BrandAvatar';
 import { aiUsageCalendar } from '@/frontend/utils/constants';
 
 import { useAiUsageOverview } from '../hooks/useAiUsageOverview';
@@ -20,7 +23,7 @@ const costSymbols = {
 
 export function AiUsageSummaryCard() {
   const { i18n, t } = useTranslation();
-  const { calendarData, data, hasData, isError, isLoading, isRefreshing, refetch } =
+  const { calendarData, data, hasData, isError, isLoading, isRefreshing, refetch, topProviders } =
     useAiUsageOverview();
   const isInitialLoading = isLoading && !hasData;
   const showInitialError = isError && !hasData;
@@ -138,6 +141,18 @@ export function AiUsageSummaryCard() {
               </Text>
             </View>
           </View>
+          <View
+            className="mt-4 min-h-6 flex-row items-center gap-2"
+            testID="ai-usage-summary-providers"
+          >
+            {topProviders.map((provider) => (
+              <AiUsageProviderPill
+                key={provider.providerId ?? provider.providerName ?? 'unknown'}
+                providerId={provider.providerId}
+                providerName={provider.providerName}
+              />
+            ))}
+          </View>
         </View>
       )}
     </View>
@@ -159,6 +174,41 @@ const styles = StyleSheet.create({
     minHeight: 104,
   },
 });
+
+function AiUsageProviderPill({
+  providerId,
+  providerName,
+}: {
+  providerId: string | null;
+  providerName: string | null;
+}) {
+  const { t } = useTranslation();
+  const { theme } = useUniwind();
+  const label = providerName || providerId || t('aiUsage.unknownProvider');
+  const iconSource = resolveProviderIcon(providerId ?? '');
+
+  return (
+    <View
+      className="min-w-0 flex-1 flex-row items-center gap-2"
+      testID={`ai-usage-summary-provider-${providerId ?? 'unknown'}`}
+    >
+      {iconSource ? (
+        <BrandAvatar label={label} size={24}>
+          <BrandAvatarIcon
+            iconId={providerId ?? undefined}
+            recyclingKey={providerId ?? undefined}
+            source={iconSource[theme === 'dark' ? 'dark' : 'light']}
+          />
+        </BrandAvatar>
+      ) : (
+        <BrandAvatar label={label} size={24} />
+      )}
+      <Text className="min-w-0 shrink text-default-foreground text-sm" numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
 
 function formatTotalTokens(
   buckets: readonly AiUsageRecordTimelineBucket[] | undefined,

--- a/src/frontend/features/home/aiUsage/components/__tests__/AiUsageCalendar.test.tsx
+++ b/src/frontend/features/home/aiUsage/components/__tests__/AiUsageCalendar.test.tsx
@@ -34,7 +34,13 @@ jest.mock('uniwind', () => ({ useUniwind: () => ({ theme: 'light' }) }));
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     i18n: { language: 'en-US', resolvedLanguage: 'en-US' },
-    t: (key: string) => ({ 'aiUsage.replay': 'Replay usage animation' })[key] ?? key,
+    t: (key: string, options?: { count?: number }) =>
+      ({
+        'aiUsage.activeDays': `${options?.count} active days`,
+        'aiUsage.less': 'Less',
+        'aiUsage.more': 'More',
+        'aiUsage.replay': 'Replay usage animation',
+      })[key] ?? key,
   }),
 }));
 
@@ -125,6 +131,24 @@ describe('AiUsageCalendar', () => {
     const expectedCellSize = (324 - aiUsageCalendar.summaryCellGap * 26) / 27;
     expect(squareProps).toHaveLength(183);
     expect(squareProps?.every((props) => props.cellSize === expectedCellSize)).toBe(true);
+    expect(renderer?.root.findByProps({ testID: 'ai-usage-active-days' }).props.children).toBe(
+      '2 active days',
+    );
+    const legendLevelTestIDs = new Set(
+      renderer?.root
+        .findAll((node) => /^ai-usage-legend-level-\d$/.test(node.props.testID))
+        .map((node) => node.props.testID),
+    );
+    expect(legendLevelTestIDs).toEqual(
+      new Set(Array.from({ length: 5 }, (_, level) => `ai-usage-legend-level-${level}`)),
+    );
+    const firstLegendLevel = renderer?.root.findByProps({ testID: 'ai-usage-legend-level-0' });
+    expect(firstLegendLevel?.props.className).toBe('size-3');
+
+    const summary = renderer?.root.findByProps({ testID: 'ai-usage-calendar-summary' });
+    const legend = renderer?.root.findByProps({ testID: 'ai-usage-calendar-legend' });
+    expect(summary?.props.className).not.toContain('bg-');
+    expect(legend?.props.className).not.toContain('bg-');
   });
 
   it('dims dates before usage begins and rebases the wave to its first active week', async () => {

--- a/src/frontend/features/home/aiUsage/components/__tests__/AiUsageSummaryCard.test.tsx
+++ b/src/frontend/features/home/aiUsage/components/__tests__/AiUsageSummaryCard.test.tsx
@@ -44,6 +44,7 @@ jest.mock('react-i18next', () => ({
         'aiUsage.loadError': 'Usage statistics could not be loaded.',
         'aiUsage.loading': 'Loading usage statistics',
         'aiUsage.retry': 'Retry',
+        'aiUsage.tokens': 'Tokens',
         'aiUsage.title': 'Usage Statistics',
         'aiUsage.viewDetails': 'View details',
       })[key] ?? key,
@@ -84,7 +85,17 @@ describe('AiUsageSummaryCard', () => {
     expect(calendar?.props.animationStartDateKey).toBe('2026-04-15');
     expect(calendar?.props.layout).toBe('fit');
     expect(textValues()).toEqual(
-      expect.arrayContaining(['Usage Statistics', 'View details', '$1,227.37', 'Cost']),
+      expect.arrayContaining([
+        'Usage Statistics',
+        'View details',
+        '2,235,732',
+        'Tokens',
+        '$1,227.37',
+        'Cost',
+      ]),
+    );
+    expect(renderer?.root.findByProps({ testID: 'ai-usage-summary-metrics' }).props.className).toBe(
+      'mt-4 flex-row gap-6',
     );
     expect(textValues()).not.toEqual(
       expect.arrayContaining(['Total tokens', 'Cache hit rate', 'Daily activity']),
@@ -156,7 +167,10 @@ function queryResult(overrides: Record<string, unknown> = {}) {
   return {
     calendarData,
     data: {
-      buckets: [],
+      buckets: [
+        { date: '2026-08-01', totalTokens: 1_500_000 },
+        { date: '2026-08-02', totalTokens: 735_732 },
+      ],
       costTotals: [{ currency: 'USD', total: 1227.37 }],
       dailyCosts: [],
     },

--- a/src/frontend/features/home/aiUsage/components/__tests__/AiUsageSummaryCard.test.tsx
+++ b/src/frontend/features/home/aiUsage/components/__tests__/AiUsageSummaryCard.test.tsx
@@ -21,6 +21,29 @@ jest.mock('lucide-uniwind/png', () => ({
   RefreshCwIcon: () => null,
 }));
 
+jest.mock('@cherrystudio/ui/icons', () => ({
+  resolveProviderIcon: (providerId: string) => ({
+    dark: `${providerId}-dark`,
+    light: `${providerId}-light`,
+  }),
+}));
+
+jest.mock('uniwind', () => ({
+  useResolveClassNames: () => ({}),
+  useUniwind: () => ({ theme: 'light' }),
+}));
+
+jest.mock('@/frontend/components/BrandAvatar', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    BrandAvatar: ({ children, ...props }: { children?: ReactNode }) =>
+      React.createElement('MockBrandAvatar', props, children),
+    BrandAvatarIcon: (props: Record<string, unknown>) =>
+      React.createElement('MockBrandAvatarIcon', props),
+  };
+});
+
 jest.mock('../../hooks/useAiUsageOverview', () => ({
   useAiUsageOverview: () => mockUseAiUsageOverview(),
 }));
@@ -46,6 +69,7 @@ jest.mock('react-i18next', () => ({
         'aiUsage.retry': 'Retry',
         'aiUsage.tokens': 'Tokens',
         'aiUsage.title': 'Usage Statistics',
+        'aiUsage.unknownProvider': 'Unknown provider',
         'aiUsage.viewDetails': 'View details',
       })[key] ?? key,
   }),
@@ -92,11 +116,20 @@ describe('AiUsageSummaryCard', () => {
         'Tokens',
         '$1,227.37',
         'Cost',
+        'Anthropic',
+        'OpenAI',
+        'Google',
       ]),
     );
     expect(renderer?.root.findByProps({ testID: 'ai-usage-summary-metrics' }).props.className).toBe(
       'mt-4 flex-row gap-6',
     );
+    expect(
+      renderer?.root.findByProps({ testID: 'ai-usage-summary-providers' }).props.className,
+    ).toBe('mt-4 min-h-6 flex-row items-center gap-2');
+    expect(
+      renderer?.root.findByProps({ testID: 'ai-usage-summary-provider-openai' }).props.className,
+    ).toBe('min-w-0 flex-1 flex-row items-center gap-2');
     expect(textValues()).not.toEqual(
       expect.arrayContaining(['Total tokens', 'Cache hit rate', 'Daily activity']),
     );
@@ -181,6 +214,11 @@ function queryResult(overrides: Record<string, unknown> = {}) {
     isRefreshing: false,
     range,
     refetch: mockRefetch,
+    topProviders: [
+      { groupBy: 'provider', providerId: 'anthropic', providerName: 'Anthropic' },
+      { groupBy: 'provider', providerId: 'openai', providerName: 'OpenAI' },
+      { groupBy: 'provider', providerId: 'google', providerName: 'Google' },
+    ],
     ...overrides,
   };
 }

--- a/src/frontend/features/home/aiUsage/components/__tests__/AiUsageSummaryCard.test.tsx
+++ b/src/frontend/features/home/aiUsage/components/__tests__/AiUsageSummaryCard.test.tsx
@@ -37,8 +37,10 @@ jest.mock('../AiUsageCalendar', () => {
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
+    i18n: { language: 'en-US', resolvedLanguage: 'en-US' },
     t: (key: string) =>
       ({
+        'aiUsage.cost': 'Cost',
         'aiUsage.loadError': 'Usage statistics could not be loaded.',
         'aiUsage.loading': 'Loading usage statistics',
         'aiUsage.retry': 'Retry',
@@ -81,18 +83,42 @@ describe('AiUsageSummaryCard', () => {
     expect(calendar?.props.data).toBe(calendarData);
     expect(calendar?.props.animationStartDateKey).toBe('2026-04-15');
     expect(calendar?.props.layout).toBe('fit');
-    expect(textValues()).toEqual(expect.arrayContaining(['Usage Statistics', 'View details']));
+    expect(textValues()).toEqual(
+      expect.arrayContaining(['Usage Statistics', 'View details', '$1,227.37', 'Cost']),
+    );
     expect(textValues()).not.toEqual(
       expect.arrayContaining(['Total tokens', 'Cache hit rate', 'Daily activity']),
     );
   });
 
   it('keeps the summary calendar mounted during its first load', async () => {
-    mockUseAiUsageOverview.mockReturnValue(queryResult({ hasData: false, isLoading: true }));
+    mockUseAiUsageOverview.mockReturnValue(
+      queryResult({ data: undefined, hasData: false, isLoading: true }),
+    );
 
     await renderCard();
 
     expect(renderer?.root.findByProps({ testID: 'ai-usage-calendar' }).props.isLoading).toBe(true);
+    expect(textValues()).toContain('--');
+  });
+
+  it('keeps cost totals separated by currency', async () => {
+    mockUseAiUsageOverview.mockReturnValue(
+      queryResult({
+        data: {
+          buckets: [],
+          costTotals: [
+            { currency: 'CNY', total: 48 },
+            { currency: 'USD', total: 12.3 },
+          ],
+          dailyCosts: [],
+        },
+      }),
+    );
+
+    await renderCard();
+
+    expect(textValues()).toContain('¥48.00 · $12.30');
   });
 
   it('shows a localized no-cache error and retries', async () => {
@@ -129,6 +155,11 @@ describe('AiUsageSummaryCard', () => {
 function queryResult(overrides: Record<string, unknown> = {}) {
   return {
     calendarData,
+    data: {
+      buckets: [],
+      costTotals: [{ currency: 'USD', total: 1227.37 }],
+      dailyCosts: [],
+    },
     error: undefined,
     hasData: true,
     isError: false,

--- a/src/frontend/features/home/aiUsage/hooks/__tests__/useAiUsageOverview.test.tsx
+++ b/src/frontend/features/home/aiUsage/hooks/__tests__/useAiUsageOverview.test.tsx
@@ -1,4 +1,8 @@
-import type { AiUsageRecordTimelineResponse } from '@cherrystudio/universal/data/api/schemas/aiUsageRecords';
+import type {
+  AiUsageRecordStatsMetrics,
+  AiUsageRecordStatsResponse,
+  AiUsageRecordTimelineResponse,
+} from '@cherrystudio/universal/data/api/schemas/aiUsageRecords';
 import type { ApiClient } from '@cherrystudio/universal/data/api/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type EffectCallback, type ReactNode, useEffect } from 'react';
@@ -49,9 +53,38 @@ const response: AiUsageRecordTimelineResponse = {
   costTotals: [],
   dailyCosts: [],
 };
+const emptyMetrics: AiUsageRecordStatsMetrics = {
+  costCurrency: null,
+  estimatedRequestCount: 0,
+  recordCount: 0,
+  requestCount: 0,
+  totalCacheReadTokens: 0,
+  totalCacheWriteTokens: 0,
+  totalCost: 0,
+  totalInputTokens: 0,
+  totalNoCacheTokens: 0,
+  totalOutputTokens: 0,
+  totalTokens: 0,
+  unpricedRequestCount: 0,
+};
+const statsResponse: AiUsageRecordStatsResponse = {
+  buckets: [
+    {
+      ...emptyMetrics,
+      groupBy: 'provider',
+      providerId: 'anthropic',
+      providerName: 'Anthropic',
+      totalTokens: 500,
+    },
+  ],
+  other: emptyMetrics,
+  totals: { ...emptyMetrics, totalTokens: 500 },
+};
 const dataApi = {
   delete: jest.fn(),
-  get: jest.fn(async () => response),
+  get: jest.fn(async (path: string) =>
+    path === '/ai-usage-records/stats' ? statsResponse : response,
+  ),
   patch: jest.fn(),
   post: jest.fn(),
   put: jest.fn(),
@@ -112,15 +145,27 @@ describe('useAiUsageOverview', () => {
     expect(dataApi.get).toHaveBeenCalledWith('/ai-usage-records/timeline', {
       query: { from: range.from, limit: 1, metric: 'tokens', to: range.to },
     });
+    expect(dataApi.get).toHaveBeenCalledWith('/ai-usage-records/stats', {
+      query: {
+        from: range.from,
+        groupBy: 'provider',
+        limit: 3,
+        metric: 'tokens',
+        to: range.to,
+      },
+    });
     expect(Object.keys(latestResult?.calendarData ?? {})).toHaveLength(183);
     expect(latestResult?.calendarData).not.toHaveProperty('2026-01-01');
     expect(latestResult?.calendarData).toHaveProperty('2026-08-02', 1);
-
-    await act(async () => focusEffect?.());
-    expect(dataApi.get).toHaveBeenCalledTimes(1);
+    expect(latestResult?.topProviders).toEqual([
+      expect.objectContaining({ providerId: 'anthropic', totalTokens: 500 }),
+    ]);
 
     await act(async () => focusEffect?.());
     expect(dataApi.get).toHaveBeenCalledTimes(2);
+
+    await act(async () => focusEffect?.());
+    expect(dataApi.get).toHaveBeenCalledTimes(4);
   });
 
   test('moves the local-date range forward when Home regains focus after midnight', async () => {
@@ -139,9 +184,18 @@ describe('useAiUsageOverview', () => {
     await flushQueryNotifications();
 
     const range = getAiUsageSummaryRange(new Date());
-    expect(dataApi.get).toHaveBeenCalledTimes(2);
-    expect(dataApi.get).toHaveBeenLastCalledWith('/ai-usage-records/timeline', {
+    expect(dataApi.get).toHaveBeenCalledTimes(4);
+    expect(dataApi.get).toHaveBeenCalledWith('/ai-usage-records/timeline', {
       query: { from: range.from, limit: 1, metric: 'tokens', to: range.to },
+    });
+    expect(dataApi.get).toHaveBeenCalledWith('/ai-usage-records/stats', {
+      query: {
+        from: range.from,
+        groupBy: 'provider',
+        limit: 3,
+        metric: 'tokens',
+        to: range.to,
+      },
     });
   });
 });

--- a/src/frontend/features/home/aiUsage/hooks/useAiUsageOverview.ts
+++ b/src/frontend/features/home/aiUsage/hooks/useAiUsageOverview.ts
@@ -9,18 +9,35 @@ import { buildAiUsageCalendarData, getAiUsageSummaryRange } from '../utils/aiUsa
 export function useAiUsageOverview() {
   const [endDate, setEndDate] = useState(() => new Date());
   const range = useMemo(() => getAiUsageSummaryRange(endDate), [endDate]);
-  const query = useMemo(
+  const timelineQueryParams = useMemo(
     () => ({ from: range.from, limit: 1, metric: 'tokens' as const, to: range.to }),
     [range],
   );
-  const timelineQuery = useQuery('/ai-usage-records/timeline', { query });
+  const topProvidersQueryParams = useMemo(
+    () => ({
+      from: range.from,
+      groupBy: 'provider' as const,
+      limit: 3,
+      metric: 'tokens' as const,
+      to: range.to,
+    }),
+    [range],
+  );
+  const timelineQuery = useQuery('/ai-usage-records/timeline', { query: timelineQueryParams });
+  const topProvidersQuery = useQuery('/ai-usage-records/stats', {
+    query: topProvidersQueryParams,
+  });
   const hasFocusedOnceRef = useRef(false);
   const endDateKeyRef = useRef(toLocalDateKey(endDate));
-  const refetchRef = useRef(timelineQuery.refetch);
+  const refetch = useCallback(
+    () => Promise.all([timelineQuery.refetch(), topProvidersQuery.refetch()]),
+    [timelineQuery.refetch, topProvidersQuery.refetch],
+  );
+  const refetchRef = useRef(refetch);
 
   useEffect(() => {
-    refetchRef.current = timelineQuery.refetch;
-  }, [timelineQuery.refetch]);
+    refetchRef.current = refetch;
+  }, [refetch]);
 
   useFocusEffect(
     useCallback(() => {
@@ -45,11 +62,16 @@ export function useAiUsageOverview() {
     () => buildAiUsageCalendarData(buckets ?? [], range),
     [buckets, range],
   );
+  const topProviders =
+    topProvidersQuery.data?.buckets.filter((bucket) => bucket.groupBy === 'provider') ?? [];
 
   return {
     ...timelineQuery,
     calendarData,
     hasData: timelineQuery.data !== undefined,
+    isRefreshing: timelineQuery.isRefreshing || topProvidersQuery.isRefreshing,
     range,
+    refetch,
+    topProviders,
   };
 }

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -1,9 +1,12 @@
 {
+  "aiUsage.activeDays": "{{count}} active days",
   "aiUsage.average": "Average",
   "aiUsage.dayAccessibility": "{{date}}, {{tokens}} Tokens",
   "aiUsage.loadError": "Usage statistics could not be loaded.",
+  "aiUsage.less": "Less",
   "aiUsage.loading": "Loading usage statistics",
   "aiUsage.mostUsed": "Most Used",
+  "aiUsage.more": "More",
   "aiUsage.noUsageForDay": "No usage on this day",
   "aiUsage.other": "Other",
   "aiUsage.otherModels": "Other models",

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -21,6 +21,7 @@
   "aiUsage.showThisWeek": "Show This Week",
   "aiUsage.title": "Usage Statistics",
   "aiUsage.tokenUsage": "Token Usage",
+  "aiUsage.tokens": "Tokens",
   "aiUsage.tokensValue": "{{tokens}} Tokens",
   "aiUsage.unknownModel": "Unknown model",
   "aiUsage.unknownProvider": "Unknown provider",

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -1,6 +1,7 @@
 {
   "aiUsage.activeDays": "{{count}} active days",
   "aiUsage.average": "Average",
+  "aiUsage.cost": "Cost",
   "aiUsage.dayAccessibility": "{{date}}, {{tokens}} Tokens",
   "aiUsage.loadError": "Usage statistics could not be loaded.",
   "aiUsage.less": "Less",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -21,6 +21,7 @@
   "aiUsage.showThisWeek": "显示本周",
   "aiUsage.title": "用量统计",
   "aiUsage.tokenUsage": "Token 用量",
+  "aiUsage.tokens": "Tokens",
   "aiUsage.tokensValue": "{{tokens}} Tokens",
   "aiUsage.unknownModel": "未知模型",
   "aiUsage.unknownProvider": "未知服务商",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -1,9 +1,12 @@
 {
+  "aiUsage.activeDays": "活跃{{count}}天",
   "aiUsage.average": "平均",
   "aiUsage.dayAccessibility": "{{date}}，{{tokens}} Tokens",
   "aiUsage.loadError": "无法加载用量统计。",
+  "aiUsage.less": "少",
   "aiUsage.loading": "正在加载用量统计",
   "aiUsage.mostUsed": "最常使用",
+  "aiUsage.more": "多",
   "aiUsage.noUsageForDay": "当天暂无用量",
   "aiUsage.other": "其他",
   "aiUsage.otherModels": "其他模型",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -1,6 +1,7 @@
 {
   "aiUsage.activeDays": "活跃{{count}}天",
   "aiUsage.average": "平均",
+  "aiUsage.cost": "花费",
   "aiUsage.dayAccessibility": "{{date}}，{{tokens}} Tokens",
   "aiUsage.loadError": "无法加载用量统计。",
   "aiUsage.less": "少",


### PR DESCRIPTION
Enhances the Home AI usage card with active-day context, a square less-to-more legend, and side-by-side Token and cost totals for the existing 183-day range. Adds a cached Top 3 provider query ranked by Token usage and presents provider icons and names in three aligned, background-free columns. Keeps timeline and provider summaries synchronized on Home focus, handles multi-currency totals with compact symbols, and adds localized copy. Includes focused component and hook coverage; TypeScript, lint, formatting, and targeted tests pass.