### PR TITLE
refactor(bootstrap): split backend composition by ownership

### DIFF
--- a/src/backend/data/services/README.md
+++ b/src/backend/data/services/README.md
@@ -16,7 +16,7 @@ Mobile data services migrated from the desktop `src/main/data/services` director
 ## Runtime
 
 Services that are part of the mobile data layer are instantiated by
-`src/bootstrap/composition/createBackendServices.ts`. That concrete graph is private to bootstrap;
-resource operations are exposed directly through handlers in `src/backend/data/api`, while
-`src/bootstrap/composition/createBackend.ts` exposes only orchestration that qualifies for a
-frontend-visible `XxxModule` in `src/shared/contracts`.
+`src/bootstrap/composition/createDataServices.ts` and assembled by `createBackendServices.ts`.
+That concrete graph is private to bootstrap; resource operations are exposed directly through
+handlers in `src/backend/data/api`, while `src/bootstrap/composition/createBackend.ts` exposes only
+orchestration that qualifies for a frontend-visible `XxxModule` in `src/shared/contracts`.

--- a/src/bootstrap/composition/README.md
+++ b/src/bootstrap/composition/README.md
@@ -5,8 +5,11 @@ dependency interfaces. It is wiring code, not a service locator and not a home f
 
 ## Current Modules
 
-- `createBackendServices.ts` constructs the private desktop-aligned services plus mobile AI, MCP,
-  tool-resolver, and device-adapter dependencies.
+- `createDataServices.ts` constructs the private desktop-aligned persistence graph.
+- `createPlatformAdapters.ts` creates the device-permission and managed-file adapters.
+- `createAiServices.ts` constructs AI, MCP, web-search, and tool-resolution runtimes from narrow
+  data and platform dependencies.
+- `createBackendServices.ts` assembles those ownership modules into the private backend graph.
 - `createBackend.ts` creates the app-owned `ChatRuntime`, builds factory-shaped workflow modules,
   adapts the graph into the workflow-only `Backend` interface, and supplies the MCP mutation
   coordinator required by Data API handlers.

--- a/src/bootstrap/composition/__tests__/createBackendServices.test.ts
+++ b/src/bootstrap/composition/__tests__/createBackendServices.test.ts
@@ -1,0 +1,70 @@
+import type { CacheService } from '@/backend/data/CacheService';
+import type { DbService } from '@/backend/data/db/DbService';
+
+import { createBackendServices } from '../createBackendServices';
+
+const mockDataServices = {
+  aiUsageRecord: { kind: 'ai-usage-record' },
+  assistant: { kind: 'assistant' },
+  dataOnly: { kind: 'data-only' },
+  fileEntry: { kind: 'file-entry' },
+  mcpServer: { kind: 'mcp-server' },
+  model: { kind: 'model' },
+  preference: { kind: 'preference' },
+  provider: { kind: 'provider' },
+};
+const mockPlatformAdapters = {
+  devicePermissions: { kind: 'device-permissions' },
+  fileContent: { kind: 'file-content' },
+  platformOnly: { kind: 'platform-only' },
+};
+const mockAiServices = {
+  ai: { kind: 'ai' },
+  aiOnly: { kind: 'ai-only' },
+  mcpRuntime: { kind: 'mcp-runtime' },
+  tools: { kind: 'tools' },
+  webSearch: { kind: 'web-search' },
+};
+
+const mockCreateDataServices = jest.fn((_dependencies: unknown) => mockDataServices);
+const mockCreatePlatformAdapters = jest.fn((_dependencies: unknown) => mockPlatformAdapters);
+const mockCreateAiServices = jest.fn((_dependencies: unknown) => mockAiServices);
+
+jest.mock('../createDataServices', () => ({
+  createDataServices: (dependencies: unknown) => mockCreateDataServices(dependencies),
+}));
+jest.mock('../createPlatformAdapters', () => ({
+  createPlatformAdapters: (dependencies: unknown) => mockCreatePlatformAdapters(dependencies),
+}));
+jest.mock('../createAiServices', () => ({
+  createAiServices: (dependencies: unknown) => mockCreateAiServices(dependencies),
+}));
+
+describe('createBackendServices', () => {
+  test('assembles ownership modules through their narrow dependencies', () => {
+    const cache = { kind: 'cache' } as unknown as CacheService;
+    const dbService = { kind: 'database' } as unknown as DbService;
+
+    const services = createBackendServices(dbService, cache);
+
+    expect(mockCreateDataServices).toHaveBeenCalledWith({ cache, dbService });
+    expect(mockCreatePlatformAdapters).toHaveBeenCalledWith({
+      fileEntry: mockDataServices.fileEntry,
+    });
+    expect(mockCreateAiServices).toHaveBeenCalledWith({
+      aiUsageRecord: mockDataServices.aiUsageRecord,
+      assistant: mockDataServices.assistant,
+      devicePermissions: mockPlatformAdapters.devicePermissions,
+      fileContent: mockPlatformAdapters.fileContent,
+      mcpServer: mockDataServices.mcpServer,
+      model: mockDataServices.model,
+      preference: mockDataServices.preference,
+      provider: mockDataServices.provider,
+    });
+    expect(services).toEqual({
+      ...mockDataServices,
+      ...mockPlatformAdapters,
+      ...mockAiServices,
+    });
+  });
+});

