### PR TITLE
feat(ui): add dynamic toast and standardize alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "expo": "~57.0.6",
     "expo-auth-session": "~57.0.3",
     "expo-blob": "^57.0.1",
+    "expo-blur": "~57.0.1",
     "expo-build-properties": "~57.0.5",
     "expo-calendar": "~57.0.1",
     "expo-clipboard": "^57.0.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,7 +65,9 @@
   "peerDependencies": {
     "@expo/ui": "*",
     "@swmansion/react-native-bottom-sheet": "*",
+    "expo-blur": "*",
     "expo-glass-effect": "*",
+    "expo-haptics": "*",
     "expo-linear-gradient": "*",
     "expo-paste-input": "*",
     "expo-screen-corner-radius": "*",

--- a/packages/ui/src/components/dynamic-toast/__tests__/dynamic-toast.test.tsx
+++ b/packages/ui/src/components/dynamic-toast/__tests__/dynamic-toast.test.tsx
@@ -1,0 +1,180 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { DynamicToast, type DynamicToastContextValue, useDynamicToast } from '..';
+import { Collapsed as AndroidCollapsed, Expanded as AndroidExpanded } from '../inner.android';
+import { Collapsed as IosCollapsed, Expanded as IosExpanded } from '../inner.ios';
+
+jest.mock('expo-blur', () => {
+  const React = jest.requireActual('react');
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    BlurView: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement(MockView, { ...props, testID: 'blur-view' }, children),
+  };
+});
+
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: { Light: 'light' },
+  impactAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 47 }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const ReactNative = jest.requireActual('react-native');
+  const createSharedValue = (initialValue: unknown) => {
+    let value = initialValue;
+
+    return {
+      get: () => value,
+      set: (nextValue: unknown) => {
+        value = nextValue;
+      },
+    };
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      View: ReactNative.View,
+      createAnimatedComponent: (component: unknown) => component,
+    },
+    Easing: {
+      bezier: jest.fn(() => jest.fn()),
+    },
+    createAnimatedComponent: (component: unknown) => component,
+    useAnimatedProps: (factory: () => object) => factory(),
+    useAnimatedStyle: (factory: () => object) => factory(),
+    useDerivedValue: (factory: () => unknown) => ({ get: factory }),
+    useSharedValue: createSharedValue,
+    withTiming: jest.fn((value: unknown) => value),
+  };
+});
+
+describe('DynamicToast', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('defaults to the top safe area and supports bottom placement', () => {
+    act(() => {
+      renderer = create(
+        <DynamicToast.Provider>
+          <DynamicToast.Viewport>
+            <DynamicToast.Collapsed>
+              <Text>Syncing</Text>
+            </DynamicToast.Collapsed>
+          </DynamicToast.Viewport>
+        </DynamicToast.Provider>,
+      );
+    });
+
+    const topWrapper = renderer!.root.findAllByType(View).find((node) => {
+      const style = StyleSheet.flatten(node.props.style);
+      return style?.zIndex === 1000;
+    });
+    expect(StyleSheet.flatten(topWrapper!.props.style)).toMatchObject({ top: 67 });
+
+    act(() => {
+      renderer!.update(
+        <DynamicToast.Provider>
+          <DynamicToast.Viewport offset={8} placement="bottom">
+            <DynamicToast.Collapsed>
+              <Text>Syncing</Text>
+            </DynamicToast.Collapsed>
+          </DynamicToast.Viewport>
+        </DynamicToast.Provider>,
+      );
+    });
+
+    const bottomWrapper = renderer!.root.findAllByType(View).find((node) => {
+      const style = StyleSheet.flatten(node.props.style);
+      return style?.zIndex === 1000;
+    });
+    expect(StyleSheet.flatten(bottomWrapper!.props.style)).toMatchObject({ bottom: 42 });
+  });
+
+  it('expands on long press and triggers light haptics', () => {
+    const haptics = jest.requireMock('expo-haptics') as {
+      impactAsync: jest.Mock;
+      ImpactFeedbackStyle: { Light: string };
+    };
+    let toastState: DynamicToastContextValue | undefined;
+
+    function StateProbe() {
+      toastState = useDynamicToast();
+      return null;
+    }
+
+    act(() => {
+      renderer = create(
+        <DynamicToast.Provider>
+          <StateProbe />
+          <DynamicToast.Viewport>
+            <DynamicToast.Collapsed />
+          </DynamicToast.Viewport>
+        </DynamicToast.Provider>,
+      );
+    });
+
+    const toast = renderer!.root.findByProps({ delayLongPress: 200 });
+
+    act(() => toast.props.onLongPress());
+
+    expect(toastState?.state.isExpanded.get()).toBe(true);
+    expect(haptics.impactAsync).toHaveBeenCalledWith(haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('uses blur only in the iOS implementation', () => {
+    act(() => {
+      renderer = create(
+        <DynamicToast.Provider>
+          <DynamicToast.Viewport>
+            <IosCollapsed />
+            <IosExpanded />
+          </DynamicToast.Viewport>
+        </DynamicToast.Provider>,
+      );
+    });
+
+    expect(
+      renderer!.root.findAllByType(View).filter((node) => node.props.testID === 'blur-view'),
+    ).toHaveLength(2);
+
+    act(() => {
+      renderer!.update(
+        <DynamicToast.Provider>
+          <DynamicToast.Viewport>
+            <AndroidCollapsed />
+            <AndroidExpanded />
+          </DynamicToast.Viewport>
+        </DynamicToast.Provider>,
+      );
+    });
+
+    expect(
+      renderer!.root.findAllByType(View).filter((node) => node.props.testID === 'blur-view'),
+    ).toHaveLength(0);
+  });
+
+  it('throws when the state hook is used outside the provider', () => {
+    function InvalidConsumer() {
+      useDynamicToast();
+      return null;
+    }
+
+    expect(() => {
+      act(() => {
+        renderer = create(<InvalidConsumer />);
+      });
+    }).toThrow('useDynamicToast must be used within DynamicToast.Provider');
+  });
+});

--- a/packages/ui/src/components/dynamic-toast/dynamic-toast.motion.ts
+++ b/packages/ui/src/components/dynamic-toast/dynamic-toast.motion.ts
@@ -1,0 +1,7 @@
+import { duration, easing } from '../../motion';
+
+export const toastEnterMotion = { duration: duration.slow, easing: easing.overshoot } as const;
+export const toastExitMotion = { duration: duration.base, easing: easing.settle } as const;
+export const toastFadeMotion = { duration: duration.fast, easing: easing.settle } as const;
+export const toastMorphMotion = { duration: duration.base, easing: easing.settle } as const;
+export const toastPressMotion = { duration: duration.fast, easing: easing.settle } as const;

--- a/packages/ui/src/components/dynamic-toast/index.ts
+++ b/packages/ui/src/components/dynamic-toast/index.ts
@@ -1,0 +1,23 @@
+import { Collapsed, Expanded } from './inner';
+import { Provider } from './provider';
+import { Action, Backdrop, Close, Viewport } from './toast';
+
+export { Collapsed, Expanded } from './inner';
+export type { DynamicToastContentProps } from './inner.types';
+export * from './provider';
+export { Action, Backdrop, Close, Viewport } from './toast';
+export type {
+  DynamicToastActionProps,
+  DynamicToastPlacement,
+  DynamicToastViewportProps,
+} from './toast';
+
+export const DynamicToast = {
+  Action,
+  Backdrop,
+  Close,
+  Collapsed,
+  Expanded,
+  Provider,
+  Viewport,
+};

--- a/packages/ui/src/components/dynamic-toast/inner-base.tsx
+++ b/packages/ui/src/components/dynamic-toast/inner-base.tsx
@@ -1,0 +1,103 @@
+import * as Haptics from 'expo-haptics';
+import type { ReactNode } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import Animated, {
+  createAnimatedComponent,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { toastFadeMotion } from './dynamic-toast.motion';
+import type { DynamicToastContentProps, DynamicToastContentVariant } from './inner.types';
+import {
+  COLLAPSED_HEIGHT,
+  COLLAPSED_SPACE,
+  COLLAPSED_WIDTH,
+  EXPANDED_HEIGHT,
+  EXPANDED_SPACE,
+  useDynamicToast,
+} from './provider';
+import { useDynamicToastLayout } from './toast';
+
+const AnimatedPressable = createAnimatedComponent(Pressable);
+
+type DynamicToastContentBaseProps = DynamicToastContentProps & {
+  backdrop?: ReactNode;
+  variant: DynamicToastContentVariant;
+};
+
+export function DynamicToastContentBase({
+  backdrop,
+  children,
+  variant,
+}: DynamicToastContentBaseProps) {
+  const {
+    actions: { expand, setPressed },
+    state: { isExpanded, isPresented },
+  } = useDynamicToast();
+  const { expandedWidth, placement } = useDynamicToastLayout();
+  const isCollapsed = variant === 'collapsed';
+  const edgeStyle = placement === 'top' ? styles.top : styles.bottom;
+  const sizeStyle = isCollapsed
+    ? { left: (expandedWidth - COLLAPSED_WIDTH) / 2, width: COLLAPSED_WIDTH }
+    : { left: 0, width: expandedWidth };
+  const animatedStyle = useAnimatedStyle(() => {
+    const shouldShow = isCollapsed !== isExpanded.get();
+
+    return {
+      opacity: withTiming(shouldShow ? 1 : 0, toastFadeMotion),
+      pointerEvents: isPresented.get() && shouldShow ? ('auto' as const) : ('none' as const),
+    };
+  });
+
+  return (
+    <AnimatedPressable
+      delayLongPress={isCollapsed ? 200 : undefined}
+      onLongPress={
+        isCollapsed
+          ? () => {
+              setPressed(false);
+              expand();
+              void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            }
+          : undefined
+      }
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      style={[
+        styles.content,
+        isCollapsed ? styles.collapsed : styles.expanded,
+        edgeStyle,
+        sizeStyle,
+        animatedStyle,
+      ]}
+    >
+      {backdrop}
+      {children}
+    </AnimatedPressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  bottom: {
+    bottom: 0,
+  },
+  collapsed: {
+    height: COLLAPSED_HEIGHT,
+    paddingHorizontal: COLLAPSED_SPACE,
+  },
+  content: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    position: 'absolute',
+    zIndex: 1,
+  },
+  expanded: {
+    height: EXPANDED_HEIGHT,
+    paddingHorizontal: EXPANDED_SPACE,
+  },
+  top: {
+    top: 0,
+  },
+});

--- a/packages/ui/src/components/dynamic-toast/inner-base.tsx
+++ b/packages/ui/src/components/dynamic-toast/inner-base.tsx
@@ -1,11 +1,7 @@
 import * as Haptics from 'expo-haptics';
 import type { ReactNode } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
-import Animated, {
-  createAnimatedComponent,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
+import { createAnimatedComponent, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 
 import { toastFadeMotion } from './dynamic-toast.motion';
 import type { DynamicToastContentProps, DynamicToastContentVariant } from './inner.types';

--- a/packages/ui/src/components/dynamic-toast/inner.android.tsx
+++ b/packages/ui/src/components/dynamic-toast/inner.android.tsx
@@ -1,0 +1,10 @@
+import { DynamicToastContentBase } from './inner-base';
+import type { DynamicToastContentProps } from './inner.types';
+
+export function Collapsed(props: DynamicToastContentProps) {
+  return <DynamicToastContentBase {...props} variant="collapsed" />;
+}
+
+export function Expanded(props: DynamicToastContentProps) {
+  return <DynamicToastContentBase {...props} variant="expanded" />;
+}

--- a/packages/ui/src/components/dynamic-toast/inner.ios.tsx
+++ b/packages/ui/src/components/dynamic-toast/inner.ios.tsx
@@ -1,0 +1,48 @@
+import { BlurView } from 'expo-blur';
+import { StyleSheet } from 'react-native';
+import { createAnimatedComponent, useAnimatedProps } from 'react-native-reanimated';
+
+import { DynamicToastContentBase } from './inner-base';
+import type { DynamicToastContentProps, DynamicToastContentVariant } from './inner.types';
+import { useDynamicToast } from './provider';
+
+const AnimatedBlurView = createAnimatedComponent(BlurView);
+
+type IosContentProps = DynamicToastContentProps & {
+  variant: DynamicToastContentVariant;
+};
+
+function IosContent({ variant, ...props }: IosContentProps) {
+  const {
+    meta: { expansionProgress },
+  } = useDynamicToast();
+  const isCollapsed = variant === 'collapsed';
+  const animatedProps = useAnimatedProps(() => {
+    const expansion = expansionProgress.get();
+    const hiddenProgress = isCollapsed ? expansion : 1 - expansion;
+
+    return { intensity: hiddenProgress * 30 };
+  });
+
+  return (
+    <DynamicToastContentBase
+      {...props}
+      backdrop={
+        <AnimatedBlurView
+          animatedProps={animatedProps}
+          pointerEvents="none"
+          style={StyleSheet.absoluteFill}
+        />
+      }
+      variant={variant}
+    />
+  );
+}
+
+export function Collapsed(props: DynamicToastContentProps) {
+  return <IosContent {...props} variant="collapsed" />;
+}
+
+export function Expanded(props: DynamicToastContentProps) {
+  return <IosContent {...props} variant="expanded" />;
+}

--- a/packages/ui/src/components/dynamic-toast/inner.tsx
+++ b/packages/ui/src/components/dynamic-toast/inner.tsx
@@ -1,0 +1,3 @@
+// Default exports for type resolution. Metro resolves the native platform file.
+export { Collapsed, Expanded } from './inner.android';
+export type { DynamicToastContentProps } from './inner.types';

--- a/packages/ui/src/components/dynamic-toast/inner.types.ts
+++ b/packages/ui/src/components/dynamic-toast/inner.types.ts
@@ -1,0 +1,7 @@
+import type { ReactNode } from 'react';
+
+export type DynamicToastContentProps = {
+  children?: ReactNode;
+};
+
+export type DynamicToastContentVariant = 'collapsed' | 'expanded';

--- a/packages/ui/src/components/dynamic-toast/provider.tsx
+++ b/packages/ui/src/components/dynamic-toast/provider.tsx
@@ -1,0 +1,126 @@
+import { createContext, type ReactNode, use, useMemo } from 'react';
+import {
+  type DerivedValue,
+  type SharedValue,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import {
+  toastEnterMotion,
+  toastExitMotion,
+  toastFadeMotion,
+  toastMorphMotion,
+  toastPressMotion,
+} from './dynamic-toast.motion';
+
+export const COLLAPSED_WIDTH = 194;
+export const EXPANDED_HEIGHT = 75;
+export const COLLAPSED_HEIGHT = 40;
+export const SPACE = 20;
+export const COLLAPSED_SPACE = 8;
+export const EXPANDED_SPACE = 12;
+
+export type DynamicToastState = {
+  isBackdropPressed: SharedValue<boolean>;
+  isExpanded: SharedValue<boolean>;
+  isPresented: SharedValue<boolean>;
+  isPressed: SharedValue<boolean>;
+};
+
+export type DynamicToastActions = {
+  collapse: () => void;
+  expand: () => void;
+  hide: () => void;
+  setBackdropPressed: (isPressed: boolean) => void;
+  setPressed: (isPressed: boolean) => void;
+  show: () => void;
+};
+
+export type DynamicToastMeta = {
+  expansionProgress: DerivedValue<number>;
+  presentationProgress: DerivedValue<number>;
+  pressProgress: DerivedValue<number>;
+  visibilityProgress: DerivedValue<number>;
+};
+
+export type DynamicToastContextValue = {
+  actions: DynamicToastActions;
+  meta: DynamicToastMeta;
+  state: DynamicToastState;
+};
+
+export const DynamicToastContext = createContext<DynamicToastContextValue | null>(null);
+
+export function Provider({ children }: { children: ReactNode }) {
+  const isExpanded = useSharedValue(false);
+  const isPresented = useSharedValue(false);
+  const isPressed = useSharedValue(false);
+  const isBackdropPressed = useSharedValue(false);
+  const expansionProgress = useDerivedValue(() =>
+    withTiming(isExpanded.get() ? 1 : 0, toastMorphMotion),
+  );
+  const presentationProgress = useDerivedValue(() => {
+    const isPresentedValue = isPresented.get();
+    return withTiming(
+      isPresentedValue ? 1 : 0,
+      isPresentedValue ? toastEnterMotion : toastExitMotion,
+    );
+  });
+  const pressProgress = useDerivedValue(() =>
+    withTiming(isPressed.get() ? 1 : 0, toastPressMotion),
+  );
+  const visibilityProgress = useDerivedValue(() =>
+    withTiming(isPresented.get() ? 1 : 0, toastFadeMotion),
+  );
+  const contextValue = useMemo<DynamicToastContextValue>(
+    () => ({
+      actions: {
+        collapse: () => isExpanded.set(false),
+        expand: () => isExpanded.set(true),
+        hide: () => {
+          isExpanded.set(false);
+          isPresented.set(false);
+        },
+        setBackdropPressed: (isPressedValue) => isBackdropPressed.set(isPressedValue),
+        setPressed: (isPressedValue) => isPressed.set(isPressedValue),
+        show: () => isPresented.set(true),
+      },
+      meta: {
+        expansionProgress,
+        presentationProgress,
+        pressProgress,
+        visibilityProgress,
+      },
+      state: {
+        isBackdropPressed,
+        isExpanded,
+        isPresented,
+        isPressed,
+      },
+    }),
+    [
+      expansionProgress,
+      isBackdropPressed,
+      isExpanded,
+      isPresented,
+      isPressed,
+      presentationProgress,
+      pressProgress,
+      visibilityProgress,
+    ],
+  );
+
+  return <DynamicToastContext value={contextValue}>{children}</DynamicToastContext>;
+}
+
+export function useDynamicToast() {
+  const context = use(DynamicToastContext);
+
+  if (!context) {
+    throw new Error('useDynamicToast must be used within DynamicToast.Provider');
+  }
+
+  return context;
+}

--- a/packages/ui/src/components/dynamic-toast/provider.tsx
+++ b/packages/ui/src/components/dynamic-toast/provider.tsx
@@ -58,20 +58,20 @@ export function Provider({ children }: { children: ReactNode }) {
   const isPresented = useSharedValue(false);
   const isPressed = useSharedValue(false);
   const isBackdropPressed = useSharedValue(false);
-  const expansionProgress = useDerivedValue(() =>
+  const expansionProgress = useDerivedValue<number>(() =>
     withTiming(isExpanded.get() ? 1 : 0, toastMorphMotion),
   );
-  const presentationProgress = useDerivedValue(() => {
+  const presentationProgress = useDerivedValue<number>(() => {
     const isPresentedValue = isPresented.get();
     return withTiming(
       isPresentedValue ? 1 : 0,
       isPresentedValue ? toastEnterMotion : toastExitMotion,
     );
   });
-  const pressProgress = useDerivedValue(() =>
+  const pressProgress = useDerivedValue<number>(() =>
     withTiming(isPressed.get() ? 1 : 0, toastPressMotion),
   );
-  const visibilityProgress = useDerivedValue(() =>
+  const visibilityProgress = useDerivedValue<number>(() =>
     withTiming(isPresented.get() ? 1 : 0, toastFadeMotion),
   );
   const contextValue = useMemo<DynamicToastContextValue>(

--- a/packages/ui/src/components/dynamic-toast/toast.tsx
+++ b/packages/ui/src/components/dynamic-toast/toast.tsx
@@ -1,0 +1,279 @@
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  type ReactNode,
+  use,
+  useMemo,
+} from 'react';
+import {
+  Pressable,
+  type PressableProps,
+  type StyleProp,
+  StyleSheet,
+  useWindowDimensions,
+  type ViewStyle,
+} from 'react-native';
+import Animated, {
+  createAnimatedComponent,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { toastPressMotion } from './dynamic-toast.motion';
+import {
+  COLLAPSED_HEIGHT,
+  COLLAPSED_WIDTH,
+  EXPANDED_HEIGHT,
+  SPACE,
+  useDynamicToast,
+} from './provider';
+
+const AnimatedPressable = createAnimatedComponent(Pressable);
+
+export type DynamicToastPlacement = 'bottom' | 'top';
+
+type DynamicToastLayoutContextValue = {
+  expandedWidth: number;
+  placement: DynamicToastPlacement;
+};
+
+const DynamicToastLayoutContext = createContext<DynamicToastLayoutContextValue | null>(null);
+
+export function useDynamicToastLayout() {
+  const context = use(DynamicToastLayoutContext);
+
+  if (!context) {
+    throw new Error('DynamicToast content must be used within DynamicToast.Viewport');
+  }
+
+  return context;
+}
+
+export type DynamicToastViewportProps = {
+  children?: ReactNode;
+  offset?: number;
+  placement?: DynamicToastPlacement;
+};
+
+export function Viewport({
+  children,
+  offset = SPACE,
+  placement = 'top',
+}: DynamicToastViewportProps) {
+  const {
+    meta: { expansionProgress, presentationProgress, pressProgress, visibilityProgress },
+  } = useDynamicToast();
+  const { width } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const expandedWidth = Math.min(width - SPACE * 2, 430);
+  const entranceDirection = placement === 'top' ? -1 : 1;
+  const layoutValue = useMemo(() => ({ expandedWidth, placement }), [expandedWidth, placement]);
+  const wrapperPosition =
+    placement === 'top' ? { top: insets.top + offset } : { bottom: insets.bottom + offset };
+
+  const entranceStyle = useAnimatedStyle(() => {
+    const expansion = expansionProgress.get();
+    const presentation = presentationProgress.get();
+    const press = pressProgress.get();
+    const height = COLLAPSED_HEIGHT + (EXPANDED_HEIGHT - COLLAPSED_HEIGHT) * expansion;
+    const pressedScale = 1 + (0.1 - expansion * 0.05) * press;
+
+    return {
+      opacity: visibilityProgress.get(),
+      transform: [
+        {
+          translateY: entranceDirection * 2 * (height + SPACE) * (1 - presentation),
+        },
+        { scale: 0.2 + (pressedScale - 0.2) * presentation },
+      ],
+    };
+  });
+
+  const backgroundStyle = useAnimatedStyle(() => {
+    const expansion = expansionProgress.get();
+    const collapsedScaleX = COLLAPSED_WIDTH / expandedWidth;
+    const collapsedScaleY = COLLAPSED_HEIGHT / EXPANDED_HEIGHT;
+
+    return {
+      transform: [
+        { scaleX: collapsedScaleX + (1 - collapsedScaleX) * expansion },
+        { scaleY: collapsedScaleY + (1 - collapsedScaleY) * expansion },
+      ],
+    };
+  });
+
+  return (
+    <DynamicToastLayoutContext value={layoutValue}>
+      <Animated.View
+        pointerEvents="box-none"
+        style={[
+          styles.viewport,
+          { left: (width - expandedWidth) / 2, width: expandedWidth },
+          wrapperPosition,
+          entranceStyle,
+        ]}
+      >
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            StyleSheet.absoluteFill,
+            styles.background,
+            { transformOrigin: placement === 'top' ? 'top' : 'bottom' },
+            backgroundStyle,
+          ]}
+        />
+        {children}
+      </Animated.View>
+    </DynamicToastLayoutContext>
+  );
+}
+
+export function Backdrop() {
+  const {
+    actions: { collapse, setBackdropPressed },
+    state: { isExpanded },
+  } = useDynamicToast();
+  const animatedStyle = useAnimatedStyle(() => ({
+    pointerEvents: isExpanded.get() ? 'auto' : 'none',
+  }));
+
+  return (
+    <AnimatedPressable
+      accessible={false}
+      onPressIn={() => {
+        collapse();
+        setBackdropPressed(true);
+      }}
+      onPressOut={() => setBackdropPressed(false)}
+      style={[StyleSheet.absoluteFill, animatedStyle]}
+    />
+  );
+}
+
+export type DynamicToastActionProps = Omit<PressableProps, 'children' | 'style'> & {
+  children: ReactNode;
+  color?: string;
+  fadeOpacity?: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+const buttonColorAliases: Record<string, string> = {
+  orange: '#ff9500',
+  white: '#ffffff',
+};
+
+function resolveColor(color: string) {
+  return buttonColorAliases[color.toLowerCase()] ?? color;
+}
+
+function withOpacity(color: string, opacity: number) {
+  const hex = color.match(/^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
+
+  if (!hex) {
+    return color;
+  }
+
+  const [, red, green, blue] = hex;
+  const alpha = Math.min(1, Math.max(0, opacity));
+  return `rgba(${Number.parseInt(red!, 16)}, ${Number.parseInt(green!, 16)}, ${Number.parseInt(blue!, 16)}, ${alpha})`;
+}
+
+type ColorableChildProps = {
+  color?: string;
+};
+
+export function Action({
+  children,
+  color = 'white',
+  fadeOpacity = 0.35,
+  onPress,
+  onPressIn,
+  onPressOut,
+  style,
+  ...props
+}: DynamicToastActionProps) {
+  const scale = useSharedValue(1);
+  const resolvedColor = resolveColor(color);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.get() }],
+  }));
+
+  return (
+    <AnimatedPressable
+      {...props}
+      accessibilityRole={props.accessibilityRole ?? 'button'}
+      onPress={(event) => {
+        event.stopPropagation();
+        onPress?.(event);
+      }}
+      onPressIn={(event) => {
+        scale.set(withTiming(0.95, toastPressMotion));
+        onPressIn?.(event);
+      }}
+      onPressOut={(event) => {
+        scale.set(withTiming(1, toastPressMotion));
+        onPressOut?.(event);
+      }}
+      style={[
+        styles.action,
+        { backgroundColor: withOpacity(resolvedColor, fadeOpacity) },
+        animatedStyle,
+        style,
+      ]}
+    >
+      {Children.map(children, (child) =>
+        isValidElement<ColorableChildProps>(child)
+          ? cloneElement(child, { color: child.props.color ?? resolvedColor })
+          : child,
+      )}
+    </AnimatedPressable>
+  );
+}
+
+export function Close({ onPress, ...props }: DynamicToastActionProps) {
+  const {
+    actions: { hide },
+  } = useDynamicToast();
+
+  return (
+    <Action
+      {...props}
+      onPress={(event) => {
+        try {
+          onPress?.(event);
+        } finally {
+          hide();
+        }
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  action: {
+    alignItems: 'center',
+    aspectRatio: 1,
+    borderCurve: 'continuous',
+    borderRadius: '50%',
+    height: 50,
+    justifyContent: 'center',
+  },
+  background: {
+    backgroundColor: '#000000',
+    borderColor: '#ff950080',
+    borderCurve: 'continuous',
+    borderRadius: 45,
+    borderWidth: 0.5,
+    overflow: 'hidden',
+  },
+  viewport: {
+    alignItems: 'center',
+    height: EXPANDED_HEIGHT,
+    position: 'absolute',
+    zIndex: 1000,
+  },
+});

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './alert';
 export * from './bottom-sheet';
 export * from './button';
 export * from './composer';
+export * from './dynamic-toast';
 export * from './input';
 export * from './menu';
 export * from './portal';

--- a/packages/ui/stories/components/primitives/dynamic-toast.stories.tsx
+++ b/packages/ui/stories/components/primitives/dynamic-toast.stories.tsx
@@ -1,0 +1,108 @@
+import {
+  Button,
+  DynamicToast,
+  type DynamicToastViewportProps,
+  useDynamicToast,
+} from '@cherrystudio/ui/components';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import { XIcon } from 'lucide-uniwind/png';
+import { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { initialWindowMetrics, SafeAreaProvider } from 'react-native-safe-area-context';
+
+type DynamicToastPreviewProps = Pick<DynamicToastViewportProps, 'offset' | 'placement'>;
+
+function DynamicToastPreview({ offset, placement }: DynamicToastPreviewProps) {
+  const {
+    actions: { collapse, expand, hide, show },
+  } = useDynamicToast();
+
+  useEffect(() => {
+    show();
+    return hide;
+  }, [hide, show]);
+
+  return (
+    <>
+      <View className="flex-1 items-center justify-center gap-3 px-6">
+        <View className="flex-row gap-2">
+          <Button onPress={show} size="sm">
+            Show
+          </Button>
+          <Button onPress={hide} size="sm" variant="outline">
+            Hide
+          </Button>
+        </View>
+        <View className="flex-row gap-2">
+          <Button
+            onPress={() => {
+              show();
+              expand();
+            }}
+            size="sm"
+            variant="secondary"
+          >
+            Expand
+          </Button>
+          <Button onPress={collapse} size="sm" variant="ghost">
+            Collapse
+          </Button>
+        </View>
+      </View>
+
+      <DynamicToast.Backdrop />
+      <DynamicToast.Viewport offset={offset} placement={placement}>
+        <DynamicToast.Collapsed>
+          <Text className="z-10 text-sm font-semibold text-white">Syncing</Text>
+          <Text className="z-10 text-sm tabular-nums text-white">42%</Text>
+        </DynamicToast.Collapsed>
+        <DynamicToast.Expanded>
+          <Text className="z-10 text-lg font-semibold text-white">Sync in progress</Text>
+          <View className="z-10">
+            <DynamicToast.Close accessibilityLabel="Hide toast">
+              <XIcon color="#ffffff" size={24} />
+            </DynamicToast.Close>
+          </View>
+        </DynamicToast.Expanded>
+      </DynamicToast.Viewport>
+    </>
+  );
+}
+
+const meta = {
+  title: 'Components/Primitives/Dynamic Toast',
+  component: DynamicToast.Viewport,
+  args: {
+    offset: 12,
+    placement: 'top',
+  },
+  argTypes: {
+    children: { control: false },
+    offset: {
+      control: { max: 64, min: 0, step: 4, type: 'number' },
+    },
+    placement: {
+      control: 'inline-radio',
+      options: ['top', 'bottom'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <SafeAreaProvider initialMetrics={initialWindowMetrics} style={{ flex: 1 }}>
+        <Story />
+      </SafeAreaProvider>
+    ),
+  ],
+} satisfies Meta<typeof DynamicToast.Viewport>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <DynamicToast.Provider>
+      <DynamicToastPreview offset={args.offset} placement={args.placement} />
+    </DynamicToast.Provider>
+  ),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       expo-blob:
         specifier: ^57.0.1
         version: 57.0.1(expo@57.0.6)
+      expo-blur:
+        specifier: ~57.0.1
+        version: 57.0.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       expo-build-properties:
         specifier: ~57.0.5
         version: 57.0.5(expo@57.0.6)
@@ -589,9 +592,15 @@ importers:
       '@swmansion/react-native-bottom-sheet':
         specifier: '*'
         version: 0.15.3(react-native-safe-area-context@5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      expo-blur:
+        specifier: '*'
+        version: 57.0.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       expo-glass-effect:
         specifier: '*'
         version: 57.0.1(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      expo-haptics:
+        specifier: '*'
+        version: 57.0.1(expo@57.0.6)
       expo-linear-gradient:
         specifier: '*'
         version: 57.0.1(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -5655,6 +5664,13 @@ packages:
     resolution: {integrity: sha512-wBcXcmLdEv0VF+E4ogWGGUAUdVuMJLXZ7Zfc4lFHLahMkcw5Bu7wDFAc1m1x8qlwnmjda0Xd/2jI/sYJw5Y9pg==}
     peerDependencies:
       expo: '*'
+
+  expo-blur@57.0.2:
+    resolution: {integrity: sha512-Aoud8H8lmlNkbRufyvRLefmGFELdBf1n5Te/Xm+Zx8ORINH+aXL+gKb5mbftFSha860+I7pMArz77TBYz8HDVg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-build-properties@57.0.5:
     resolution: {integrity: sha512-n2H8CSKuJoTunmdHyqek6IYSypNPhdhPaTmnpdYRCHRdYX+yzAEbYCzQdFRm1u37EgeNTlRYjQnYYKCHyD+4Iw==}
@@ -13989,6 +14005,12 @@ snapshots:
   expo-blob@57.0.1(expo@57.0.6):
     dependencies:
       expo: 57.0.6(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.5)(expo-router@57.0.6)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+
+  expo-blur@57.0.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      expo: 57.0.6(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.5)(expo-router@57.0.6)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
 
   expo-build-properties@57.0.5(expo@57.0.6):
     dependencies:

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -11,7 +11,7 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { withUniwind } from 'uniwind';
 
 import { AppBootstrapGate, AppBootstrapProvider } from '@/bootstrap';
-import { AppAlertProvider } from '@/frontend/components/AppAlertProvider';
+import { AlertProvider } from '@/frontend/components/AlertProvider';
 import { NavigationThemeProvider } from '@/frontend/components/navigation';
 import { QueryProvider } from '@/frontend/data';
 import { useThemeColor } from '@/frontend/hooks/useThemeColor';
@@ -32,11 +32,11 @@ export default function RootLayout() {
             <AppBootstrapProvider>
               <AppBootstrapGate>
                 <NavigationThemeProvider>
-                  <AppAlertProvider>
+                  <AlertProvider>
                     <BottomSheetProvider>
                       <RootStack />
                     </BottomSheetProvider>
-                  </AppAlertProvider>
+                  </AlertProvider>
                 </NavigationThemeProvider>
               </AppBootstrapGate>
             </AppBootstrapProvider>

--- a/src/frontend/components/AlertProvider.tsx
+++ b/src/frontend/components/AlertProvider.tsx
@@ -16,13 +16,13 @@ import {
 import { useTranslation } from 'react-i18next';
 import { Keyboard } from 'react-native';
 
-type MessageAlertOptions = {
+export type AlertShowOptions = {
   actionLabel?: string;
   description?: string;
   title: string;
 };
 
-type ConfirmationAlertOptions = {
+export type AlertConfirmOptions = {
   confirmLabel: string;
   description?: string;
   onConfirm: () => Promise<void> | void;
@@ -30,7 +30,7 @@ type ConfirmationAlertOptions = {
   title: string;
 };
 
-type PromptAlertOptions = {
+export type AlertPromptOptions = {
   confirmLabel: string;
   description?: string;
   input: Omit<AlertInput, 'onChangeText' | 'value'> & { initialValue: string };
@@ -48,34 +48,32 @@ type QueuedAlert = {
   title: string;
 };
 
-type AppAlertContextValue = {
-  showConfirmation: (options: ConfirmationAlertOptions) => void;
-  showMessage: (options: MessageAlertOptions) => void;
-  showPrompt: (options: PromptAlertOptions) => void;
+export type AlertController = {
+  confirm: (options: AlertConfirmOptions) => void;
+  prompt: (options: AlertPromptOptions) => void;
+  show: (options: AlertShowOptions) => void;
 };
 
-const AppAlertContext = createContext<AppAlertContextValue | null>(null);
+type AlertContextValue = {
+  alert: AlertController;
+};
 
-export function AppAlertProvider({ children }: PropsWithChildren) {
+const AlertContext = createContext<AlertContextValue | null>(null);
+
+export function AlertProvider({ children }: PropsWithChildren) {
   const { t } = useTranslation();
   const nextAlertIdRef = useRef(0);
   const [queue, setQueue] = useState<QueuedAlert[]>([]);
   const activeAlert = queue[0];
 
-  const enqueue = useCallback((alert: Omit<QueuedAlert, 'id'>) => {
+  const enqueue = useCallback((nextAlert: Omit<QueuedAlert, 'id'>) => {
     const id = nextAlertIdRef.current;
     nextAlertIdRef.current += 1;
-    setQueue((current) => [...current, { ...alert, id }]);
+    setQueue((current) => [...current, { ...nextAlert, id }]);
   }, []);
 
-  const showConfirmation = useCallback(
-    ({
-      confirmLabel,
-      description,
-      onConfirm,
-      role = 'default',
-      title,
-    }: ConfirmationAlertOptions) => {
+  const confirm = useCallback(
+    ({ confirmLabel, description, onConfirm, role = 'default', title }: AlertConfirmOptions) => {
       Keyboard.dismiss();
       enqueue({
         actions: [
@@ -95,15 +93,15 @@ export function AppAlertProvider({ children }: PropsWithChildren) {
     [enqueue, t],
   );
 
-  const showMessage = useCallback(
-    ({ actionLabel = t('common.ok'), description, title }: MessageAlertOptions) => {
+  const show = useCallback(
+    ({ actionLabel = t('common.ok'), description, title }: AlertShowOptions) => {
       enqueue({ actions: [{ label: actionLabel }], description, title });
     },
     [enqueue, t],
   );
 
-  const showPrompt = useCallback(
-    ({ confirmLabel, description, input, onConfirm, title }: PromptAlertOptions) => {
+  const prompt = useCallback(
+    ({ confirmLabel, description, input, onConfirm, title }: AlertPromptOptions) => {
       Keyboard.dismiss();
       enqueue({
         actions: [
@@ -147,10 +145,11 @@ export function AppAlertProvider({ children }: PropsWithChildren) {
     }
   }, []);
 
-  const contextValue = useMemo(
-    () => ({ showConfirmation, showMessage, showPrompt }),
-    [showConfirmation, showMessage, showPrompt],
+  const alert = useMemo<AlertController>(
+    () => ({ confirm, prompt, show }),
+    [confirm, prompt, show],
   );
+  const contextValue = useMemo(() => ({ alert }), [alert]);
 
   const actions =
     activeAlert?.actions.map(({ onPress, ...action }) => ({
@@ -162,7 +161,7 @@ export function AppAlertProvider({ children }: PropsWithChildren) {
     : undefined;
 
   return (
-    <AppAlertContext value={contextValue}>
+    <AlertContext value={contextValue}>
       {children}
       <Alert
         key={activeAlert?.id ?? 'empty'}
@@ -171,18 +170,18 @@ export function AppAlertProvider({ children }: PropsWithChildren) {
         input={input}
         isOpen={Boolean(activeAlert)}
         onOpenChange={handleOpenChange}
-        testID="app-alert"
+        testID="alert"
         title={activeAlert?.title ?? ''}
       />
-    </AppAlertContext>
+    </AlertContext>
   );
 }
 
-export function useAppAlert() {
-  const context = use(AppAlertContext);
+export function useAlert() {
+  const context = use(AlertContext);
 
   if (!context) {
-    throw new Error('useAppAlert must be used within AppAlertProvider');
+    throw new Error('useAlert must be used within AlertProvider');
   }
 
   return context;

--- a/src/frontend/components/__tests__/AlertProvider.test.tsx
+++ b/src/frontend/components/__tests__/AlertProvider.test.tsx
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
-import { AppAlertProvider, useAppAlert } from '../AppAlertProvider';
+import { AlertProvider, useAlert } from '../AlertProvider';
 
 jest.mock('@cherrystudio/ui/components', () => {
   const React = require('react');
   const { View } = require('react-native');
 
   return {
-    Alert: (props: object) => React.createElement(View, { ...props, mockComponent: 'app-alert' }),
+    Alert: (props: object) => React.createElement(View, { ...props, mockComponent: 'alert' }),
   };
 });
 
@@ -16,17 +16,17 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-type AlertApi = ReturnType<typeof useAppAlert>;
+type AlertController = ReturnType<typeof useAlert>['alert'];
 
-let alertApi: AlertApi | undefined;
+let alertController: AlertController | undefined;
 let renderer: ReactTestRenderer | undefined;
 
 function Probe() {
-  const api = useAppAlert();
+  const { alert } = useAlert();
 
   useEffect(() => {
-    alertApi = api;
-  }, [api]);
+    alertController = alert;
+  }, [alert]);
 
   return null;
 }
@@ -37,14 +37,14 @@ async function flushEffects() {
   });
 }
 
-describe('AppAlertProvider', () => {
+describe('AlertProvider', () => {
   beforeEach(async () => {
-    alertApi = undefined;
+    alertController = undefined;
     await act(async () => {
       renderer = create(
-        <AppAlertProvider>
+        <AlertProvider>
           <Probe />
-        </AppAlertProvider>,
+        </AlertProvider>,
       );
     });
   });
@@ -58,7 +58,7 @@ describe('AppAlertProvider', () => {
     const confirmation = deferred<void>();
 
     act(() => {
-      alertApi?.showConfirmation({
+      alertController?.confirm({
         confirmLabel: 'Delete',
         onConfirm: () => confirmation.promise,
         role: 'destructive',
@@ -67,7 +67,7 @@ describe('AppAlertProvider', () => {
     });
     await flushEffects();
 
-    let alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    let alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     expect(alert.props.isOpen).toBe(true);
     expect(alert.props.actions.map((action: { label: string }) => action.label)).toEqual([
       'common.cancel',
@@ -80,7 +80,7 @@ describe('AppAlertProvider', () => {
     });
     await flushEffects();
 
-    alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     expect(alert.props.isOpen).toBe(false);
     confirmation.resolve();
     await confirmation.promise;
@@ -88,17 +88,17 @@ describe('AppAlertProvider', () => {
 
   it('presents queued messages in order after a closed confirmation', async () => {
     act(() => {
-      alertApi?.showConfirmation({
+      alertController?.confirm({
         confirmLabel: 'Delete',
         onConfirm: () => {
-          alertApi?.showMessage({ title: 'Delete failed' });
+          alertController?.show({ title: 'Delete failed' });
         },
         title: 'Delete item?',
       });
     });
     await flushEffects();
 
-    let alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    let alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     act(() => {
       alert.props.actions[1].onPress();
       alert.props.onOpenChange(false);
@@ -106,24 +106,24 @@ describe('AppAlertProvider', () => {
     await flushEffects();
     await flushEffects();
 
-    alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     expect(alert.props.isOpen).toBe(true);
     expect(alert.props.title).toBe('Delete failed');
     expect(alert.props.actions[0].label).toBe('common.ok');
   });
 
   it('keeps showing messages after the requesting consumer unmounts', async () => {
-    const persistentApi = alertApi;
+    const persistentAlert = alertController;
 
     await act(async () => {
-      renderer?.update(<AppAlertProvider />);
+      renderer?.update(<AlertProvider />);
     });
     act(() => {
-      persistentApi?.showMessage({ title: 'Background failure' });
+      persistentAlert?.show({ title: 'Background failure' });
     });
     await flushEffects();
 
-    const alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    const alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     expect(alert.props.isOpen).toBe(true);
     expect(alert.props.title).toBe('Background failure');
   });
@@ -132,7 +132,7 @@ describe('AppAlertProvider', () => {
     const onConfirm = jest.fn();
 
     act(() => {
-      alertApi?.showPrompt({
+      alertController?.prompt({
         confirmLabel: 'Save',
         input: {
           accessibilityLabel: 'Topic name',
@@ -147,7 +147,7 @@ describe('AppAlertProvider', () => {
     });
     await flushEffects();
 
-    let alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    let alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     expect(alert.props.input).toEqual(
       expect.objectContaining({
         accessibilityLabel: 'Topic name',
@@ -159,7 +159,7 @@ describe('AppAlertProvider', () => {
     );
 
     act(() => alert.props.input.onChangeText('Renamed topic'));
-    alert = renderer!.root.findByProps({ mockComponent: 'app-alert' });
+    alert = renderer!.root.findByProps({ mockComponent: 'alert' });
     expect(alert.props.input.value).toBe('Renamed topic');
 
     act(() => {
@@ -168,7 +168,7 @@ describe('AppAlertProvider', () => {
     });
     expect(onConfirm).toHaveBeenCalledWith('Renamed topic');
     await flushEffects();
-    expect(renderer!.root.findByProps({ mockComponent: 'app-alert' }).props.isOpen).toBe(false);
+    expect(renderer!.root.findByProps({ mockComponent: 'alert' }).props.isOpen).toBe(false);
   });
 });
 

--- a/src/frontend/features/README.md
+++ b/src/frontend/features/README.md
@@ -98,4 +98,4 @@ ESLint enforces these (see the boundary blocks in `eslint.config.js`):
 Reusable modules that remain in `src/frontend/components` include app shell modules (`headers`,
 `navigation`), shared flows such as `modelPicker`, the neutral `messageTabs`
 scope/selection/source-registry shared by the messages shell and its tab bodies, shared UI
-behavior such as `AppAlertProvider`, and native dependency adapters such as `nativePrimitives`.
+behavior such as `AlertProvider`, and native dependency adapters such as `nativePrimitives`.

--- a/src/frontend/features/assistants/AssistantEditScreen.tsx
+++ b/src/frontend/features/assistants/AssistantEditScreen.tsx
@@ -9,13 +9,13 @@ import {
 import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { ChevronDownIcon } from 'lucide-uniwind/png';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import {
   ModelPickerBottomSheet,
@@ -87,7 +87,7 @@ function AssistantEditForm({
 }) {
   const { t } = useTranslation();
   const router = useRouter();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const isEditing = Boolean(assistantId);
   const { createAssistant, isCreating, isUpdating, updateAssistant } = useAssistantMutations();
   const modelPickerData = useModelPickerData();
@@ -174,7 +174,7 @@ function AssistantEditForm({
     const dto = buildAssistantDto(form, assistant?.settings);
 
     if (!dto.ok) {
-      toast.show({ label: t(dto.errorKey), variant: 'danger' });
+      alert.show({ title: t(dto.errorKey) });
       return;
     }
 
@@ -187,12 +187,9 @@ function AssistantEditForm({
 
       router.back();
     } catch {
-      toast.show({
-        label: t('assistant.toast.saveFailed'),
-        variant: 'danger',
-      });
+      alert.show({ title: t('assistant.toast.saveFailed') });
     }
-  }, [assistant?.settings, assistantId, createAssistant, form, router, t, toast, updateAssistant]);
+  }, [alert, assistant?.settings, assistantId, createAssistant, form, router, t, updateAssistant]);
   const title = isEditing ? t('assistant.edit.title') : t('assistant.create.title');
   const saveActions = useMemo<HeaderToolbarAction[]>(
     () => [

--- a/src/frontend/features/assistants/AssistantListScreen.tsx
+++ b/src/frontend/features/assistants/AssistantListScreen.tsx
@@ -17,7 +17,7 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { type HeaderToolbarAction, TabRootHeader } from '@/frontend/components/headers';
 import {
   areAllSelected,
@@ -39,7 +39,7 @@ export default function AssistantListScreen() {
   const router = useRouter();
   const { assistants, isLoading } = useAssistantsApi();
   const { deleteAssistant, deleteAssistants } = useAssistantMutations();
-  const { showConfirmation, showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const { closeOpen, notifyClose, notifyWillOpen } = useExclusiveSwipeable();
   const setBottomTabBarHidden = useSetBottomTabBarHidden();
   const bottomInset = useMessageListBottomInset();
@@ -147,19 +147,19 @@ export default function AssistantListScreen() {
   );
   const requestDeleteAssistant = useCallback(
     (assistant: Assistant) => {
-      showConfirmation({
+      alert.confirm({
         confirmLabel: t('common.delete'),
         description: t('assistant.delete.message', { name: assistant.name }),
         role: 'destructive',
         title: t('assistant.delete.title'),
         onConfirm: () => {
           void deleteAssistant(assistant.id).catch(() => {
-            showMessage({ title: t('assistant.toast.deleteFailed') });
+            alert.show({ title: t('assistant.toast.deleteFailed') });
           });
         },
       });
     },
-    [deleteAssistant, showConfirmation, showMessage, t],
+    [alert, deleteAssistant, t],
   );
   const deleteSelectedAssistants = useCallback(async () => {
     const ids = [...selectedIds];
@@ -172,24 +172,24 @@ export default function AssistantListScreen() {
     try {
       await deleteAssistants(ids);
     } catch {
-      showMessage({ title: t('assistant.selection.deleteFailed') });
+      alert.show({ title: t('assistant.selection.deleteFailed') });
     } finally {
       setPendingDeletionIds(new Set());
     }
-  }, [deleteAssistants, exitEditing, selectedIds, showMessage, t]);
+  }, [alert, deleteAssistants, exitEditing, selectedIds, t]);
   const requestDeleteSelectedAssistants = useCallback(() => {
     if (selectedIds.size === 0) {
       return;
     }
 
-    showConfirmation({
+    alert.confirm({
       confirmLabel: t('common.delete'),
       description: t('assistant.selection.deleteMessage', { count: selectedIds.size }),
       onConfirm: deleteSelectedAssistants,
       role: 'destructive',
       title: t('assistant.selection.deleteTitle'),
     });
-  }, [deleteSelectedAssistants, selectedIds.size, showConfirmation, t]);
+  }, [alert, deleteSelectedAssistants, selectedIds.size, t]);
   const scrollContentStyle = useMemo(
     () => ({ paddingBottom: bottomInset, paddingHorizontal: 8 }),
     [bottomInset],

--- a/src/frontend/features/assistants/__tests__/AssistantEditScreen.test.tsx
+++ b/src/frontend/features/assistants/__tests__/AssistantEditScreen.test.tsx
@@ -19,7 +19,7 @@ let mockResolvableModelIds: string[];
 let mockPickerSelectedModelIds: (UniqueModelId | null)[];
 const mockCreateAssistant = jest.fn();
 const mockRouterBack = jest.fn();
-const mockToastShow = jest.fn();
+const mockAlertShow = jest.fn();
 const mockUpdateAssistant = jest.fn();
 
 jest.mock('expo-router', () => ({
@@ -47,8 +47,8 @@ jest.mock('@cherrystudio/ui/components', () => {
   };
 });
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 
 jest.mock('lucide-uniwind/png', () => ({
@@ -173,7 +173,7 @@ describe('AssistantEditScreen', () => {
     mockCreateAssistant.mockReset();
     mockCreateAssistant.mockResolvedValue(undefined);
     mockRouterBack.mockReset();
-    mockToastShow.mockReset();
+    mockAlertShow.mockReset();
     mockUpdateAssistant.mockReset();
     mockUpdateAssistant.mockResolvedValue(undefined);
   });
@@ -337,10 +337,21 @@ describe('AssistantEditScreen', () => {
     await save();
 
     expect(mockUpdateAssistant).not.toHaveBeenCalled();
-    expect(mockToastShow).toHaveBeenCalledWith({
-      label: 'assistant.form.maxToolCallsInvalid',
-      variant: 'danger',
+    expect(mockAlertShow).toHaveBeenCalledWith({
+      title: 'assistant.form.maxToolCallsInvalid',
     });
+  });
+
+  it('shows an alert when saving fails', async () => {
+    mockAssistant = makeAssistant();
+    mockIsLoading = false;
+    mockUpdateAssistant.mockRejectedValueOnce(new Error('Save failed'));
+    render();
+
+    await save();
+
+    expect(mockRouterBack).not.toHaveBeenCalled();
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'assistant.toast.saveFailed' });
   });
 });
 

--- a/src/frontend/features/assistants/__tests__/AssistantListScreen.test.tsx
+++ b/src/frontend/features/assistants/__tests__/AssistantListScreen.test.tsx
@@ -11,10 +11,10 @@ const assistantB = { emoji: 'B', id: 'assistant-b', name: 'Assistant B' } as Ass
 const mockDeleteAssistant = jest.fn(async () => undefined);
 const mockPush = jest.fn();
 const mockSetBottomTabBarHidden = jest.fn();
-const mockShowConfirmation = jest.fn((options: ConfirmationOptions) => {
+const mockAlertConfirm = jest.fn((options: ConfirmationOptions) => {
   currentConfirmation = options;
 });
-const mockShowMessage = jest.fn();
+const mockAlertShow = jest.fn();
 let currentConfirmation: ConfirmationOptions | undefined;
 let deletion = deferred<void>();
 let mockAssistants: readonly Assistant[] = [assistantA, assistantB];
@@ -69,10 +69,12 @@ jest.mock('react-native-reanimated', () => {
   };
 });
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({
-    showConfirmation: mockShowConfirmation,
-    showMessage: mockShowMessage,
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({
+    alert: {
+      confirm: mockAlertConfirm,
+      show: mockAlertShow,
+    },
   }),
 }));
 
@@ -198,7 +200,7 @@ describe('AssistantListScreen batch deletion', () => {
       await deletion.promise.catch(() => undefined);
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith({ title: 'assistant.selection.deleteFailed' });
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'assistant.selection.deleteFailed' });
     expect(renderer?.root.findAllByProps({ accessibilityLabel: assistantA.name })).not.toHaveLength(
       0,
     );

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -2,12 +2,12 @@ import type { Message } from '@cherrystudio/universal/data/types/message';
 import { useKeyboardChatComposerInset } from '@legendapp/list/keyboard';
 import type { LegendListRef } from '@legendapp/list/react-native';
 import { useHeaderHeight } from 'expo-router/react-navigation';
-import { useToast } from 'heroui-native/toast';
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { View } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { useComposerDockLayout } from '@/frontend/components/composer';
 import type { MessagesViewModel } from '@/frontend/hooks/chat';
 import { isIOS } from '@/frontend/utils/constants';
@@ -53,7 +53,7 @@ export function ChatWorkspace({ messageWindow, renderGateKey, topicId }: ChatWor
   const chatTopic = useChatTopic(topicId);
   const headerHeight = useHeaderHeight();
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const listRef = useRef<LegendListRef | null>(null);
   const composerRef = useRef<View | null>(null);
   const isAtBottom = useSharedValue(true);
@@ -73,10 +73,10 @@ export function ChatWorkspace({ messageWindow, renderGateKey, topicId }: ChatWor
         await chat.respondToolApproval({ ...input, topicId });
       } catch (error) {
         logger.error('Tool approval response failed', error as Error);
-        toast.show({ label: t('chat.tool.approval.failed'), variant: 'danger' });
+        alert.show({ title: t('chat.tool.approval.failed') });
       }
     },
-    [chat, t, toast, topicId],
+    [alert, chat, t, topicId],
   );
   const requiresInitialHistoryLayout = shouldWaitForInitialHistoryLayout({
     hasHistoryBeforePendingTurn: chatTopic.hasHistoryBeforePendingTurn,

--- a/src/frontend/features/messages/components/SelectionControls.tsx
+++ b/src/frontend/features/messages/components/SelectionControls.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import {
   useMessageScope,
   useMessageSelectionActions,
@@ -12,7 +12,7 @@ import { SelectionToolbar } from '@/frontend/components/messageTabs/SelectionToo
 
 export function SelectionControls() {
   const { t } = useTranslation();
-  const { showConfirmation, showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const { scope } = useMessageScope();
   const source = useMessageSelectionSource(scope);
   const { beginDeletion, finishDeletion, toggleAll } = useMessageSelectionActions();
@@ -29,7 +29,7 @@ export function SelectionControls() {
       return;
     }
 
-    showConfirmation({
+    alert.confirm({
       confirmLabel: t('common.delete'),
       description: t(source.copy.deleteMessage, { count: ids.length }),
       onConfirm: () => {
@@ -37,14 +37,14 @@ export function SelectionControls() {
         void source
           .deleteSelected(ids)
           .catch(() => {
-            showMessage({ title: t(source.copy.deleteFailed) });
+            alert.show({ title: t(source.copy.deleteFailed) });
           })
           .finally(() => finishDeletion(scope, ids));
       },
       role: 'destructive',
       title: t(source.copy.deleteTitle),
     });
-  }, [beginDeletion, finishDeletion, scope, selectedIds, showConfirmation, showMessage, source, t]);
+  }, [alert, beginDeletion, finishDeletion, scope, selectedIds, source, t]);
 
   return (
     <>

--- a/src/frontend/features/messages/components/__tests__/SelectionControls.test.tsx
+++ b/src/frontend/features/messages/components/__tests__/SelectionControls.test.tsx
@@ -17,10 +17,10 @@ type ConfirmationOptions = {
   onConfirm: () => void;
 };
 
-const mockShowConfirmation = jest.fn((options: ConfirmationOptions) => {
+const mockAlertConfirm = jest.fn((options: ConfirmationOptions) => {
   currentConfirmation = options;
 });
-const mockShowMessage = jest.fn();
+const mockAlertShow = jest.fn();
 let currentActions: ReturnType<typeof useMessageSelectionActions> | undefined;
 let currentConfirmation: ConfirmationOptions | undefined;
 let currentPendingIds: ReadonlySet<string> | undefined;
@@ -29,10 +29,12 @@ let deletion = deferred<void>();
 let mockDeleteSelected = jest.fn<Promise<void>, [readonly string[]]>(() => deletion.promise);
 let renderer: ReactTestRenderer | undefined;
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({
-    showConfirmation: mockShowConfirmation,
-    showMessage: mockShowMessage,
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({
+    alert: {
+      confirm: mockAlertConfirm,
+      show: mockAlertShow,
+    },
   }),
 }));
 
@@ -152,7 +154,7 @@ describe('SelectionControls', () => {
       await deletion.promise.catch(() => undefined);
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith({ title: 'delete.failed' });
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'delete.failed' });
     expect(currentState).toMatchObject({ isDeletionPending: false, isEditing: false });
     expect(currentPendingIds).toEqual(new Set());
   });

--- a/src/frontend/features/paintings/DrawingList.tsx
+++ b/src/frontend/features/paintings/DrawingList.tsx
@@ -1,7 +1,6 @@
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
 import { useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { CheckIcon, ImageIcon } from 'lucide-uniwind/png';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +14,7 @@ import {
 } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import {
   COMPOSER_PHOTO_SELECTION_LIMIT,
   type ComposerAttachmentDraft,
@@ -51,7 +51,7 @@ const pageEdge = 16;
 
 export function DrawingList() {
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const router = useRouter();
   const { scope } = useMessageScope();
   const { isEditing, selectedIds } = useMessageSelectionState();
@@ -106,13 +106,10 @@ export function DrawingList() {
         const uri = await new MediaLibrary.Asset(photo.id).getUri();
         openPaintingWithAttachments([createPhotoAttachmentDraft({ ...photo, uri })]);
       } catch (error) {
-        toast.show({
-          label: error instanceof Error ? error.message : String(error),
-          variant: 'danger',
-        });
+        alert.show({ title: error instanceof Error ? error.message : String(error) });
       }
     },
-    [openPaintingWithAttachments, toast],
+    [alert, openPaintingWithAttachments],
   );
   const handleViewAllPress = useCallback(async () => {
     try {
@@ -144,12 +141,9 @@ export function DrawingList() {
       });
       openPaintingWithAttachments(attachments);
     } catch (error) {
-      toast.show({
-        label: error instanceof Error ? error.message : String(error),
-        variant: 'danger',
-      });
+      alert.show({ title: error instanceof Error ? error.message : String(error) });
     }
-  }, [openPaintingWithAttachments, toast]);
+  }, [alert, openPaintingWithAttachments]);
 
   return (
     <ScrollView

--- a/src/frontend/features/paintings/PaintingViewerScreen/hooks/__tests__/usePaintingViewerActions.test.tsx
+++ b/src/frontend/features/paintings/PaintingViewerScreen/hooks/__tests__/usePaintingViewerActions.test.tsx
@@ -2,6 +2,7 @@ import type { ApiClient } from '@cherrystudio/universal/data/api/types';
 import type { Painting } from '@cherrystudio/universal/data/types/painting';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
+import { Linking } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { DataApiProvider } from '@/frontend/data/DataApiProvider';
@@ -15,23 +16,30 @@ const mockCreatePaintingDraftHandoff = jest.fn((_input: unknown) => 'handoff');
 const mockCreatePaintingOutputAttachmentDraft = jest.fn((_output: unknown) => ({
   id: 'painting-output',
 }));
-const mockShowMessage = jest.fn();
+const mockAlertConfirm = jest.fn();
+const mockAlertShow = jest.fn();
+const mockCreateAsset = jest.fn();
+const mockGetPermissions = jest.fn();
+const mockRequestPermissions = jest.fn();
+const mockToastShow = jest.fn();
+const mockOpenSettings = jest.spyOn(Linking, 'openSettings');
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ back: mockRouterBack, push: mockRouterPush }),
 }));
 
 jest.mock('expo-media-library', () => ({
-  Asset: { create: jest.fn() },
-  requestPermissionsAsync: jest.fn(),
+  Asset: { create: (...args: unknown[]) => mockCreateAsset(...args) },
+  getPermissionsAsync: (...args: unknown[]) => mockGetPermissions(...args),
+  requestPermissionsAsync: (...args: unknown[]) => mockRequestPermissions(...args),
 }));
 
 jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: jest.fn() } }),
+  useToast: () => ({ toast: { show: mockToastShow } }),
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({ showMessage: mockShowMessage }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { confirm: mockAlertConfirm, show: mockAlertShow } }),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -83,6 +91,10 @@ describe('usePaintingViewerActions', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     actions = undefined;
+    mockCreateAsset.mockResolvedValue(undefined);
+    mockGetPermissions.mockResolvedValue({ canAskAgain: true, granted: true });
+    mockOpenSettings.mockResolvedValue(undefined);
+    mockRequestPermissions.mockResolvedValue({ canAskAgain: true, granted: true });
     queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: Infinity } } });
     await act(async () => {
       renderer = create(
@@ -106,6 +118,93 @@ describe('usePaintingViewerActions', () => {
       params: { paintingId: painting.id },
       pathname: '/paintings/[paintingId]/conversation',
     });
+  });
+
+  it('saves immediately when write-only photo access is already granted', async () => {
+    await act(async () => actions?.download());
+
+    expect(mockGetPermissions).toHaveBeenCalledWith(true);
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+    expect(mockCreateAsset).toHaveBeenCalledWith('file:///painting.png');
+  });
+
+  it('requests photo access only after Alert confirmation', async () => {
+    mockGetPermissions.mockResolvedValueOnce({ canAskAgain: true, granted: false });
+
+    await act(async () => actions?.download());
+
+    expect(mockAlertConfirm).toHaveBeenCalledWith({
+      confirmLabel: 'settings.permissions.writeAccess',
+      description: 'painting.viewer.savePermissionDenied',
+      onConfirm: expect.any(Function),
+      title: 'settings.permissions.accessRequired',
+    });
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+
+    const { onConfirm } = mockAlertConfirm.mock.calls[0][0] as {
+      onConfirm: () => Promise<void>;
+    };
+    await act(onConfirm);
+
+    expect(mockRequestPermissions).toHaveBeenCalledWith(true);
+    expect(mockCreateAsset).toHaveBeenCalledWith('file:///painting.png');
+  });
+
+  it('offers to open system settings when photo access cannot be requested again', async () => {
+    mockGetPermissions.mockResolvedValueOnce({ canAskAgain: false, granted: false });
+
+    await act(async () => actions?.download());
+
+    expect(mockAlertConfirm).toHaveBeenCalledWith({
+      confirmLabel: 'settings.permissions.openSystemSettings',
+      description: 'painting.viewer.savePermissionDenied',
+      onConfirm: expect.any(Function),
+      title: 'settings.permissions.accessRequired',
+    });
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+
+    const { onConfirm } = mockAlertConfirm.mock.calls[0][0] as {
+      onConfirm: () => Promise<void>;
+    };
+    await act(onConfirm);
+
+    expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers system settings when a native permission request is denied permanently', async () => {
+    mockGetPermissions.mockResolvedValueOnce({ canAskAgain: true, granted: false });
+    mockRequestPermissions.mockResolvedValueOnce({ canAskAgain: false, granted: false });
+
+    await act(async () => actions?.download());
+    const { onConfirm } = mockAlertConfirm.mock.calls[0][0] as {
+      onConfirm: () => Promise<void>;
+    };
+    await act(onConfirm);
+
+    expect(mockAlertConfirm).toHaveBeenLastCalledWith({
+      confirmLabel: 'settings.permissions.openSystemSettings',
+      description: 'painting.viewer.savePermissionDenied',
+      onConfirm: expect.any(Function),
+      title: 'settings.permissions.accessRequired',
+    });
+  });
+
+  it('shows a Toast after saving to Photos', async () => {
+    await act(async () => actions?.download());
+
+    expect(mockCreateAsset).toHaveBeenCalledWith('file:///painting.png');
+    expect(mockToastShow).toHaveBeenCalledWith({
+      label: 'painting.viewer.saved',
+      variant: 'success',
+    });
+  });
+
+  it('shows an Alert when saving to Photos fails', async () => {
+    mockCreateAsset.mockRejectedValueOnce(new Error('Save failed'));
+
+    await act(async () => actions?.download());
+
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'painting.viewer.saveFailed' });
   });
 
   it('opens edit with the current output attached and no prefilled prompt', () => {
@@ -154,6 +253,6 @@ describe('usePaintingViewerActions', () => {
       pageParams: [undefined],
       pages: [{ items: [painting] }],
     });
-    expect(mockShowMessage).toHaveBeenCalledWith({ title: 'painting.viewer.deleteFailed' });
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'painting.viewer.deleteFailed' });
   });
 });

--- a/src/frontend/features/paintings/PaintingViewerScreen/hooks/usePaintingViewerActions.ts
+++ b/src/frontend/features/paintings/PaintingViewerScreen/hooks/usePaintingViewerActions.ts
@@ -4,8 +4,9 @@ import { useRouter } from 'expo-router';
 import { useToast } from 'heroui-native/toast';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Linking } from 'react-native';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 
 import { useDeletePaintings } from '../../hooks/usePaintings';
 import { createPaintingDraftHandoff } from '../../utils/paintingDraftHandoff';
@@ -22,33 +23,73 @@ export function usePaintingViewerActions({
 }) {
   const { t } = useTranslation();
   const { toast } = useToast();
-  const { showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const router = useRouter();
   const deletePaintings = useDeletePaintings();
+
+  const saveToPhotos = useCallback(async () => {
+    try {
+      await MediaLibrary.Asset.create(currentOutput.uri);
+      toast.show({ label: t('painting.viewer.saved'), variant: 'success' });
+    } catch {
+      alert.show({ title: t('painting.viewer.saveFailed') });
+    }
+  }, [alert, currentOutput, t, toast]);
+
+  const showOpenSettingsAlert = useCallback(() => {
+    alert.confirm({
+      confirmLabel: t('settings.permissions.openSystemSettings'),
+      description: t('painting.viewer.savePermissionDenied'),
+      onConfirm: () =>
+        Linking.openSettings().catch(() => {
+          alert.show({ title: t('painting.viewer.savePermissionDenied') });
+        }),
+      title: t('settings.permissions.accessRequired'),
+    });
+  }, [alert, t]);
+
+  const requestPhotoAccessAndSave = useCallback(async () => {
+    try {
+      const permission = await MediaLibrary.requestPermissionsAsync(true);
+      if (permission.granted) {
+        await saveToPhotos();
+      } else if (!permission.canAskAgain) {
+        showOpenSettingsAlert();
+      }
+    } catch {
+      alert.show({ title: t('painting.viewer.saveFailed') });
+    }
+  }, [alert, saveToPhotos, showOpenSettingsAlert, t]);
 
   const download = useCallback(async () => {
     try {
       // Write-only (add-only) access is enough to save; the legacy
       // saveToLibraryAsync throws in SDK 57, so use the class-based Asset.create.
-      const permission = await MediaLibrary.requestPermissionsAsync(true);
-      if (!permission.granted) {
-        toast.show({ label: t('painting.viewer.savePermissionDenied'), variant: 'danger' });
-        return;
+      const permission = await MediaLibrary.getPermissionsAsync(true);
+      if (permission.granted) {
+        await saveToPhotos();
+      } else if (permission.canAskAgain) {
+        alert.confirm({
+          confirmLabel: t('settings.permissions.writeAccess'),
+          description: t('painting.viewer.savePermissionDenied'),
+          onConfirm: requestPhotoAccessAndSave,
+          title: t('settings.permissions.accessRequired'),
+        });
+      } else {
+        showOpenSettingsAlert();
       }
-      await MediaLibrary.Asset.create(currentOutput.uri);
-      toast.show({ label: t('painting.viewer.saved'), variant: 'success' });
     } catch {
-      toast.show({ label: t('painting.viewer.saveFailed'), variant: 'danger' });
+      alert.show({ title: t('painting.viewer.saveFailed') });
     }
-  }, [currentOutput, t, toast]);
+  }, [alert, requestPhotoAccessAndSave, saveToPhotos, showOpenSettingsAlert, t]);
 
   const remove = useCallback(() => {
     const deletion = deletePaintings([painting.id]);
     router.back();
     void deletion.catch(() => {
-      showMessage({ title: t('painting.viewer.deleteFailed') });
+      alert.show({ title: t('painting.viewer.deleteFailed') });
     });
-  }, [deletePaintings, painting.id, router, showMessage, t]);
+  }, [alert, deletePaintings, painting.id, router, t]);
 
   // Both edit and resize reopen the composer seeded with the current output as an
   // input attachment; paintingId additionally preselects the painting's model.

--- a/src/frontend/features/paintings/__tests__/DrawingList.test.tsx
+++ b/src/frontend/features/paintings/__tests__/DrawingList.test.tsx
@@ -52,8 +52,8 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: jest.fn() } }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: jest.fn() } }),
 }));
 
 jest.mock('lucide-uniwind/png', () => ({

--- a/src/frontend/features/settings/FontSizeSettingsScreen.tsx
+++ b/src/frontend/features/settings/FontSizeSettingsScreen.tsx
@@ -1,9 +1,9 @@
 import { Slider } from '@cherrystudio/ui/components';
-import { useToast } from 'heroui-native/toast';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, Text, View } from 'react-native';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader } from '@/frontend/components/headers';
 import { MarkdownText } from '@/frontend/components/markdown';
 import { usePreference } from '@/frontend/data/hooks';
@@ -14,7 +14,7 @@ import { FONT_SIZE_STEP_LABEL_KEYS } from './utils/fontSizeOptions';
 
 export default function FontSizeSettingsScreen() {
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const [storedStep, setStoredStep] = usePreference('ui.font_size_step');
   const [draftStep, setDraftStep] = useState(() => normalizeFontSizeStep(storedStep));
   const persistenceVersionRef = useRef(0);
@@ -34,7 +34,7 @@ export default function FontSizeSettingsScreen() {
       const restoredStep = normalizeFontSizeStep(storedStep);
       setDraftStep(restoredStep);
       applyFontSizeStepPreference(restoredStep);
-      toast.show({ label: t('settings.fontSize.saveFailed'), variant: 'danger' });
+      alert.show({ title: t('settings.fontSize.saveFailed') });
     });
   };
 

--- a/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { useBackendModule } from '@/frontend/data';
 import { useMcpServerApiById, useMcpServerMutations } from '@/frontend/hooks/mcp/useMcpServers';
@@ -122,7 +122,7 @@ function McpServerEditor({
   const router = useRouter();
   const { toast } = useToast();
   const mcp = useBackendModule('mcp');
-  const { showConfirmation, showMessage } = useAppAlert();
+  const { alert } = useAlert();
 
   const isCreating = !serverId;
   const {
@@ -149,7 +149,7 @@ function McpServerEditor({
   const handleSave = useCallback(async () => {
     const dto = buildDto(form, t('settings.mcp.defaultName'));
     if (!dto.ok) {
-      toast.show({ label: t(dto.errorKey, dto.errorOptions), variant: 'danger' });
+      alert.show({ title: t(dto.errorKey, dto.errorOptions) });
       return;
     }
 
@@ -179,11 +179,11 @@ function McpServerEditor({
       }
     } catch (error) {
       logger.error('Failed to save MCP server', error as Error);
-      toast.show({ label: t('settings.mcp.toast.saveFailed'), variant: 'danger' });
+      alert.show({ title: t('settings.mcp.toast.saveFailed') });
     } finally {
       setIsSaving(false);
     }
-  }, [createServer, form, mcp, router, serverId, t, toast, updateServer]);
+  }, [alert, createServer, form, mcp, router, serverId, t, updateServer]);
 
   const handleToggleTool = useCallback(
     async (toolName: string, enabled: boolean, knownToolNames: string[]) => {
@@ -199,10 +199,10 @@ function McpServerEditor({
         await updateServer(serverId, { disabledTools: nextDisabled });
       } catch (error) {
         logger.error('Failed to toggle MCP tool', error as Error);
-        toast.show({ label: t('settings.mcp.toast.saveFailed'), variant: 'danger' });
+        alert.show({ title: t('settings.mcp.toast.saveFailed') });
       }
     },
-    [server, serverId, t, toast, updateServer],
+    [alert, server, serverId, t, updateServer],
   );
 
   const handleToggleAutoApprove = useCallback(
@@ -219,10 +219,10 @@ function McpServerEditor({
         await updateServer(serverId, { disabledAutoApproveTools: nextDisabled });
       } catch (error) {
         logger.error('Failed to toggle MCP tool auto-approve', error as Error);
-        toast.show({ label: t('settings.mcp.toast.saveFailed'), variant: 'danger' });
+        alert.show({ title: t('settings.mcp.toast.saveFailed') });
       }
     },
-    [server, serverId, t, toast, updateServer],
+    [alert, server, serverId, t, updateServer],
   );
 
   const handleToggleServer = useCallback(async () => {
@@ -235,9 +235,9 @@ function McpServerEditor({
       await updateServer(serverId, { isActive: nextIsActive });
     } catch (error) {
       logger.error('Failed to toggle MCP server', error as Error);
-      toast.show({ label: t('settings.mcp.toast.saveFailed'), variant: 'danger' });
+      alert.show({ title: t('settings.mcp.toast.saveFailed') });
     }
-  }, [server, serverId, t, toast, updateServer]);
+  }, [alert, server, serverId, t, updateServer]);
 
   const handleDelete = useCallback(() => {
     if (!serverId) {
@@ -252,23 +252,23 @@ function McpServerEditor({
       })
       .catch((error) => {
         logger.error('Failed to delete MCP server', error as Error);
-        showMessage({ title: t('settings.mcp.toast.deleteFailed') });
+        alert.show({ title: t('settings.mcp.toast.deleteFailed') });
       });
-  }, [deleteServer, router, serverId, showMessage, t, toast]);
+  }, [alert, deleteServer, router, serverId, t, toast]);
 
   const requestDelete = useCallback(() => {
     if (!serverId || !server) {
       return;
     }
 
-    showConfirmation({
+    alert.confirm({
       confirmLabel: t('common.delete'),
       description: t('settings.mcp.delete.message', { name: server.name }),
       onConfirm: handleDelete,
       role: 'destructive',
       title: t('settings.mcp.delete.title'),
     });
-  }, [handleDelete, server, serverId, showConfirmation, t]);
+  }, [alert, handleDelete, server, serverId, t]);
 
   const isBusy = isSaving || isCreateMutationPending || isUpdating;
   const saveActions = useMemo<HeaderToolbarAction[]>(

--- a/src/frontend/features/settings/McpScreen/__tests__/McpServerScreen.test.tsx
+++ b/src/frontend/features/settings/McpScreen/__tests__/McpServerScreen.test.tsx
@@ -36,8 +36,8 @@ let mockServerLoading = false;
 const mockCreateServer = jest.fn();
 const mockDeleteServer = jest.fn();
 const mockGetServerInfo = jest.fn();
-const mockShowConfirmation = jest.fn();
-const mockShowMessage = jest.fn();
+const mockAlertConfirm = jest.fn();
+const mockAlertShow = jest.fn();
 const mockRouterBack = jest.fn();
 const mockRouterReplace = jest.fn();
 const mockServerRefetch = jest.fn();
@@ -85,10 +85,12 @@ jest.mock('@/frontend/components/headers', () => ({
   },
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({
-    showConfirmation: mockShowConfirmation,
-    showMessage: mockShowMessage,
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({
+    alert: {
+      confirm: mockAlertConfirm,
+      show: mockAlertShow,
+    },
   }),
 }));
 
@@ -318,9 +320,8 @@ describe('McpServerScreen tabs', () => {
     });
 
     expect(mockGetServerInfo).not.toHaveBeenCalled();
-    expect(mockToastShow).toHaveBeenCalledWith({
-      label: 'settings.mcp.fields.baseUrlInvalid',
-      variant: 'danger',
+    expect(mockAlertShow).toHaveBeenCalledWith({
+      title: 'settings.mcp.fields.baseUrlInvalid',
     });
   });
 
@@ -348,9 +349,8 @@ describe('McpServerScreen tabs', () => {
     });
 
     expect(mockGetServerInfo).not.toHaveBeenCalled();
-    expect(mockToastShow).toHaveBeenCalledWith({
-      label: 'settings.mcp.headers.invalidLine:2',
-      variant: 'danger',
+    expect(mockAlertShow).toHaveBeenCalledWith({
+      title: 'settings.mcp.headers.invalidLine:2',
     });
   });
 
@@ -597,7 +597,7 @@ describe('McpServerScreen tabs', () => {
 
     chrome.props.onDelete();
 
-    expect(mockShowConfirmation).toHaveBeenCalledWith(
+    expect(mockAlertConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
         confirmLabel: 'common.delete',
         description: 'settings.mcp.delete.message',
@@ -607,7 +607,7 @@ describe('McpServerScreen tabs', () => {
     );
     mockDeleteServer.mockResolvedValue(undefined);
     await act(async () => {
-      await mockShowConfirmation.mock.calls[0][0].onConfirm();
+      await mockAlertConfirm.mock.calls[0][0].onConfirm();
     });
     expect(mockRouterBack).toHaveBeenCalled();
   });

--- a/src/frontend/features/settings/McpScreen/components/McpToolsSection.tsx
+++ b/src/frontend/features/settings/McpScreen/components/McpToolsSection.tsx
@@ -5,11 +5,11 @@ import {
 } from '@cherrystudio/universal/ai/tools/mcpSourcePolicy';
 import type { StreamableHttpMcpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { useQuery } from '@tanstack/react-query';
-import { useToast } from 'heroui-native/toast';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { queryKeys, useBackendModule } from '@/frontend/data';
 
 import { SettingsDialogActionButton } from '../../components/SettingsDialogActionButton';
@@ -33,7 +33,7 @@ export function McpToolsSection({
   server,
 }: McpToolsSectionProps) {
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const mcp = useBackendModule('mcp');
   const isToggleInFlight = useRef(false);
   const [isTogglePending, setIsTogglePending] = useState(false);
@@ -75,13 +75,13 @@ export function McpToolsSection({
 
       const fresh = await toolsQuery.refetch();
       if (fresh.isError || !fresh.data) {
-        toast.show({ label: t('settings.mcp.tools.refreshFailed'), variant: 'danger' });
+        alert.show({ title: t('settings.mcp.tools.refreshFailed') });
         return undefined;
       }
 
       return fresh.data.map((tool) => tool.name);
     },
-    [server, t, toast, toolsQuery],
+    [alert, server, t, toolsQuery],
   );
 
   const runToggle = useCallback(async (toggle: () => Promise<void>) => {

--- a/src/frontend/features/settings/McpScreen/components/__tests__/McpToolsSection.test.tsx
+++ b/src/frontend/features/settings/McpScreen/components/__tests__/McpToolsSection.test.tsx
@@ -11,7 +11,7 @@ import { McpToolsSection } from '../McpToolsSection';
 type ToolsQueryResult = { data?: { name: string }[]; isError: boolean };
 
 const mockRefetch = jest.fn<Promise<ToolsQueryResult>, []>();
-const mockToastShow = jest.fn();
+const mockAlertShow = jest.fn();
 const mockUseQuery = jest.fn((_options: unknown) => ({
   ...mockToolsQuery,
   refetch: mockRefetch,
@@ -41,8 +41,8 @@ jest.mock('@cherrystudio/ui/components', () => {
   };
 });
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 
 jest.mock('../../../components/SettingsDialogActionButton', () => {
@@ -229,9 +229,8 @@ describe('McpToolsSection auto-approve toggle', () => {
     await toggleFirstToolAutoApprove(true);
 
     expect(onToggleAutoApprove).not.toHaveBeenCalled();
-    expect(mockToastShow).toHaveBeenCalledWith({
-      label: 'settings.mcp.tools.refreshFailed',
-      variant: 'danger',
+    expect(mockAlertShow).toHaveBeenCalledWith({
+      title: 'settings.mcp.tools.refreshFailed',
     });
   });
 

--- a/src/frontend/features/settings/ProfileSettingsScreen.tsx
+++ b/src/frontend/features/settings/ProfileSettingsScreen.tsx
@@ -3,12 +3,12 @@ import { type MenuAction, MenuView, type NativeActionEvent } from '@expo/ui/comm
 import { loggerService } from '@logger';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { SaveIcon } from 'lucide-uniwind/png';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { ProfileAvatarEditBadge, ProfileAvatarImage } from '@/frontend/components/ProfileAvatar';
 import { useBackendModule } from '@/frontend/data';
@@ -22,7 +22,7 @@ type AvatarSourceValue = 'camera' | 'photos';
 export default function ProfileSettingsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const inputRef = useRef<TextInput>(null);
   const [userName, setUserName] = usePreference('app.user.name');
   const profile = useBackendModule('profile');
@@ -50,9 +50,9 @@ export default function ProfileSettingsScreen() {
   const reportAvatarSaveError = useCallback(
     (error: unknown) => {
       logger.error('Failed to save user avatar', error as Error);
-      toast.show({ label: t('settings.profile.avatarSaveError'), variant: 'danger' });
+      alert.show({ title: t('settings.profile.avatarSaveError') });
     },
-    [t, toast],
+    [alert, t],
   );
 
   const selectAvatarFromCamera = useCallback(async () => {

--- a/src/frontend/features/settings/ProviderScreen/NewProviderScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/NewProviderScreen.tsx
@@ -5,13 +5,13 @@ import { type MenuAction, MenuView, type NativeActionEvent } from '@expo/ui/comm
 import * as Crypto from 'expo-crypto';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { EyeIcon, EyeOffIcon, ImageUpIcon, RotateCcwIcon } from 'lucide-uniwind/png';
 import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, Text, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { Image } from '@/frontend/components/nativePrimitives';
 import { useBackendModule, useMutation } from '@/frontend/data';
@@ -36,7 +36,7 @@ type CreateProviderFormValues = {
 export default function NewProviderScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const providers = useBackendModule('providers');
 
   const [name, setName] = useState('');
@@ -143,9 +143,10 @@ export default function NewProviderScreen() {
         });
       })
       .catch(() => {
-        toast.show({ label: t('settings.provider.add.error'), variant: 'danger' });
+        alert.show({ title: t('settings.provider.add.error') });
       });
   }, [
+    alert,
     anthropicUrl,
     apiKey,
     avatarDraftUri,
@@ -158,7 +159,6 @@ export default function NewProviderScreen() {
     router,
     submitProvider,
     t,
-    toast,
   ]);
 
   const rightActions = useMemo<HeaderToolbarAction[]>(

--- a/src/frontend/features/settings/ProviderScreen/ProviderApiKeySettingsScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/ProviderApiKeySettingsScreen.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, View } from 'react-native';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader } from '@/frontend/components/headers';
 
 import {
@@ -72,7 +72,7 @@ function ProviderApiKeySettingsForm({
   const [apiKeyErrors, setApiKeyErrors] = useState<Record<string, string>>({});
   const [pendingApiKeyIds, setPendingApiKeyIds] = useState<ReadonlySet<string>>(() => new Set());
   const pendingApiKeyIdsRef = useRef<ReadonlySet<string>>(new Set());
-  const { showConfirmation, showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const { addKey, entries, removeKey, restoreKey, updateKey, updateKeyEnabled } =
     useProviderApiServiceApiKeysDraft(apiKeys);
   const hasUnsavedChanges =
@@ -188,7 +188,7 @@ function ProviderApiKeySettingsForm({
         return;
       }
 
-      showConfirmation({
+      alert.confirm({
         confirmLabel: t('common.remove'),
         description: t('settings.provider.apiService.removeApiKeyMessage'),
         onConfirm: () => {
@@ -201,7 +201,7 @@ function ProviderApiKeySettingsForm({
 
             if (!didSave) {
               restoreKey(entry, entryIndex);
-              showMessage({ title: t('settings.provider.apiService.saveFailed') });
+              alert.show({ title: t('settings.provider.apiService.saveFailed') });
             }
           })();
         },
@@ -209,7 +209,7 @@ function ProviderApiKeySettingsForm({
         title: t('settings.provider.apiService.removeApiKeyTitle'),
       });
     },
-    [apiKeys, entries, removeKey, restoreKey, saveEntries, showConfirmation, showMessage, t],
+    [alert, apiKeys, entries, removeKey, restoreKey, saveEntries, t],
   );
 
   return (

--- a/src/frontend/features/settings/ProviderScreen/ProviderDetailScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/ProviderDetailScreen.tsx
@@ -8,7 +8,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, StyleSheet, View } from 'react-native';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { useBackendModule, useMutation } from '@/frontend/data';
 import {
@@ -46,7 +46,7 @@ export default function ProviderDetailSettingsScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const { showConfirmation, showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const providers = useBackendModule('providers');
   const [apiKeysVisible, setApiKeysVisible] = useState(false);
   const [activeTab, setActiveTab] = useState<ProviderDetailTab>('configuration');
@@ -135,10 +135,10 @@ export default function ProviderDetailSettingsScreen() {
       const nextApiKeys = buildApiKeyEntriesFromInput(input, apiKeys ?? []);
 
       void replaceApiKeysMutation.mutateAsync(nextApiKeys).catch(() => {
-        toast.show({ label: t('settings.provider.apiService.saveFailed'), variant: 'danger' });
+        alert.show({ title: t('settings.provider.apiService.saveFailed') });
       });
     },
-    [apiKeys, replaceApiKeysMutation, t, toast],
+    [alert, apiKeys, replaceApiKeysMutation, t],
   );
   const openModelAddSettings = useCallback(() => {
     if (!providerId) {
@@ -250,22 +250,22 @@ export default function ProviderDetailSettingsScreen() {
         toast.show({ label: t('settings.provider.toast.deleted'), variant: 'success' });
       })
       .catch(() => {
-        showMessage({ title: t('settings.provider.toast.deleteFailed') });
+        alert.show({ title: t('settings.provider.toast.deleteFailed') });
       });
-  }, [deleteProviderMutation, providerId, router, showMessage, t, toast]);
+  }, [alert, deleteProviderMutation, providerId, router, t, toast]);
   const requestDeleteProvider = useCallback(() => {
     if (!provider || !providers.canRemove(provider)) {
       return;
     }
 
-    showConfirmation({
+    alert.confirm({
       confirmLabel: t('common.delete'),
       description: t('settings.provider.delete.message', { name: provider.name }),
       onConfirm: handleDeleteProvider,
       role: 'destructive',
       title: t('settings.provider.delete.title'),
     });
-  }, [handleDeleteProvider, provider, providers, showConfirmation, t]);
+  }, [alert, handleDeleteProvider, provider, providers, t]);
 
   if (!providerId || providerQuery.isError) {
     return <Redirect href="/settings/provider" />;

--- a/src/frontend/features/settings/ProviderScreen/__tests__/ProviderApiKeySettingsScreen.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/__tests__/ProviderApiKeySettingsScreen.test.tsx
@@ -43,8 +43,8 @@ jest.mock('@/frontend/components/headers', () => ({
   BackHeader: () => null,
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({ showConfirmation: jest.fn(), showMessage: jest.fn() }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { confirm: jest.fn(), show: jest.fn() } }),
 }));
 
 jest.mock('react-i18next', () => ({

--- a/src/frontend/features/settings/ProviderScreen/__tests__/ProviderDetailScreen.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/__tests__/ProviderDetailScreen.test.tsx
@@ -49,8 +49,8 @@ let mockSpinnerRenderCount: number;
 let mockChromeRenderCount: number;
 let mockSectionRenders: SectionProps[];
 const mockReplaceApiKeys = jest.fn(async () => undefined);
-const mockShowConfirmation = jest.fn();
-const mockShowMessage = jest.fn();
+const mockAlertConfirm = jest.fn();
+const mockAlertShow = jest.fn();
 let queryClient: QueryClient;
 
 const providersBackend = {
@@ -75,10 +75,12 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({
-    showConfirmation: mockShowConfirmation,
-    showMessage: mockShowMessage,
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({
+    alert: {
+      confirm: mockAlertConfirm,
+      show: mockAlertShow,
+    },
   }),
 }));
 

--- a/src/frontend/features/settings/ProviderScreen/apiService/hooks/__tests__/useProviderApiServiceSheetClose.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/apiService/hooks/__tests__/useProviderApiServiceSheetClose.test.tsx
@@ -8,7 +8,7 @@ type HookResult = ReturnType<typeof useProviderApiServiceSheetClose>;
 const mockGoBack = jest.fn();
 const mockDispatch = jest.fn();
 const mockAddListener = jest.fn(() => jest.fn());
-const mockShowConfirmation = jest.fn();
+const mockAlertConfirm = jest.fn();
 
 jest.mock('expo-router', () => ({
   useNavigation: () => ({
@@ -22,8 +22,8 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({ showConfirmation: mockShowConfirmation }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { confirm: mockAlertConfirm } }),
 }));
 
 function HookHarness({
@@ -69,7 +69,7 @@ describe('useProviderApiServiceSheetClose', () => {
 
     act(() => hookResultRef.current?.requestClose());
 
-    expect(mockShowConfirmation).toHaveBeenCalledWith(
+    expect(mockAlertConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
         confirmLabel: 'common.discard',
         description: 'settings.provider.apiService.discardMessage',
@@ -83,7 +83,7 @@ describe('useProviderApiServiceSheetClose', () => {
     renderHook();
     act(() => hookResultRef.current?.requestClose());
 
-    act(() => mockShowConfirmation.mock.calls[0][0].onConfirm());
+    act(() => mockAlertConfirm.mock.calls[0][0].onConfirm());
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
@@ -94,6 +94,6 @@ describe('useProviderApiServiceSheetClose', () => {
     act(() => hookResultRef.current?.requestClose());
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
-    expect(mockShowConfirmation).not.toHaveBeenCalled();
+    expect(mockAlertConfirm).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/features/settings/ProviderScreen/apiService/hooks/useProviderApiServiceSheetClose.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/hooks/useProviderApiServiceSheetClose.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard } from 'react-native';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 
 /** Confirms before leaving an edit screen that still holds uncommitted input. */
 export function useProviderApiServiceSheetClose({
@@ -16,7 +16,7 @@ export function useProviderApiServiceSheetClose({
 }) {
   const navigation = useNavigation();
   const { t } = useTranslation();
-  const { showConfirmation } = useAppAlert();
+  const { alert } = useAlert();
   const isConfirmedCloseRef = useRef(false);
 
   const closeWithoutPrompt = useCallback(() => {
@@ -27,7 +27,7 @@ export function useProviderApiServiceSheetClose({
   const confirmDiscard = useCallback(
     (onConfirm: () => void) => {
       Keyboard.dismiss();
-      showConfirmation({
+      alert.confirm({
         confirmLabel: t('common.discard'),
         description: t('settings.provider.apiService.discardMessage'),
         onConfirm,
@@ -35,7 +35,7 @@ export function useProviderApiServiceSheetClose({
         title: t('settings.provider.apiService.discardTitle'),
       });
     },
-    [showConfirmation, t],
+    [alert, t],
   );
 
   const requestClose = useCallback(() => {

--- a/src/frontend/features/settings/ProviderScreen/components/CherryInOauth.tsx
+++ b/src/frontend/features/settings/ProviderScreen/components/CherryInOauth.tsx
@@ -1,13 +1,12 @@
 import { Button, Section } from '@cherrystudio/ui/components';
 import { resolveProviderIcon } from '@cherrystudio/ui/icons/providers';
-import { useToast } from 'heroui-native/toast';
 import { LogInIcon, LogOutIcon, WalletIcon } from 'lucide-uniwind/png';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { Image } from '@/frontend/components/nativePrimitives';
 import { openExternalUrl } from '@/frontend/utils/openExternalUrl';
 
@@ -30,13 +29,12 @@ type CherryInOauthProps = {
 export function CherryInOauth({ providerId, onOAuthComplete }: CherryInOauthProps) {
   const { t } = useTranslation();
   const { theme } = useUniwind();
-  const { showConfirmation } = useAppAlert();
+  const { alert } = useAlert();
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
   const providerIcon = resolveProviderIcon('cherryin');
-  const { toast } = useToast();
   const requestLogoutConfirmation = useCallback(
     ({ message, onConfirm, title }: { message: string; onConfirm: () => void; title: string }) => {
-      showConfirmation({
+      alert.confirm({
         confirmLabel: t('settings.provider.oauth.cherryIn.logout'),
         description: message,
         onConfirm,
@@ -44,7 +42,7 @@ export function CherryInOauth({ providerId, onOAuthComplete }: CherryInOauthProp
         title,
       });
     },
-    [showConfirmation, t],
+    [alert, t],
   );
 
   const {
@@ -74,13 +72,12 @@ export function CherryInOauth({ providerId, onOAuthComplete }: CherryInOauthProp
         return;
       }
       const message = error instanceof Error ? error.message : 'OAuth failed';
-      toast.show({
-        label: t('settings.provider.oauth.cherryIn.error'),
+      alert.show({
         description: message,
-        variant: 'danger',
+        title: t('settings.provider.oauth.cherryIn.error'),
       });
     }
-  }, [handleOAuthLogin, t, toast]);
+  }, [alert, handleOAuthLogin, t]);
 
   const handleTopup = useCallback(() => {
     void openExternalUrl(CHERRYIN_TOPUP_URL);

--- a/src/frontend/features/settings/ProviderScreen/hooks/__tests__/useCherryInOauth.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/hooks/__tests__/useCherryInOauth.test.tsx
@@ -8,6 +8,7 @@ const mockPromptAsync = jest.fn();
 const mockCompleteAuthorization = jest.fn(async () => undefined);
 const mockLogout = jest.fn(async () => undefined);
 const mockGetBalance = jest.fn(async () => ({ balance: 42 }));
+const mockAlertShow = jest.fn();
 const mockAuthRequestConfig: { value: unknown } = { value: undefined };
 const mockRedirectParts: { value: unknown } = { value: undefined };
 
@@ -39,7 +40,9 @@ jest.mock('@/frontend/data', () => ({
   useQuery: () => ({ data: undefined, refetch: jest.fn(async () => undefined) }),
 }));
 
-jest.mock('heroui-native', () => ({ useToast: () => ({ toast: { show: jest.fn() } }) }));
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
+}));
 jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
 import { useCherryInOauth, UserCancelledError } from '../useCherryInOauth';

--- a/src/frontend/features/settings/ProviderScreen/hooks/useCherryInOauth.ts
+++ b/src/frontend/features/settings/ProviderScreen/hooks/useCherryInOauth.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as AuthSession from 'expo-auth-session';
-import { useToast } from 'heroui-native';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { queryKeys, useBackendModule, useQuery } from '@/frontend/data';
 import type { CompleteOAuthAuthorizationInput } from '@/shared/contracts';
 import { resolveAuthorizeConfig } from '@/shared/oauth';
@@ -31,7 +31,7 @@ export interface UseCherryInOauthOptions {
 export function useCherryInOauth(options: UseCherryInOauthOptions) {
   const { providerId, requestConfirmation, onOAuthComplete } = options;
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const oauth = useBackendModule('oauth');
   const cherryin = useBackendModule('cherryin');
   const queryClient = useQueryClient();
@@ -120,17 +120,16 @@ export function useCherryInOauth(options: UseCherryInOauthOptions) {
           await authConfigQuery.refetch();
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';
-          toast.show({
-            variant: 'warning',
-            label: t('settings.provider.oauth.cherryIn.logout_warning'),
+          alert.show({
             description: message,
+            title: t('settings.provider.oauth.cherryIn.logout_warning'),
           });
         }
 
         setIsLoggingOut(false);
       },
     });
-  }, [authConfigQuery, logoutMutation, requestConfirmation, t, toast]);
+  }, [alert, authConfigQuery, logoutMutation, requestConfirmation, t]);
 
   const handleOAuthLogin = useCallback(async () => {
     if (!request) {

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelCheck.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelCheck.test.tsx
@@ -6,7 +6,7 @@ import { useProviderModelCheck } from '../useProviderModelCheck';
 type ModelCheck = ReturnType<typeof useProviderModelCheck>;
 
 const mockCheckHealth = jest.fn();
-const mockShowMessage = jest.fn();
+const mockAlertShow = jest.fn();
 const mockToastShow = jest.fn();
 
 jest.mock('@tanstack/react-query', () => ({
@@ -21,8 +21,8 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({ showMessage: mockShowMessage }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 
 jest.mock('@/frontend/data', () => ({
@@ -74,7 +74,7 @@ describe('useProviderModelCheck', () => {
 
     await act(async () => modelCheck?.startCheck());
 
-    expect(mockShowMessage).toHaveBeenCalledWith({
+    expect(mockAlertShow).toHaveBeenCalledWith({
       description: 'Unauthorized',
       title: 'settings.provider.models.checkFailed',
     });

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelAdd.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelAdd.ts
@@ -4,6 +4,7 @@ import { useToast } from 'heroui-native/toast';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { useMutation, useQuery } from '@/frontend/data';
 
 import {
@@ -27,6 +28,7 @@ type UseProviderModelAddOptions = {
 
 export function useProviderModelAdd({ provider }: UseProviderModelAddOptions) {
   const { t } = useTranslation();
+  const { alert } = useAlert();
   const { toast } = useToast();
   const modelsQuery = useQuery('/models', { query: { providerId: provider.id } });
   const addModelsMutation = useMutation('POST', '/models', { refresh: ['/models'] });
@@ -176,14 +178,12 @@ export function useProviderModelAdd({ provider }: UseProviderModelAddOptions) {
     };
     return await submit()
       .catch(() => {
-        toast.show({
-          label: t('settings.provider.models.addFailed'),
-          variant: 'danger',
-        });
+        alert.show({ title: t('settings.provider.models.addFailed') });
         return false;
       })
       .finally(() => setIsSubmitting(false));
   }, [
+    alert,
     formState,
     addModels,
     existingModels,

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelCheck.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelCheck.ts
@@ -5,7 +5,7 @@ import { useToast } from 'heroui-native/toast';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { queryKeys, useBackendModule } from '@/frontend/data';
 
 import {
@@ -42,7 +42,7 @@ export function useProviderModelCheck({
 }: UseProviderModelCheckOptions) {
   const { t } = useTranslation();
   const { toast } = useToast();
-  const { showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const modelsBackend = useBackendModule('models');
   const queryClient = useQueryClient();
   const [checkState, setCheckState] = useState<ProviderModelCheckState>(() =>
@@ -149,7 +149,7 @@ export function useProviderModelCheck({
           variant: 'success',
         });
       } else {
-        showMessage({
+        alert.show({
           description: result.error || t('settings.provider.models.checkFailedStatus'),
           title: t('settings.provider.models.checkFailed'),
         });
@@ -165,7 +165,7 @@ export function useProviderModelCheck({
           },
           providerId,
         });
-        showMessage({
+        alert.show({
           description:
             error instanceof Error
               ? error.message
@@ -186,7 +186,7 @@ export function useProviderModelCheck({
     queryClient,
     selectedApiKey,
     selectedModel,
-    showMessage,
+    alert,
     t,
     toast,
   ]);

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPull.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPull.ts
@@ -4,6 +4,7 @@ import { useToast } from 'heroui-native/toast';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { queryKeys, useBackendModule } from '@/frontend/data';
 import { isModelPullTimeoutError } from '@/shared/contracts';
 
@@ -24,6 +25,7 @@ export function useProviderModelPull({
   providerId,
 }: UseProviderModelPullOptions) {
   const { t } = useTranslation();
+  const { alert } = useAlert();
   const { toast } = useToast();
   const models = useBackendModule('models');
   const queryClient = useQueryClient();
@@ -57,18 +59,17 @@ export function useProviderModelPull({
     };
     return await load()
       .catch((error): ProviderModelPullLoadResult => {
-        toast.show({
-          label: t(
+        alert.show({
+          title: t(
             isModelPullTimeoutError(error)
               ? 'settings.provider.models.pullTimedOut'
               : 'settings.provider.models.pullFailed',
           ),
-          variant: 'danger',
         });
         return 'error';
       })
       .finally(() => setIsPreviewLoading(false));
-  }, [onPreviewReady, models, providerId, queryClient, t, toast]);
+  }, [alert, onPreviewReady, models, providerId, queryClient, t, toast]);
 
   /**
    * Commits one row's worth of change immediately, the way desktop's pull dialog
@@ -90,11 +91,11 @@ export function useProviderModelPull({
         }
         return true;
       } catch {
-        toast.show({ label: t('settings.provider.models.pullApplyFailed'), variant: 'danger' });
+        alert.show({ title: t('settings.provider.models.pullApplyFailed') });
         return false;
       }
     },
-    [models, providerId, queryClient, t, toast],
+    [alert, models, providerId, queryClient, t],
   );
 
   return {

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelRemove.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelRemove.ts
@@ -1,8 +1,8 @@
 import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import { useToast } from 'heroui-native/toast';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { useMutation } from '@/frontend/data';
 import { usePreference } from '@/frontend/data/hooks';
 
@@ -19,7 +19,7 @@ const emptyModelIdSet: ReadonlySet<UniqueModelId> = new Set();
  */
 export function useProviderModelRemove() {
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const removeModelMutation = useMutation('DELETE', '/models/:uniqueModelId*', {
     refresh: ['/models'],
   });
@@ -37,7 +37,7 @@ export function useProviderModelRemove() {
       try {
         await deleteModel({ params: { uniqueModelId: model.id } });
       } catch {
-        toast.show({ label: t('settings.provider.models.removeFailed'), variant: 'danger' });
+        alert.show({ title: t('settings.provider.models.removeFailed') });
       } finally {
         setRemovingIds((current) => {
           const next = new Set(current);
@@ -46,7 +46,7 @@ export function useProviderModelRemove() {
         });
       }
     },
-    [deleteModel, removingIds, t, toast],
+    [alert, deleteModel, removingIds, t],
   );
 
   return {

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchApiKeySettingsScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchApiKeySettingsScreen.tsx
@@ -8,7 +8,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, View } from 'react-native';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader } from '@/frontend/components/headers';
 
 import {
@@ -55,7 +55,7 @@ export default function WebSearchApiKeySettingsScreen() {
   const [apiKeyErrors, setApiKeyErrors] = useState<Record<string, string>>({});
   const [pendingApiKeyIds, setPendingApiKeyIds] = useState<ReadonlySet<string>>(() => new Set());
   const pendingApiKeyIdsRef = useRef<ReadonlySet<string>>(new Set());
-  const { showConfirmation, showMessage } = useAppAlert();
+  const { alert } = useAlert();
 
   const closeSheet = useCallback(() => {
     router.back();
@@ -168,7 +168,7 @@ export default function WebSearchApiKeySettingsScreen() {
         return;
       }
 
-      showConfirmation({
+      alert.confirm({
         confirmLabel: t('common.remove'),
         description: t('settings.websearch.provider.removeApiKeyMessage'),
         onConfirm: () => {
@@ -181,7 +181,7 @@ export default function WebSearchApiKeySettingsScreen() {
 
             if (!didSave) {
               restoreApiKey(entry, entryIndex);
-              showMessage({ title: t('settings.websearch.provider.saveFailed') });
+              alert.show({ title: t('settings.websearch.provider.saveFailed') });
             }
           })();
         },
@@ -189,7 +189,7 @@ export default function WebSearchApiKeySettingsScreen() {
         title: t('settings.websearch.provider.removeApiKeyTitle'),
       });
     },
-    [entries, removeApiKey, restoreApiKey, saveEntries, showConfirmation, showMessage, t],
+    [alert, entries, removeApiKey, restoreApiKey, saveEntries, t],
   );
 
   if (!provider || !canManageApiKeys) {

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchCheckScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchCheckScreen.tsx
@@ -14,7 +14,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, Text, View } from 'react-native';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { BackHeader } from '@/frontend/components/headers';
 import {
   SingleSelectionSheet,
@@ -37,7 +37,7 @@ export default function WebSearchCheckScreen() {
   const { providerId } = useLocalSearchParams<{ providerId?: string }>();
   const { t } = useTranslation();
   const { toast } = useToast();
-  const { showMessage } = useAppAlert();
+  const { alert } = useAlert();
   const webSearch = useBackendModule('webSearch');
   const webSearchProviders = useWebSearchProviderPreferences();
   const [isApiKeySheetOpen, setIsApiKeySheetOpen] = useState(false);
@@ -87,7 +87,7 @@ export default function WebSearchCheckScreen() {
     }
 
     if (!selectedApiKey) {
-      showMessage({
+      alert.show({
         description: t('settings.websearch.provider.checkNoApiKeys'),
         title: t('settings.websearch.provider.checkFailed'),
       });
@@ -115,7 +115,7 @@ export default function WebSearchCheckScreen() {
         toast.show({ label: message, variant: 'success' });
       } else {
         const message = result.error || t('settings.websearch.provider.checkFailed');
-        showMessage({
+        alert.show({
           description: message,
           title: t('settings.websearch.provider.checkFailed'),
         });
@@ -126,7 +126,7 @@ export default function WebSearchCheckScreen() {
       }
       const message =
         error instanceof Error ? error.message : t('settings.websearch.provider.checkFailed');
-      showMessage({
+      alert.show({
         description: message,
         title: t('settings.websearch.provider.checkFailed'),
       });

--- a/src/frontend/features/settings/WebSearchScreen/__tests__/WebSearchApiKeySettingsScreen.test.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/__tests__/WebSearchApiKeySettingsScreen.test.tsx
@@ -14,8 +14,8 @@ type ProviderOverrides = Record<string, { apiKeys?: string[] } | undefined>;
 let mockProviderOverrides: ProviderOverrides;
 let mockKeyFormProps: KeyFormProps | undefined;
 const mockSetPreference = jest.fn();
-const mockShowConfirmation = jest.fn();
-const mockShowMessage = jest.fn();
+const mockAlertConfirm = jest.fn();
+const mockAlertShow = jest.fn();
 
 jest.mock('expo-router', () => ({
   Redirect: () => null,
@@ -27,10 +27,12 @@ jest.mock('@/frontend/components/headers', () => ({
   BackHeader: () => null,
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({
-    showConfirmation: mockShowConfirmation,
-    showMessage: mockShowMessage,
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({
+    alert: {
+      confirm: mockAlertConfirm,
+      show: mockAlertShow,
+    },
   }),
 }));
 
@@ -139,7 +141,7 @@ describe('WebSearchApiKeySettingsScreen', () => {
     const keyId = keyForm().apiKeys[0].id;
 
     act(() => keyForm().onRemove(keyId));
-    act(() => mockShowConfirmation.mock.calls[0][0].onConfirm());
+    act(() => mockAlertConfirm.mock.calls[0][0].onConfirm());
     expect(keyForm().apiKeys).toEqual([]);
 
     saving.reject(new Error('save failed'));
@@ -149,7 +151,7 @@ describe('WebSearchApiKeySettingsScreen', () => {
     });
 
     expect(keyForm().apiKeys.map((entry) => entry.key)).toEqual(['key-a']);
-    expect(mockShowMessage).toHaveBeenCalledWith({
+    expect(mockAlertShow).toHaveBeenCalledWith({
       title: 'settings.websearch.provider.saveFailed',
     });
   });

--- a/src/frontend/features/settings/WebSearchScreen/__tests__/WebSearchCheckScreen.test.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/__tests__/WebSearchCheckScreen.test.tsx
@@ -5,7 +5,7 @@ import WebSearchCheckScreen from '../WebSearchCheckScreen';
 const mockCheckProvider = jest.fn(
   async (): Promise<{ error?: string; valid: boolean }> => ({ valid: true }),
 );
-const mockShowMessage = jest.fn();
+const mockAlertShow = jest.fn();
 const mockToastShow = jest.fn();
 
 jest.mock('expo-router', () => ({
@@ -29,8 +29,8 @@ jest.mock('heroui-native/toast', () => ({
 }));
 
 jest.mock('@/frontend/components/headers', () => ({ BackHeader: () => null }));
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: () => ({ showMessage: mockShowMessage }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 
 jest.mock('@/frontend/components/selectionSheet', () => {
@@ -108,7 +108,7 @@ describe('WebSearchCheckScreen', () => {
 
     await act(async () => button.props.onPress());
 
-    expect(mockShowMessage).toHaveBeenCalledWith({
+    expect(mockAlertShow).toHaveBeenCalledWith({
       description: 'Invalid API key',
       title: 'settings.websearch.provider.checkFailed',
     });

--- a/src/frontend/features/settings/__tests__/FontSizeSettingsScreen.test.tsx
+++ b/src/frontend/features/settings/__tests__/FontSizeSettingsScreen.test.tsx
@@ -3,8 +3,8 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import FontSizeSettingsScreen from '../FontSizeSettingsScreen';
 
 const mockApplyFontSizeStep = jest.fn();
+const mockAlertShow = jest.fn();
 const mockSetStoredStep = jest.fn(async () => undefined);
-const mockToastShow = jest.fn();
 
 jest.mock('@/frontend/components/headers', () => ({
   BackHeader: () => null,
@@ -34,8 +34,8 @@ jest.mock('@cherrystudio/ui/components', () => {
   return { Slider };
 });
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -82,9 +82,8 @@ describe('FontSizeSettingsScreen', () => {
 
     expect(mockApplyFontSizeStep).toHaveBeenLastCalledWith(0);
     expect(renderer?.root.findByType('MarkdownText').props.fontSizeStep).toBe(0);
-    expect(mockToastShow).toHaveBeenCalledWith({
-      label: 'settings.fontSize.saveFailed',
-      variant: 'danger',
+    expect(mockAlertShow).toHaveBeenCalledWith({
+      title: 'settings.fontSize.saveFailed',
     });
   });
 });

--- a/src/frontend/features/settings/__tests__/ProfileSettingsScreen.test.tsx
+++ b/src/frontend/features/settings/__tests__/ProfileSettingsScreen.test.tsx
@@ -67,8 +67,8 @@ jest.mock('@cherrystudio/ui/components', () => {
   };
 });
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: jest.fn() } }),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: jest.fn() } }),
 }));
 
 jest.mock('lucide-uniwind/png', () => ({

--- a/src/frontend/features/topics/TopicList.tsx
+++ b/src/frontend/features/topics/TopicList.tsx
@@ -1,7 +1,6 @@
 import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import type { Topic } from '@cherrystudio/universal/data/types/topic';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
-import { useToast } from 'heroui-native/toast';
 import { CheckIcon, PencilIcon, PinIcon, PinOffIcon, Trash2Icon } from 'lucide-uniwind/png';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +18,7 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import {
   useMessageListBottomInset,
   useMessagePendingDeletionIds,
@@ -99,7 +99,7 @@ function formatTopicUpdatedAt(updatedAt: string, locale: string | undefined, yes
 
 const TopicListView = memo(function TopicListView() {
   const { t } = useTranslation();
-  const { toast } = useToast();
+  const { alert } = useAlert();
   const bottomInset = useMessageListBottomInset();
   const { isPinActionDisabled, isTopicListLoading, pinnedTopicIds, topics } = useTopicListTopics();
   const { loadMoreTopics, openTopic, toggleTopicPin } = useTopicListActions();
@@ -141,10 +141,10 @@ const TopicListView = memo(function TopicListView() {
   const handleTogglePin = useCallback(
     (topicId: string) => {
       void toggleTopicPin(topicId).catch(() => {
-        toast.show({ label: t('topic.pin.failed'), variant: 'danger' });
+        alert.show({ title: t('topic.pin.failed') });
       });
     },
-    [t, toast, toggleTopicPin],
+    [alert, t, toggleTopicPin],
   );
 
   const renderItem = useCallback(

--- a/src/frontend/features/topics/__tests__/TopicList.test.tsx
+++ b/src/frontend/features/topics/__tests__/TopicList.test.tsx
@@ -7,7 +7,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { TopicList } from '../TopicList';
 
 const mockToggleTopicPin = jest.fn(async () => undefined);
-const mockToastShow = jest.fn();
+const mockAlertShow = jest.fn();
 const mockTopic = {
   assistantId: 'assistant-1',
   id: 'topic-1',
@@ -43,10 +43,6 @@ jest.mock('@legendapp/list/react-native', () => {
   };
 });
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
-}));
-
 jest.mock('lucide-uniwind/png', () => ({
   CheckIcon: () => null,
   PencilIcon: () => null,
@@ -66,6 +62,7 @@ jest.mock('react-i18next', () => ({
         'navigation.newChat': 'New chat',
         'topic.actions.pin': 'Pin topic',
         'topic.actions.unpin': 'Unpin topic',
+        'topic.pin.failed': 'Failed to update pin state',
         'topic.updatedAt.yesterday': 'Yesterday',
       })[key] ?? key,
   }),
@@ -111,6 +108,10 @@ jest.mock('react-native-safe-area-context', () => ({
 
 jest.mock('@/frontend/hooks/chat', () => ({
   useAssistantsApi: () => ({ assistants: [mockAssistant] }),
+}));
+
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 
 jest.mock('@/frontend/hooks/useExclusiveSwipeable', () => ({
@@ -176,6 +177,22 @@ describe('TopicList pin action', () => {
     });
 
     expect(mockToggleTopicPin).toHaveBeenCalledWith('topic-1');
+  });
+
+  it('shows an alert when updating the pin state fails', async () => {
+    mockToggleTopicPin.mockRejectedValueOnce(new Error('Pin failed'));
+
+    await act(async () => {
+      renderer = create(<TopicList />);
+    });
+
+    const pinButton = renderer?.root.findByProps({ accessibilityLabel: 'Pin topic' });
+
+    await act(async () => {
+      pinButton?.props.onPress();
+    });
+
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'Failed to update pin state' });
   });
 
   it('uses a highlighted background and unpin action for pinned topics', async () => {

--- a/src/frontend/features/topics/components/__tests__/useTopicActionAlerts.test.tsx
+++ b/src/frontend/features/topics/components/__tests__/useTopicActionAlerts.test.tsx
@@ -2,7 +2,7 @@ import type { Topic } from '@cherrystudio/universal/data/types/topic';
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 
 import { useTopicListActions } from '../../context/TopicListProvider';
 import { useTopicActionAlerts } from '../useTopicActionAlerts';
@@ -11,20 +11,20 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-jest.mock('@/frontend/components/AppAlertProvider', () => ({
-  useAppAlert: jest.fn(),
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: jest.fn(),
 }));
 
 jest.mock('../../context/TopicListProvider', () => ({
   useTopicListActions: jest.fn(),
 }));
 
-const mockShowConfirmation = jest.fn();
-const mockShowMessage = jest.fn();
-const mockShowPrompt = jest.fn();
+const mockAlertConfirm = jest.fn();
+const mockAlertShow = jest.fn();
+const mockAlertPrompt = jest.fn();
 const mockDeleteTopic = jest.fn(async () => undefined);
 const mockRenameTopic = jest.fn(async () => undefined);
-const useAppAlertMock = useAppAlert as jest.MockedFunction<typeof useAppAlert>;
+const useAlertMock = useAlert as jest.MockedFunction<typeof useAlert>;
 const useTopicListActionsMock = useTopicListActions as jest.MockedFunction<
   typeof useTopicListActions
 >;
@@ -51,10 +51,12 @@ describe('useTopicActionAlerts', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     actions = undefined;
-    useAppAlertMock.mockReturnValue({
-      showConfirmation: mockShowConfirmation,
-      showMessage: mockShowMessage,
-      showPrompt: mockShowPrompt,
+    useAlertMock.mockReturnValue({
+      alert: {
+        confirm: mockAlertConfirm,
+        prompt: mockAlertPrompt,
+        show: mockAlertShow,
+      },
     });
     useTopicListActionsMock.mockReturnValue({
       deleteTopic: mockDeleteTopic,
@@ -78,7 +80,7 @@ describe('useTopicActionAlerts', () => {
   test('requests a native prompt and renames with its trimmed value', async () => {
     act(() => actions?.requestRename(topic));
 
-    expect(mockShowPrompt).toHaveBeenCalledWith(
+    expect(mockAlertPrompt).toHaveBeenCalledWith(
       expect.objectContaining({
         confirmLabel: 'common.save',
         input: {
@@ -92,7 +94,7 @@ describe('useTopicActionAlerts', () => {
       }),
     );
 
-    const prompt = mockShowPrompt.mock.calls[0][0];
+    const prompt = mockAlertPrompt.mock.calls[0][0];
     act(() => prompt.onConfirm('  Renamed topic  '));
     await act(async () => Promise.resolve());
     expect(mockRenameTopic).toHaveBeenCalledWith('topic-1', 'Renamed topic');
@@ -102,10 +104,10 @@ describe('useTopicActionAlerts', () => {
     mockRenameTopic.mockRejectedValueOnce(new Error('rename failed'));
     act(() => actions?.requestRename(topic));
 
-    const prompt = mockShowPrompt.mock.calls[0][0];
+    const prompt = mockAlertPrompt.mock.calls[0][0];
     act(() => prompt.onConfirm('Renamed topic'));
     await act(async () => Promise.resolve());
 
-    expect(mockShowMessage).toHaveBeenCalledWith({ title: 'topic.rename.failed' });
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'topic.rename.failed' });
   });
 });

--- a/src/frontend/features/topics/components/useTopicActionAlerts.ts
+++ b/src/frontend/features/topics/components/useTopicActionAlerts.ts
@@ -2,7 +2,7 @@ import type { Topic } from '@cherrystudio/universal/data/types/topic';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useAppAlert } from '@/frontend/components/AppAlertProvider';
+import { useAlert } from '@/frontend/components/AlertProvider';
 
 import { useTopicListActions } from '../context/TopicListProvider';
 
@@ -14,11 +14,11 @@ type TopicActionAlerts = {
 export function useTopicActionAlerts(): TopicActionAlerts {
   const { t } = useTranslation();
   const { deleteTopic, renameTopic } = useTopicListActions();
-  const { showConfirmation, showMessage, showPrompt } = useAppAlert();
+  const { alert } = useAlert();
 
   const requestRename = useCallback(
     (topic: Topic) => {
-      showPrompt({
+      alert.prompt({
         confirmLabel: t('common.save'),
         input: {
           accessibilityLabel: t('topic.renameTitle'),
@@ -34,30 +34,30 @@ export function useTopicActionAlerts(): TopicActionAlerts {
           }
 
           void renameTopic(topic.id, trimmedName).catch(() => {
-            showMessage({ title: t('topic.rename.failed') });
+            alert.show({ title: t('topic.rename.failed') });
           });
         },
         title: t('topic.renameTitle'),
       });
     },
-    [renameTopic, showMessage, showPrompt, t],
+    [alert, renameTopic, t],
   );
 
   const requestDelete = useCallback(
     (topic: Topic) => {
-      showConfirmation({
+      alert.confirm({
         confirmLabel: t('common.delete'),
         description: t('topic.deleteMessage'),
         onConfirm: () => {
           void deleteTopic(topic.id).catch(() => {
-            showMessage({ title: t('topic.deleteFailed') });
+            alert.show({ title: t('topic.deleteFailed') });
           });
         },
         role: 'destructive',
         title: t('topic.deleteTitle'),
       });
     },
-    [deleteTopic, showConfirmation, showMessage, t],
+    [alert, deleteTopic, t],
   );
 
   return { requestDelete, requestRename };


### PR DESCRIPTION
Adds a composable native Dynamic Toast to Package UI with top/bottom placement, iOS and Android implementations, Motion tokens, Storybook coverage, and tests.
Renames AppAlertProvider to AlertProvider, exposes alert.show/confirm/prompt, and migrates app failures from danger toasts to alerts while retaining transient success and warning toasts.
Updates painting saves to request photo access only after confirmation and direct permanently denied users to system settings.
Validation: pnpm format:check, pnpm lint, pnpm typecheck, and pnpm test.