### PR TITLE
test(ai-contract): add AI SDK behavior contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "skills:check": "tsx scripts/skills-check.ts",
     "docs:check-links": "tsx scripts/check-doc-links.ts",
     "test": "pnpm packages:build && pnpm test:packages && pnpm test:app",
+    "test:ai-contract": "jest src/backend/ai/__tests__/behavior --runInBand",
     "test:app": "jest",
     "test:packages": "pnpm test:ai-sdk-provider && pnpm test:ai-core",
     "test:ai-sdk-provider": "pnpm --filter @cherrystudio/ai-sdk-provider test",

--- a/src/backend/ai/__tests__/_harness/contracts.ts
+++ b/src/backend/ai/__tests__/_harness/contracts.ts
@@ -1,0 +1,131 @@
+import type {
+  EmbeddingModelV3CallOptions,
+  ImageModelV3CallOptions,
+  LanguageModelV3CallOptions,
+} from '@ai-sdk/provider';
+import type { CherryUIMessage } from '@cherrystudio/universal/data/types/message';
+import { readUIMessageStream, type UIMessageChunk } from 'ai';
+
+export function projectLanguageCall(call: LanguageModelV3CallOptions) {
+  const value = {
+    abortSignal: projectSignal(call.abortSignal),
+    frequencyPenalty: call.frequencyPenalty,
+    headers: call.headers,
+    maxOutputTokens: call.maxOutputTokens,
+    presencePenalty: call.presencePenalty,
+    prompt: call.prompt,
+    providerOptions: call.providerOptions,
+    seed: call.seed,
+    stopSequences: call.stopSequences,
+    temperature: call.temperature,
+    toolChoice: call.toolChoice,
+    tools: call.tools,
+    topK: call.topK,
+    topP: call.topP,
+  };
+  return sanitize(value, collectCitationIds(value));
+}
+
+export function projectImageCall(call: ImageModelV3CallOptions) {
+  return sanitize({
+    abortSignal: projectSignal(call.abortSignal),
+    aspectRatio: call.aspectRatio,
+    files: call.files?.map((file) =>
+      file.type === 'url'
+        ? { providerOptions: file.providerOptions, type: file.type, url: file.url }
+        : {
+            data: typeof file.data === 'string' ? file.data : Array.from(file.data),
+            mediaType: file.mediaType,
+            providerOptions: file.providerOptions,
+            type: file.type,
+          },
+    ),
+    headers: call.headers,
+    mask: call.mask,
+    n: call.n,
+    prompt: call.prompt,
+    providerOptions: call.providerOptions,
+    seed: call.seed,
+    size: call.size,
+  });
+}
+
+export function projectEmbeddingCall(call: EmbeddingModelV3CallOptions) {
+  return sanitize({
+    abortSignal: projectSignal(call.abortSignal),
+    headers: call.headers,
+    providerOptions: call.providerOptions,
+    values: call.values,
+  });
+}
+
+export function projectContractValue(value: unknown) {
+  return sanitize(value, collectCitationIds(value));
+}
+
+export async function collectStreamContract(stream: ReadableStream<UIMessageChunk>) {
+  const [chunkStream, messageStream] = stream.tee();
+  const [chunks, messages] = await Promise.all([
+    collectReadable(chunkStream),
+    collectAsync(
+      readUIMessageStream<CherryUIMessage>({
+        stream: messageStream,
+        terminateOnError: true,
+      }),
+    ),
+  ]);
+  return { chunks, finalMessage: messages.at(-1) };
+}
+
+export async function collectReadable<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader();
+  const values: T[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return values;
+    values.push(value);
+  }
+}
+
+async function collectAsync<T>(stream: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of stream) values.push(value);
+  return values;
+}
+
+function projectSignal(signal: AbortSignal | undefined) {
+  return signal ? { aborted: signal.aborted } : undefined;
+}
+
+function collectCitationIds(value: unknown, ids = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectCitationIds(entry, ids));
+    return ids;
+  }
+  if (typeof value !== 'object' || value === null) return ids;
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === 'id' && typeof entry === 'string' && /^[0-9a-f]{8}-\d+$/.test(entry)) {
+      ids.add(entry);
+    }
+    collectCitationIds(entry, ids);
+  }
+  return ids;
+}
+
+function sanitize(value: unknown, citationIds: Set<string> = new Set()): unknown {
+  if (value === undefined || typeof value === 'function') return undefined;
+  if (typeof value === 'string') {
+    return Array.from(citationIds).reduce(
+      (text, citationId, index) => text.replaceAll(citationId, `<citation-${index + 1}>`),
+      value,
+    );
+  }
+  if (value instanceof Uint8Array) return Array.from(value);
+  if (Array.isArray(value)) return value.map((entry) => sanitize(entry, citationIds));
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, entry]) => [key, sanitize(entry, citationIds)] as const)
+      .filter((entry) => entry[1] !== undefined),
+  );
+}

--- a/src/backend/ai/__tests__/_harness/mockProvider.ts
+++ b/src/backend/ai/__tests__/_harness/mockProvider.ts
@@ -1,0 +1,135 @@
+import type {
+  EmbeddingModelV3,
+  ImageModelV3,
+  LanguageModelV3,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
+  LanguageModelV3Usage,
+} from '@ai-sdk/provider';
+import { ProviderExtension, extensionRegistry } from '@cherrystudio/ai-core/provider';
+import { simulateReadableStream } from 'ai';
+import { MockProviderV3, mockValues } from 'ai/test';
+
+export const CONTRACT_ADAPTER_ID = 'openai-compatible';
+
+export const CONTRACT_USAGE: LanguageModelV3Usage = {
+  inputTokens: {
+    cacheRead: 2,
+    cacheWrite: 1,
+    noCache: 7,
+    total: 10,
+  },
+  outputTokens: {
+    reasoning: 1,
+    text: 4,
+    total: 5,
+  },
+};
+
+type ContractModels = {
+  embedding?: EmbeddingModelV3;
+  image?: ImageModelV3;
+  language?: LanguageModelV3;
+};
+
+export function installMockProvider(models: ContractModels): () => void {
+  const original = extensionRegistry.get(CONTRACT_ADAPTER_ID);
+  if (!original) throw new Error(`Missing ${CONTRACT_ADAPTER_ID} provider extension`);
+
+  const provider = new MockProviderV3({
+    ...(models.language ? { languageModels: { [models.language.modelId]: models.language } } : {}),
+    ...(models.image ? { imageModels: { [models.image.modelId]: models.image } } : {}),
+    ...(models.embedding
+      ? { embeddingModels: { [models.embedding.modelId]: models.embedding } }
+      : {}),
+  });
+
+  extensionRegistry.unregister(CONTRACT_ADAPTER_ID);
+  extensionRegistry.register(
+    ProviderExtension.create({
+      create: () => provider,
+      name: CONTRACT_ADAPTER_ID,
+      supportsImageGeneration: true,
+    }),
+  );
+
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    extensionRegistry.unregister(CONTRACT_ADAPTER_ID);
+    extensionRegistry.register(original);
+  };
+}
+
+export function textStreamResult(
+  text: string,
+  options: { id?: string; usage?: LanguageModelV3Usage } = {},
+): LanguageModelV3StreamResult {
+  const id = options.id ?? 'text-1';
+  return streamResult([
+    { type: 'stream-start', warnings: [] },
+    { id, type: 'text-start' },
+    { delta: text, id, type: 'text-delta' },
+    { id, type: 'text-end' },
+    {
+      finishReason: { raw: 'stop', unified: 'stop' },
+      type: 'finish',
+      usage: options.usage ?? CONTRACT_USAGE,
+    },
+  ]);
+}
+
+export function toolCallStreamResult(input: {
+  args: unknown;
+  callId?: string;
+  toolName: string;
+}): LanguageModelV3StreamResult {
+  return streamResult([
+    { type: 'stream-start', warnings: [] },
+    {
+      input: JSON.stringify(input.args),
+      toolCallId: input.callId ?? 'tool-call-1',
+      toolName: input.toolName,
+      type: 'tool-call',
+    },
+    {
+      finishReason: { raw: 'tool_calls', unified: 'tool-calls' },
+      type: 'finish',
+      usage: CONTRACT_USAGE,
+    },
+  ]);
+}
+
+export function streamResult(
+  chunks: LanguageModelV3StreamPart[],
+  options: { chunkDelayInMs?: number | null; initialDelayInMs?: number | null } = {},
+): LanguageModelV3StreamResult {
+  return {
+    stream: simulateReadableStream({
+      chunks,
+      chunkDelayInMs: options.chunkDelayInMs ?? null,
+      initialDelayInMs: options.initialDelayInMs ?? null,
+    }),
+  };
+}
+
+export function streamSequence(
+  ...results: LanguageModelV3StreamResult[]
+): LanguageModelV3['doStream'] {
+  const next = mockValues(...results);
+  return async () => next();
+}
+
+export function textGenerateResult(
+  text: string,
+  usage: LanguageModelV3Usage = CONTRACT_USAGE,
+): LanguageModelV3GenerateResult {
+  return {
+    content: [{ text, type: 'text' }],
+    finishReason: { raw: 'stop', unified: 'stop' },
+    usage,
+    warnings: [],
+  };
+}

