### PR TITLE
fix(ui): prevent effect-driven first-frame layout shifts

### DIFF
--- a/src/app/(tabs)/(messages)/_layout.tsx
+++ b/src/app/(tabs)/(messages)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router';
 
 import { useThemeColor } from '@/frontend/hooks/useThemeColor';
-import { isIOS, isLiquidGlassAvailable } from '@/frontend/utils/constants';
+import { isIOS } from '@/frontend/utils/constants';
 
 export default function MessagesStackLayout() {
   const foregroundColor = useThemeColor('foreground');
@@ -11,7 +11,7 @@ export default function MessagesStackLayout() {
       screenOptions={{
         headerShadowVisible: isIOS ? undefined : false,
         headerShown: isIOS,
-        headerTransparent: isLiquidGlassAvailable,
+        headerTransparent: false,
         headerTintColor: foregroundColor,
       }}
     />

--- a/src/frontend/features/assistants/AssistantDetailScreen.tsx
+++ b/src/frontend/features/assistants/AssistantDetailScreen.tsx
@@ -1,14 +1,13 @@
 import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
 import { Button } from 'heroui-native/button';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { ModelPickerIcon, useModelPickerData } from '@/frontend/components/modelPicker';
-import { useSetBottomTabBarHidden } from '@/frontend/components/navigation';
 import { useAssistantApiById } from '@/frontend/hooks/chat';
 import { screenBottomActionInset } from '@/frontend/utils/constants';
 
@@ -16,17 +15,11 @@ export default function AssistantDetailScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const setBottomTabBarHidden = useSetBottomTabBarHidden();
   const { assistantId, returnTopicId } = useLocalSearchParams<{
     assistantId: string;
     returnTopicId?: string;
   }>();
   const { assistant, error, isLoading } = useAssistantApiById(assistantId);
-
-  useEffect(() => {
-    setBottomTabBarHidden(true);
-    return () => setBottomTabBarHidden(false);
-  }, [setBottomTabBarHidden]);
 
   const returnToTopic = useCallback(() => {
     if (!returnTopicId) {

--- a/src/frontend/features/assistants/AssistantListScreen.tsx
+++ b/src/frontend/features/assistants/AssistantListScreen.tsx
@@ -42,7 +42,7 @@ export default function AssistantListScreen() {
   const { assistants, isLoading } = useAssistantsApi();
   const { deleteAssistant } = useAssistantMutations();
   const { confirmDialog, requestConfirm } = useConfirmDialog();
-  const { notifyClose, notifyWillOpen } = useExclusiveSwipeable();
+  const { closeOpen, notifyClose, notifyWillOpen } = useExclusiveSwipeable();
   const setBottomTabBarHidden = useSetBottomTabBarHidden();
   const bottomInset = useMessageListBottomInset();
   const [isEditing, setIsEditing] = useState(false);
@@ -54,17 +54,23 @@ export default function AssistantListScreen() {
       return;
     }
 
-    setBottomTabBarHidden(isEditing);
     return () => setBottomTabBarHidden(false);
-  }, [isEditing, setBottomTabBarHidden]);
+  }, [setBottomTabBarHidden]);
 
   const enterEditing = useCallback(() => {
+    closeOpen();
     setIsEditing(true);
-  }, []);
+    if (process.env.EXPO_OS === 'android') {
+      setBottomTabBarHidden(true);
+    }
+  }, [closeOpen, setBottomTabBarHidden]);
   const exitEditing = useCallback(() => {
     setIsEditing(false);
     setSelectedIds(new Set());
-  }, []);
+    if (process.env.EXPO_OS === 'android') {
+      setBottomTabBarHidden(false);
+    }
+  }, [setBottomTabBarHidden]);
   const toggleAssistant = useCallback((assistantId: string) => {
     setSelectedIds((current) => toggleSelection(current, assistantId));
   }, []);