--- a/src/bootstrap/composition/createAiServices.ts
+++ b/src/bootstrap/composition/createAiServices.ts
@@ -1,0 +1,40 @@
+import { AiService } from '@/backend/ai/AiService';
+import { McpRuntimeService } from '@/backend/ai/mcp';
+import { ToolResolver } from '@/backend/ai/tools';
+import { WebSearchService } from '@/backend/services/webSearch/WebSearchService';
+
+import type { DataServices } from './createDataServices';
+import type { PlatformAdapters } from './createPlatformAdapters';
+
+type AiServicesDependencies = Pick<
+  DataServices,
+  'aiUsageRecord' | 'assistant' | 'mcpServer' | 'model' | 'preference' | 'provider'
+> &
+  Pick<PlatformAdapters, 'devicePermissions' | 'fileContent'>;
+
+export function createAiServices(dependencies: AiServicesDependencies) {
+  const mcpRuntime = new McpRuntimeService({ mcpServer: dependencies.mcpServer });
+  const webSearch = new WebSearchService(dependencies.preference);
+  const toolResolver = new ToolResolver({
+    devicePermissions: dependencies.devicePermissions,
+    mcpRuntime,
+    preference: dependencies.preference,
+    webSearch,
+  });
+  const ai = new AiService({
+    assistant: dependencies.assistant,
+    aiUsageRecord: dependencies.aiUsageRecord,
+    fileContent: dependencies.fileContent,
+    model: dependencies.model,
+    preference: dependencies.preference,
+    provider: dependencies.provider,
+    tools: toolResolver,
+  });
+
+  return {
+    ai,
+    mcpRuntime,
+    tools: toolResolver,
+    webSearch,
+  };
+}

--- a/src/bootstrap/composition/createBackendServices.ts
+++ b/src/bootstrap/composition/createBackendServices.ts
@@ -1,143 +1,29 @@
-import type { FileEntryId } from '@cherrystudio/universal/data/types/file';
-
-import { AiService } from '@/backend/ai/AiService';
-import { McpRuntimeService } from '@/backend/ai/mcp';
-import { ToolResolver } from '@/backend/ai/tools';
 import type { CacheService } from '@/backend/data/CacheService';
 import type { DbService } from '@/backend/data/db/DbService';