--- a/src/backend/ai/__tests__/_harness/services.ts
+++ b/src/backend/ai/__tests__/_harness/services.ts
@@ -1,0 +1,196 @@
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import {
+  type Assistant,
+  DEFAULT_ASSISTANT_SETTINGS,
+} from '@cherrystudio/universal/data/types/assistant';
+import type { Model } from '@cherrystudio/universal/data/types/model';
+import type { Provider } from '@cherrystudio/universal/data/types/provider';
+
+import type { AiServiceDependencies } from '@/backend/ai/AiService';
+import type { ToolEntry } from '@/backend/ai/tools/adapters/aiSdk/types';
+import { ToolResolver } from '@/backend/ai/tools/ToolResolver';
+
+type ContractFixtureOptions = {
+  assistantPrompt?: string;
+  assistantSettings?: Partial<Assistant['settings']>;
+  capabilities?: Model['capabilities'];
+  defaultModelId?: Model['id'] | null;
+  fileUri?: string;
+  mcpEntries?: ToolEntry[];
+  modelId?: string;
+  modelOverrides?: Partial<Model>;
+  providerOverrides?: Partial<Provider>;
+};
+
+export type ContractFixture = ReturnType<typeof createContractFixture>;
+
+export function createContractFixture(options: ContractFixtureOptions = {}) {
+  const provider = createProvider(options.providerOverrides);
+  const model = createModel(provider.id, options.modelId ?? 'gpt-4o-mini', {
+    capabilities: options.capabilities ?? [],
+    ...options.modelOverrides,
+  });
+  const assistant = createAssistant(model.id, {
+    prompt: options.assistantPrompt ?? 'You are a precise assistant.',
+    settings: { ...DEFAULT_ASSISTANT_SETTINGS, ...options.assistantSettings },
+  });
+  const recordInvocation = jest.fn(async () => undefined);
+  const resolveRenderableUri = jest.fn(async () => options.fileUri);
+  const getToolEntriesForAssistant = jest.fn(async () => options.mcpEntries ?? []);
+  const searchKeywords = jest.fn(async () => ({
+    capability: 'searchKeywords' as const,
+    inputs: ['Cherry Studio current release'],
+    providerId: 'contract-search',
+    query: 'Cherry Studio current release',
+    results: [
+      {
+        content: 'Cherry Studio is available on mobile.',
+        sourceInput: 'Cherry Studio current release',
+        title: 'Cherry Studio',
+        url: 'https://example.com/cherry',
+      },
+    ],
+  }));
+  const fetchUrls = jest.fn(async () => ({
+    capability: 'fetchUrls' as const,
+    inputs: ['https://example.com/cherry'],
+    providerId: 'contract-search',
+    results: [
+      {
+        content: 'Cherry Studio mobile documentation.',
+        sourceInput: 'https://example.com/cherry',
+        title: 'Cherry Studio',
+        url: 'https://example.com/cherry',
+      },
+    ],
+  }));
+  const preference = {
+    get: jest.fn(async (key: string) => {
+      if (key === 'chat.default_model_id') return options.defaultModelId ?? model.id;
+      if (key.startsWith('permissions.')) return 'never';
+      return null;
+    }),
+    getMultipleRawCached: jest.fn(() => ({
+      'chat.web_search.exclude_domains': [],
+      'chat.web_search.max_results': 5,
+    })),
+  };
+  const webSearch = { fetchUrls, searchKeywords };
+  const tools = new ToolResolver({
+    devicePermissions: {
+      getStatusForPreference: jest.fn(async () => 'unavailable' as const),
+    },
+    mcpRuntime: { getToolEntriesForAssistant },
+    preference: preference as never,
+    webSearch: webSearch as never,
+  });
+  const resolveApiKey = jest.fn(async (_providerId: string, override?: string) => ({
+    apiKeySelection: override
+      ? { attribution: 'unknown' as const }
+      : { attribution: 'explicit' as const, id: 'key-1', masked: 'co****ey' },
+    value: override ?? 'contract-key',
+  }));
+
+  const services = {
+    aiUsageRecord: { recordInvocation },
+    assistant: { getById: jest.fn(async () => assistant) },
+    fileContent: { resolveRenderableUri },
+    model: { getById: jest.fn(async (id: Model['id']) => (id === model.id ? model : undefined)) },
+    preference,
+    provider: {
+      getAuthConfig: jest.fn(async () => null),
+      getByProviderId: jest.fn(async () => provider),
+      getRotatedApiKey: jest.fn(async () => 'contract-key'),
+      resolveApiKey,
+    },
+    tools,
+  } as unknown as AiServiceDependencies;
+
+  return {
+    assistant,
+    model,
+    provider,
+    services,
+    spies: {
+      fetchUrls,
+      getToolEntriesForAssistant,
+      recordInvocation,
+      resolveApiKey,
+      resolveRenderableUri,
+      searchKeywords,
+    },
+  };
+}
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    apiFeatures: {
+      arrayContent: true,
+      developerRole: true,
+      reportsActualCost: false,
+      serviceTier: true,
+      streamOptions: true,
+      verbosity: false,
+    },
+    apiKeys: [],
+    authType: 'api-key',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+        adapterFamily: 'openai-compatible',
+        baseUrl: 'https://contract.invalid/v1',
+      },
+      [ENDPOINT_TYPE.OPENAI_EMBEDDINGS]: {
+        adapterFamily: 'openai-compatible',
+        baseUrl: 'https://contract.invalid/v1',
+      },
+      [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION]: {
+        adapterFamily: 'openai-compatible',
+        baseUrl: 'https://contract.invalid/v1',
+      },
+    },
+    id: 'contract-provider',
+    isEnabled: true,
+    name: 'Contract Provider',
+    settings: {},
+    ...overrides,
+  };
+}
+
+function createModel(providerId: string, modelId: string, overrides: Partial<Model> = {}): Model {
+  return {
+    capabilities: [],
+    id: `${providerId}::${modelId}`,
+    isDeprecated: false,
+    isEnabled: true,
+    isHidden: false,
+    modelId,
+    name: modelId,
+    providerId,
+    supportsStreaming: true,
+    ...overrides,
+  } as Model;
+}
+
+function createAssistant(modelId: Model['id'], overrides: Partial<Assistant> = {}): Assistant {
+  return {
+    createdAt: '2026-01-01T00:00:00.000Z',
+    description: '',
+    emoji: '',
+    groupId: null,
+    id: '00000000-0000-4000-8000-000000000001',
+    knowledgeBaseIds: [],
+    mcpServerIds: [],
+    modelId,
+    modelName: null,
+    name: 'Contract Assistant',
+    orderKey: 'a0',
+    prompt: '',
+    settings: DEFAULT_ASSISTANT_SETTINGS,
+    tags: [],
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export { MODEL_CAPABILITY };

--- a/src/backend/ai/__tests__/behavior/AiService.checkModel.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.checkModel.test.ts
@@ -1,0 +1,182 @@
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider';
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { MockEmbeddingModelV3, MockLanguageModelV3 } from 'ai/test';
+import * as Crypto from 'expo-crypto';
+
+import { AiService } from '@/backend/ai/AiService';
+
+import { projectEmbeddingCall, projectLanguageCall } from '../_harness/contracts';
+import { installMockProvider, textGenerateResult } from '../_harness/mockProvider';
+import { createContractFixture } from '../_harness/services';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(async () => {
+    throw new Error('Unexpected expo.fetch call in AI SDK contract test');
+  }),
+}));
+
+describe('AiService.checkModel AI SDK contract', () => {
+  let restoreProvider: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected fetch call in AI SDK contract test'));
+    jest.spyOn(Crypto, 'randomUUID').mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+  });
+
+  afterEach(() => {
+    restoreProvider?.();
+    restoreProvider = undefined;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('probes language models through generateText', async () => {
+    const fixture = createContractFixture();
+    const languageModel = new MockLanguageModelV3({
+      doGenerate: textGenerateResult('ok'),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const result = await new AiService(fixture.services).checkModel({
+      requestOptions: { maxRetries: 2 },
+      timeout: 1000,
+      uniqueModelId: fixture.model.id,
+    });
+
+    expect(languageModel.doGenerateCalls).toHaveLength(1);
+    expect(projectLanguageCall(languageModel.doGenerateCalls[0])).toMatchSnapshot(
+      'language probe call',
+    );
+    expect(result.latency).toEqual(expect.any(Number));
+    expect(result.latency).toBeGreaterThanOrEqual(0);
+  });
+
+  test('probes embedding models with override context and records usage', async () => {
+    const fixture = embeddingFixture();
+    const embeddingModel = new MockEmbeddingModelV3({
+      doEmbed: {
+        embeddings: [[0.1, 0.2, 0.3]],
+        usage: { tokens: 4 },
+        warnings: [],
+      },
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ embedding: embeddingModel });
+
+    await new AiService(fixture.services).checkModel({
+      apiKeyOverride: 'override-key',
+      requestOptions: {
+        headers: { 'X-Check': 'embedding', 'X-Empty': undefined },
+        maxRetries: 3,
+      },
+      timeout: 1000,
+      uniqueModelId: fixture.model.id,
+    });
+
+    expect(embeddingModel.doEmbedCalls).toHaveLength(1);
+    expect(projectEmbeddingCall(embeddingModel.doEmbedCalls[0])).toMatchSnapshot(
+      'embedding probe call',
+    );
+    expect(fixture.spies.resolveApiKey).toHaveBeenCalledWith(fixture.provider.id, 'override-key');
+    expect(fixture.spies.recordInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ messageRef: null, modelId: fixture.model.modelId }),
+        modality: 'embedding',
+        usage: { inputTokens: 4, totalTokens: 4 },
+      }),
+    );
+  });
+
+  test('propagates caller aborts into the active language probe', async () => {
+    const fixture = createContractFixture();
+    const { doGenerate, started } = abortableGenerate();
+    const languageModel = new MockLanguageModelV3({
+      doGenerate,
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+    const controller = new AbortController();
+    const abortReason = new Error('caller cancelled model check');
+
+    const rejection = captureRejection(
+      new AiService(fixture.services).checkModel({
+        requestOptions: { signal: controller.signal },
+        timeout: 1000,
+        uniqueModelId: fixture.model.id,
+      }),
+    );
+    const call = await started;
+    controller.abort(abortReason);
+
+    await expect(rejection).resolves.toBe(abortReason);
+    expect(call.abortSignal).toMatchObject({ aborted: true, reason: abortReason });
+  });
+
+  test('aborts an active language probe when the check timeout expires', async () => {
+    jest.useFakeTimers();
+    const fixture = createContractFixture();
+    const { doGenerate, started } = abortableGenerate();
+    const languageModel = new MockLanguageModelV3({
+      doGenerate,
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const rejection = captureRejection(
+      new AiService(fixture.services).checkModel({
+        timeout: 25,
+        uniqueModelId: fixture.model.id,
+      }),
+    );
+    const call = await started;
+    await jest.advanceTimersByTimeAsync(25);
+    const error = await rejection;
+
+    expect(error).toMatchObject({ message: 'Check model timeout' });
+    expect(call.abortSignal).toMatchObject({ aborted: true });
+    expect(call.abortSignal?.reason).toMatchObject({ message: 'Check model timeout' });
+  });
+});
+
+function embeddingFixture() {
+  return createContractFixture({
+    capabilities: [MODEL_CAPABILITY.EMBEDDING],
+    modelId: 'contract-embedding',
+    modelOverrides: { endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS] },
+  });
+}
+
+function abortableGenerate() {
+  let notifyStarted!: (options: LanguageModelV3CallOptions) => void;
+  const started = new Promise<LanguageModelV3CallOptions>((resolve) => {
+    notifyStarted = resolve;
+  });
+  const doGenerate = async (options: LanguageModelV3CallOptions) => {
+    notifyStarted(options);
+    return new Promise<never>((_, reject) => {
+      const signal = options.abortSignal;
+      if (signal?.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+  };
+  return { doGenerate, started };
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected promise to reject');
+}

--- a/src/backend/ai/__tests__/behavior/AiService.generateImage.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.generateImage.test.ts
@@ -1,0 +1,190 @@
+import type { ImageModelV3CallOptions } from '@ai-sdk/provider';
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { MockImageModelV3 } from 'ai/test';
+import * as Crypto from 'expo-crypto';
+
+import { AiService } from '@/backend/ai/AiService';
+
+import { projectContractValue, projectImageCall } from '../_harness/contracts';
+import { installMockProvider } from '../_harness/mockProvider';
+import { createContractFixture } from '../_harness/services';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(async () => {
+    throw new Error('Unexpected expo.fetch call in AI SDK contract test');
+  }),
+}));
+
+const PNG_BASE64 = 'iVBORw0KGgo=';
+
+describe('AiService.generateImage AI SDK contract', () => {
+  let restoreProvider: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected fetch call in AI SDK contract test'));
+    jest.spyOn(Crypto, 'randomUUID').mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+  });
+
+  afterEach(() => {
+    restoreProvider?.();
+    restoreProvider = undefined;
+    jest.restoreAllMocks();
+  });
+
+  test('maps generation parameters into the image model call and records usage', async () => {
+    const fixture = imageFixture();
+    const doGenerate = jest.fn(async (_options: ImageModelV3CallOptions) => imageResult());
+    const imageModel = new MockImageModelV3({
+      doGenerate,
+      maxImagesPerCall: 4,
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ image: imageModel });
+
+    const result = await new AiService(fixture.services).generateImage({
+      mode: 'generate',
+      paramValues: {
+        background: 'transparent',
+        numImages: 2,
+        quality: 'high',
+        seed: 42,
+        size: '1024x1024',
+      },
+      prompt: 'Draw two cherries.',
+      requestOptions: { headers: { 'X-Contract': 'image' } },
+      uniqueModelId: fixture.model.id,
+    });
+
+    expect(projectImageCall(doGenerate.mock.calls[0][0])).toMatchSnapshot('generation call');
+    expect(projectContractValue(result)).toMatchSnapshot('generation result');
+    expect(fixture.spies.recordInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageCount: 2,
+        modality: 'image',
+        usage: { inputTokens: 3, outputTokens: 5, totalTokens: 8 },
+      }),
+    );
+  });
+
+  test('maps input data URLs into image-edit files without using HTTP', async () => {
+    const fixture = imageFixture();
+    const doGenerate = jest.fn(async (_options: ImageModelV3CallOptions) => imageResult(1));
+    const imageModel = new MockImageModelV3({
+      doGenerate,
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ image: imageModel });
+
+    await new AiService(fixture.services).generateImage({
+      inputImages: [`data:image/png;base64,${PNG_BASE64}`],
+      mode: 'edit',
+      paramValues: {},
+      prompt: 'Add a leaf.',
+      uniqueModelId: fixture.model.id,
+    });
+
+    expect(projectImageCall(doGenerate.mock.calls[0][0])).toMatchSnapshot('image edit call');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(jest.requireMock('expo/fetch').fetch).not.toHaveBeenCalled();
+  });
+
+  test('preserves image-model failures unchanged', async () => {
+    const fixture = imageFixture();
+    const modelError = new Error('image model failed');
+    const imageModel = new MockImageModelV3({
+      doGenerate: async () => {
+        throw modelError;
+      },
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ image: imageModel });
+
+    const error = await captureRejection(
+      new AiService(fixture.services).generateImage({
+        mode: 'generate',
+        paramValues: {},
+        prompt: 'Fail.',
+        uniqueModelId: fixture.model.id,
+      }),
+    );
+
+    expect(error).toBe(modelError);
+  });
+
+  test('forwards aborts to the image model and preserves the abort reason', async () => {
+    const fixture = imageFixture();
+    let notifyStarted!: (options: ImageModelV3CallOptions) => void;
+    const started = new Promise<ImageModelV3CallOptions>((resolve) => {
+      notifyStarted = resolve;
+    });
+    const imageModel = new MockImageModelV3({
+      doGenerate: async (options) => {
+        notifyStarted(options);
+        return new Promise((_, reject) => {
+          const signal = options.abortSignal;
+          if (signal?.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      },
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ image: imageModel });
+    const controller = new AbortController();
+    const abortReason = new Error('cancelled image generation');
+
+    const rejection = captureRejection(
+      new AiService(fixture.services).generateImage({
+        mode: 'generate',
+        paramValues: {},
+        prompt: 'Wait.',
+        requestOptions: { signal: controller.signal },
+        uniqueModelId: fixture.model.id,
+      }),
+    );
+    const call = await started;
+    controller.abort(abortReason);
+    const error = await rejection;
+
+    expect(call.abortSignal).toMatchObject({ aborted: true, reason: abortReason });
+    expect(error).toBe(abortReason);
+  });
+});
+
+function imageFixture() {
+  return createContractFixture({
+    capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+    modelId: 'contract-image',
+    modelOverrides: { endpointTypes: [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION] },
+  });
+}
+
+function imageResult(count = 2) {
+  return {
+    images: Array.from({ length: count }, () => PNG_BASE64),
+    response: {
+      headers: {},
+      modelId: 'contract-image',
+      timestamp: new Date('2026-08-08T00:00:00.000Z'),
+    },
+    usage: { inputTokens: 3, outputTokens: 5, totalTokens: 8 },
+    warnings: [],
+  };
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected promise to reject');
+}

--- a/src/backend/ai/__tests__/behavior/AiService.generateText.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.generateText.test.ts
@@ -1,0 +1,112 @@
+import type { ModelMessage } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import * as Crypto from 'expo-crypto';
+
+import { AiService } from '@/backend/ai/AiService';
+
+import { projectContractValue, projectLanguageCall } from '../_harness/contracts';
+import { installMockProvider, textGenerateResult } from '../_harness/mockProvider';
+import { createContractFixture } from '../_harness/services';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(async () => {
+    throw new Error('Unexpected expo.fetch call in AI SDK contract test');
+  }),
+}));
+
+describe('AiService.generateText AI SDK contract', () => {
+  let restoreProvider: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected fetch call in AI SDK contract test'));
+    jest.spyOn(Crypto, 'randomUUID').mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    restoreProvider?.();
+    restoreProvider = undefined;
+    jest.restoreAllMocks();
+  });
+
+  test('uses the explicit system prompt and returns text with recorded usage', async () => {
+    const fixture = createContractFixture({ assistantPrompt: 'Assistant-owned prompt.' });
+    const languageModel = new MockLanguageModelV3({
+      doGenerate: textGenerateResult('Contract title'),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const result = await new AiService(fixture.services).generateText({
+      assistantId: fixture.assistant.id,
+      prompt: 'Name this conversation.',
+      system: 'Return a short title.',
+    });
+
+    expect(projectLanguageCall(languageModel.doGenerateCalls[0])).toMatchSnapshot('prompt call');
+    expect(projectContractValue(result)).toMatchSnapshot('prompt result');
+    expect(result.text).toBe('Contract title');
+    expect(fixture.spies.recordInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ messageRef: null }),
+        modality: 'language',
+        usage: expect.objectContaining({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }),
+      }),
+    );
+  });
+
+  test('passes model messages when no prompt string is supplied', async () => {
+    const fixture = createContractFixture();
+    const languageModel = new MockLanguageModelV3({
+      doGenerate: textGenerateResult('Summary'),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+    const messages: ModelMessage[] = [
+      { content: [{ text: 'Question', type: 'text' }], role: 'user' },
+      { content: [{ text: 'Answer', type: 'text' }], role: 'assistant' },
+      { content: [{ text: 'Summarize', type: 'text' }], role: 'user' },
+    ];
+
+    await new AiService(fixture.services).generateText({
+      messages,
+      uniqueModelId: fixture.model.id,
+    });
+
+    expect(projectLanguageCall(languageModel.doGenerateCalls[0])).toMatchSnapshot('messages call');
+  });
+
+  test('preserves model failures and rejects pre-aborted requests without calling the model', async () => {
+    const fixture = createContractFixture();
+    const modelError = new Error('generation failed');
+    const languageModel = new MockLanguageModelV3({
+      doGenerate: async () => {
+        throw modelError;
+      },
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+    const service = new AiService(fixture.services);
+
+    await expect(
+      service.generateText({ prompt: 'Fail', uniqueModelId: fixture.model.id }),
+    ).rejects.toBe(modelError);
+
+    const controller = new AbortController();
+    const abortReason = new Error('cancelled before generate');
+    controller.abort(abortReason);
+    await expect(
+      service.generateText({
+        prompt: 'Do not run',
+        requestOptions: { signal: controller.signal },
+        uniqueModelId: fixture.model.id,
+      }),
+    ).rejects.toBe(abortReason);
+    expect(languageModel.doGenerateCalls).toHaveLength(1);
+  });
+});

--- a/src/backend/ai/__tests__/behavior/AiService.streamText.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.streamText.test.ts
@@ -1,0 +1,185 @@
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import type { CherryUIMessage } from '@cherrystudio/universal/data/types/message';
+import { MockLanguageModelV3 } from 'ai/test';
+import * as Crypto from 'expo-crypto';
+
+import { AiService } from '@/backend/ai/AiService';
+
+import {
+  collectStreamContract,
+  projectContractValue,
+  projectLanguageCall,
+} from '../_harness/contracts';
+import { installMockProvider, textStreamResult } from '../_harness/mockProvider';
+import { createContractFixture } from '../_harness/services';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(async () => {
+    throw new Error('Unexpected expo.fetch call in AI SDK contract test');
+  }),
+}));
+
+jest.mock('expo-file-system', () => ({
+  File: class MockFile {
+    readonly type = 'image/png';
+
+    async base64() {
+      return 'iVBORw0KGgo=';
+    }
+  },
+}));
+
+describe('AiService.streamText AI SDK contract', () => {
+  let restoreProvider: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected fetch call in AI SDK contract test'));
+    jest.spyOn(Crypto, 'randomUUID').mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+  });
+
+  afterEach(() => {
+    restoreProvider?.();
+    restoreProvider = undefined;
+    jest.restoreAllMocks();
+  });
+
+  test('projects a plain model stream into stable chunks, final message, and usage', async () => {
+    const fixture = createContractFixture();
+    const languageModel = new MockLanguageModelV3({
+      doStream: textStreamResult('Hello from the contract model.'),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      chatId: 'topic-1',
+      messageId: 'assistant-message-1',
+      messages: [userMessage('Hello')],
+      requestOptions: { signal: new AbortController().signal },
+      trigger: 'submit-message',
+    });
+    const output = await collectStreamContract(stream);
+
+    expect(projectLanguageCall(languageModel.doStreamCalls[0])).toMatchSnapshot('plain model call');
+    expect(projectContractValue(output)).toMatchSnapshot('plain stream output');
+    expect(output.finalMessage).toMatchObject({
+      id: 'assistant-message-1',
+      metadata: {
+        completionTokens: 5,
+        promptTokens: 10,
+        thoughtsTokens: 1,
+        totalTokens: 15,
+      },
+      parts: expect.arrayContaining([
+        {
+          providerMetadata: undefined,
+          state: 'done',
+          text: 'Hello from the contract model.',
+          type: 'text',
+        },
+      ]),
+      role: 'assistant',
+    });
+    expect(fixture.spies.recordInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          messageRef: { id: 'assistant-message-1', kind: 'chat' },
+        }),
+        modality: 'language',
+        usage: expect.objectContaining({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }),
+      }),
+    );
+  });
+
+  test('preserves rich input and resolves a managed attachment before the model boundary', async () => {
+    const fixture = createContractFixture({
+      assistantPrompt: 'Answer from the supplied evidence.',
+      capabilities: [MODEL_CAPABILITY.IMAGE_RECOGNITION],
+      fileUri: 'file:///contract/image.png',
+      modelOverrides: {
+        parameterSupport: {
+          maxTokens: true,
+          stopSequences: true,
+          systemMessage: true,
+          temperature: { max: 2, min: 0, supported: true },
+          topP: { max: 1, min: 0, supported: true },
+        },
+      },
+    });
+    const languageModel = new MockLanguageModelV3({
+      doStream: textStreamResult('The image contains a cherry.'),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const message: CherryUIMessage = {
+      id: 'user-message-1',
+      parts: [
+        { text: 'What is shown?', type: 'text' },
+        {
+          filename: 'image.png',
+          mediaType: 'image/png',
+          providerMetadata: { cherry: { fileEntryId: 'file-entry-1' } },
+          type: 'file',
+          url: 'file:///stale/image.png',
+        },
+      ],
+      role: 'user',
+    };
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      callOverrides: {
+        maxOutputTokens: 256,
+        stopSequences: ['END'],
+        temperature: 0.3,
+        topP: 0.8,
+      },
+      chatId: 'topic-1',
+      messageId: 'assistant-message-2',
+      messages: [message],
+      requestOptions: {
+        headers: { 'X-Contract': 'rich-input' },
+        signal: new AbortController().signal,
+      },
+      trigger: 'submit-message',
+    });
+    await collectStreamContract(stream);
+
+    expect(fixture.spies.resolveRenderableUri).toHaveBeenCalledWith('file-entry-1');
+    expect(projectLanguageCall(languageModel.doStreamCalls[0])).toMatchSnapshot('rich model call');
+    expect(languageModel.doStreamCalls[0]).toMatchObject({
+      headers: { 'X-Contract': 'rich-input' },
+      maxOutputTokens: 256,
+      stopSequences: ['END'],
+      temperature: 0.3,
+      topP: 0.8,
+    });
+  });
+
+  test('rejects before creating a model stream when no abort signal is supplied', async () => {
+    const fixture = createContractFixture();
+
+    await expect(
+      new AiService(fixture.services).streamText({
+        assistantId: fixture.assistant.id,
+        chatId: 'topic-1',
+        messages: [],
+        trigger: 'submit-message',
+      }),
+    ).rejects.toThrow('streamText requires requestOptions.signal');
+  });
+});
+
+function userMessage(text: string): CherryUIMessage {
+  return {
+    id: 'user-message-1',
+    parts: [{ text, type: 'text' }],
+    role: 'user',
+  };
+}