@@ -238,12 +244,6 @@ function AssistantListRow({
   const swipeableRef = useRef<SwipeableMethods>(null);
   const isSwipeOpen = useSharedValue(0);
   const pressProgress = useSharedValue(0);
-
-  useEffect(() => {
-    if (isEditing) {
-      swipeableRef.current?.close();
-    }
-  }, [isEditing]);
 
   const handleDeletePress = useCallback(() => {
     swipeableRef.current?.close();

--- a/src/frontend/features/assistants/__tests__/AssistantDetailScreen.test.tsx
+++ b/src/frontend/features/assistants/__tests__/AssistantDetailScreen.test.tsx
@@ -11,7 +11,6 @@ type HeaderAction = { key: string; label?: string; onPress?: () => void };
 
 const mockPush = jest.fn();
 const mockDismissTo = jest.fn();
-const mockSetBottomTabBarHidden = jest.fn();
 let mockAssistantId: string | undefined;
 let mockAssistant: Assistant | undefined;
 let mockError: Error | undefined;
@@ -61,10 +60,6 @@ jest.mock('react-native-safe-area-context', () => ({
 jest.mock('@/frontend/components/modelPicker', () => ({
   ModelPickerIcon: () => null,
   useModelPickerData: () => ({ getModelItem: () => mockModelItem }),
-}));
-
-jest.mock('@/frontend/components/navigation', () => ({
-  useSetBottomTabBarHidden: () => mockSetBottomTabBarHidden,
 }));
 
 jest.mock('@/frontend/hooks/chat', () => ({
@@ -167,18 +162,6 @@ describe('AssistantDetailScreen', () => {
     expect(emoji?.props.className).toContain('text-emoji-6xl');
     expect(emoji?.props.style).toBeUndefined();
     expect(emoji?.props.allowFontScaling).not.toBe(false);
-  });
-
-  it('hides the bottom tabs while the detail screen is mounted', async () => {
-    mockAssistant = makeAssistant();
-
-    await render();
-    expect(mockSetBottomTabBarHidden).toHaveBeenCalledWith(true);
-
-    await act(async () => renderer?.unmount());
-    renderer = undefined;
-
-    expect(mockSetBottomTabBarHidden).toHaveBeenLastCalledWith(false);
   });
 
   it('falls back to the stored model name when the model left the catalog', async () => {

--- a/src/frontend/features/chat/input/components/ChatInputPhotoGrid.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputPhotoGrid.tsx
@@ -1,6 +1,6 @@
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { ChevronLeftIcon, ImagesIcon, InfoIcon } from 'lucide-uniwind/png';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
@@ -81,21 +81,24 @@ const ChatInputPhotoCell = memo(function ChatInputPhotoCell({
   const appliedSelectionRef = useRef(isSelected);
   const previousItemIdRef = useRef(item.id);
 
-  useEffect(() => {
-    if (previousItemIdRef.current !== item.id) {
-      previousItemIdRef.current = item.id;
-      appliedSelectionRef.current = isSelected;
-      selectionProgress.set(isSelected ? 1 : 0);
+  useLayoutEffect(() => {
+    if (previousItemIdRef.current === item.id) {
       return;
     }
 
+    previousItemIdRef.current = item.id;
+    appliedSelectionRef.current = isSelected;
+    selectionProgress.set(isSelected ? 1 : 0);
+  }, [isSelected, item.id, selectionProgress]);
+
+  useEffect(() => {
     if (appliedSelectionRef.current === isSelected) {
       return;
     }
 
     appliedSelectionRef.current = isSelected;
     selectionProgress.set(withTiming(isSelected ? 1 : 0, PHOTO_SELECTION_TIMING));
-  }, [isSelected, item.id, selectionProgress]);
+  }, [isSelected, selectionProgress]);
 
   const imageStyle = useAnimatedStyle(() => ({
     borderRadius: interpolate(selectionProgress.value, [0, 1], [0, 12]),

--- a/src/frontend/features/home/aiUsage/components/AiUsageWeeklySection.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageWeeklySection.tsx
@@ -3,7 +3,7 @@ import {
   type LegendListRef,
   type LegendListRenderItemProps,
 } from '@legendapp/list/react-native';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type NativeScrollEvent, type NativeSyntheticEvent, StyleSheet, View } from 'react-native';
 
@@ -53,8 +53,8 @@ export function AiUsageWeeklySection({
 }: AiUsageWeeklySectionProps) {
   const { t } = useTranslation();
   const listRef = useRef<LegendListRef>(null);
-  const visiblePageIndexRef = useRef<number | null>(null);
-  const visibleWeekDataKeyRef = useRef<string | null>(null);
+  const visiblePageIndexRef = useRef(activePageIndex);
+  const visibleWeekDataKeyRef = useRef(weekDataKey);
   const { onLayout, ref: viewportRef, width: pageWidth } = useMeasuredWidth();
   const previousPage = pages[activePageIndex - ADJACENT_PAGE_DISTANCE];
   const activePage = pages[activePageIndex];
@@ -92,7 +92,7 @@ export function AiUsageWeeklySection({
     ],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const needsSync =
       visiblePageIndexRef.current !== activePageIndex ||
       visibleWeekDataKeyRef.current !== weekDataKey;
@@ -174,7 +174,7 @@ export function AiUsageWeeklySection({
               extraData={listExtraData}
               getFixedItemSize={getFixedItemSize}
               horizontal
-              initialScrollIndex={AI_USAGE_CURRENT_WEEK_PAGE_INDEX}
+              initialScrollIndex={activePageIndex}
               itemsAreEqual={areDetailPagesEqual}
               keyExtractor={getWeekPageKey}
               nestedScrollEnabled

--- a/src/frontend/features/home/aiUsage/components/__tests__/AiUsageWeeklySection.test.tsx
+++ b/src/frontend/features/home/aiUsage/components/__tests__/AiUsageWeeklySection.test.tsx
@@ -96,7 +96,7 @@ describe('AiUsageWeeklySection', () => {
     expect(list?.props.style).toEqual({ height: 283 });
     expect(list?.props.dataKey).toBe('2026-07-27');
     expect(list?.props.getFixedItemSize()).toBe(320);
-    expect(mockScrollToIndex).toHaveBeenCalledWith({ animated: false, index: 7 });
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
     expect(renderer?.root.findAllByProps({ testID: 'ai-usage-show-current-week' })).toHaveLength(0);
     expect(chartNodes().map((node) => node.props.timeline !== undefined)).toEqual([
       false,
@@ -152,6 +152,19 @@ describe('AiUsageWeeklySection', () => {
     expect(mockSelectPage).toHaveBeenLastCalledWith(7);
   });
 
+  test('starts at the active page and reanchors when the week data changes', async () => {
+    await renderSection(6);
+
+    expect(
+      renderer?.root.findByProps({ testID: 'ai-usage-week-list' }).props.initialScrollIndex,
+    ).toBe(6);
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+    await updateSection(6, '2026-08-03');
+
+    expect(mockScrollToIndex).toHaveBeenCalledWith({ animated: false, index: 6 });
+  });
+
   async function renderSection(activePageIndex: number) {
     await act(async () => {
       renderer = create(section(activePageIndex));
@@ -162,18 +175,18 @@ describe('AiUsageWeeklySection', () => {
     );
   }
 
-  async function updateSection(activePageIndex: number) {
-    await act(async () => renderer?.update(section(activePageIndex)));
+  async function updateSection(activePageIndex: number, weekDataKey = '2026-07-27') {
+    await act(async () => renderer?.update(section(activePageIndex, weekDataKey)));
   }
 
-  function section(activePageIndex: number) {
+  function section(activePageIndex: number, weekDataKey = '2026-07-27') {
     return (
       <AiUsageWeeklySection
         activePageIndex={activePageIndex}
         locale="en-US"
         pages={pages}
         todayDateKey="2026-08-02"
-        weekDataKey="2026-07-27"
+        weekDataKey={weekDataKey}
         onSelectDate={mockSelectDate}
         onSelectPage={mockSelectPage}
       />

--- a/src/frontend/features/messages/MessagesScreen/MessagesScreen.ios.tsx
+++ b/src/frontend/features/messages/MessagesScreen/MessagesScreen.ios.tsx
@@ -1,5 +1,4 @@
 import { Stack, useRouter } from 'expo-router';
-import { useHeaderHeight } from 'expo-router/react-navigation';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 
@@ -10,7 +9,6 @@ import {
   useMessageSelectionActions,
   useMessageSelectionState,
 } from '@/frontend/components/messageTabs';
-import { isLiquidGlassAvailable } from '@/frontend/utils/constants';
 
 import { MessagePager } from '../components/MessagePager';
 import { MessageScopeTabs } from '../components/MessageScopeTabs';
@@ -22,15 +20,11 @@ export function MessagesScreen() {
   const { scope, setScope } = useMessageScope();
   const { enterEditing, exitEditing } = useMessageSelectionActions();
   const { isEditing } = useMessageSelectionState();
-  const headerHeight = useHeaderHeight();
   const isConversationScope = scope === 'conversations';
 
   return (
     <>
-      <View
-        className="flex-1 bg-background"
-        style={{ paddingTop: isLiquidGlassAvailable ? headerHeight : 0 }}
-      >
+      <View className="flex-1 bg-background">
         <MessagePager />
         <SelectionControls />
       </View>

--- a/src/frontend/features/topics/TopicList.tsx
+++ b/src/frontend/features/topics/TopicList.tsx
@@ -108,7 +108,12 @@ const TopicListView = memo(function TopicListView() {
   const selectionSource = useTopicSelectionSource();
   useRegisterSelectionSource('conversations', selectionSource);
   const { dialogs, requestDelete, requestRename } = useTopicActionDialogs();
-  const { notifyClose, notifyWillOpen } = useExclusiveSwipeable();
+  const { closeOpen, notifyClose, notifyWillOpen } = useExclusiveSwipeable();
+  useEffect(() => {
+    if (isEditing) {
+      closeOpen();
+    }
+  }, [closeOpen, isEditing]);
   // Bottom inset is stable across the edit⇄done flip (see useMessageListBottomInset),
   // so this style reference stays put and the list never reflows on toggle.
   const contentContainerStyle = useMemo(
@@ -240,12 +245,6 @@ const TopicRow = memo(function TopicRow({
     i18n.resolvedLanguage,
     t('topic.updatedAt.yesterday'),
   );
-
-  useEffect(() => {
-    if (isEditing) {
-      swipeableRef.current?.close();
-    }
-  }, [isEditing]);
 
   const handlePress = useCallback(() => {
     if (isEditing) {

--- a/src/frontend/hooks/__tests__/useExclusiveSwipeable.test.tsx
+++ b/src/frontend/hooks/__tests__/useExclusiveSwipeable.test.tsx
@@ -55,6 +55,16 @@ describe('useExclusiveSwipeable', () => {
     expect(row.close).not.toHaveBeenCalled();
   });
 
+  it('closes and forgets the tracked row on demand', () => {
+    const row = createSwipeable();
+
+    hook?.notifyWillOpen(row as never);
+    hook?.closeOpen();
+    hook?.notifyWillOpen(row as never);
+
+    expect(row.close).toHaveBeenCalledTimes(1);
+  });
+
   it('forgets a row once it reports closing, so a later open of it does not self-close', () => {
     const row = createSwipeable();
 

--- a/src/frontend/hooks/useExclusiveSwipeable.ts
+++ b/src/frontend/hooks/useExclusiveSwipeable.ts
@@ -8,6 +8,12 @@ import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSw
 export function useExclusiveSwipeable() {
   const openRef = useRef<SwipeableMethods | null>(null);
 
+  const closeOpen = useCallback(() => {
+    const open = openRef.current;
+    openRef.current = null;
+    open?.close();
+  }, []);
+
   const notifyWillOpen = useCallback((swipeable: SwipeableMethods) => {
     if (openRef.current && openRef.current !== swipeable) {
       openRef.current.close();
@@ -21,5 +27,5 @@ export function useExclusiveSwipeable() {
     }
   }, []);
 
-  return { notifyClose, notifyWillOpen };
+  return { closeOpen, notifyClose, notifyWillOpen };
 }


### PR DESCRIPTION
Removes the iOS messages screen's React-driven header inset and uses the nontransparent native header to prevent the cold-start content shift. Synchronizes recycled photo selection and the AI weekly pager before paint, with correct active-page initialization. Keeps assistant detail tabs visible and centralizes swipeable closing when entering selection mode. Validation: 23 targeted tests, TypeScript, ESLint, oxlint, formatting, simulator cold-entry recordings, and git diff checks.