### PR TITLE
fix(chat-scroll): prevent streamed reply drag races

### DIFF
--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -40,6 +40,7 @@ type ChatInputProps = {
    * the binding and this is ignored.
    */
   assistantId?: string;
+  dismissKeyboardOnSend?: boolean;
   topicId?: string;
 };
 
@@ -52,7 +53,7 @@ type PendingWebSearchState = {
 // 诊断埋点：量化输入框「真实 model 名」解析耗时（pref 段 + model DB 段）。`[PERF]` 前缀。
 const perfLog = loggerService.withContext('ChatPerf');
 
-export function ChatInput({ assistantId, topicId }: ChatInputProps) {
+export function ChatInput({ assistantId, dismissKeyboardOnSend, topicId }: ChatInputProps) {
   const modelSettings = useModelSettingSelections();
   usePrefetchModelPickerData();
   const rawDefaultModel = modelSettings.selections.default;
@@ -274,6 +275,7 @@ export function ChatInput({ assistantId, topicId }: ChatInputProps) {
   return (
     <>
       <ChatInputSurface
+        dismissKeyboardOnSend={dismissKeyboardOnSend}
         isSendEnabled
         isStreaming={chatTopic.isBusy}
         modelIcon={selectedModelIcon}

--- a/src/frontend/features/chat/input/components/ChatInputPrimaryActionButton.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputPrimaryActionButton.tsx
@@ -3,11 +3,7 @@ import { ArrowUpIcon, SquareIcon } from 'lucide-uniwind/png';
 import { useTranslation } from 'react-i18next';
 import { Pressable } from 'react-native';
 
-import {
-  useChatInputActions,
-  useChatInputMeta,
-  useChatInputState,
-} from '../context/ChatInputProvider';
+import { useChatInputMeta, useChatInputState } from '../context/ChatInputProvider';
 import { hasChatInputSendableContent } from '../utils/chatInputAttachments';
 
 const buttonSize = 32;
@@ -28,7 +24,6 @@ export function ChatInputPrimaryActionButton({
   onStopPress,
 }: ChatInputPrimaryActionButtonProps) {
   const { t } = useTranslation();
-  const { setInputFocused } = useChatInputActions();
   const { inputRef } = useChatInputMeta();
   const { attachments, draft } = useChatInputState();
   const trimmedDraft = draft.trim();
@@ -49,7 +44,6 @@ export function ChatInputPrimaryActionButton({
     }
 
     if (shouldShowSend) {
-      setInputFocused(false);
       await onSendPress(trimmedDraft);
       return;
     }

--- a/src/frontend/features/chat/input/components/ChatInputSurface.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputSurface.tsx
@@ -54,6 +54,7 @@ const logger = loggerService.withContext('ChatInputSurface');
 
 type ChatInputSurfaceProps = {
   allowEmptySend?: boolean;
+  dismissKeyboardOnSend?: boolean;
   getSendErrorLabel?: (error: unknown) => string | undefined;
   isSendEnabled: boolean;
   isStreaming: boolean;
@@ -81,6 +82,7 @@ export type ChatInputSendPayload = {
 
 export function ChatInputSurface({
   allowEmptySend = false,
+  dismissKeyboardOnSend = true,
   getSendErrorLabel,
   isSendEnabled,
   isStreaming,
@@ -182,27 +184,12 @@ export function ChatInputSurface({
       const draftSnapshot = draft;
       const attachmentSnapshot = [...attachments];
 
-      // 无动画瞬时收起键盘，再插入消息 + 钉顶。两个要点：
-      // 1) `animated: false`——键盘/composer 在一帧内落定，dismiss() 的 Promise 几乎立刻
-      //    resolve（keyboardDidHide 无动画即触发），因此不会像旧代码 `await` 带动画 dismiss
-      //    那样先干等 ~250ms 键盘滑落（那是「pin 前卡卡的」两段式时序的成因）。
-      // 2) `await` 它、再 onSendPress——键盘收起与插入+钉顶**串行**，插入/钉顶落在已稳定的
-      //    满视口上。若不 await（键盘带动画滑落时并发插入+钉顶），键盘 inset 动画、
-      //    anchoredEndSpace 空白重算、pin scrollToEnd、MVCP 会在同 ~100ms 内互相打架，
-      //    底部内容来回弹（实测 cBot 2378→2226→2330→2226）——正是「发送到 pin 中间布局跳动」。
-      //    先让视口一次到位，转场只剩一次确定性钉顶，无并发、无弹跳。
-      setInputFocused(false);
       setDraft('');
       clearAttachments();
-      // 瞬时收起键盘且**不阻塞**消息插入。要点：
-      // - 不 `await`：dismiss() 的 Promise 要等 keyboardDidHide 原生事件（实测 ~429ms），
-      //   若 await 它再 onSendPress，会把消息插入白白拖后 ~429ms（＝「点发送过好久消息才出来」）。
-      //   改为不 await 后，从点发送到消息出现只剩 DB 写入等真实开销（实测暖态 ~76ms）。
-      // - `animated: false` + 不 `blur()`：blur() 会触发一段带动画的键盘隐藏；改用无动画 dismiss
-      //   让键盘一帧瞬时消失、先于随后到来的钉顶滚动，二者不重叠 → 无「发送到 pin 中间布局跳动」
-      //   （旧的并发带动画版实测 cBot 来回弹 2378→2226→2330→2226；此版转场为单帧一步到位）。
-      // - 键盘仍会收起（keepFocus 默认 false，dismiss 会 resign first responder），对齐 v0/ChatGPT。
-      void KeyboardController.dismiss({ animated: false });
+      if (dismissKeyboardOnSend) {
+        setInputFocused(false);
+        void KeyboardController.dismiss({ animated: false });
+      }
 
       try {
         await onSendPress({ attachments: attachmentSnapshot, text });
@@ -221,6 +208,7 @@ export function ChatInputSurface({
     [
       attachments,
       clearAttachments,
+      dismissKeyboardOnSend,
       draft,
       getSendErrorLabel,
       onSendPress,

--- a/src/frontend/features/chat/input/components/__tests__/ChatInputSurface.test.tsx
+++ b/src/frontend/features/chat/input/components/__tests__/ChatInputSurface.test.tsx
@@ -171,7 +171,7 @@ jest.mock('../../hooks/useChatInputPhotoPicker', () => ({
 
 describe('ChatInputSurface', () => {
   beforeEach(() => {
-    mockToastShow.mockReset();
+    jest.clearAllMocks();
   });
 
   test('restores draft and attachments and shows a toast when send rejects', async () => {
@@ -267,6 +267,65 @@ describe('ChatInputSurface', () => {
       label: 'painting.input.invalidCustomSize',
       variant: 'danger',
     });
+  });
+
+  test('dismisses the keyboard immediately by default when sending', async () => {
+    const onSendPress = jest.fn(async () => undefined);
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(async () => {
+      renderer = create(
+        <ChatInputProvider>
+          <SeedChatInputState attachments={[]} draft="hello" />
+          <ChatInputSurface
+            isSendEnabled
+            isStreaming={false}
+            modelLabel="Model"
+            onModelPickerPress={jest.fn()}
+            onSendPress={onSendPress}
+            onStopPress={jest.fn()}
+          />
+        </ChatInputProvider>,
+      );
+    });
+
+    const sendButton = renderer?.root.findByProps({
+      accessibilityLabel: 'chat.input.action.sendMessage',
+    });
+    await act(async () => sendButton?.props.onPress());
+
+    expect(KeyboardController.dismiss).toHaveBeenCalledWith({ animated: false });
+    expect(onSendPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('can delegate send-time keyboard dismissal to the message list', async () => {
+    const onSendPress = jest.fn(async () => undefined);
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(async () => {
+      renderer = create(
+        <ChatInputProvider>
+          <SeedChatInputState attachments={[]} draft="hello" />
+          <ChatInputSurface
+            dismissKeyboardOnSend={false}
+            isSendEnabled
+            isStreaming={false}
+            modelLabel="Model"
+            onModelPickerPress={jest.fn()}
+            onSendPress={onSendPress}
+            onStopPress={jest.fn()}
+          />
+        </ChatInputProvider>,
+      );
+    });
+
+    const sendButton = renderer?.root.findByProps({
+      accessibilityLabel: 'chat.input.action.sendMessage',
+    });
+    await act(async () => sendButton?.props.onPress());
+
+    expect(KeyboardController.dismiss).not.toHaveBeenCalled();
+    expect(onSendPress).toHaveBeenCalledTimes(1);
   });
 
   test('keeps a persistent placeholder action button that does not send without content', async () => {

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -1,9 +1,11 @@
 import type { Message } from '@cherrystudio/universal/data/types/message';
+import { useKeyboardChatComposerInset } from '@legendapp/list/keyboard';
 import type { LegendListRef } from '@legendapp/list/react-native';
 import { useHeaderHeight } from 'expo-router/react-navigation';
 import { useToast } from 'heroui-native/toast';
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { View } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
 
 import type { MessagesViewModel } from '@/frontend/hooks/chat';
@@ -53,6 +55,7 @@ export function ChatWorkspace({ messageWindow, renderGateKey, topicId }: ChatWor
   const { t } = useTranslation();
   const { toast } = useToast();
   const listRef = useRef<LegendListRef | null>(null);
+  const composerRef = useRef<View | null>(null);
   const isAtBottom = useSharedValue(true);
   const handleScrollToEnd = useCallback(() => {
     void listRef.current?.scrollToEnd({ animated: true });
@@ -85,8 +88,12 @@ export function ChatWorkspace({ messageWindow, renderGateKey, topicId }: ChatWor
     requiresInitialHistoryLayout,
   });
   const contentTopInset = isIOS ? headerHeight : 0;
-  const { contentBottomInset, handleInputHeightChange, inputHeightShared } =
+  const { contentBottomInset, handleInputHeightChange, inputHeightShared, keyboardOffset } =
     useFloatingChatInputLayout();
+  const { contentInsetEndAdjustment, onComposerLayout } = useKeyboardChatComposerInset(
+    listRef,
+    composerRef,
+  );
 
   // 冷/暖进入差异取证：记录 数据加载态 + 遮罩可见性 + 可见消息数 + 锚点 的每次变化。
   useEffect(() => {
@@ -107,16 +114,25 @@ export function ChatWorkspace({ messageWindow, renderGateKey, topicId }: ChatWor
           key={listRenderKey}
           anchorIndex={anchorIndex}
           contentBottomInset={contentBottomInset}
+          contentInsetEndAdjustment={contentInsetEndAdjustment}
           contentTopInset={contentTopInset}
           isAtBottom={isAtBottom}
+          keyboardOffset={keyboardOffset}
           listRef={listRef}
           messages={visibleMessages}
           onLoadOlder={loadOlder}
           onPrefetchOlder={messageWindow.prefetchOlder}
           onReady={markListLoaded}
+          pendingUserMessageId={chatTopic.pendingUserMessage?.id}
         />
       </MessageSlideInProvider>
-      <ChatComposer onHeightChange={handleInputHeightChange} topicId={topicId} />
+      <ChatComposer
+        composerRef={composerRef}
+        dismissKeyboardOnSend={false}
+        onComposerLayout={onComposerLayout}
+        onHeightChange={handleInputHeightChange}
+        topicId={topicId}
+      />
       <ScrollToBottomButton
         gap={SCROLL_BUTTON_GAP_ABOVE_INPUT}
         inputHeight={inputHeightShared}

--- a/src/frontend/features/chat/workspace/components/ChatComposer.tsx
+++ b/src/frontend/features/chat/workspace/components/ChatComposer.tsx
@@ -1,10 +1,16 @@
+import type { RefObject } from 'react';
+import type { LayoutChangeEvent, View } from 'react-native';
+
 import { ChatInputProvider } from '../../input/context/ChatInputProvider';
 import { FloatingChatInput } from './FloatingChatInput';
 
 type ChatComposerProps = {
   /** Assistant to bind a newly created topic to; ignored once `topicId` exists. */
   assistantId?: string;
+  composerRef?: RefObject<View | null>;
+  dismissKeyboardOnSend?: boolean;
   onHeightChange: (height: number) => void;
+  onComposerLayout?: (event: LayoutChangeEvent) => void;
   topicId?: string;
 };
 
@@ -14,11 +20,21 @@ type ChatComposerProps = {
  * The reasoning-effort control lives inside the model picker sheet
  * (ChatInputReasoningSection), not as a separate floating panel.
  */
-export function ChatComposer({ assistantId, onHeightChange, topicId }: ChatComposerProps) {
+export function ChatComposer({
+  assistantId,
+  composerRef,
+  dismissKeyboardOnSend,
+  onHeightChange,
+  onComposerLayout,
+  topicId,
+}: ChatComposerProps) {
   return (
     <ChatInputProvider>
       <FloatingChatInput
         assistantId={assistantId}
+        composerRef={composerRef}
+        dismissKeyboardOnSend={dismissKeyboardOnSend}
+        onComposerLayout={onComposerLayout}
         onHeightChange={onHeightChange}
         topicId={topicId}
       />

--- a/src/frontend/features/chat/workspace/components/ChatMessageList.tsx
+++ b/src/frontend/features/chat/workspace/components/ChatMessageList.tsx
@@ -1,5 +1,5 @@
 import type { Message } from '@cherrystudio/universal/data/types/message';
-import { KeyboardAwareLegendList } from '@legendapp/list/keyboard';
+import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list/keyboard';
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { ScrollShadow } from 'heroui-native/scroll-shadow';
 import {
@@ -7,6 +7,7 @@ import {
   useCallback,
   useEffect,
   useEffectEvent,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -15,13 +16,17 @@ import {
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
+  Platform,
   View,
 } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 
 import { LinearGradient } from '@/frontend/components/nativePrimitives';
+import { usePreference } from '@/frontend/data/hooks';
+import { resolveTypographyScale } from '@/frontend/utils/typographyScale';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 
+import { chatInputMessageListGap } from '../../input/chatInputLayout';
 import { AssistantMessageItem, UserMessageItem } from '../../messageItem';
 import { getMessageListScrollSignal } from '../utils/messageListScrollSignals';
 
@@ -32,6 +37,8 @@ const scrollLog = loggerService.withContext('ChatScroll');
 
 // 被锚定的用户消息距内容区顶部（顶部安全区/导航栏之下）的视觉间距。
 const ANCHOR_TOP_GAP = 12;
+const ANCHOR_MAX_TEXT_LINES = 2;
+const USER_MESSAGE_VERTICAL_PADDING = 32;
 // 撤遮罩（onReady）前要求内容高度保持「静默」的窗口：这段时间内没有任何 contentSize 变化才判定
 // settle 完成。用于覆盖**冷 markdown 解析**——首次进入 topic 时 streamdown/代码/数学的 tokenize
 // 与 layout 全冷、耗时最长，行的真实高度可能在初始 rAF 之后才测出。若此时已 reportReady 撤遮罩，
@@ -54,16 +61,43 @@ const MAINTAIN_VISIBLE_CONTENT_POSITION = {
   shouldRestorePosition: shouldRestoreMessagePosition,
 };
 
+const MESSAGE_LIST_CONTENT_CONTAINER_STYLE = {
+  paddingBottom: chatInputMessageListGap,
+  paddingTop: 12,
+};
+const TAIL_FOLLOW_END_THRESHOLD = 20;
+
+type TailFollowPhase = 'anchoring' | 'following' | 'paused';
+
+type TailFollowState = {
+  anchorMessageId: string | undefined;
+  phase: TailFollowPhase;
+};
+
+function createTailFollowState(anchorMessageId: string | undefined): TailFollowState {
+  return { anchorMessageId, phase: 'anchoring' };
+}
+
+function resolveTailFollowState(
+  state: TailFollowState,
+  anchorMessageId: string | undefined,
+): TailFollowState {
+  return state.anchorMessageId === anchorMessageId ? state : createTailFollowState(anchorMessageId);
+}
+
 type ChatMessageListProps = {
   anchorIndex: number;
   contentBottomInset: number;
+  contentInsetEndAdjustment: SharedValue<number>;
   contentTopInset: number;
   isAtBottom: SharedValue<boolean>;
+  keyboardOffset: number;
   listRef: RefObject<LegendListRef | null>;
   messages: readonly Message[];
   onLoadOlder: () => Promise<void>;
   onPrefetchOlder: () => void;
   onReady?: () => void;
+  pendingUserMessageId?: string;
 };
 
 function renderMessageItem({ item }: LegendListRenderItemProps<Message>) {
@@ -90,14 +124,18 @@ function getMessageItemType(item: Message) {
 export function ChatMessageList({
   anchorIndex,
   contentBottomInset,
+  contentInsetEndAdjustment,
   contentTopInset,
   isAtBottom,
+  keyboardOffset,
   listRef,
   messages,
   onLoadOlder,
   onPrefetchOlder,
   onReady,
+  pendingUserMessageId,
 }: ChatMessageListProps) {
+  const [fontSizeStep] = usePreference('ui.font_size_step');
   const [contentBaseHeight, setContentBaseHeight] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
   const didReportReadyRef = useRef(false);
@@ -105,6 +143,12 @@ export function ChatMessageList({
   const pendingReadyFrameRef = useRef<number | null>(null);
   const pendingReadySettleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const readyGenerationRef = useRef(0);
+  const pendingTailFollowFrameRef = useRef<number | null>(null);
+  const pendingInteractionEndFrameRef = useRef<number | null>(null);
+  const isTouchingListRef = useRef(false);
+  const isDraggingListRef = useRef(false);
+  const isMomentumScrollingRef = useRef(false);
+  const isUserInteractingRef = useRef(false);
   const lastMessageId = messages[messages.length - 1]?.id;
   const listHeader = useMemo(() => <View style={{ height: contentTopInset }} />, [contentTopInset]);
   const handleStartReached = useCallback(() => {
@@ -112,23 +156,117 @@ export function ChatMessageList({
     void onLoadOlder();
   }, [onLoadOlder]);
   const hasAnchor = anchorIndex >= 0;
+  const anchorMessage = hasAnchor ? messages[anchorIndex] : undefined;
+  const anchorMessageId = anchorMessage?.id;
+  const [tailFollowState, setTailFollowState] = useState<TailFollowState>(() =>
+    createTailFollowState(anchorMessageId),
+  );
+  const tailFollowPhase = resolveTailFollowState(tailFollowState, anchorMessageId).phase;
+  const tailFollowPhaseRef = useRef(tailFollowPhase);
+  const isFollowing = tailFollowPhase === 'following';
+  const anchorHasFile = anchorMessage?.data.parts?.some((part) => part.type === 'file') ?? false;
+  const anchorMaxSize = anchorHasFile
+    ? undefined
+    : ANCHOR_MAX_TEXT_LINES * resolveTypographyScale(fontSizeStep).base.lineHeight +
+      USER_MESSAGE_VERTICAL_PADDING;
+  const { freeze, scrollMessageToEnd } = useKeyboardScrollToEnd({ listRef });
   // 被锚定用户消息的固定落点：距内容区顶部（导航栏/安全区之下）ANCHOR_TOP_GAP。
   // anchoredEndSpace 与钉顶滚动共用同一偏移，保证「预留空白算出的位置」和「滚动落点」一致。
   const anchorOffset = contentTopInset + ANCHOR_TOP_GAP;
-  const visibleHeightAboveInput = Math.max(0, viewportHeight - contentBottomInset);
-  // 锚定期间内容区始终视为「已撑满」，恒为浮动输入框预留底部空间。
-  const bottomPadding =
-    hasAnchor || (viewportHeight > 0 && contentBaseHeight > visibleHeightAboveInput)
-      ? contentBottomInset
-      : 0;
 
-  const contentContainerStyle = useMemo(
-    () => ({
-      paddingBottom: bottomPadding,
-      paddingTop: 12,
-    }),
-    [bottomPadding],
-  );
+  useLayoutEffect(() => {
+    tailFollowPhaseRef.current = tailFollowPhase;
+  }, [tailFollowPhase]);
+
+  // LegendList 的 maintainScrollAtEnd 会在 rAF 中捕获旧配置，拖动已暂停后仍可能执行一次。
+  // 在应用层合并 follow 请求，并在直接派发给原生 ScrollView 前重新检查同步交互锁。
+  const cancelPendingTailFollow = useCallback(() => {
+    if (pendingTailFollowFrameRef.current !== null) {
+      cancelAnimationFrame(pendingTailFollowFrameRef.current);
+      pendingTailFollowFrameRef.current = null;
+    }
+  }, []);
+
+  const scheduleTailFollow = useCallback(() => {
+    if (
+      tailFollowPhaseRef.current !== 'following' ||
+      isUserInteractingRef.current ||
+      pendingTailFollowFrameRef.current !== null
+    ) {
+      return;
+    }
+
+    pendingTailFollowFrameRef.current = requestAnimationFrame(() => {
+      pendingTailFollowFrameRef.current = null;
+
+      if (tailFollowPhaseRef.current !== 'following' || isUserInteractingRef.current) {
+        return;
+      }
+
+      const nativeScrollRef = listRef.current?.getNativeScrollRef() as
+        | { scrollToEnd?: (options: { animated?: boolean }) => void }
+        | null
+        | undefined;
+      nativeScrollRef?.scrollToEnd?.({ animated: false });
+    });
+  }, [listRef]);
+
+  const isListAtEnd = useCallback(() => {
+    const listState = listRef.current?.getState();
+    if (!listState || listState.scrollLength <= 0) {
+      return false;
+    }
+
+    const distanceFromEnd = listState.contentLength - listState.scrollLength - listState.scroll;
+    return Number.isFinite(distanceFromEnd) && distanceFromEnd <= TAIL_FOLLOW_END_THRESHOLD;
+  }, [listRef]);
+
+  const resumeTailFollowAtEnd = useCallback(() => {
+    if (!anchorMessageId || tailFollowPhaseRef.current !== 'paused' || !isListAtEnd()) {
+      return;
+    }
+
+    tailFollowPhaseRef.current = 'following';
+    setTailFollowState((previous) => {
+      const current = resolveTailFollowState(previous, anchorMessageId);
+      return current.phase === 'paused' ? { ...current, phase: 'following' } : current;
+    });
+    scheduleTailFollow();
+  }, [anchorMessageId, isListAtEnd, scheduleTailFollow]);
+
+  const cancelPendingInteractionEnd = useCallback(() => {
+    if (pendingInteractionEndFrameRef.current !== null) {
+      cancelAnimationFrame(pendingInteractionEndFrameRef.current);
+      pendingInteractionEndFrameRef.current = null;
+    }
+  }, []);
+
+  const finishUserInteraction = useCallback(() => {
+    if (isTouchingListRef.current || isDraggingListRef.current || isMomentumScrollingRef.current) {
+      return;
+    }
+
+    isUserInteractingRef.current = false;
+    if (tailFollowPhaseRef.current === 'paused') {
+      resumeTailFollowAtEnd();
+    } else {
+      scheduleTailFollow();
+    }
+  }, [resumeTailFollowAtEnd, scheduleTailFollow]);
+
+  const scheduleInteractionEnd = useCallback(() => {
+    cancelPendingInteractionEnd();
+    pendingInteractionEndFrameRef.current = requestAnimationFrame(() => {
+      pendingInteractionEndFrameRef.current = null;
+      finishUserInteraction();
+    });
+  }, [cancelPendingInteractionEnd, finishUserInteraction]);
+
+  const beginUserInteraction = useCallback(() => {
+    isUserInteractingRef.current = true;
+    cancelPendingInteractionEnd();
+    cancelPendingTailFollow();
+  }, [cancelPendingInteractionEnd, cancelPendingTailFollow]);
 
   // 把刚发送的用户消息锚定到内容区顶部，并在其下方补足空白，让助手回复流式生长其间。
   //
@@ -136,10 +274,7 @@ export function ChatMessageList({
   // （含刚 mount 的助手 pending 占位、hasUnknownTailSize=false）后，才把预留空白算成真实值
   // 并回调 onReady。此刻落点已是终值。
   //
-  // 关键：这里用 `animated: false` 瞬时定位，**不是**动画滚动。对齐 v0 iOS 的做法——
-  // 动画滚动（animated:true）会在 ~300ms 内追一个「还在异步收敛」的目标（estimatedItemSize
-  // 300→真实、空白 0→真实都在动画途中阶跃），滚动一路纠偏 = pin 前的抖动。改成测量就绪后
-  // 一次性瞬定，消息直接落到顶部、无追逐、无过冲；入场的柔和感交给气泡自身的 fade。
+  // 首轮瞬时定位，后续实时发送在权威尺寸就绪后动画钉顶；历史恢复仍瞬时定位。
   const scrolledAnchorKeyRef = useRef<string | undefined>(undefined);
   const handleAnchorReady = useCallback(
     (info: { anchorKey: string | undefined }) => {
@@ -153,39 +288,128 @@ export function ChatMessageList({
         anchorKey: info.anchorKey,
         t: Date.now(),
       });
+      const isPendingUserMessage = info.anchorKey === pendingUserMessageId;
+      const shouldAnimate = isPendingUserMessage && anchorIndex > 0;
       requestAnimationFrame(() => {
-        void listRef.current?.scrollToEnd({ animated: false });
+        void scrollMessageToEnd({
+          animated: shouldAnimate,
+          closeKeyboard: isPendingUserMessage,
+        });
       });
     },
-    [listRef],
+    [anchorIndex, pendingUserMessageId, scrollMessageToEnd],
   );
 
-  // 不设 anchorMaxSize：用被锚定用户消息的**真实完整高度**参与预留空白计算，使其顶部恒钉在
-  // anchorOffset（导航栏之下）、从顶部完整显示。此前用 120 截断会把超长消息「超出的部分滚出屏顶」，
-  // 表现为发送后消息「从中间钉」、顶部钻进 header（空话题首条尤其明显）。代价：比整屏还高的消息，
-  // 其助手回复会落在首屏之下、需向下滚动（对齐 ChatGPT 的行为）。
+  const handleAnchoredEndSpaceSizeChanged = useCallback(
+    (size: number) => {
+      if (size > 0 || !anchorMessageId) {
+        return;
+      }
+
+      const nextPhase = isUserInteractingRef.current ? 'paused' : 'following';
+      tailFollowPhaseRef.current = nextPhase;
+      setTailFollowState((previous) => {
+        const current = resolveTailFollowState(previous, anchorMessageId);
+        if (current.phase !== 'anchoring') {
+          return current;
+        }
+
+        return { ...current, phase: nextPhase };
+      });
+    },
+    [anchorMessageId],
+  );
+
+  const handleEndVisible = useCallback(
+    (visible: boolean) => {
+      if (!visible || isUserInteractingRef.current) {
+        return;
+      }
+
+      resumeTailFollowAtEnd();
+    },
+    [resumeTailFollowAtEnd],
+  );
+
+  const handleScrollBeginDrag = useCallback(() => {
+    isDraggingListRef.current = true;
+    beginUserInteraction();
+
+    if (!anchorMessageId) {
+      return;
+    }
+
+    tailFollowPhaseRef.current =
+      tailFollowPhaseRef.current === 'following' ? 'paused' : tailFollowPhaseRef.current;
+    setTailFollowState((previous) => {
+      const current = resolveTailFollowState(previous, anchorMessageId);
+      if (current.phase !== 'following') {
+        return current;
+      }
+
+      return { ...current, phase: 'paused' };
+    });
+  }, [anchorMessageId, beginUserInteraction]);
+
+  const handleScrollEndDrag = useCallback(() => {
+    isDraggingListRef.current = false;
+    scheduleInteractionEnd();
+  }, [scheduleInteractionEnd]);
+
+  const handleMomentumScrollBegin = useCallback(() => {
+    isMomentumScrollingRef.current = true;
+    beginUserInteraction();
+  }, [beginUserInteraction]);
+
+  const handleMomentumScrollEnd = useCallback(() => {
+    isMomentumScrollingRef.current = false;
+    scheduleInteractionEnd();
+  }, [scheduleInteractionEnd]);
+
+  const handleTouchStart = useCallback(() => {
+    isTouchingListRef.current = true;
+    beginUserInteraction();
+  }, [beginUserInteraction]);
+
+  const handleTouchEnd = useCallback(() => {
+    isTouchingListRef.current = false;
+    scheduleInteractionEnd();
+  }, [scheduleInteractionEnd]);
+
+  const handleItemSizeChanged = useCallback(() => {
+    scheduleTailFollow();
+  }, [scheduleTailFollow]);
+
+  // 纯文本按当前字号最多以两行参与锚点计算；文件/图片使用完整实测高度，避免媒体被顶出屏幕。
   const anchoredEndSpace = useMemo(
     () =>
       hasAnchor
         ? {
             anchorIndex,
+            anchorMaxSize,
             anchorOffset,
             onReady: handleAnchorReady,
+            onSizeChanged: handleAnchoredEndSpaceSizeChanged,
           }
         : undefined,
-    [anchorIndex, anchorOffset, handleAnchorReady, hasAnchor],
+    [
+      anchorIndex,
+      anchorMaxSize,
+      anchorOffset,
+      handleAnchorReady,
+      handleAnchoredEndSpaceSizeChanged,
+      hasAnchor,
+    ],
   );
 
-  // 锚定期间禁用 maintainScrollAtEnd：流式更新同一条消息时 legend-list 仍判为 dataChange
-  // （对象引用变、无 itemsAreEqual），保留 onDataChange 会逐帧滚到底=跟随。改由下方 effect 在
-  // 「新消息到达」时滚一次把消息钉顶，流式期间靠 maintainVisibleContentPosition 把消息稳在顶部。
-  const maintainScrollAtEnd = useMemo(
-    () =>
-      hasAnchor
-        ? undefined
-        : { animated: false, on: { dataChange: true, itemLayout: true, layout: true } },
-    [hasAnchor],
-  );
+  const maintainVisibleContentPosition = isFollowing
+    ? Platform.OS === 'android'
+      ? false
+      : undefined
+    : MAINTAIN_VISIBLE_CONTENT_POSITION;
+  // 导航转场会短暂产生 0x0 ScrollView；此时接入 animated inset 会让 iOS 指示器收到 NaN。
+  const resolvedContentInsetEndAdjustment =
+    viewportHeight > 0 ? contentInsetEndAdjustment : undefined;
 
   // 把列表「是否精确在最底部」同步到共享值，驱动悬浮的「滚动到底部」按钮显隐。
   const sharedValues = useMemo(() => ({ isAtEnd: isAtBottom }), [isAtBottom]);
@@ -231,23 +455,26 @@ export function ChatMessageList({
     onReady?.();
   });
 
-  const handleContentSizeChange = useCallback(
-    (_width: number, height: number) => {
-      // ready=true 的 contentSize 变化 = 遮罩已撤/即将撤之后仍有高度修正 = 泄漏到可见区的跳动源。
-      // 冷首次进入 markdown 解析慢，末次修正可能迟到落在 ready 之后 → 复现「第一次进入才跳」。
-      scrollLog.debug('[SCROLL] contentSize', {
-        h: Math.round(height),
-        ready: didReportReadyRef.current,
-        t: Date.now(),
-      });
-      setContentBaseHeight(Math.max(0, height - bottomPadding));
-    },
-    [bottomPadding],
-  );
+  const handleContentSizeChange = useCallback((_width: number, height: number) => {
+    // ready=true 的 contentSize 变化 = 遮罩已撤/即将撤之后仍有高度修正 = 泄漏到可见区的跳动源。
+    // 冷首次进入 markdown 解析慢，末次修正可能迟到落在 ready 之后 → 复现「第一次进入才跳」。
+    scrollLog.debug('[SCROLL] contentSize', {
+      h: Math.round(height),
+      ready: didReportReadyRef.current,
+      t: Date.now(),
+    });
+    setContentBaseHeight(Math.max(0, height - chatInputMessageListGap));
+  }, []);
 
   const handleLayout = useCallback((event: LayoutChangeEvent) => {
     setViewportHeight(event.nativeEvent.layout.height);
   }, []);
+
+  useEffect(() => {
+    if (isFollowing) {
+      scheduleTailFollow();
+    }
+  }, [isFollowing, messages, scheduleTailFollow]);
 
   useEffect(() => {
     readyGenerationRef.current += 1;
@@ -264,7 +491,7 @@ export function ChatMessageList({
       return;
     }
 
-    const shouldScrollToEndBeforeReady = bottomPadding > 0;
+    const shouldScrollToEndBeforeReady = contentBottomInset > 0;
 
     pendingReadyFrameRef.current = requestAnimationFrame(() => {
       pendingReadyFrameRef.current = requestAnimationFrame(() => {
@@ -293,7 +520,7 @@ export function ChatMessageList({
 
         if (shouldScrollToEndBeforeReady) {
           scrollLog.debug('[SCROLL] gateScrollToEnd', {
-            bottomPadding,
+            contentBottomInset,
             contentBaseHeight: Math.round(contentBaseHeight),
             viewportHeight: Math.round(viewportHeight),
             t: Date.now(),
@@ -306,8 +533,8 @@ export function ChatMessageList({
       });
     });
   }, [
-    bottomPadding,
     cancelPendingReadyFrame,
+    contentBottomInset,
     contentBaseHeight,
     lastMessageId,
     listRef,
@@ -317,9 +544,11 @@ export function ChatMessageList({
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
+      cancelPendingInteractionEnd();
       cancelPendingReadyFrame();
+      cancelPendingTailFollow();
     };
-  }, [cancelPendingReadyFrame]);
+  }, [cancelPendingInteractionEnd, cancelPendingReadyFrame, cancelPendingTailFollow]);
 
   return (
     <ScrollShadow
@@ -330,32 +559,42 @@ export function ChatMessageList({
     >
       <KeyboardAwareLegendList
         ref={listRef}
+        applyWorkaroundForContentInsetHitTestBug
         anchoredEndSpace={anchoredEndSpace}
-        automaticallyAdjustsScrollIndicatorInsets
-        contentContainerStyle={contentContainerStyle}
+        contentContainerStyle={MESSAGE_LIST_CONTENT_CONTAINER_STYLE}
         contentInsetAdjustmentBehavior="never"
+        contentInsetEndAdjustment={resolvedContentInsetEndAdjustment}
         data={messages}
         drawDistance={80}
         estimatedItemSize={300}
         estimatedHeaderSize={contentTopInset}
+        freeze={freeze}
         getItemType={getMessageItemType}
         keyExtractor={messageKeyExtractor}
         keyboardDismissMode="interactive"
         keyboardLiftBehavior="whenAtEnd"
+        keyboardOffset={keyboardOffset}
         keyboardShouldPersistTaps="handled"
         ListHeaderComponent={listHeader}
         initialScrollAtEnd
-        maintainScrollAtEnd={maintainScrollAtEnd}
-        maintainScrollAtEndThreshold={0.12}
-        maintainVisibleContentPosition={MAINTAIN_VISIBLE_CONTENT_POSITION}
+        maintainVisibleContentPosition={maintainVisibleContentPosition}
         onContentSizeChange={handleContentSizeChange}
+        onEndVisible={handleEndVisible}
+        onItemSizeChanged={handleItemSizeChanged}
         onLayout={handleLayout}
+        onMomentumScrollBegin={handleMomentumScrollBegin}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
         onScroll={handleScroll}
-        scrollEventThrottle={16}
+        onScrollBeginDrag={handleScrollBeginDrag}
+        onScrollEndDrag={handleScrollEndDrag}
         onStartReached={handleStartReached}
         onStartReachedThreshold={0.05}
+        onTouchCancel={handleTouchEnd}
+        onTouchEnd={handleTouchEnd}
+        onTouchStart={handleTouchStart}
         recycleItems={false}
         renderItem={renderMessageItem}
+        scrollEventThrottle={16}
         scrollsToTop
         sharedValues={sharedValues}
         className="flex-1"

--- a/src/frontend/features/chat/workspace/components/FloatingChatInput.tsx
+++ b/src/frontend/features/chat/workspace/components/FloatingChatInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { type RefObject, useCallback } from 'react';
 import { type LayoutChangeEvent, View } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -12,13 +12,19 @@ import {
 
 type FloatingChatInputProps = {
   assistantId?: string;
+  composerRef?: RefObject<View | null>;
+  dismissKeyboardOnSend?: boolean;
   onHeightChange: (height: number) => void;
+  onComposerLayout?: (event: LayoutChangeEvent) => void;
   topicId?: string;
 };
 
 export function FloatingChatInput({
   assistantId,
+  composerRef,
+  dismissKeyboardOnSend,
   onHeightChange,
+  onComposerLayout,
   topicId,
 }: FloatingChatInputProps) {
   const { bottom } = useSafeAreaInsets();
@@ -28,12 +34,14 @@ export function FloatingChatInput({
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
       onHeightChange(event.nativeEvent.layout.height);
+      onComposerLayout?.(event);
     },
-    [onHeightChange],
+    [onComposerLayout, onHeightChange],
   );
 
   return (
     <View
+      ref={composerRef}
       className="absolute right-0 bottom-0 left-0 z-10"
       pointerEvents="box-none"
       style={{
@@ -43,7 +51,11 @@ export function FloatingChatInput({
       onLayout={handleLayout}
     >
       <KeyboardStickyView offset={{ opened: keyboardInputOffset }}>
-        <ChatInput assistantId={assistantId} topicId={topicId} />
+        <ChatInput
+          assistantId={assistantId}
+          dismissKeyboardOnSend={dismissKeyboardOnSend}
+          topicId={topicId}
+        />
       </KeyboardStickyView>
     </View>
   );

--- a/src/frontend/features/chat/workspace/components/README.md
+++ b/src/frontend/features/chat/workspace/components/README.md
@@ -6,20 +6,20 @@ When the active topic changes, `ChatWorkspace` remounts `ChatMessageList` with a
 
 The new list renders and measures behind the cover first. After the list reports ready, the cover and loading indicator exit together with a short eased fade.
 
-## Short Conversations
+## Composer Inset
 
-If the measured message content height fits above the floating input, the list does not call `scrollToEnd`.
+The floating composer reports its measured height through `useKeyboardChatComposerInset`. The list waits for its first non-zero viewport layout before attaching that shared inset; this avoids sending an invalid animated scroll-indicator inset while a navigation transition still has the list at `0x0`.
 
-The content stays at the top with the normal top padding. This keeps short topics from being bottom-pinned or hidden under the transparent header.
+`KeyboardAwareLegendList` then owns composer spacing and keyboard lift. The content container keeps only the fixed visual gap below the final message.
 
-## Long Conversations
+## Live Turn Anchoring
 
-If the measured message content height is taller than the visible area above the floating input, the list adds bottom padding equal to the floating input inset.
+The latest user message is anchored below the header. `anchoredEndSpace` reserves the remaining viewport while the assistant reply is short, then reports when that space is exhausted.
 
-Before removing the cover, the list calls `scrollToEnd({ animated: false })`. The user sees the topic already positioned at the latest message, without a visible scroll animation.
+Text anchors use a two-line height cap. Messages containing files use their complete measured height.
 
-## Later Message Updates
+## Tail Following
 
-`maintainScrollAtEnd` only listens to `dataChange`. If the user is already near the bottom, new messages keep the list at the bottom without animation.
+After the reserved space is exhausted, data and item-size changes schedule one non-animated native `scrollToEnd` per frame. The callback rechecks the current phase and the synchronous interaction lock immediately before dispatching.
 
-Layout and item-layout changes do not force the list back to the bottom. This lets the user scroll upward without being pulled back by measurement updates.
+Touch, drag, and momentum events cancel pending follow work and pause following. End-visibility changes are ignored while an interaction is active. Following resumes only after the list's measured distance from the end is within the 20-pixel threshold, including after the existing scroll-to-bottom button reaches the end.

--- a/src/frontend/features/chat/workspace/components/__tests__/ChatMessageList.test.tsx
+++ b/src/frontend/features/chat/workspace/components/__tests__/ChatMessageList.test.tsx
@@ -1,0 +1,437 @@
+import type { Message } from '@cherrystudio/universal/data/types/message';
+import type { LegendListRef } from '@legendapp/list/react-native';
+import type { ReactNode } from 'react';
+import { type LayoutChangeEvent, Platform } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ChatMessageList } from '../ChatMessageList';
+
+type AnchoredEndSpaceConfig = {
+  anchorMaxSize?: number;
+  onReady?: (info: { anchorKey: string | undefined }) => void;
+  onSizeChanged?: (size: number) => void;
+};
+
+type MockLegendListProps = {
+  applyWorkaroundForContentInsetHitTestBug?: boolean;
+  anchoredEndSpace?: AnchoredEndSpaceConfig;
+  contentContainerStyle?: { paddingBottom?: number; paddingTop?: number };
+  contentInsetEndAdjustment?: SharedValue<number>;
+  freeze?: unknown;
+  keyboardOffset?: number;
+  maintainScrollAtEnd?: unknown;
+  maintainScrollAtEndThreshold?: number;
+  maintainVisibleContentPosition?: unknown;
+  onEndVisible?: (visible: boolean) => void;
+  onItemSizeChanged?: () => void;
+  onLayout?: (event: LayoutChangeEvent) => void;
+  onMomentumScrollBegin?: () => void;
+  onMomentumScrollEnd?: () => void;
+  onScrollBeginDrag?: () => void;
+  onScrollEndDrag?: () => void;
+  onTouchEnd?: () => void;
+  onTouchStart?: () => void;
+};
+
+let mockLatestListProps: MockLegendListProps | undefined;
+const mockFreeze = { get: jest.fn(), set: jest.fn(), value: false };
+const mockScrollMessageToEnd = jest.fn(async () => undefined);
+const mockListScrollToEnd = jest.fn();
+let mockListMetrics = { contentLength: 500, scroll: 0, scrollLength: 500 };
+const listRef = {
+  current: {
+    getNativeScrollRef: () => ({ scrollToEnd: mockListScrollToEnd }),
+    getState: () => mockListMetrics,
+  } as unknown as LegendListRef,
+};
+let mockFontSizeStep = 0;
+const originalPlatform = Platform.OS;
+
+jest.mock('@legendapp/list/keyboard', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    KeyboardAwareLegendList: (props: MockLegendListProps) => {
+      mockLatestListProps = props;
+      return <MockView testID="chat-message-list" />;
+    },
+    useKeyboardScrollToEnd: () => ({
+      freeze: mockFreeze,
+      scrollMessageToEnd: mockScrollMessageToEnd,
+    }),
+  };
+});
+
+jest.mock('heroui-native/scroll-shadow', () => ({
+  ScrollShadow: ({ children }: { children: ReactNode }) => children,
+}));
+
+jest.mock('@/frontend/components/nativePrimitives', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return { LinearGradient: MockView };
+});
+
+jest.mock('@/frontend/data/hooks', () => ({
+  usePreference: () => [mockFontSizeStep, jest.fn()],
+}));
+
+jest.mock('@/shared/core/logger/LoggerService', () => ({
+  loggerService: {
+    withContext: () => ({ debug: jest.fn() }),
+  },
+}));
+
+jest.mock('../../../messageItem', () => ({
+  AssistantMessageItem: () => null,
+  UserMessageItem: () => null,
+}));
+
+const now = '2026-08-06T00:00:00.000Z';
+
+function createMessage(
+  id: string,
+  role: Message['role'],
+  parts: Message['data']['parts'] = [],
+): Message {
+  return {
+    createdAt: now,
+    data: { parts },
+    id,
+    parentId: null,
+    role,
+    searchableText: '',
+    siblingsGroupId: 0,
+    status: role === 'assistant' ? 'pending' : 'success',
+    topicId: 'topic-1',
+    updatedAt: now,
+  };
+}
+
+function textPart(text: string): NonNullable<Message['data']['parts']>[number] {
+  return { text, type: 'text' };
+}
+
+function filePart(): NonNullable<Message['data']['parts']>[number] {
+  return {
+    filename: 'photo.png',
+    mediaType: 'image/png',
+    type: 'file',
+    url: 'file:///photo.png',
+  };
+}
+
+const isAtBottom = {
+  get: () => true,
+  set: jest.fn(),
+  value: true,
+} as unknown as SharedValue<boolean>;
+
+const contentInsetEndAdjustment = {
+  get: () => 72,
+  set: jest.fn(),
+  value: 72,
+} as unknown as SharedValue<number>;
+
+function listProps(
+  messages: readonly Message[],
+  anchorIndex: number,
+  pendingUserMessageId?: string,
+) {
+  return {
+    anchorIndex,
+    contentBottomInset: 80,
+    contentInsetEndAdjustment,
+    contentTopInset: 44,
+    isAtBottom,
+    keyboardOffset: 26,
+    listRef,
+    messages,
+    onLoadOlder: jest.fn(async () => undefined),
+    onPrefetchOlder: jest.fn(),
+    pendingUserMessageId,
+  };
+}
+
+describe('ChatMessageList anchored tail following', () => {
+  let renderer: ReactTestRenderer | undefined;
+  let cancelAnimationFrameSpy: jest.SpyInstance;
+  let frameCallbacks: Map<number, FrameRequestCallback>;
+  let nextFrameId: number;
+  let requestAnimationFrameSpy: jest.SpyInstance;
+
+  const flushAnimationFrames = () => {
+    const callbacks = [...frameCallbacks.values()];
+    frameCallbacks.clear();
+    callbacks.forEach((callback) => callback(0));
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListMetrics = { contentLength: 500, scroll: 0, scrollLength: 500 };
+    mockFontSizeStep = 0;
+    mockLatestListProps = undefined;
+    frameCallbacks = new Map();
+    nextFrameId = 1;
+    requestAnimationFrameSpy = jest
+      .spyOn(global, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        const frameId = nextFrameId++;
+        frameCallbacks.set(frameId, callback);
+        return frameId;
+      });
+    cancelAnimationFrameSpy = jest
+      .spyOn(global, 'cancelAnimationFrame')
+      .mockImplementation((frameId) => {
+        if (frameId != null) {
+          frameCallbacks.delete(frameId);
+        }
+      });
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: originalPlatform });
+    cancelAnimationFrameSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+  });
+
+  test('caps text anchors at two current body lines and leaves file anchors uncapped', () => {
+    const textMessages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(textMessages, 0)} />);
+    });
+
+    expect(mockLatestListProps?.anchoredEndSpace?.anchorMaxSize).toBe(80);
+
+    mockFontSizeStep = 2;
+    act(() => renderer?.update(<ChatMessageList {...listProps(textMessages, 0)} />));
+    expect(mockLatestListProps?.anchoredEndSpace?.anchorMaxSize).toBe(88);
+
+    const fileMessages = [
+      createMessage('user-1', 'user', [filePart()]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => renderer?.update(<ChatMessageList {...listProps(fileMessages, 0)} />));
+
+    expect(mockLatestListProps?.anchoredEndSpace?.anchorMaxSize).toBeUndefined();
+  });
+
+  test('attaches composer spacing after the list has a valid viewport', () => {
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(messages, 0)} />);
+    });
+
+    expect(mockLatestListProps?.applyWorkaroundForContentInsetHitTestBug).toBe(true);
+    expect(mockLatestListProps?.contentInsetEndAdjustment).toBeUndefined();
+
+    act(() => {
+      mockLatestListProps?.onLayout?.({
+        nativeEvent: { layout: { height: 600, width: 390, x: 0, y: 0 } },
+      } as LayoutChangeEvent);
+    });
+
+    expect(mockLatestListProps?.contentInsetEndAdjustment).toBe(contentInsetEndAdjustment);
+    expect(mockLatestListProps?.keyboardOffset).toBe(26);
+    expect(mockLatestListProps?.contentContainerStyle).toEqual({
+      paddingBottom: 8,
+      paddingTop: 12,
+    });
+  });
+
+  test('follows after overflow, pauses on drag, and resumes only at the end', () => {
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(messages, 0)} />);
+    });
+
+    expect(mockLatestListProps?.maintainScrollAtEnd).toBeUndefined();
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toMatchObject({ data: true });
+
+    act(() => mockLatestListProps?.anchoredEndSpace?.onSizeChanged?.(0));
+    act(() => flushAnimationFrames());
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toBeUndefined();
+
+    act(() => {
+      mockLatestListProps?.onTouchStart?.();
+      mockLatestListProps?.onScrollBeginDrag?.();
+    });
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toMatchObject({ data: true });
+
+    act(() => mockLatestListProps?.onItemSizeChanged?.());
+    act(() => flushAnimationFrames());
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
+
+    mockListMetrics = { contentLength: 1_500, scroll: 200, scrollLength: 500 };
+    act(() => {
+      mockLatestListProps?.onEndVisible?.(true);
+      mockLatestListProps?.onTouchEnd?.();
+      mockLatestListProps?.onScrollEndDrag?.();
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toMatchObject({ data: true });
+
+    mockListMetrics = { contentLength: 1_500, scroll: 1_000, scrollLength: 500 };
+    act(() => {
+      mockLatestListProps?.onEndVisible?.(true);
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toBeUndefined();
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(2);
+  });
+
+  test('cancels a queued follow before a touch can begin dragging', () => {
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(messages, 0)} />);
+    });
+    act(() => mockLatestListProps?.anchoredEndSpace?.onSizeChanged?.(0));
+
+    const escapedFollowCallback = [...frameCallbacks.values()][0];
+    expect(escapedFollowCallback).toBeDefined();
+
+    act(() => mockLatestListProps?.onTouchStart?.());
+    expect(frameCallbacks.size).toBe(0);
+
+    act(() => escapedFollowCallback?.(0));
+    expect(mockListScrollToEnd).not.toHaveBeenCalled();
+  });
+
+  test('does not resume while momentum is active', () => {
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(messages, 0)} />);
+    });
+    act(() => mockLatestListProps?.anchoredEndSpace?.onSizeChanged?.(0));
+    act(() => flushAnimationFrames());
+
+    act(() => {
+      mockLatestListProps?.onTouchStart?.();
+      mockLatestListProps?.onScrollBeginDrag?.();
+      mockLatestListProps?.onMomentumScrollBegin?.();
+      mockLatestListProps?.onTouchEnd?.();
+      mockLatestListProps?.onScrollEndDrag?.();
+      mockLatestListProps?.onEndVisible?.(true);
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toMatchObject({ data: true });
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mockLatestListProps?.onMomentumScrollEnd?.();
+      flushAnimationFrames();
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toBeUndefined();
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    ['ios', undefined],
+    ['android', false],
+  ] as const)('uses the %s MVCP behavior while following', (platform, expected) => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: platform });
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(messages, 0)} />);
+    });
+
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toMatchObject({ data: true });
+    act(() => mockLatestListProps?.anchoredEndSpace?.onSizeChanged?.(0));
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toBe(expected);
+  });
+
+  test('preserves follow state across prepend and resets it for a new anchor id', () => {
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(messages, 0)} />);
+    });
+    act(() => mockLatestListProps?.anchoredEndSpace?.onSizeChanged?.(0));
+
+    const prepended = [createMessage('older-1', 'assistant'), ...messages];
+    act(() => renderer?.update(<ChatMessageList {...listProps(prepended, 1)} />));
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toBeUndefined();
+
+    const nextTurn = [
+      ...prepended,
+      createMessage('user-2', 'user', [textPart('next')]),
+      createMessage('assistant-2', 'assistant'),
+    ];
+    act(() => renderer?.update(<ChatMessageList {...listProps(nextTurn, 3)} />));
+    expect(mockLatestListProps?.maintainVisibleContentPosition).toMatchObject({ data: true });
+  });
+
+  test('pins each live anchor once and coordinates keyboard dismissal', () => {
+    const firstTurn = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(<ChatMessageList {...listProps(firstTurn, 0, 'user-1')} />);
+    });
+    act(() => mockLatestListProps?.anchoredEndSpace?.onReady?.({ anchorKey: 'user-1' }));
+    act(() => mockLatestListProps?.anchoredEndSpace?.onReady?.({ anchorKey: 'user-1' }));
+    act(() => flushAnimationFrames());
+
+    expect(mockScrollMessageToEnd).toHaveBeenCalledTimes(1);
+    expect(mockScrollMessageToEnd).toHaveBeenLastCalledWith({
+      animated: false,
+      closeKeyboard: true,
+    });
+    expect(mockLatestListProps?.freeze).toBe(mockFreeze);
+
+    const secondTurn = [
+      ...firstTurn,
+      createMessage('user-2', 'user', [textPart('next')]),
+      createMessage('assistant-2', 'assistant'),
+    ];
+    act(() => renderer?.update(<ChatMessageList {...listProps(secondTurn, 2, 'user-2')} />));
+    act(() => mockLatestListProps?.anchoredEndSpace?.onReady?.({ anchorKey: 'user-2' }));
+    act(() => flushAnimationFrames());
+
+    expect(mockScrollMessageToEnd).toHaveBeenLastCalledWith({
+      animated: true,
+      closeKeyboard: true,
+    });
+
+    const historicalTurn = [
+      ...secondTurn,
+      createMessage('user-3', 'user', [textPart('history')]),
+      createMessage('assistant-3', 'assistant'),
+    ];
+    act(() => renderer?.update(<ChatMessageList {...listProps(historicalTurn, 4)} />));
+    act(() => mockLatestListProps?.anchoredEndSpace?.onReady?.({ anchorKey: 'user-3' }));
+    act(() => flushAnimationFrames());
+
+    expect(mockScrollMessageToEnd).toHaveBeenLastCalledWith({
+      animated: false,
+      closeKeyboard: false,
+    });
+  });
+});

--- a/src/frontend/features/chat/workspace/hooks/useFloatingChatInputLayout.ts
+++ b/src/frontend/features/chat/workspace/hooks/useFloatingChatInputLayout.ts
@@ -2,12 +2,17 @@ import { useCallback, useState } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { chatInputMessageListGap, getChatInputMinimumHeight } from '../../input/chatInputLayout';
+import {
+  chatInputMessageListGap,
+  getChatInputKeyboardStickyOffset,
+  getChatInputMinimumHeight,
+} from '../../input/chatInputLayout';
 
 export function useFloatingChatInputLayout() {
   const { bottom } = useSafeAreaInsets();
   const minimumInputHeight = getChatInputMinimumHeight(bottom);
-  // 逐帧裸高度走共享值（驱动悬浮按钮定位），离散 clamp 高度走 state（驱动列表 padding）：
+  const keyboardOffset = getChatInputKeyboardStickyOffset(bottom);
+  // 逐帧裸高度走共享值（驱动悬浮按钮定位），离散 clamp 高度走 state（驱动遮挡区尺寸）：
   // clamp 后同值不变，命中 React eager bail-out，避免逐帧 onLayout 重渲染整个 ChatWorkspace。
   const inputHeightShared = useSharedValue(minimumInputHeight);
   const [clampedInputHeight, setClampedInputHeight] = useState(minimumInputHeight);
@@ -31,5 +36,6 @@ export function useFloatingChatInputLayout() {
     handleInputHeightChange,
     inputHeight,
     inputHeightShared,
+    keyboardOffset,
   };
 }

--- a/src/frontend/features/paintings/PaintingConversationScreen/PaintingConversationScreen.tsx
+++ b/src/frontend/features/paintings/PaintingConversationScreen/PaintingConversationScreen.tsx
@@ -1,9 +1,10 @@
 import type { Message } from '@cherrystudio/universal/data/types/message';
+import { useKeyboardChatComposerInset } from '@legendapp/list/keyboard';
 import type { LegendListRef } from '@legendapp/list/react-native';
 import * as Crypto from 'expo-crypto';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useHeaderHeight } from 'expo-router/react-navigation';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { type RefObject, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, type LayoutChangeEvent, Text, View } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
@@ -97,11 +98,16 @@ function PaintingConversationWorkspace({
   const router = useRouter();
   const headerHeight = useHeaderHeight();
   const listRef = useRef<LegendListRef | null>(null);
+  const composerRef = useRef<View | null>(null);
   const isAtBottom = useSharedValue(true);
   const [pendingTurn, setPendingTurn] = useState<PendingTurn | null>(null);
   const generation = usePaintingGeneration({ initialOutputs: [] });
-  const { contentBottomInset, handleInputHeightChange, inputHeightShared } =
+  const { contentBottomInset, handleInputHeightChange, inputHeightShared, keyboardOffset } =
     useFloatingChatInputLayout();
+  const { contentInsetEndAdjustment, onComposerLayout } = useKeyboardChatComposerInset(
+    listRef,
+    composerRef,
+  );
   const messages = useMemo<Message[]>(
     () =>
       pendingTurn
@@ -148,14 +154,18 @@ function PaintingConversationWorkspace({
       <ChatMessageList
         anchorIndex={0}
         contentBottomInset={contentBottomInset}
+        contentInsetEndAdjustment={contentInsetEndAdjustment}
         contentTopInset={isIOS ? headerHeight : 0}
         isAtBottom={isAtBottom}
+        keyboardOffset={keyboardOffset}
         listRef={listRef}
         messages={messages}
         onLoadOlder={handleLoadOlder}
         onPrefetchOlder={handlePrefetchOlder}
       />
       <FloatingPaintingInput
+        composerRef={composerRef}
+        onComposerLayout={onComposerLayout}
         onHeightChange={handleInputHeightChange}
         onCancel={generation.cancel}
         onGenerate={handleGenerate}
@@ -174,21 +184,29 @@ function PaintingConversationWorkspace({
 }
 
 function FloatingPaintingInput({
+  composerRef,
+  onComposerLayout,
   onHeightChange,
   ...inputProps
 }: {
+  composerRef: RefObject<View | null>;
+  onComposerLayout: (event: LayoutChangeEvent) => void;
   onHeightChange: (height: number) => void;
 } & Parameters<typeof PaintingInput>[0]) {
   const { bottom } = useSafeAreaInsets();
   const bottomPadding = Math.max(bottom, chatInputMinBottomPadding);
   const keyboardInputOffset = getChatInputKeyboardStickyOffset(bottom);
   const handleLayout = useCallback(
-    (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
-    [onHeightChange],
+    (event: LayoutChangeEvent) => {
+      onHeightChange(event.nativeEvent.layout.height);
+      onComposerLayout(event);
+    },
+    [onComposerLayout, onHeightChange],
   );
 
   return (
     <View
+      ref={composerRef}
       className="absolute right-0 bottom-0 left-0 z-10"
       pointerEvents="box-none"
       style={{

--- a/src/frontend/features/paintings/PaintingConversationScreen/__tests__/PaintingConversationScreen.test.tsx
+++ b/src/frontend/features/paintings/PaintingConversationScreen/__tests__/PaintingConversationScreen.test.tsx
@@ -15,10 +15,14 @@ type PaintingInputProps = {
 };
 
 type MessageListProps = {
+  contentInsetEndAdjustment: unknown;
+  keyboardOffset: number;
   messages: Message[];
 };
 
 const mockRouterReplace = jest.fn();
+const mockContentInsetEndAdjustment = { value: 88 };
+const mockOnComposerLayout = jest.fn();
 const mockGenerate = jest.fn<Promise<PaintingGenerationResult>, [PaintingGenerationInput]>();
 let mockPaintingInputProps: PaintingInputProps | undefined;
 let mockMessageListProps: MessageListProps | undefined;
@@ -79,6 +83,13 @@ jest.mock('expo-crypto', () => ({
   },
 }));
 
+jest.mock('@legendapp/list/keyboard', () => ({
+  useKeyboardChatComposerInset: () => ({
+    contentInsetEndAdjustment: mockContentInsetEndAdjustment,
+    onComposerLayout: mockOnComposerLayout,
+  }),
+}));
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
@@ -127,7 +138,9 @@ jest.mock('@/frontend/features/chat/workspace', () => ({
   useFloatingChatInputLayout: () => ({
     contentBottomInset: 0,
     handleInputHeightChange: jest.fn(),
+    inputHeight: 88,
     inputHeightShared: { value: 0 },
+    keyboardOffset: 26,
   }),
 }));
 
@@ -228,5 +241,7 @@ describe('PaintingConversationScreen', () => {
       'assistant',
     ]);
     expect(mockMessageListProps?.messages[0].searchableText).toBe(mockPainting.prompt);
+    expect(mockMessageListProps?.contentInsetEndAdjustment).toBe(mockContentInsetEndAdjustment);
+    expect(mockMessageListProps?.keyboardOffset).toBe(26);
   });
 });


### PR DESCRIPTION
Aligns ChatMessageList with Margelo-style anchoring and streamed-tail following, while pausing application-owned scrolling immediately on touch, drag, or momentum and resuming only after the list end is verified. Coordinates floating composer insets and keyboard dismissal across chat and painting flows, including deferred animated inset attachment to avoid invalid iOS viewport values. Adds regression coverage for anchor state transitions, keyboard behavior, inset wiring, and painting integration, and updates the component documentation. Full app tests, typecheck, format check, and lint complete successfully; lint retains 45 existing warnings.