--- a/src/backend/ai/__tests__/behavior/AiService.termination.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.termination.test.ts
@@ -1,0 +1,275 @@
+import type {
+  LanguageModelV3CallOptions,
+  LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
+} from '@ai-sdk/provider';
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { tool, type ToolSet, type UIMessageChunk } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import * as Crypto from 'expo-crypto';
+import * as z from 'zod';
+
+import { AiService } from '@/backend/ai/AiService';
+import { WebSearchConfigError } from '@/backend/services/webSearch/WebSearchConfigError';
+
+import { collectStreamContract } from '../_harness/contracts';
+import { installMockProvider, toolCallStreamResult } from '../_harness/mockProvider';
+import { createContractFixture } from '../_harness/services';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(async () => {
+    throw new Error('Unexpected expo.fetch call in AI SDK contract test');
+  }),
+}));
+
+describe('AiService terminal AI SDK contract', () => {
+  let restoreProvider: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected fetch call in AI SDK contract test'));
+    jest.spyOn(Crypto, 'randomUUID').mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    restoreProvider?.();
+    restoreProvider = undefined;
+    jest.restoreAllMocks();
+  });
+
+  test('rejects the service promise when model resolution fails before Agent creation', async () => {
+    const fixture = createContractFixture();
+
+    await expect(
+      new AiService(fixture.services).streamText({
+        chatId: 'topic-1',
+        messages: [],
+        requestOptions: { signal: new AbortController().signal },
+        trigger: 'submit-message',
+        uniqueModelId: 'contract-provider::missing-model',
+      }),
+    ).rejects.toThrow('Cannot resolve model: contract-provider::missing-model');
+  });
+
+  test('preserves partial chunks and rejects the reader with the original model stream error', async () => {
+    const fixture = createContractFixture();
+    const providerError = new Error('provider stream failed');
+    const languageModel = new MockLanguageModelV3({
+      doStream: failingPartialStream(providerError),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const stream = await streamText(fixture, new AbortController());
+    const outcome = await readUntilError(stream);
+
+    expect(outcome.error).toBe(providerError);
+    expect(outcome.chunks).toContainEqual({ delta: 'partial', id: 'text-1', type: 'text-delta' });
+    expect(outcome.chunks).not.toContainEqual(expect.objectContaining({ type: 'finish' }));
+  });
+
+  test('closes cleanly after an in-flight abort without recording unfinished usage', async () => {
+    const fixture = createContractFixture();
+    const requestController = new AbortController();
+    const abortReason = new Error('user cancelled');
+    const languageModel = new MockLanguageModelV3({
+      doStream: async (options) => abortablePartialStream(options),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const stream = await streamText(fixture, requestController);
+    const reader = stream.getReader();
+    const chunks: UIMessageChunk[] = [];
+    while (!chunks.some((chunk) => chunk.type === 'text-delta')) {
+      const next = await reader.read();
+      if (next.done) throw new Error('stream closed before partial text');
+      chunks.push(next.value);
+    }
+    requestController.abort(abortReason);
+    const terminal = await reader.read();
+
+    expect(terminal.done).toBe(true);
+    expect(chunks).toContainEqual({ delta: 'partial', id: 'text-1', type: 'text-delta' });
+    expect(chunks).not.toContainEqual(expect.objectContaining({ type: 'finish' }));
+    expect(fixture.spies.recordInvocation).not.toHaveBeenCalled();
+  });
+
+  test('turns a permanent web-search configuration failure into a terminal stream error', async () => {
+    const fixture = createContractFixture({
+      assistantSettings: { enableWebSearch: true },
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
+    });
+    fixture.spies.searchKeywords.mockRejectedValue(
+      new WebSearchConfigError('provider_not_configured', 'search is not configured'),
+    );
+    const languageModel = new MockLanguageModelV3({
+      doStream: toolCallStreamResult({
+        args: { query: 'Cherry Studio current release' },
+        toolName: 'web_search',
+      }),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const outcome = await readUntilError(
+      await streamText(fixture, new AbortController(), { messageId: 'assistant-search-error' }),
+    );
+
+    expect(outcome.error).toMatchObject({
+      i18nKey: 'web_search_provider_unavailable',
+      name: 'ToolLoopTerminalError',
+    });
+    expect(outcome.chunks).toContainEqual(
+      expect.objectContaining({
+        output: expect.objectContaining({ retryable: false, terminal: true }),
+        type: 'tool-output-available',
+      }),
+    );
+    expect(languageModel.doStreamCalls).toHaveLength(1);
+  });
+
+  test('turns the configured tool-call cap into a terminal stream error', async () => {
+    const fixture = createContractFixture({
+      assistantSettings: { enableMaxToolCalls: true, maxToolCalls: 1 },
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
+    });
+    const languageModel = new MockLanguageModelV3({
+      doStream: toolCallStreamResult({ args: { value: 'one' }, toolName: 'repeat' }),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const outcome = await readUntilError(
+      await streamText(fixture, new AbortController(), {
+        tools: {
+          repeat: tool({
+            execute: async ({ value }) => value,
+            inputSchema: z.object({ value: z.string() }),
+          }),
+        },
+      }),
+    );
+
+    expect(outcome.error).toMatchObject({
+      i18nKey: 'tool_call_limit_reached',
+      name: 'ToolLoopTerminalError',
+    });
+    expect(languageModel.doStreamCalls).toHaveLength(1);
+  });
+
+  test('treats shouldYield at a tool step boundary as a clean stop', async () => {
+    const fixture = createContractFixture({ capabilities: [MODEL_CAPABILITY.FUNCTION_CALL] });
+    const languageModel = new MockLanguageModelV3({
+      doStream: toolCallStreamResult({ args: { value: 'one' }, toolName: 'yielding' }),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      callOverrides: {
+        tools: {
+          yielding: tool({
+            execute: async ({ value }) => value,
+            inputSchema: z.object({ value: z.string() }),
+          }),
+        },
+      },
+      chatId: 'topic-1',
+      messageId: 'assistant-yield',
+      messages: [userMessage('Run once.')],
+      requestOptions: { signal: new AbortController().signal },
+      shouldYield: () => true,
+      trigger: 'submit-message',
+    });
+    const output = await collectStreamContract(stream);
+
+    expect(languageModel.doStreamCalls).toHaveLength(1);
+    expect(output.chunks).toContainEqual(expect.objectContaining({ type: 'finish' }));
+    expect(output.finalMessage?.parts).toContainEqual(
+      expect.objectContaining({ state: 'output-available', type: 'tool-yielding' }),
+    );
+  });
+});
+
+function abortablePartialStream(options: LanguageModelV3CallOptions): LanguageModelV3StreamResult {
+  return {
+    stream: new ReadableStream<LanguageModelV3StreamPart>({
+      start(controller) {
+        controller.enqueue({ type: 'stream-start', warnings: [] });
+        controller.enqueue({ id: 'text-1', type: 'text-start' });
+        controller.enqueue({ delta: 'partial', id: 'text-1', type: 'text-delta' });
+        options.abortSignal?.addEventListener(
+          'abort',
+          () => controller.error(options.abortSignal?.reason),
+          { once: true },
+        );
+      },
+    }),
+  };
+}
+
+function failingPartialStream(error: Error): LanguageModelV3StreamResult {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: 'stream-start', warnings: [] },
+    { id: 'text-1', type: 'text-start' },
+    { delta: 'partial', id: 'text-1', type: 'text-delta' },
+  ];
+  let index = 0;
+  return {
+    stream: new ReadableStream<LanguageModelV3StreamPart>({
+      pull(controller) {
+        const chunk = chunks[index++];
+        if (chunk) controller.enqueue(chunk);
+        else controller.error(error);
+      },
+    }),
+  };
+}
+
+async function readUntilError(stream: ReadableStream<UIMessageChunk>) {
+  const reader = stream.getReader();
+  const chunks: UIMessageChunk[] = [];
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) return { chunks, error: undefined };
+      chunks.push(next.value);
+    }
+  } catch (error) {
+    return { chunks, error };
+  }
+}
+
+function streamText(
+  fixture: ReturnType<typeof createContractFixture>,
+  controller: AbortController,
+  overrides: { messageId?: string; tools?: ToolSet } = {},
+) {
+  return new AiService(fixture.services).streamText({
+    assistantId: fixture.assistant.id,
+    ...(overrides.tools ? { callOverrides: { tools: overrides.tools } } : {}),
+    chatId: 'topic-1',
+    messageId: overrides.messageId ?? 'assistant-terminal',
+    messages: [userMessage('Run the contract.')],
+    requestOptions: { signal: controller.signal },
+    trigger: 'submit-message',
+  });
+}
+
+function userMessage(text: string) {
+  return {
+    id: 'user-message-1',
+    parts: [{ text, type: 'text' as const }],
+    role: 'user' as const,
+  };
+}

--- a/src/backend/ai/__tests__/behavior/AiService.tools.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.tools.test.ts
@@ -1,0 +1,307 @@
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider';
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { dynamicTool, tool } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import * as Crypto from 'expo-crypto';
+import * as z from 'zod';
+
+import { AiService } from '@/backend/ai/AiService';
+import type { ToolEntry } from '@/backend/ai/tools/adapters/aiSdk/types';
+
+import {
+  collectStreamContract,
+  projectContractValue,
+  projectLanguageCall,
+} from '../_harness/contracts';
+import {
+  installMockProvider,
+  streamSequence,
+  textStreamResult,
+  toolCallStreamResult,
+} from '../_harness/mockProvider';
+import { createContractFixture } from '../_harness/services';
+
+jest.mock('expo/fetch', () => ({
+  fetch: jest.fn(async () => {
+    throw new Error('Unexpected expo.fetch call in AI SDK contract test');
+  }),
+}));
+
+describe('AiService tool AI SDK contract', () => {
+  let restoreProvider: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected fetch call in AI SDK contract test'));
+    jest.spyOn(Crypto, 'randomUUID').mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+  });
+
+  afterEach(() => {
+    restoreProvider?.();
+    restoreProvider = undefined;
+    jest.restoreAllMocks();
+  });
+
+  test('executes a local tool, forwards timing, and sends the result into the second model call', async () => {
+    const fixture = createContractFixture({ capabilities: [MODEL_CAPABILITY.FUNCTION_CALL] });
+    const languageModel = new MockLanguageModelV3({
+      doStream: streamSequence(
+        toolCallStreamResult({ args: { city: 'Shanghai' }, toolName: 'weather' }),
+        textStreamResult('Shanghai is sunny.'),
+      ),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+    const execute = jest.fn(async ({ city }: { city: string }) => ({ city, condition: 'sunny' }));
+    const runtimeTimingSink = {
+      onToolExecutionEnd: jest.fn(),
+      onToolExecutionStart: jest.fn(),
+    };
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      callOverrides: {
+        tools: {
+          weather: tool({
+            description: 'Get the current weather for a city.',
+            execute,
+            inputSchema: z.object({ city: z.string() }),
+          }),
+        },
+      },
+      chatId: 'topic-1',
+      messageId: 'assistant-message-tool',
+      messages: [userMessage('What is the weather?')],
+      requestOptions: { signal: new AbortController().signal },
+      runtimeTimingSink,
+      trigger: 'submit-message',
+    });
+    const output = await collectStreamContract(stream);
+
+    expect(execute).toHaveBeenCalledWith(
+      { city: 'Shanghai' },
+      expect.objectContaining({ toolCallId: 'tool-call-1' }),
+    );
+    expect(runtimeTimingSink.onToolExecutionStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: 'tool-call-1',
+        input: { city: 'Shanghai' },
+        toolName: 'weather',
+      }),
+    );
+    expect(runtimeTimingSink.onToolExecutionEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: 'tool-call-1',
+        toolName: 'weather',
+        toolOutput: { output: { city: 'Shanghai', condition: 'sunny' }, type: 'tool-result' },
+      }),
+    );
+    expect(runtimeTimingSink.onToolExecutionStart.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeTimingSink.onToolExecutionEnd.mock.invocationCallOrder[0],
+    );
+    expect(languageModel.doStreamCalls).toHaveLength(2);
+    expect(languageModel.doStreamCalls.map(projectLanguageCall)).toMatchSnapshot(
+      'successful local tool model calls',
+    );
+    expect(projectContractValue(output)).toMatchSnapshot('successful local tool output');
+  });
+
+  test('returns a local tool exception to the model and still accepts its final answer', async () => {
+    const fixture = createContractFixture({ capabilities: [MODEL_CAPABILITY.FUNCTION_CALL] });
+    const languageModel = new MockLanguageModelV3({
+      doStream: streamSequence(
+        toolCallStreamResult({ args: { query: 'status' }, toolName: 'unstable' }),
+        textStreamResult('The tool failed, so no status is available.'),
+      ),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+    const toolError = new Error('tool unavailable');
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      callOverrides: {
+        tools: {
+          unstable: tool({
+            execute: async (_input: { query: string }): Promise<string> => {
+              throw toolError;
+            },
+            inputSchema: z.object({ query: z.string() }),
+          }),
+        },
+      },
+      chatId: 'topic-1',
+      messageId: 'assistant-message-error',
+      messages: [userMessage('Check the status.')],
+      requestOptions: { signal: new AbortController().signal },
+      trigger: 'submit-message',
+    });
+    const output = await collectStreamContract(stream);
+
+    expect(languageModel.doStreamCalls).toHaveLength(2);
+    expect(projectLanguageCall(languageModel.doStreamCalls[1])).toMatchSnapshot(
+      'tool error second model call',
+    );
+    expect(output.chunks).toContainEqual(
+      expect.objectContaining({ errorText: 'tool unavailable', type: 'tool-output-error' }),
+    );
+    expect(output.finalMessage).toMatchObject({
+      parts: expect.arrayContaining([
+        expect.objectContaining({
+          text: 'The tool failed, so no status is available.',
+          type: 'text',
+        }),
+      ]),
+    });
+  });
+
+  test('materializes and executes an injected MCP tool through the real ToolResolver', async () => {
+    const execute = jest.fn(async (input: unknown) => {
+      const { path } = z.object({ path: z.string() }).parse(input);
+      return `contents:${path}`;
+    });
+    const mcpEntry: ToolEntry = {
+      defer: 'never',
+      description: 'Read a file through MCP.',
+      name: 'mcp__files__read',
+      namespace: 'mcp:Files',
+      tool: dynamicTool({
+        description: 'Read a file through MCP.',
+        execute,
+        inputSchema: z.object({ path: z.string() }),
+        metadata: { cherry: { tool: { serverId: 'files', serverName: 'Files', type: 'mcp' } } },
+      }),
+    };
+    const fixture = createContractFixture({
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
+      mcpEntries: [mcpEntry],
+    });
+    const languageModel = new MockLanguageModelV3({
+      doStream: streamSequence(
+        toolCallStreamResult({ args: { path: 'README.md' }, toolName: mcpEntry.name }),
+        textStreamResult('The file was read.'),
+      ),
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      chatId: 'topic-1',
+      mcpToolIds: ['files::read'],
+      messageId: 'assistant-message-mcp',
+      messages: [userMessage('Read the README.')],
+      requestOptions: { signal: new AbortController().signal },
+      trigger: 'submit-message',
+    });
+    const output = await collectStreamContract(stream);
+
+    expect(fixture.spies.getToolEntriesForAssistant).toHaveBeenCalledWith(fixture.assistant, [
+      'files::read',
+    ]);
+    expect(execute).toHaveBeenCalledWith(
+      { path: 'README.md' },
+      expect.objectContaining({ toolCallId: 'tool-call-1' }),
+    );
+    expect(languageModel.doStreamCalls).toHaveLength(2);
+    expect(languageModel.doStreamCalls.map(projectLanguageCall)).toMatchSnapshot('MCP model calls');
+    expect(projectContractValue(output.finalMessage)).toMatchSnapshot('MCP final message');
+  });
+
+  test('returns agentic web search citations through the tool loop', async () => {
+    const fixture = createContractFixture({
+      assistantSettings: { enableWebSearch: true },
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
+    });
+    const languageModel = new MockLanguageModelV3({
+      doStream: async (options) => {
+        const citationId = findWebSearchCitationId(options);
+        return citationId
+          ? textStreamResult(`Cherry Studio is on mobile.[cite:${citationId}]`)
+          : toolCallStreamResult({
+              args: { query: 'Cherry Studio current release' },
+              toolName: 'web_search',
+            });
+      },
+      modelId: fixture.model.modelId,
+      provider: 'contract-provider',
+    });
+    restoreProvider = installMockProvider({ language: languageModel });
+
+    const stream = await new AiService(fixture.services).streamText({
+      assistantId: fixture.assistant.id,
+      chatId: 'topic-1',
+      messageId: 'assistant-message-search',
+      messages: [userMessage('Is Cherry Studio available on mobile?')],
+      requestOptions: { signal: new AbortController().signal },
+      trigger: 'submit-message',
+    });
+    const output = await collectStreamContract(stream);
+
+    expect(fixture.spies.searchKeywords).toHaveBeenCalledWith(
+      { keywords: ['Cherry Studio current release'] },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(projectLanguageCall(languageModel.doStreamCalls[0])).toMatchSnapshot(
+      'web search first model call',
+    );
+    expect(projectLanguageCall(languageModel.doStreamCalls[1])).toMatchSnapshot(
+      'web search second model call',
+    );
+    const searchChunk = output.chunks.find((chunk) => chunk.type === 'tool-output-available');
+    expect(searchChunk).toMatchObject({
+      output: [expect.objectContaining({ url: 'https://example.com/cherry' })],
+    });
+    const searchOutput = searchChunk?.output;
+    if (!Array.isArray(searchOutput) || typeof searchOutput[0]?.id !== 'string') {
+      throw new Error('Expected web_search to return a citation result');
+    }
+    const citationId = searchOutput[0].id;
+    expect(output.finalMessage).toMatchObject({
+      parts: expect.arrayContaining([
+        expect.objectContaining({
+          text: `Cherry Studio is on mobile.[cite:${citationId}]`,
+          type: 'text',
+        }),
+      ]),
+    });
+  });
+});
+
+function userMessage(text: string) {
+  return {
+    id: 'user-message-1',
+    parts: [{ text, type: 'text' as const }],
+    role: 'user' as const,
+  };
+}
+
+function findWebSearchCitationId(options: LanguageModelV3CallOptions): string | undefined {
+  for (const message of options.prompt) {
+    if (message.role !== 'tool') continue;
+    for (const part of message.content) {
+      if (
+        part.type !== 'tool-result' ||
+        part.toolName !== 'web_search' ||
+        part.output.type !== 'json' ||
+        !Array.isArray(part.output.value)
+      ) {
+        continue;
+      }
+      const first = part.output.value[0];
+      if (
+        typeof first === 'object' &&
+        first !== null &&
+        !Array.isArray(first) &&
+        typeof first.id === 'string'
+      ) {
+        return first.id;
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/backend/ai/__tests__/behavior/README.md
+++ b/src/backend/ai/__tests__/behavior/README.md
@@ -1,0 +1,35 @@
+# AI Behavior Contracts
+
+This suite protects the model-backed `AiService` behavior used during refactoring. It exercises the
+real `AiService -> buildAgentParams -> ai-core -> Agent` path against the AI SDK V3 mock model
+interface from `ai/test`. It does not emulate provider HTTP endpoints or SSE wire formats.
+
+## Ownership
+
+- `AiService.streamText.test.ts` owns baseline stream input, UI chunks, final messages, and usage.
+- `AiService.tools.test.ts` owns local tools, MCP tool entries, and agentic web search loops.
+- `AiService.termination.test.ts` owns rejection, stream error, abort, limit, and yield semantics.
+- `AiService.generateText.test.ts`, `AiService.generateImage.test.ts`, and
+  `AiService.checkModel.test.ts` own the other model-backed entry points.
+- Provider capabilities, provider-native tools, message rules, tool approval, MCP transport,
+  `ChatRuntime`, and `listModels` remain owned by their existing focused suites.
+
+The harness temporarily replaces the global `openai-compatible` extension. Run this directory in
+band, never use `test.concurrent`, and always restore the extension after each test. Both
+`globalThis.fetch` and `expo/fetch` are guarded so an unexpected network request fails immediately.
+
+## Snapshot Policy
+
+Model call options are projected into stable data before snapshotting. Runtime functions, object
+identity, and timing values are deliberately excluded. Critical fields also have explicit assertions.
+
+Snapshots describe existing behavior. A refactor-only change must not update them. If intended
+behavior changes, update the explicit assertions and snapshots in a separate behavior-change commit.
+Do not delete an older wiring test until an equivalent behavior contract is passing and its ownership
+is documented here.
+
+Run the suite with:
+
+```sh
+pnpm test:ai-contract
+```

--- a/src/backend/ai/__tests__/behavior/__snapshots__/AiService.checkModel.test.ts.snap
+++ b/src/backend/ai/__tests__/behavior/__snapshots__/AiService.checkModel.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AiService.checkModel AI SDK contract probes embedding models with override context and records usage: embedding probe call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "headers": {
+    "user-agent": "ai/6.0.183",
+    "x-check": "embedding",
+  },
+  "values": [
+    "test",
+  ],
+}
+`;
+
+exports[`AiService.checkModel AI SDK contract probes language models through generateText: language probe call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "headers": {
+    "user-agent": "ai/6.0.183",
+  },
+  "prompt": [
+    {
+      "content": "test",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "hi",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+}
+`;

--- a/src/backend/ai/__tests__/behavior/__snapshots__/AiService.generateImage.test.ts.snap
+++ b/src/backend/ai/__tests__/behavior/__snapshots__/AiService.generateImage.test.ts.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AiService.generateImage AI SDK contract maps generation parameters into the image model call and records usage: generation call 1`] = `
+{
+  "headers": {
+    "user-agent": "ai/6.0.183",
+    "x-contract": "image",
+  },
+  "n": 2,
+  "prompt": "Draw two cherries.",
+  "providerOptions": {
+    "contract-provider": {
+      "background": "transparent",
+      "quality": "high",
+      "seed": 42,
+    },
+  },
+  "seed": 42,
+  "size": "1024x1024",
+}
+`;
+
+exports[`AiService.generateImage AI SDK contract maps generation parameters into the image model call and records usage: generation result 1`] = `
+{
+  "images": [
+    {
+      "base64": "iVBORw0KGgo=",
+      "mediaType": "image/png",
+    },
+    {
+      "base64": "iVBORw0KGgo=",
+      "mediaType": "image/png",
+    },
+  ],
+  "usage": {
+    "inputTokens": 3,
+    "outputTokens": 5,
+    "totalTokens": 8,
+  },
+}
+`;
+
+exports[`AiService.generateImage AI SDK contract maps input data URLs into image-edit files without using HTTP: image edit call 1`] = `
+{
+  "files": [
+    {
+      "data": [
+        137,
+        80,
+        78,
+        71,
+        13,
+        10,
+        26,
+        10,
+      ],
+      "mediaType": "image/png",
+      "type": "file",
+    },
+  ],
+  "headers": {
+    "user-agent": "ai/6.0.183",
+  },
+  "n": 1,
+  "prompt": "Add a leaf.",
+  "providerOptions": {},
+}
+`;

--- a/src/backend/ai/__tests__/behavior/__snapshots__/AiService.generateText.test.ts.snap
+++ b/src/backend/ai/__tests__/behavior/__snapshots__/AiService.generateText.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AiService.generateText AI SDK contract passes model messages when no prompt string is supplied: messages call 1`] = `
+{
+  "headers": {
+    "user-agent": "ai/6.0.183",
+  },
+  "prompt": [
+    {
+      "content": [
+        {
+          "text": "Question",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "text": "Answer",
+          "type": "text",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "text": "Summarize",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+}
+`;
+
+exports[`AiService.generateText AI SDK contract uses the explicit system prompt and returns text with recorded usage: prompt call 1`] = `
+{
+  "headers": {
+    "user-agent": "ai/6.0.183",
+  },
+  "prompt": [
+    {
+      "content": "Return a short title.",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "Name this conversation.",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "providerOptions": {
+    "contract-provider": {},
+  },
+}
+`;
+
+exports[`AiService.generateText AI SDK contract uses the explicit system prompt and returns text with recorded usage: prompt result 1`] = `
+{
+  "text": "Contract title",
+  "usage": {
+    "cachedInputTokens": 2,
+    "inputTokenDetails": {
+      "cacheReadTokens": 2,
+      "cacheWriteTokens": 1,
+      "noCacheTokens": 7,
+    },
+    "inputTokens": 10,
+    "outputTokenDetails": {
+      "reasoningTokens": 1,
+      "textTokens": 4,
+    },
+    "outputTokens": 5,
+    "reasoningTokens": 1,
+    "totalTokens": 15,
+  },
+}
+`;

--- a/src/backend/ai/__tests__/behavior/__snapshots__/AiService.streamText.test.ts.snap
+++ b/src/backend/ai/__tests__/behavior/__snapshots__/AiService.streamText.test.ts.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AiService.streamText AI SDK contract preserves rich input and resolves a managed attachment before the model boundary: rich model call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "headers": {
+    "X-Contract": "rich-input",
+  },
+  "maxOutputTokens": 256,
+  "prompt": [
+    {
+      "content": "Answer from the supplied evidence.",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "What is shown?",
+          "type": "text",
+        },
+        {
+          "data": "iVBORw0KGgo=",
+          "filename": "image.png",
+          "mediaType": "image/png",
+          "providerOptions": {
+            "cherry": {
+              "fileEntryId": "file-entry-1",
+            },
+          },
+          "type": "file",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "providerOptions": {
+    "contract-provider": {},
+  },
+  "stopSequences": [
+    "END",
+  ],
+  "temperature": 0.3,
+  "topP": 0.8,
+}
+`;
+
+exports[`AiService.streamText AI SDK contract projects a plain model stream into stable chunks, final message, and usage: plain model call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "prompt": [
+    {
+      "content": "You are a precise assistant.",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "providerOptions": {
+    "contract-provider": {},
+  },
+}
+`;
+
+exports[`AiService.streamText AI SDK contract projects a plain model stream into stable chunks, final message, and usage: plain stream output 1`] = `
+{
+  "chunks": [
+    {
+      "messageId": "assistant-message-1",
+      "type": "start",
+    },
+    {
+      "type": "start-step",
+    },
+    {
+      "id": "text-1",
+      "type": "text-start",
+    },
+    {
+      "delta": "Hello from the contract model.",
+      "id": "text-1",
+      "type": "text-delta",
+    },
+    {
+      "id": "text-1",
+      "type": "text-end",
+    },
+    {
+      "messageMetadata": {
+        "completionTokens": 5,
+        "promptTokens": 10,
+        "thoughtsTokens": 1,
+        "totalTokens": 15,
+      },
+      "type": "message-metadata",
+    },
+    {
+      "type": "finish-step",
+    },
+    {
+      "finishReason": "stop",
+      "type": "finish",
+    },
+  ],
+  "finalMessage": {
+    "id": "assistant-message-1",
+    "metadata": {
+      "completionTokens": 5,
+      "promptTokens": 10,
+      "thoughtsTokens": 1,
+      "totalTokens": 15,
+    },
+    "parts": [
+      {
+        "type": "step-start",
+      },
+      {
+        "state": "done",
+        "text": "Hello from the contract model.",
+        "type": "text",
+      },
+    ],
+    "role": "assistant",
+  },
+}
+`;

--- a/src/backend/ai/__tests__/behavior/__snapshots__/AiService.tools.test.ts.snap
+++ b/src/backend/ai/__tests__/behavior/__snapshots__/AiService.tools.test.ts.snap
@@ -1,0 +1,745 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AiService tool AI SDK contract executes a local tool, forwards timing, and sends the result into the second model call: successful local tool model calls 1`] = `
+[
+  {
+    "abortSignal": {
+      "aborted": false,
+    },
+    "prompt": [
+      {
+        "content": "You are a precise assistant.",
+        "role": "system",
+      },
+      {
+        "content": [
+          {
+            "text": "What is the weather?",
+            "type": "text",
+          },
+        ],
+        "role": "user",
+      },
+    ],
+    "providerOptions": {
+      "contract-provider": {},
+    },
+    "toolChoice": {
+      "type": "auto",
+    },
+    "tools": [
+      {
+        "description": "Get the current weather for a city.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "city": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "city",
+          ],
+          "type": "object",
+        },
+        "name": "weather",
+        "type": "function",
+      },
+    ],
+  },
+  {
+    "abortSignal": {
+      "aborted": false,
+    },
+    "prompt": [
+      {
+        "content": "You are a precise assistant.",
+        "role": "system",
+      },
+      {
+        "content": [
+          {
+            "text": "What is the weather?",
+            "type": "text",
+          },
+        ],
+        "role": "user",
+      },
+      {
+        "content": [
+          {
+            "input": {
+              "city": "Shanghai",
+            },
+            "toolCallId": "tool-call-1",
+            "toolName": "weather",
+            "type": "tool-call",
+          },
+        ],
+        "role": "assistant",
+      },
+      {
+        "content": [
+          {
+            "output": {
+              "type": "json",
+              "value": {
+                "city": "Shanghai",
+                "condition": "sunny",
+              },
+            },
+            "toolCallId": "tool-call-1",
+            "toolName": "weather",
+            "type": "tool-result",
+          },
+        ],
+        "role": "tool",
+      },
+    ],
+    "providerOptions": {
+      "contract-provider": {},
+    },
+    "toolChoice": {
+      "type": "auto",
+    },
+    "tools": [
+      {
+        "description": "Get the current weather for a city.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "city": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "city",
+          ],
+          "type": "object",
+        },
+        "name": "weather",
+        "type": "function",
+      },
+    ],
+  },
+]
+`;
+
+exports[`AiService tool AI SDK contract executes a local tool, forwards timing, and sends the result into the second model call: successful local tool output 1`] = `
+{
+  "chunks": [
+    {
+      "messageId": "assistant-message-tool",
+      "type": "start",
+    },
+    {
+      "type": "start-step",
+    },
+    {
+      "input": {
+        "city": "Shanghai",
+      },
+      "toolCallId": "tool-call-1",
+      "toolName": "weather",
+      "type": "tool-input-available",
+    },
+    {
+      "output": {
+        "city": "Shanghai",
+        "condition": "sunny",
+      },
+      "toolCallId": "tool-call-1",
+      "type": "tool-output-available",
+    },
+    {
+      "type": "finish-step",
+    },
+    {
+      "messageMetadata": {
+        "completionTokens": 5,
+        "promptTokens": 10,
+        "thoughtsTokens": 1,
+        "totalTokens": 15,
+      },
+      "type": "message-metadata",
+    },
+    {
+      "type": "start-step",
+    },
+    {
+      "id": "text-1",
+      "type": "text-start",
+    },
+    {
+      "delta": "Shanghai is sunny.",
+      "id": "text-1",
+      "type": "text-delta",
+    },
+    {
+      "id": "text-1",
+      "type": "text-end",
+    },
+    {
+      "messageMetadata": {
+        "completionTokens": 10,
+        "promptTokens": 20,
+        "thoughtsTokens": 2,
+        "totalTokens": 30,
+      },
+      "type": "message-metadata",
+    },
+    {
+      "type": "finish-step",
+    },
+    {
+      "finishReason": "stop",
+      "type": "finish",
+    },
+  ],
+  "finalMessage": {
+    "id": "assistant-message-tool",
+    "metadata": {
+      "completionTokens": 10,
+      "promptTokens": 20,
+      "thoughtsTokens": 2,
+      "totalTokens": 30,
+    },
+    "parts": [
+      {
+        "type": "step-start",
+      },
+      {
+        "input": {
+          "city": "Shanghai",
+        },
+        "output": {
+          "city": "Shanghai",
+          "condition": "sunny",
+        },
+        "state": "output-available",
+        "toolCallId": "tool-call-1",
+        "type": "tool-weather",
+      },
+      {
+        "type": "step-start",
+      },
+      {
+        "state": "done",
+        "text": "Shanghai is sunny.",
+        "type": "text",
+      },
+    ],
+    "role": "assistant",
+  },
+}
+`;
+
+exports[`AiService tool AI SDK contract materializes and executes an injected MCP tool through the real ToolResolver: MCP final message 1`] = `
+{
+  "id": "assistant-message-mcp",
+  "metadata": {
+    "completionTokens": 10,
+    "promptTokens": 20,
+    "thoughtsTokens": 2,
+    "totalTokens": 30,
+  },
+  "parts": [
+    {
+      "type": "step-start",
+    },
+    {
+      "input": {
+        "path": "README.md",
+      },
+      "output": "contents:README.md",
+      "state": "output-available",
+      "toolCallId": "tool-call-1",
+      "toolMetadata": {
+        "cherry": {
+          "tool": {
+            "serverId": "files",
+            "serverName": "Files",
+            "type": "mcp",
+          },
+        },
+      },
+      "toolName": "mcp__files__read",
+      "type": "dynamic-tool",
+    },
+    {
+      "type": "step-start",
+    },
+    {
+      "state": "done",
+      "text": "The file was read.",
+      "type": "text",
+    },
+  ],
+  "role": "assistant",
+}
+`;
+
+exports[`AiService tool AI SDK contract materializes and executes an injected MCP tool through the real ToolResolver: MCP model calls 1`] = `
+[
+  {
+    "abortSignal": {
+      "aborted": false,
+    },
+    "prompt": [
+      {
+        "content": "You are a precise assistant.",
+        "role": "system",
+      },
+      {
+        "content": [
+          {
+            "text": "Read the README.",
+            "type": "text",
+          },
+        ],
+        "role": "user",
+      },
+    ],
+    "providerOptions": {
+      "contract-provider": {},
+    },
+    "toolChoice": {
+      "type": "auto",
+    },
+    "tools": [
+      {
+        "description": "Read a file through MCP.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "path",
+          ],
+          "type": "object",
+        },
+        "name": "mcp__files__read",
+        "type": "function",
+      },
+    ],
+  },
+  {
+    "abortSignal": {
+      "aborted": false,
+    },
+    "prompt": [
+      {
+        "content": "You are a precise assistant.",
+        "role": "system",
+      },
+      {
+        "content": [
+          {
+            "text": "Read the README.",
+            "type": "text",
+          },
+        ],
+        "role": "user",
+      },
+      {
+        "content": [
+          {
+            "input": {
+              "path": "README.md",
+            },
+            "toolCallId": "tool-call-1",
+            "toolName": "mcp__files__read",
+            "type": "tool-call",
+          },
+        ],
+        "role": "assistant",
+      },
+      {
+        "content": [
+          {
+            "output": {
+              "type": "text",
+              "value": "contents:README.md",
+            },
+            "toolCallId": "tool-call-1",
+            "toolName": "mcp__files__read",
+            "type": "tool-result",
+          },
+        ],
+        "role": "tool",
+      },
+    ],
+    "providerOptions": {
+      "contract-provider": {},
+    },
+    "toolChoice": {
+      "type": "auto",
+    },
+    "tools": [
+      {
+        "description": "Read a file through MCP.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "path",
+          ],
+          "type": "object",
+        },
+        "name": "mcp__files__read",
+        "type": "function",
+      },
+    ],
+  },
+]
+`;
+
+exports[`AiService tool AI SDK contract returns a local tool exception to the model and still accepts its final answer: tool error second model call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "prompt": [
+    {
+      "content": "You are a precise assistant.",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "Check the status.",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "input": {
+            "query": "status",
+          },
+          "toolCallId": "tool-call-1",
+          "toolName": "unstable",
+          "type": "tool-call",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "output": {
+            "type": "error-text",
+            "value": "tool unavailable",
+          },
+          "toolCallId": "tool-call-1",
+          "toolName": "unstable",
+          "type": "tool-result",
+        },
+      ],
+      "role": "tool",
+    },
+  ],
+  "providerOptions": {
+    "contract-provider": {},
+  },
+  "toolChoice": {
+    "type": "auto",
+  },
+  "tools": [
+    {
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "query": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "query",
+        ],
+        "type": "object",
+      },
+      "name": "unstable",
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`AiService tool AI SDK contract returns agentic web search citations through the tool loop: web search first model call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "prompt": [
+    {
+      "content": "You are a precise assistant.
+
+<citations>
+When a statement in your answer is based on a web_search, web_fetch, kb_search, or kb_read result, append a citation marker immediately after that statement: [cite:ID], where ID is the exact \`id\` field of the supporting result item.
+- Example: "Cherry Studio 2.0 entered beta in May. [cite:3f2a1b9c-2]"
+- Chain markers when several results support one statement: [cite:3f2a1b9c-1][cite:7d4e0a51-3]
+- Copy ids exactly as returned by the tool. Never invent, renumber, or reuse ids from other results.
+- Do not add a "References" or "Sources" section at the end - the app renders citations from the inline markers.
+- Statements from your own knowledge take no marker.
+</citations>",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "Is Cherry Studio available on mobile?",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "providerOptions": {
+    "contract-provider": {},
+  },
+  "toolChoice": {
+    "type": "auto",
+  },
+  "tools": [
+    {
+      "description": "Fetch the readable content from one or more known web page URLs.
+
+Use this when:
+- You already have specific URLs from the user, prior context, or web_search
+- You need page content from an article, documentation page, or reference URL
+- Search snippets are not enough and you need the source page text
+
+Don't use this when you only have a topic or question; call web_search first.
+
+Cite: append [cite:id] immediately after each statement a result supports, using the result's exact \`id\` field.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "urls": {
+            "description": "Absolute http(s) web page URLs to fetch and summarize. Use web_search first when you do not know the URL.",
+            "items": {
+              "minLength": 1,
+              "type": "string",
+            },
+            "maxItems": 20,
+            "minItems": 1,
+            "type": "array",
+          },
+        },
+        "required": [
+          "urls",
+        ],
+        "type": "object",
+      },
+      "name": "web_fetch",
+      "strict": true,
+      "type": "function",
+    },
+    {
+      "description": "Search the web for current information, news, and real-time data.
+
+Use this when:
+- The user asks about recent events, current prices, or live data
+- You need to verify facts you're uncertain about or that may have changed
+- The user references something you don't have context on
+
+Don't use for:
+- Math, code reasoning, or things you can answer from your training
+- Well-known facts unlikely to have changed
+
+You may call this multiple times with different queries to broaden coverage:
+- If the topic likely has more authoritative sources in another language
+  (English for tech / scientific topics, the local language for regional news,
+  Japanese for anime / manga, etc.), repeat the search with the topic translated
+  into the most likely source language.
+- If the first results miss an angle, refine with synonyms or sub-aspects.
+
+Cite: append [cite:id] immediately after each statement a result supports, using the result's exact \`id\` field.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "query": {
+            "description": "Self-contained web search query. MUST NOT use pronouns ("it", "their") or context-dependent references; expand the topic from earlier messages when the user asks a follow-up. Examples: ✓ "Anthropic Claude 4.5 release date", ✗ "when did it ship".",
+            "maxLength": 200,
+            "minLength": 2,
+            "type": "string",
+          },
+        },
+        "required": [
+          "query",
+        ],
+        "type": "object",
+      },
+      "name": "web_search",
+      "strict": true,
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`AiService tool AI SDK contract returns agentic web search citations through the tool loop: web search second model call 1`] = `
+{
+  "abortSignal": {
+    "aborted": false,
+  },
+  "prompt": [
+    {
+      "content": "You are a precise assistant.
+
+<citations>
+When a statement in your answer is based on a web_search, web_fetch, kb_search, or kb_read result, append a citation marker immediately after that statement: [cite:ID], where ID is the exact \`id\` field of the supporting result item.
+- Example: "Cherry Studio 2.0 entered beta in May. [cite:3f2a1b9c-2]"
+- Chain markers when several results support one statement: [cite:3f2a1b9c-1][cite:7d4e0a51-3]
+- Copy ids exactly as returned by the tool. Never invent, renumber, or reuse ids from other results.
+- Do not add a "References" or "Sources" section at the end - the app renders citations from the inline markers.
+- Statements from your own knowledge take no marker.
+</citations>",
+      "role": "system",
+    },
+    {
+      "content": [
+        {
+          "text": "Is Cherry Studio available on mobile?",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "input": {
+            "query": "Cherry Studio current release",
+          },
+          "toolCallId": "tool-call-1",
+          "toolName": "web_search",
+          "type": "tool-call",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "output": {
+            "type": "json",
+            "value": [
+              {
+                "content": "Cherry Studio is available on mobile.",
+                "id": "<citation-1>",
+                "title": "Cherry Studio",
+                "url": "https://example.com/cherry",
+              },
+            ],
+          },
+          "toolCallId": "tool-call-1",
+          "toolName": "web_search",
+          "type": "tool-result",
+        },
+      ],
+      "role": "tool",
+    },
+  ],
+  "providerOptions": {
+    "contract-provider": {},
+  },
+  "toolChoice": {
+    "type": "auto",
+  },
+  "tools": [
+    {
+      "description": "Fetch the readable content from one or more known web page URLs.
+
+Use this when:
+- You already have specific URLs from the user, prior context, or web_search
+- You need page content from an article, documentation page, or reference URL
+- Search snippets are not enough and you need the source page text
+
+Don't use this when you only have a topic or question; call web_search first.
+
+Cite: append [cite:id] immediately after each statement a result supports, using the result's exact \`id\` field.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "urls": {
+            "description": "Absolute http(s) web page URLs to fetch and summarize. Use web_search first when you do not know the URL.",
+            "items": {
+              "minLength": 1,
+              "type": "string",
+            },
+            "maxItems": 20,
+            "minItems": 1,
+            "type": "array",
+          },
+        },
+        "required": [
+          "urls",
+        ],
+        "type": "object",
+      },
+      "name": "web_fetch",
+      "strict": true,
+      "type": "function",
+    },
+    {
+      "description": "Search the web for current information, news, and real-time data.
+
+Use this when:
+- The user asks about recent events, current prices, or live data
+- You need to verify facts you're uncertain about or that may have changed
+- The user references something you don't have context on
+
+Don't use for:
+- Math, code reasoning, or things you can answer from your training
+- Well-known facts unlikely to have changed
+
+You may call this multiple times with different queries to broaden coverage:
+- If the topic likely has more authoritative sources in another language
+  (English for tech / scientific topics, the local language for regional news,
+  Japanese for anime / manga, etc.), repeat the search with the topic translated
+  into the most likely source language.
+- If the first results miss an angle, refine with synonyms or sub-aspects.
+
+Cite: append [cite:id] immediately after each statement a result supports, using the result's exact \`id\` field.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "query": {
+            "description": "Self-contained web search query. MUST NOT use pronouns ("it", "their") or context-dependent references; expand the topic from earlier messages when the user asks a follow-up. Examples: ✓ "Anthropic Claude 4.5 release date", ✗ "when did it ship".",
+            "maxLength": 200,
+            "minLength": 2,
+            "type": "string",
+          },
+        },
+        "required": [
+          "query",
+        ],
+        "type": "object",
+      },
+      "name": "web_search",
+      "strict": true,
+      "type": "function",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
Adds an AI SDK V3 MockProvider harness that swaps and restores the openai-compatible extension while rejecting unexpected network access.
Covers AiService streaming, local and MCP tools, web search, termination semantics, text generation, image generation, and model checks with stable model-call and output snapshots.
Documents snapshot ownership and refactor policy, and adds the serial pnpm test:ai-contract command.
Validated with package builds, repeated contract runs, all AI tests, app typecheck, lint, format checks, and the full 378-suite app test run.