-import { PreferenceService } from '@/backend/data/PreferenceService';
-import { AgentChannelService } from '@/backend/data/services/AgentChannelService';
-import { AgentGlobalSkillService } from '@/backend/data/services/AgentGlobalSkillService';
-import { AgentService } from '@/backend/data/services/AgentService';
-import { AgentSessionMessageService } from '@/backend/data/services/AgentSessionMessageService';
-import { AgentSessionService } from '@/backend/data/services/AgentSessionService';
-import { AgentTaskService } from '@/backend/data/services/AgentTaskService';
-import { AgentWorkspaceService } from '@/backend/data/services/AgentWorkspaceService';
-import { AiUsageRecordService } from '@/backend/data/services/AiUsageRecordService';
-import { AssistantService } from '@/backend/data/services/AssistantService';
-import { ContentSearchService } from '@/backend/data/services/ContentSearchService';
-import { EntitySearchService } from '@/backend/data/services/EntitySearchService';
-import { FileEntryService } from '@/backend/data/services/FileEntryService';
-import { FileRefService } from '@/backend/data/services/FileRefService';
-import { GroupService } from '@/backend/data/services/GroupService';
-import { JobService } from '@/backend/data/services/JobService';
-import { KnowledgeBaseService } from '@/backend/data/services/KnowledgeBaseService';
-import { KnowledgeItemService } from '@/backend/data/services/KnowledgeItemService';
-import { McpServerService } from '@/backend/data/services/McpServerService';
-import { MessageService } from '@/backend/data/services/MessageService';
-import { MiniAppService } from '@/backend/data/services/MiniAppService';
-import { ModelService } from '@/backend/data/services/ModelService';
-import { NoteService } from '@/backend/data/services/NoteService';
-import { PaintingService } from '@/backend/data/services/PaintingService';
-import { PinService } from '@/backend/data/services/PinService';
-import { PromptService } from '@/backend/data/services/PromptService';
-import { ProviderService } from '@/backend/data/services/ProviderService';
-import { TagService } from '@/backend/data/services/TagService';
-import { TemporaryChatService } from '@/backend/data/services/TemporaryChatService';
-import { TopicService } from '@/backend/data/services/TopicService';
-import { TranslateHistoryService } from '@/backend/data/services/TranslateHistoryService';
-import { TranslateLanguageService } from '@/backend/data/services/TranslateLanguageService';
-import { resolveFileEntry, resolveRenderableFileUri } from '@/backend/services/file/fileStorage';
-import { DevicePermissions } from '@/backend/services/permissions';
-import { WebSearchService } from '@/backend/services/webSearch/WebSearchService';
+
+import { createAiServices } from './createAiServices';
+import { createDataServices } from './createDataServices';
+import { createPlatformAdapters } from './createPlatformAdapters';
 
 export type BackendServices = ReturnType<typeof createBackendServices>;
 
 export function createBackendServices(dbService: DbService, cache: CacheService) {
-  const preference = new PreferenceService(dbService);
-  const aiUsageRecord = new AiUsageRecordService(dbService);
-  const devicePermissions = new DevicePermissions();
-  const pin = new PinService(dbService);
-  const provider = new ProviderService(dbService, pin, cache);
-  const model = new ModelService(dbService, preference, pin);
-  const tag = new TagService(dbService);
-  const group = new GroupService(dbService);
-  const job = new JobService(dbService);
-  const agentWorkspace = new AgentWorkspaceService(dbService);
-  const agentSession = new AgentSessionService(dbService, agentWorkspace, pin);
-  const agentSessionMessage = new AgentSessionMessageService(dbService);
-  const agentChannel = new AgentChannelService(dbService);
-  const agentGlobalSkill = new AgentGlobalSkillService(dbService);
-  const agentTask = new AgentTaskService(dbService, agentChannel, job);
-  const agent = new AgentService(dbService, agentSession, pin);
-  const knowledgeBase = new KnowledgeBaseService(dbService, group);
-  const knowledgeItem = new KnowledgeItemService(dbService, knowledgeBase);
-  const miniApp = new MiniAppService(dbService);
-  const note = new NoteService(dbService);
-  const prompt = new PromptService(dbService);
-  const translateHistory = new TranslateHistoryService(dbService);
-  const translateLanguage = new TranslateLanguageService(dbService);
-  const fileEntry = new FileEntryService(dbService);
-  const fileContent = {
-    resolve: (id: FileEntryId) => resolveFileEntry(fileEntry, id),
-    resolveRenderableUri: (id: FileEntryId) => resolveRenderableFileUri(fileEntry, id),
-  };
-  const fileRef = new FileRefService(dbService);
-  const painting = new PaintingService(dbService);
-  const mcpServer = new McpServerService(dbService);
-  const mcpRuntime = new McpRuntimeService({ mcpServer });
-  const topic = new TopicService(dbService, pin, tag);
-  const assistant = new AssistantService(dbService, group, topic, model, preference, tag, pin);
-  const message = new MessageService(dbService, topic);
-  const contentSearch = new ContentSearchService(dbService);
-  const entitySearch = new EntitySearchService(dbService);
-  const temporaryChat = new TemporaryChatService(dbService, aiUsageRecord);
-  const webSearch = new WebSearchService(preference);
-  const toolResolver = new ToolResolver({
-    devicePermissions,
-    mcpRuntime,
-    preference,
-    webSearch,
-  });
-  const ai = new AiService({
-    assistant,
-    aiUsageRecord,
-    fileContent,
-    model,
-    preference,
-    provider,
-    tools: toolResolver,
+  const dataServices = createDataServices({ cache, dbService });
+  const platformAdapters = createPlatformAdapters({ fileEntry: dataServices.fileEntry });
+  const aiServices = createAiServices({
+    aiUsageRecord: dataServices.aiUsageRecord,
+    assistant: dataServices.assistant,
+    devicePermissions: platformAdapters.devicePermissions,
+    fileContent: platformAdapters.fileContent,
+    mcpServer: dataServices.mcpServer,
+    model: dataServices.model,
+    preference: dataServices.preference,
+    provider: dataServices.provider,
   });
 
   return {
-    agent,
-    agentChannel,
-    agentGlobalSkill,
-    agentSession,
-    agentSessionMessage,
-    agentTask,
-    agentWorkspace,
-    ai,
-    aiUsageRecord,
-    assistant,
-    cache,
-    contentSearch,
-    devicePermissions,
-    entitySearch,
-    fileContent,
-    fileEntry,
-    fileRef,
-    group,
-    job,
-    knowledgeBase,
-    knowledgeItem,
-    mcpRuntime,
-    mcpServer,
-    message,
-    miniApp,
-    model,
-    note,
-    painting,
-    pin,
-    preference,
-    prompt,
-    provider,
-    tag,
-    temporaryChat,
-    topic,
-    tools: toolResolver,
-    translateHistory,
-    translateLanguage,
-    webSearch,
+    ...dataServices,
+    ...platformAdapters,
+    ...aiServices,
   };
 }

--- a/src/bootstrap/composition/createDataServices.ts
+++ b/src/bootstrap/composition/createDataServices.ts
@@ -1,0 +1,113 @@
+import type { CacheService } from '@/backend/data/CacheService';
+import type { DbService } from '@/backend/data/db/DbService';
+import { PreferenceService } from '@/backend/data/PreferenceService';
+import { AgentChannelService } from '@/backend/data/services/AgentChannelService';
+import { AgentGlobalSkillService } from '@/backend/data/services/AgentGlobalSkillService';
+import { AgentService } from '@/backend/data/services/AgentService';
+import { AgentSessionMessageService } from '@/backend/data/services/AgentSessionMessageService';
+import { AgentSessionService } from '@/backend/data/services/AgentSessionService';
+import { AgentTaskService } from '@/backend/data/services/AgentTaskService';
+import { AgentWorkspaceService } from '@/backend/data/services/AgentWorkspaceService';
+import { AiUsageRecordService } from '@/backend/data/services/AiUsageRecordService';
+import { AssistantService } from '@/backend/data/services/AssistantService';
+import { ContentSearchService } from '@/backend/data/services/ContentSearchService';
+import { EntitySearchService } from '@/backend/data/services/EntitySearchService';
+import { FileEntryService } from '@/backend/data/services/FileEntryService';
+import { FileRefService } from '@/backend/data/services/FileRefService';
+import { GroupService } from '@/backend/data/services/GroupService';
+import { JobService } from '@/backend/data/services/JobService';
+import { KnowledgeBaseService } from '@/backend/data/services/KnowledgeBaseService';
+import { KnowledgeItemService } from '@/backend/data/services/KnowledgeItemService';
+import { McpServerService } from '@/backend/data/services/McpServerService';
+import { MessageService } from '@/backend/data/services/MessageService';
+import { MiniAppService } from '@/backend/data/services/MiniAppService';
+import { ModelService } from '@/backend/data/services/ModelService';
+import { NoteService } from '@/backend/data/services/NoteService';
+import { PaintingService } from '@/backend/data/services/PaintingService';
+import { PinService } from '@/backend/data/services/PinService';
+import { PromptService } from '@/backend/data/services/PromptService';
+import { ProviderService } from '@/backend/data/services/ProviderService';
+import { TagService } from '@/backend/data/services/TagService';
+import { TemporaryChatService } from '@/backend/data/services/TemporaryChatService';
+import { TopicService } from '@/backend/data/services/TopicService';
+import { TranslateHistoryService } from '@/backend/data/services/TranslateHistoryService';
+import { TranslateLanguageService } from '@/backend/data/services/TranslateLanguageService';
+
+export type DataServices = ReturnType<typeof createDataServices>;
+
+export function createDataServices({
+  cache,
+  dbService,
+}: {
+  cache: CacheService;
+  dbService: DbService;
+}) {
+  const preference = new PreferenceService(dbService);
+  const aiUsageRecord = new AiUsageRecordService(dbService);
+  const pin = new PinService(dbService);
+  const provider = new ProviderService(dbService, pin, cache);
+  const model = new ModelService(dbService, preference, pin);
+  const tag = new TagService(dbService);
+  const group = new GroupService(dbService);
+  const job = new JobService(dbService);
+  const agentWorkspace = new AgentWorkspaceService(dbService);
+  const agentSession = new AgentSessionService(dbService, agentWorkspace, pin);
+  const agentSessionMessage = new AgentSessionMessageService(dbService);
+  const agentChannel = new AgentChannelService(dbService);
+  const agentGlobalSkill = new AgentGlobalSkillService(dbService);
+  const agentTask = new AgentTaskService(dbService, agentChannel, job);
+  const agent = new AgentService(dbService, agentSession, pin);
+  const knowledgeBase = new KnowledgeBaseService(dbService, group);
+  const knowledgeItem = new KnowledgeItemService(dbService, knowledgeBase);
+  const miniApp = new MiniAppService(dbService);
+  const note = new NoteService(dbService);
+  const prompt = new PromptService(dbService);
+  const translateHistory = new TranslateHistoryService(dbService);
+  const translateLanguage = new TranslateLanguageService(dbService);
+  const fileEntry = new FileEntryService(dbService);
+  const fileRef = new FileRefService(dbService);
+  const painting = new PaintingService(dbService);
+  const mcpServer = new McpServerService(dbService);
+  const topic = new TopicService(dbService, pin, tag);
+  const assistant = new AssistantService(dbService, group, topic, model, preference, tag, pin);
+  const message = new MessageService(dbService, topic);
+  const contentSearch = new ContentSearchService(dbService);
+  const entitySearch = new EntitySearchService(dbService);
+  const temporaryChat = new TemporaryChatService(dbService, aiUsageRecord);
+
+  return {
+    agent,
+    agentChannel,
+    agentGlobalSkill,
+    agentSession,
+    agentSessionMessage,
+    agentTask,
+    agentWorkspace,
+    aiUsageRecord,
+    assistant,
+    cache,
+    contentSearch,
+    entitySearch,
+    fileEntry,
+    fileRef,
+    group,
+    job,
+    knowledgeBase,
+    knowledgeItem,
+    mcpServer,
+    message,
+    miniApp,
+    model,
+    note,
+    painting,
+    pin,
+    preference,
+    prompt,
+    provider,
+    tag,
+    temporaryChat,
+    topic,
+    translateHistory,
+    translateLanguage,
+  };
+}

--- a/src/bootstrap/composition/createPlatformAdapters.ts
+++ b/src/bootstrap/composition/createPlatformAdapters.ts
@@ -1,0 +1,17 @@
+import type { FileEntryId } from '@cherrystudio/universal/data/types/file';
+
+import type { FileEntryService } from '@/backend/data/services/FileEntryService';
+import { resolveFileEntry, resolveRenderableFileUri } from '@/backend/services/file/fileStorage';
+import { DevicePermissions } from '@/backend/services/permissions';
+
+export type PlatformAdapters = ReturnType<typeof createPlatformAdapters>;
+
+export function createPlatformAdapters({ fileEntry }: { fileEntry: FileEntryService }) {
+  return {
+    devicePermissions: new DevicePermissions(),
+    fileContent: {
+      resolve: (id: FileEntryId) => resolveFileEntry(fileEntry, id),
+      resolveRenderableUri: (id: FileEntryId) => resolveRenderableFileUri(fileEntry, id),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Split backend construction into data, platform-adapter, and AI ownership modules while preserving the existing `BackendServices` interface.
- Keep the aggregate composition root limited to narrow dependency wiring and document the resulting ownership seams.
- Add focused wiring coverage for the ownership factories.

## Validation

`pnpm typecheck`, full app and package tests, lint, format check, and documentation link checks pass.