### PR TITLE
feat(paintings): run generation on durable jobs

### DIFF
--- a/docs/references/job-manager-design.md
+++ b/docs/references/job-manager-design.md
@@ -77,9 +77,20 @@ consumer is `painting.generate`
 creates the receipt and enqueues in one `withWriteTx` (with an idempotency pre-check so a
 duplicate signature joins the active job instead of orphaning a fresh receipt), and
 `usePaintingGeneration` observes the ledger by polling `GET /jobs/:id` (1 s while active, stop on
-terminal) and adopts a still-active job on mount via `GET /jobs`. Because `DbService.withWriteTx`
-is not reentrant, the in-transaction path is built entirely from `*Tx` variants
-(`PaintingService.createTx`, `JobRuntime.enqueueTx`, `JobService.findActiveByIdempotencyKeyTx`).
+terminal) and adopts a still-active job on mount via `usePaintingJobs`. Because
+`DbService.withWriteTx` is not reentrant, the in-transaction path is built entirely from `*Tx`
+variants (`PaintingService.createTx` / `resetForRetryTx`, `JobRuntime.enqueueTx`,
+`JobService.findActiveByIdempotencyKeyTx`).
+
+**The ledger is the gallery's status source.** `usePaintingJobs`
+(`src/frontend/features/paintings/hooks/usePaintingJobs.ts`) is the one subscription both the
+drawings list and the composer read: an active query (`status=pending,delayed,running`, polling at
+1 s only while non-empty) plus an untimed terminal query used purely for failure copy. An
+output-less painting is *generating* when its id appears in the active map and *interrupted*
+otherwise — deriving the interrupted state from the **absence** of an active job rather than the
+presence of a terminal one keeps it correct after job GC collects the row that explains why. That
+same hook is the only thing that invalidates `/paintings` when a generation lands while the user
+sits on the list.
 
 **As-built deviations from the design text:**
 
@@ -94,8 +105,11 @@ is not reentrant, the in-transaction path is built entirely from `*Tx` variants
   Draft picker images are materialized into durable internal file entries *before* enqueue; the
   `uri` riding along is the internal-storage path (never an ephemeral picker URI), which the
   handler reads data URLs from directly.
-- **`startGeneration` returns `{ jobId }`**, not `{ paintingId, jobId }`; the receipt reaches the
-  frontend through the completed job's output and the painting query sync.
+- **`startGeneration` returns `{ jobId, paintingId }`** and takes an optional `paintingId` to
+  retry an image-less receipt in place (bumping it back to the head of the gallery) rather than
+  minting a second one. The receipt id participates in `generationSignature`, so a retry and an
+  identical fresh generation cannot collide on idempotency. `resetForRetryTx` rejects a receipt
+  that already holds outputs — reuse would delete finished images.
 - **`internal.echo` was not built.** The jest harness
   (`src/backend/services/jobs/__tests__/_helpers.ts`) registers inline test handlers, which serve
   the proof role without needing a production-registry exclusion mechanism.
@@ -103,10 +117,14 @@ is not reentrant, the in-transaction path is built entirely from `*Tx` variants
   enqueue, the delayed-retry timer, and cold start; with only `foreground-only` handlers, an
   enqueue can only happen in the foreground, so the listener adds nothing until delayed retries
   can span a backgrounding or a Phase 2 window exists. Add it with Phase 2.
-- **Dangling receipts are kept.** A failed/cancelled/abandoned generation leaves a painting row
-  with no outputs — invisible to the list (it filters on having output), matching the old session
-  behavior. A future file-orphan-cleanup job is the designated collector; the "interrupted, tap
-  to retry" UI remains an open question.
+- **Image-less receipts are visible, and that is what makes the durability observable.**
+  `PaintingService` no longer filters the list on having outputs: the receipt row *is* the tile
+  for a generation in flight (a `PaintingSkeleton`, tapping back into its progress) and for one
+  that never landed ("interrupted", with the provider's own failure text, tapping into a
+  prefilled composer). Select-all sees them too, and deleting one cancels its running job first.
+  A user-initiated cancel deletes its receipt on the spot — being stopped on purpose is not the
+  same as being interrupted, and leaving the row would put a retry prompt in front of someone who
+  just said no.
 
 **Deliberate gaps** (settled in the 2026-08 design review, recorded so they read as decisions):
 

--- a/docs/references/job-manager-design.md
+++ b/docs/references/job-manager-design.md
@@ -1,7 +1,8 @@
 # Mobile Job Manager Design
 
-> Updated: 2026-08-03
-> Status: design proposal (runtime not yet built)
+> Updated: 2026-08-10
+> Status: Phase 1 landed and wired — `painting.generate` runs on the job ledger; see
+> [Phase 1 As-Built](#phase-1-as-built)
 > Desktop source: `CherryHQ/cherry-studio@d498753ecfd0f2572612456281ec222563ce7bf3`
 > Mobile baseline: post `v0.2` merge (`fd1552c6` desktop-sync) — the job **ledger scaffolding
 > already exists**; see [What Already Landed](#what-already-landed)
@@ -33,7 +34,9 @@ Data API. What remains is the active half, shipped deliberately small:
 
 What we do not build: desktop's pause/drain write-quiesce (no mobile backup-restore consumer;
 roughly a third of desktop `JobManager.ts` complexity), croner-armed cron timers as a correctness
-mechanism, silent-audio keep-alive, or any promise that a local job runs while the app is dead.
+mechanism, or any promise that a local job runs while the app is dead. (Silent-audio keep-alive
+was on this list; PR #473 changed the evidence — see the
+[KeepAliveCoordinator appendix](#appendix-keepalivecoordinator-design-draft).)
 
 ## What Already Landed
 
@@ -47,15 +50,77 @@ The v0.2 merge (desktop-sync `fd1552c6`) brought in, all desktop-verbatim:
 | Read repository | `src/backend/data/services/JobService.ts` | `list` / `getById` / bare `create`; `rowToSnapshot` maps timestamps to ISO strings (matches desktop's string-typed snapshot) |
 | GET-only Data API | `src/backend/data/api/handlers/jobs.ts`, aggregated in `apiHandlers.ts`, `JobService` constructed in `createBackendServices` | `/jobs` and `/jobs/:id` reads work today |
 
-Missing — the subject of this design: the runtime (claim/dispatch/fencing/retry/cancel/recovery/
-GC), the handler registry and contract, business handlers, bootstrap ownership of the pump, and
-every platform adapter.
+Since then the active half has landed too: the runtime (claim/dispatch/fencing/retry/cancel/
+recovery/GC), the handler registry and contract, the first business handler, and bootstrap
+ownership of the pump — see [Phase 1 As-Built](#phase-1-as-built). Platform adapters (Phase 2+)
+remain unbuilt.
 
 One structural consequence: `src/backend/data/db/schemas/job.ts` and the universal `jobs.ts` are
 **desktop mirrors under the `$sync-cherry-desktop` audit**. Mobile-only state must not be patched
 into them, or every future sync becomes a merge conflict and the schema-AST audit reports drift.
 The design below therefore adds **no schema at all**: everything mobile-only is derived from the
-handler registry, carried in `metadata`, or expressed as a runtime invariant.
+handler registry, carried in `metadata`, or expressed as a runtime invariant. (One as-built
+deviation exists outside the mirrors: `job_file_ref` — see
+[Phase 1 As-Built](#phase-1-as-built).)
+
+## Phase 1 As-Built
+
+> Landed 2026-08-10. This section records where the implementation deviates from the design text
+> and which gaps are deliberate; the design sections themselves are left as written.
+
+**Wired surface.** `createBackend` (`src/bootstrap/composition/createBackend.ts`) constructs the
+runtime via `createJobRuntime({ dbService, jobService, handlers })` with the frozen handler array
+and chains `await jobRuntime.dispose()` ahead of `chat.dispose()`; `runPostReadyTasks` fires
+`pump({ reason: 'cold-start' })`, whose first pass lazily runs startup recovery and GC. The first
+consumer is `painting.generate`
+(`src/backend/services/paintings/tasks/paintingGenerateJobHandler.ts`): the paintings module
+creates the receipt and enqueues in one `withWriteTx` (with an idempotency pre-check so a
+duplicate signature joins the active job instead of orphaning a fresh receipt), and
+`usePaintingGeneration` observes the ledger by polling `GET /jobs/:id` (1 s while active, stop on
+terminal) and adopts a still-active job on mount via `GET /jobs`. Because `DbService.withWriteTx`
+is not reentrant, the in-transaction path is built entirely from `*Tx` variants
+(`PaintingService.createTx`, `JobRuntime.enqueueTx`, `JobService.findActiveByIdempotencyKeyTx`).
+
+**As-built deviations from the design text:**
+
+- **`job_file_ref` exists but Phase 1 does not write it.** The table
+  (`src/backend/data/db/schemas/fileRelations.ts:88`, migration 0007) landed ahead of this
+  design — a deviation from "no schema at all", though it touches file relations, not the `job`
+  mirror. Phase 1 leaves it empty on purpose: the painting receipt's `painting_file_ref` rows
+  already pin the input files, created in the same transaction as the enqueue, so a job-level ref
+  would be redundant. It waits for a consumer whose files have no domain receipt of their own.
+- **Handler input carries internal URIs alongside IDs.** As-built input is
+  `{ images: { fileEntryId, mediaType, uri }[], mode, modelId, paintingId, paramValues, prompt }`.
+  Draft picker images are materialized into durable internal file entries *before* enqueue; the
+  `uri` riding along is the internal-storage path (never an ephemeral picker URI), which the
+  handler reads data URLs from directly.
+- **`startGeneration` returns `{ jobId }`**, not `{ paintingId, jobId }`; the receipt reaches the
+  frontend through the completed job's output and the painting query sync.
+- **`internal.echo` was not built.** The jest harness
+  (`src/backend/services/jobs/__tests__/_helpers.ts`) registers inline test handlers, which serve
+  the proof role without needing a production-registry exclusion mechanism.
+- **No `AppState` pump listener yet** (Ownership item 4). Phase 1's dispatch triggers are
+  enqueue, the delayed-retry timer, and cold start; with only `foreground-only` handlers, an
+  enqueue can only happen in the foreground, so the listener adds nothing until delayed retries
+  can span a backgrounding or a Phase 2 window exists. Add it with Phase 2.
+- **Dangling receipts are kept.** A failed/cancelled/abandoned generation leaves a painting row
+  with no outputs — invisible to the list (it filters on having output), matching the old session
+  behavior. A future file-orphan-cleanup job is the designated collector; the "interrupted, tap
+  to retry" UI remains an open question.
+
+**Deliberate gaps** (settled in the 2026-08 design review, recorded so they read as decisions):
+
+- **Chat stays out of the job system** (see [First handlers](#first-handlers)): a job is a fixed
+  serializable input awaiting a result; a chat turn is an interactive stream with approvals.
+  Background continuation for both comes from a shared keep-alive primitive instead — see the
+  [KeepAliveCoordinator appendix](#appendix-keepalivecoordinator-design-draft).
+- **Pause/drain write-quiesce is not ported.** Port it together with the backup feature — its
+  only desktop consumer — using the desktop contract as the reference.
+- **No push surface for progress.** Polling only, per Deviation 7; a CacheService-backed push
+  face waits for a handler with high-frequency progress.
+- **Schedules stay dormant** (Phase 4): `job_schedule` is written and read by nothing on mobile;
+  desktop's `AgentTaskService` semantics occupy the table's shape, awaiting a mobile executor and
+  a product feature that needs one.
 
 ## Desktop: What We Port And What We Don't
 
@@ -90,16 +155,17 @@ Follows the standard "new backend module" drop points; read-path files already e
 ```text
 packages/universal/src/data/api/schemas/jobs.ts   # landed — desktop mirror, do not fork
 src/backend/data/db/schemas/job.ts                # landed — desktop mirror, do not fork
-src/backend/data/services/JobService.ts           # landed reads; ADD claim/terminal/retry writers
+src/backend/data/services/JobService.ts           # landed — reads + claim/terminal/retry writers
 src/backend/data/api/handlers/jobs.ts             # landed — GET-only, stays read-only
-src/backend/services/jobs/JobRuntime.ts           # NEW: orchestrator (enqueue/cancel/pump)
-src/backend/services/jobs/jobRegistry.ts          # NEW: declaration-merging JobRegistry
-src/backend/services/jobs/types.ts                # NEW: JobHandler / JobContext / EnqueueOptions
-src/backend/services/jobs/runtime/backoff.ts      # NEW: ported pure functions + their tests
+src/backend/services/jobs/JobRuntime.ts           # landed — orchestrator (enqueue/cancel/pump)
+src/backend/services/jobs/jobRegistry.ts          # landed — declaration-merging JobRegistry
+src/backend/services/jobs/types.ts                # landed — JobHandler / JobContext / EnqueueOptions
+src/backend/services/jobs/runtime/backoff.ts      # landed — ported pure functions + their tests
 src/backend/services/jobs/runtime/catchUp.ts
 src/backend/services/jobs/runtime/recovery.ts
 src/backend/services/jobs/adapters/               # Phase 2+: wake & lease platform seams
 src/backend/services/<domain>/tasks/<Name>JobHandler.ts   # handlers live with their domain
+src/backend/services/paintings/tasks/paintingGenerateJobHandler.ts   # landed — first handler
 ```
 
 Handler runtime types (`JobHandler`, `JobContext`) stay app-side, exactly as desktop keeps them
@@ -125,7 +191,8 @@ runtime files carry the repo's alignment-comment convention
    whole design: *cold start is the only reliable "no writer is streaming into this" signal,
    because the OS suspends rather than kills a backgrounded app*.
 4. A single `AppState` listener (inside the runtime, not in React) pumps on `active`. Frontend
-   never imports the runtime; routes and hooks never own dispatch.
+   never imports the runtime; routes and hooks never own dispatch. *(The listener is deferred to
+   Phase 2 — see [Phase 1 As-Built](#phase-1-as-built).)*
 
 React routes, `ChatSessionProvider`, and hooks must not own the job dispatcher. This is the
 navigation-ownership fix that PR #473 could not deliver.
@@ -333,20 +400,25 @@ go/no-go checklist enforced at review time.
 
 - The receipt (`PaintingRepository.create`) is already the durable destination, created before
   generation — today's session logic ports almost directly into a handler.
-- Input: `{ paintingId, prompt, modelId, mode, paramValues, inputFileIds }` — file-entry IDs, not
-  ephemeral URIs; the handler re-reads data URLs from storage.
+- Input (as built): `{ images: { fileEntryId, mediaType, uri }[], mode, modelId, paintingId,
+  paramValues, prompt }` — draft picker images are materialized into durable internal file
+  entries before enqueue, so the URIs are internal-storage paths, never ephemeral picker URIs;
+  the handler reads data URLs from them.
 - `executionClass: 'foreground-only'`, `recovery: 'abandon'`, `maxAttempts: 1`, queue
   `'painting'`, concurrency 1. Mobile `generateImage` is a single un-resumable provider call with
   no task ID; process death mid-call is an ambiguous external outcome, so recovery must not
   resubmit. Idempotency key: reuse the session's existing `generationSignature` so double-taps
   join the active job instead of double-charging.
-- `PaintingsBackend` gains `startGeneration(input) → { paintingId, jobId }` and cancel;
-  `usePaintingGeneration` drops its AbortController ownership, awaits `finished` while mounted,
-  and re-attaches via the paintings query + `GET /jobs/:id` after navigation. This delivers the
-  actual product ask — generation survives leaving the screen — with zero OS background APIs.
+- `PaintingsModule` gains `startGeneration(input) → { jobId }` (receipt + `enqueueTx` atomically
+  in one `withWriteTx`, with an idempotency pre-check so a duplicate signature joins the active
+  job instead of orphaning a fresh receipt) and `cancelGeneration(jobId)`;
+  `usePaintingGeneration` drops its AbortController ownership, polls `GET /jobs/:id` while a job
+  is active, and adopts a still-active job on mount via `GET /jobs`. This delivers the actual
+  product ask — generation survives leaving the screen — with zero OS background APIs.
 
 **`internal.echo`** — dev/test-only proof handler (desktop `dummy.echo` precedent), excluded from
-the production registry; drives the jest suite and the device sanity pass.
+the production registry; drives the jest suite and the device sanity pass. *(Not built: the jest
+harness registers inline test handlers instead — see [Phase 1 As-Built](#phase-1-as-built).)*
 
 **Deliberately not chat.** `ChatSession` stays route-owned for now; an agent turn is a workflow
 with approvals and tool calls, not a replayable job, and no provider recovery contract exists.
@@ -394,7 +466,9 @@ type JobExecutionLease = {
   `modules/pdf-text-extractor` + `scripts/with-health-connect.js`) for iOS 26
   `BGContinuedProcessingTask` and an honestly-typed Android foreground service. iOS 17–25 gets
   `beginBackgroundTask` checkpoint grace only — the product copy must not promise long
-  continuation there, and silent audio is not a fallback.
+  continuation there. *(The first draft added "silent audio is not a fallback"; PR #473 revised
+  that on evidence — see the
+  [KeepAliveCoordinator appendix](#appendix-keepalivecoordinator-design-draft).)*
 - **Transfers**: system-owned engines (background `URLSession`, Android UIDT/WorkManager) behind a
   separate transfer adapter; a JS handler loop never owns bytes.
 
@@ -491,8 +565,6 @@ readers know they are decisions, not oversights:
 
 ## Open Questions
 
-- **`useJob` polling cadence**: Phase 1 re-attach uses query + `GET /jobs/:id`; pick a bounded
-  `refetchInterval` for active jobs (only while an active job exists) and stop conditions.
 - **Painting UX copy**: force-quit mid-generation now surfaces an honest failed/abandoned receipt
   instead of silently vanishing work — needs a small UI state for "interrupted, tap to retry".
 - **Sync-audit registration**: confirm with the `$sync-cherry-desktop` skill that the jobs mirror
@@ -500,5 +572,56 @@ readers know they are decisions, not oversights:
   `*Tx`-only surface) read as `semantic-port` rather than drift.
 
 Resolved since the first draft: the drizzle partial unique index generates correctly (verified in
-`0006_*.sql`), and snapshot timestamps follow desktop's ISO-string convention via the landed
-`rowToSnapshot`.
+`0006_*.sql`); snapshot timestamps follow desktop's ISO-string convention via the landed
+`rowToSnapshot`; and the `useJob` polling cadence is settled as-built (1 s `refetchInterval`
+while a job is active, stop on terminal snapshots, restore-on-mount via `GET /jobs` filtered by
+type + active statuses).
+
+## Appendix: KeepAliveCoordinator (design draft)
+
+> Status: design only — implementation is blocked on PR #473 merging. Do not build before then.
+
+Phase 1 ships `painting.generate` as `foreground-only`: backgrounding the app mid-generation
+suspends the JS runtime, and the job settles only on resume (or is abandoned by the next
+cold-start recovery). PR #473's `BackgroundReplyService`
+(`src/backend/services/backgroundReply/BackgroundReplyService.ts` on that branch) proves the
+missing capability for chat: a silent audio session keeps Hermes scheduled while a reply streams
+in the background — the OpenMinis approach, already shipped on the App Store. The mechanism is
+not chat-specific; only its packaging is. The first draft of this document ruled silent audio
+out; that ruling is revised on this evidence.
+
+**What #473 does that the extraction must preserve:**
+
+- iOS-only and preference-gated (`chat.background_reply.enabled`); the service no-ops elsewhere.
+- expo-audio session: `setAudioModeAsync({ shouldPlayInBackground: true, playsInSilentMode:
+  true, interruptionMode: 'mixWithOthers' })`, looping `assets/audio/silence.m4a` at volume
+  `0.001`.
+- `reconcileAudio()` is reference counting in disguise: audio plays iff at least one turn is in
+  a generating phase and stops when none is. Every async start/stop rides a serial operation
+  queue (`operationTail`), so transitions cannot interleave.
+- The Live Activity half (expo-widgets, 1 s-throttled updates, ended on foregrounding, orphan
+  cleanup at construction) is a separate concern that merely shares the service today.
+
+**Extraction shape** — split #473's service along that seam:
+
+```ts
+type KeepAliveCoordinator = {
+  /** 0→1 starts the silent audio session; idempotent per holder. */
+  acquire(tag: string): KeepAliveLease;
+};
+type KeepAliveLease = { release(): void }; // 1→0 stops the session; idempotent
+```
+
+- Owned by composition alongside `JobRuntime`; disposed with it; keeps #473's serial operation
+  queue and preference gate inside the coordinator.
+- Consumer 1 — chat: `BackgroundReplyService` keeps its turns and the Live Activity, and its
+  `reconcileAudio` collapses into acquire-on-generating / release-on-settle.
+- Consumer 2 — jobs: a handler opts in declaratively (a keep-alive flag derived from its
+  execution class); the dispatch loop wraps `execute` in acquire/release, so the coordinator
+  never observes job state and the runtime never owns audio.
+- `painting.generate` then moves `executionClass` to `'user-continued'`: the class states the
+  product promise ("keeps running while you do something else"), and keep-alive is the mechanism
+  honoring it on iOS today — Phase 3's honest leases (iOS 26 Continued Processing, Android FGS)
+  can replace the mechanism later without touching the class.
+
+Android is out of scope for the extraction (it would be FGS + WakeLock, a Phase 3 concern).

--- a/packages/ai-runtime/src/provider/__tests__/openaiImageUrlPatch.test.ts
+++ b/packages/ai-runtime/src/provider/__tests__/openaiImageUrlPatch.test.ts
@@ -1,0 +1,57 @@
+import { OpenAIImageModel } from '@ai-sdk/openai/internal';
+import { describe, expect, it } from 'vitest';
+
+// Guards the image hunks in patches/@ai-sdk__openai@3.0.53.patch. The upstream
+// image response schema requires `data[].b64_json`, but aggregator gateways route
+// url-returning models here: CherryIN sends everything that is neither Google nor
+// Qwen to `OpenAIImageModel` (packages/ai-sdk-provider cherryin-provider.ts), and
+// so does dmxapi. Kolors answers with `data: [{ url }]` — a valid HTTP 200 that,
+// unpatched, fails schema validation (AI_TypeValidationError → "Invalid JSON
+// response") and breaks every such generation. The patch makes `b64_json` optional,
+// accepts `url`, and maps whichever is present; `ai`'s patched `generateImage` then
+// downloads the url into base64. The sibling patch for @ai-sdk/openai-compatible has
+// carried the same hunks all along — this one only caught up. If an SDK upgrade drops
+// the patch, this test fails loudly.
+describe('patched @ai-sdk/openai image schema tolerates url-returning models', () => {
+  it('parses a 200 whose data carries a url instead of b64_json', async () => {
+    const model = imageModel({ data: [{ url: 'https://cdn.example/kolors.png' }] });
+
+    const result = await model.doGenerate(generateOptions());
+
+    expect(result.images).toEqual(['https://cdn.example/kolors.png']);
+  });
+
+  it('still prefers b64_json when the provider returns it', async () => {
+    const model = imageModel({ data: [{ b64_json: 'QUJD' }] });
+
+    const result = await model.doGenerate(generateOptions());
+
+    expect(result.images).toEqual(['QUJD']);
+  });
+});
+
+function imageModel(body: unknown) {
+  return new OpenAIImageModel('kolors', {
+    provider: 'cherryin.image',
+    url: () => 'https://api.cherry-ai.com/v1/images/generations',
+    headers: () => ({}),
+    fetch: async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  });
+}
+
+function generateOptions(): Parameters<OpenAIImageModel['doGenerate']>[0] {
+  return {
+    aspectRatio: undefined,
+    files: undefined,
+    mask: undefined,
+    n: 1,
+    prompt: 'a cat',
+    providerOptions: {},
+    seed: undefined,
+    size: '1024x1024',
+  };
+}

--- a/packages/ui/src/components/composer/__tests__/composer.test.tsx
+++ b/packages/ui/src/components/composer/__tests__/composer.test.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, TextInput, View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { Composer } from '../composer';
@@ -232,6 +232,38 @@ describe('Composer', () => {
       uris: ['file:///pasted.jpg'],
     });
     expect(onPaste).toHaveBeenNthCalledWith(2, { type: 'unsupported' });
+  });
+
+  it('returns a controlled multiline input to its single-line height when cleared', () => {
+    const onChangeText = jest.fn();
+    const onSend = jest.fn();
+    const children = <Composer.Input testID="composer-input" />;
+    const tree = render({ children, onChangeText, onSend, value: 'first\nsecond\nthird' });
+    const populatedInput = tree.root.findByType(TextInput);
+
+    expect(StyleSheet.flatten(populatedInput.props.style)?.height).toBeUndefined();
+
+    act(() => {
+      tree.update(
+        <Composer onChangeText={onChangeText} onSend={onSend} value="">
+          {children}
+        </Composer>,
+      );
+    });
+
+    const input = tree.root.findByType(TextInput);
+    expect(StyleSheet.flatten(input.props.style)?.height).toEqual(expect.any(Number));
+
+    act(() => {
+      tree.update(
+        <Composer onChangeText={onChangeText} onSend={onSend} value={'new\nmultiline'}>
+          {children}
+        </Composer>,
+      );
+    });
+
+    const repopulatedInput = tree.root.findByType(TextInput);
+    expect(StyleSheet.flatten(repopulatedInput.props.style)?.height).toBeUndefined();
   });
 
   it('carries an icon and a label in a pill without letting the icon shrink', () => {

--- a/packages/ui/src/components/composer/components/composer-input.tsx
+++ b/packages/ui/src/components/composer/components/composer-input.tsx
@@ -1,5 +1,5 @@
 import { TextInputWrapper } from 'expo-paste-input';
-import { TextInput } from 'react-native';
+import { PixelRatio, TextInput } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
 
 import { useComposerActions, useComposerState } from '../composer.context';
@@ -8,6 +8,8 @@ import type { ComposerInputProps } from '../composer.types';
 import { composerTextStyle } from '../composerTextStyle';
 
 const inputStyle = { ...textInputBoxStyle, ...composerTextStyle };
+// Android receives 24 from `text-base`; iOS overrides it to a measured 20.
+const textLineHeight = composerTextStyle.lineHeight ?? 24;
 
 /** The text field, growing with its content up to a capped height. */
 export function ComposerInput({
@@ -21,6 +23,17 @@ export function ComposerInput({
   const { value } = useComposerState('Composer.Input');
   const { changeText } = useComposerActions('Composer.Input');
   const placeholderStyle = useResolveClassNames('text-muted-foreground');
+  // Native multiline inputs can retain their previous intrinsic height after a
+  // controlled clear. Clamp only the empty state; non-empty text still grows
+  // naturally up to textInputBoxStyle.maxHeight.
+  const emptyInputStyle =
+    value.length === 0
+      ? {
+          height: Math.ceil(
+            textLineHeight * PixelRatio.getFontScale() + textInputBoxStyle.paddingVertical * 2,
+          ),
+        }
+      : undefined;
 
   return (
     // Wrapped unconditionally, even with no `onPaste`. It costs one native view,
@@ -38,7 +51,7 @@ export function ComposerInput({
           typeof placeholderStyle.color === 'string' ? placeholderStyle.color : undefined
         }
         ref={ref}
-        style={[inputStyle, style]}
+        style={[inputStyle, emptyInputStyle, style]}
         testID={testID}
         value={value}
       />

--- a/patches/@ai-sdk__openai@3.0.53.patch
+++ b/patches/@ai-sdk__openai@3.0.53.patch
@@ -1,8 +1,18 @@
 diff --git a/dist/index.js b/dist/index.js
-index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11edd1ce23d8 100644
+index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..12c496c201b42efb5276d6e3977831701c3acc16 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -1753,13 +1753,15 @@ var modelMaxImagesPerCall = {
+@@ -1725,7 +1725,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
+       created: import_v48.z.number().nullish(),
+       data: import_v48.z.array(
+         import_v48.z.object({
+-          b64_json: import_v48.z.string(),
++          b64_json: import_v48.z.string().nullish(),
++          url: import_v48.z.string().nullish(),
+           revised_prompt: import_v48.z.string().nullish()
+         })
+       ),
+@@ -1753,13 +1754,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -19,7 +29,33 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3778,6 +3780,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
+@@ -1843,7 +1846,11 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.flatMap((item) => {
++          if (typeof item.b64_json === 'string') return [item.b64_json];
++          if (typeof item.url === 'string') return [item.url];
++          return [];
++        }),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1899,7 +1906,11 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.flatMap((item) => {
++        if (typeof item.b64_json === 'string') return [item.b64_json];
++        if (typeof item.url === 'string') return [item.url];
++        return [];
++      }),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3778,6 +3789,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
          summary_index: import_v421.z.number(),
          delta: import_v421.z.string()
        }),
@@ -31,7 +67,7 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
        import_v421.z.object({
          type: import_v421.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v421.z.string(),
-@@ -6105,6 +6112,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6105,6 +6121,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -50,10 +86,20 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
                if (store) {
                  controller.enqueue({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c9341f5dd81 100644
+index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..2898b275a600395e0a2a45aff04a7c2864f04bc2 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -1768,13 +1768,15 @@ var modelMaxImagesPerCall = {
+@@ -1740,7 +1740,8 @@ var openaiImageResponseSchema = lazySchema7(
+       created: z8.number().nullish(),
+       data: z8.array(
+         z8.object({
+-          b64_json: z8.string(),
++          b64_json: z8.string().nullish(),
++          url: z8.string().nullish(),
+           revised_prompt: z8.string().nullish()
+         })
+       ),
+@@ -1768,13 +1769,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -70,7 +116,33 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3855,6 +3857,11 @@ var openaiResponsesChunkSchema = lazySchema19(
+@@ -1858,7 +1861,11 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.flatMap((item) => {
++          if (typeof item.b64_json === 'string') return [item.b64_json];
++          if (typeof item.url === 'string') return [item.url];
++          return [];
++        }),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1914,7 +1921,11 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.flatMap((item) => {
++        if (typeof item.b64_json === 'string') return [item.b64_json];
++        if (typeof item.url === 'string') return [item.url];
++        return [];
++      }),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3855,6 +3866,11 @@ var openaiResponsesChunkSchema = lazySchema19(
          summary_index: z21.number(),
          delta: z21.string()
        }),
@@ -82,7 +154,7 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
        z21.object({
          type: z21.literal("response.reasoning_summary_part.done"),
          item_id: z21.string(),
-@@ -6184,6 +6191,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6184,6 +6200,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -101,10 +173,20 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e2f314180 100644
+index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..1425cfe057a8526a11b8c522d128a04602b7a33c 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -1780,13 +1780,15 @@ var modelMaxImagesPerCall = {
+@@ -1752,7 +1752,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
+       created: import_v48.z.number().nullish(),
+       data: import_v48.z.array(
+         import_v48.z.object({
+-          b64_json: import_v48.z.string(),
++          b64_json: import_v48.z.string().nullish(),
++          url: import_v48.z.string().nullish(),
+           revised_prompt: import_v48.z.string().nullish()
+         })
+       ),
+@@ -1780,13 +1781,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -121,7 +203,33 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3720,6 +3722,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
+@@ -1870,7 +1873,11 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.flatMap((item) => {
++          if (typeof item.b64_json === 'string') return [item.b64_json];
++          if (typeof item.url === 'string') return [item.url];
++          return [];
++        }),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1926,7 +1933,11 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.flatMap((item) => {
++        if (typeof item.b64_json === 'string') return [item.b64_json];
++        if (typeof item.url === 'string') return [item.url];
++        return [];
++      }),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3720,6 +3731,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
          summary_index: import_v417.z.number(),
          delta: import_v417.z.string()
        }),
@@ -133,7 +241,7 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
        import_v417.z.object({
          type: import_v417.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v417.z.string(),
-@@ -6366,6 +6373,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6366,6 +6382,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -152,10 +260,20 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb8df5a965 100644
+index db50beda01459008c836cd5648e024340fe31e90..2431cfb21d49c77a7b1df78171a34ebaa8221d7d 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
-@@ -1760,13 +1760,15 @@ var modelMaxImagesPerCall = {
+@@ -1732,7 +1732,8 @@ var openaiImageResponseSchema = lazySchema7(
+       created: z8.number().nullish(),
+       data: z8.array(
+         z8.object({
+-          b64_json: z8.string(),
++          b64_json: z8.string().nullish(),
++          url: z8.string().nullish(),
+           revised_prompt: z8.string().nullish()
+         })
+       ),
+@@ -1760,13 +1761,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -172,7 +290,33 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3746,6 +3748,11 @@ var openaiResponsesChunkSchema = lazySchema15(
+@@ -1850,7 +1853,11 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.flatMap((item) => {
++          if (typeof item.b64_json === 'string') return [item.b64_json];
++          if (typeof item.url === 'string') return [item.url];
++          return [];
++        }),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1906,7 +1913,11 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.flatMap((item) => {
++        if (typeof item.b64_json === 'string') return [item.b64_json];
++        if (typeof item.url === 'string') return [item.url];
++        return [];
++      }),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3746,6 +3757,11 @@ var openaiResponsesChunkSchema = lazySchema15(
          summary_index: z17.number(),
          delta: z17.string()
        }),
@@ -184,7 +328,7 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
        z17.object({
          type: z17.literal("response.reasoning_summary_part.done"),
          item_id: z17.string(),
-@@ -6422,6 +6429,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6422,6 +6438,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ patchedDependencies:
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
   '@ai-sdk/openai-compatible@2.0.62': d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee
-  '@ai-sdk/openai@3.0.53': b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17
+  '@ai-sdk/openai@3.0.53': 47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
   '@bottom-tabs/react-navigation@1.4.0': 3b020e5c2082d73190742b6c8fbdf6712b3db373d93c237c4ee935a92118a61e
   '@magrinj/expo-quick-look@0.3.1': 2b97fda8470c046179cf3e97282b6984fd1b926d2f54df9056a5cc455f073f2f
@@ -79,7 +79,7 @@ importers:
         version: 3.0.37(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+        version: 3.0.53(patch_hash=47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.4.3)
@@ -476,7 +476,7 @@ importers:
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+        version: 3.0.53(patch_hash=47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.4.3)
@@ -552,7 +552,7 @@ importers:
         version: 3.0.37(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+        version: 3.0.53(patch_hash=47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.4.3)
@@ -622,7 +622,7 @@ importers:
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+        version: 3.0.53(patch_hash=47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.4.3)
@@ -9289,7 +9289,7 @@ snapshots:
 
   '@ai-sdk/azure@3.0.54(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+      '@ai-sdk/openai': 3.0.53(patch_hash=47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62)(zod@4.4.3)
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
@@ -9377,7 +9377,7 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.53(patch_hash=47168cbc7adb7c20e625b441185d9608937e842a65c6539752f10c61e1907f62)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)

--- a/src/backend/ai/provider/config.ts
+++ b/src/backend/ai/provider/config.ts
@@ -504,8 +504,6 @@ function mapGatewayEndpointType(
       return 'openai';
     case ENDPOINT_TYPE.OPENAI_RESPONSES:
       return 'openai-response';
-    case ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION:
-      return 'image-generation';
     case ENDPOINT_TYPE.JINA_RERANK:
       return 'jina-rerank';
     default:

--- a/src/backend/data/services/PaintingService.ts
+++ b/src/backend/data/services/PaintingService.ts
@@ -7,7 +7,7 @@ import type {
   PaintingFileRole,
   PaintingFiles,
 } from '@cherrystudio/universal/data/types/painting';
-import { and, asc, eq, exists, gt, inArray, or } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, or } from 'drizzle-orm';
 
 import type { Database, DbService } from '@/backend/data/db/DbService';
 import {
@@ -17,7 +17,7 @@ import {
   paintingTable,
 } from '@/backend/data/db/schemas';
 
-import { insertWithOrderKey } from './utils/orderKey';
+import { computeNewOrderKey, insertWithOrderKey } from './utils/orderKey';
 import { timestampToISO } from './utils/rowMappers';
 
 const defaultLimit = 20;
@@ -40,26 +40,17 @@ export class PaintingService {
     return this.dbService.getDb();
   }
 
-  private hasOutputFilter() {
-    return exists(
-      this.db
-        .select({ id: paintingFileRefTable.id })
-        .from(paintingFileRefTable)
-        .where(
-          and(
-            eq(paintingFileRefTable.sourceId, paintingTable.id),
-            eq(paintingFileRefTable.role, 'output'),
-          ),
-        ),
-    );
-  }
-
+  /**
+   * Output-less receipts are listed too: while `painting.generate` runs (or
+   * after it was interrupted) the row is all the gallery has to show, and
+   * hiding it would leave the user with no way back to a running generation
+   * and no way to delete an abandoned one.
+   */
   async listByCursor(
     params: { cursor?: string; limit?: number } = {},
   ): Promise<CursorPaginationResponse<Painting>> {
     const limit = Math.min(Math.max(params.limit ?? defaultLimit, 1), maxLimit);
     const cursor = params.cursor ? decodeCursor(params.cursor) : undefined;
-    const hasOutput = this.hasOutputFilter();
     const afterCursor = cursor
       ? or(
           gt(paintingTable.orderKey, cursor.orderKey),
@@ -70,7 +61,7 @@ export class PaintingService {
     const rows = await this.db
       .select()
       .from(paintingTable)
-      .where(afterCursor ? and(hasOutput, afterCursor) : hasOutput)
+      .where(afterCursor)
       .orderBy(asc(paintingTable.orderKey), asc(paintingTable.id))
       .limit(limit + 1);
     const pageRows = rows.slice(0, limit);
@@ -89,7 +80,6 @@ export class PaintingService {
     const rows = await this.db
       .select({ id: paintingTable.id })
       .from(paintingTable)
-      .where(this.hasOutputFilter())
       .orderBy(asc(paintingTable.orderKey), asc(paintingTable.id));
     return rows.map((row) => row.id);
   }
@@ -128,6 +118,61 @@ export class PaintingService {
     await insertFileRefsTx(tx, inserted.id, 'input', inputFileIds);
 
     return rowToPainting(inserted, { input: inputFileIds, output: [] });
+  }
+
+  /**
+   * Re-points an interrupted receipt at a fresh attempt: new prompt/model, new
+   * input refs, back to the head of the list. A retry is another attempt at the
+   * same painting rather than a new one, so reusing the row keeps its gallery
+   * tile in place instead of stranding the interrupted one beside it.
+   *
+   * Rides the caller's write transaction (`withWriteTx` is not reentrant).
+   */
+  async resetForRetryTx(tx: Database, id: string, input: CreatePaintingInput): Promise<Painting> {
+    const [row] = await tx
+      .select({ id: paintingTable.id })
+      .from(paintingTable)
+      .where(eq(paintingTable.id, id))
+      .limit(1);
+    if (!row) {
+      throw DataApiErrorFactory.notFound('Painting', id);
+    }
+
+    const existingFiles = await loadFilesTx(tx, [id]);
+    if ((existingFiles.get(id)?.output.length ?? 0) > 0) {
+      // Reuse would drop finished images on the floor. Callers are meant to
+      // gate on the interrupted state (zero outputs); getting here means the
+      // caller mistook a finished painting for one worth retrying.
+      throw DataApiErrorFactory.validation(
+        { paintingId: ['Painting already has outputs'] },
+        `Painting ${id} already has outputs and cannot be reused for a retry`,
+      );
+    }
+
+    const inputFileIds = [...(input.inputFileIds ?? [])];
+    const orderKey = await computeNewOrderKey(
+      tx,
+      paintingTable,
+      { position: 'first' },
+      { excludePkValue: id, pkColumn: paintingTable.id },
+    );
+    await tx
+      .delete(paintingFileRefTable)
+      .where(and(eq(paintingFileRefTable.sourceId, id), eq(paintingFileRefTable.role, 'input')));
+    await insertFileRefsTx(tx, id, 'input', inputFileIds);
+    const [updated] = await tx
+      .update(paintingTable)
+      .set({
+        modelId: normalizeModelId(input.providerId, input.modelId),
+        orderKey,
+        prompt: input.prompt,
+        providerId: input.providerId,
+        updatedAt: Date.now(),
+      })
+      .where(eq(paintingTable.id, id))
+      .returning();
+
+    return rowToPainting(updated as PaintingRow, { input: inputFileIds, output: [] });
   }
 
   async replaceOutputs(id: string, outputFileIds: readonly FileEntryId[]): Promise<Painting> {

--- a/src/backend/data/services/PaintingService.ts
+++ b/src/backend/data/services/PaintingService.ts
@@ -109,23 +109,25 @@ export class PaintingService {
   }
 
   async create(input: CreatePaintingInput): Promise<Painting> {
-    const inputFileIds = [...(input.inputFileIds ?? [])];
-    const row = (await this.dbService.withWriteTx(async (tx) => {
-      const inserted = (await insertWithOrderKey(
-        tx,
-        paintingTable,
-        {
-          modelId: normalizeModelId(input.providerId, input.modelId),
-          prompt: input.prompt,
-          providerId: input.providerId,
-        },
-        { pkColumn: paintingTable.id, position: 'first' },
-      )) as PaintingRow;
-      await insertFileRefsTx(tx, inserted.id, 'input', inputFileIds);
-      return inserted;
-    })) as PaintingRow;
+    return this.dbService.withWriteTx((tx) => this.createTx(tx, input));
+  }
 
-    return rowToPainting(row, { input: inputFileIds, output: [] });
+  /** Rides the caller's write transaction (`withWriteTx` is not reentrant). */
+  async createTx(tx: Database, input: CreatePaintingInput): Promise<Painting> {
+    const inputFileIds = [...(input.inputFileIds ?? [])];
+    const inserted = (await insertWithOrderKey(
+      tx,
+      paintingTable,
+      {
+        modelId: normalizeModelId(input.providerId, input.modelId),
+        prompt: input.prompt,
+        providerId: input.providerId,
+      },
+      { pkColumn: paintingTable.id, position: 'first' },
+    )) as PaintingRow;
+    await insertFileRefsTx(tx, inserted.id, 'input', inputFileIds);
+
+    return rowToPainting(inserted, { input: inputFileIds, output: [] });
   }
 
   async replaceOutputs(id: string, outputFileIds: readonly FileEntryId[]): Promise<Painting> {

--- a/src/backend/data/services/__tests__/PaintingService.test.ts
+++ b/src/backend/data/services/__tests__/PaintingService.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { DatabaseSync } from 'node:sqlite';
 
+import type { FileEntryId } from '@cherrystudio/universal/data/types/file';
 import { drizzle } from 'drizzle-orm/sqlite-proxy';
 
 import type { Database, DbService } from '@/backend/data/db/DbService';
@@ -14,6 +15,7 @@ jest.mock('uuid', () => ({
 }));
 
 jest.mock('../utils/orderKey', () => ({
+  computeNewOrderKey: jest.fn(async () => 'Zz'),
   insertWithOrderKey: jest.fn(),
 }));
 
@@ -22,12 +24,13 @@ type MigrationJournal = { entries: { tag: string }[] };
 describe('PaintingService integration', () => {
   let sqlite: DatabaseSync;
   let service: PaintingService;
+  let database: Database;
 
   beforeEach(() => {
     sqlite = new DatabaseSync(':memory:');
     sqlite.exec('PRAGMA foreign_keys = ON');
     applyMigrations(sqlite);
-    const database = drizzle(
+    database = drizzle(
       async (sql, params, method) => {
         const statement = sqlite.prepare(sql);
         if (method === 'run') {
@@ -63,18 +66,23 @@ describe('PaintingService integration', () => {
 
   afterEach(() => sqlite.close());
 
-  it('pages newest output receipts first and filters receipts without outputs', async () => {
+  it('pages newest receipts first and keeps output-less ones so the gallery can show them', async () => {
     insertPainting(sqlite, 'painting-new', 'a0', 3);
-    insertPainting(sqlite, 'painting-empty', 'a1', 2);
+    insertPainting(sqlite, 'painting-pending', 'a1', 2);
     insertPainting(sqlite, 'painting-old', 'a2', 1);
     insertFileAndRef(sqlite, 'new-output', 'painting-new', 'output', 3);
+    insertFileAndRef(sqlite, 'pending-input', 'painting-pending', 'input', 2);
     insertFileAndRef(sqlite, 'old-input', 'painting-old', 'input', 1);
     insertFileAndRef(sqlite, 'old-output', 'painting-old', 'output', 1);
 
-    const firstPage = await service.listByCursor({ limit: 1 });
-    const secondPage = await service.listByCursor({ cursor: firstPage.nextCursor, limit: 1 });
+    const firstPage = await service.listByCursor({ limit: 2 });
+    const secondPage = await service.listByCursor({ cursor: firstPage.nextCursor, limit: 2 });
 
-    expect(firstPage.items.map((painting) => painting.id)).toEqual(['painting-new']);
+    expect(firstPage.items.map((painting) => painting.id)).toEqual([
+      'painting-new',
+      'painting-pending',
+    ]);
+    expect(firstPage.items[1].files).toEqual({ input: ['pending-input'], output: [] });
     expect(firstPage.nextCursor).toBeDefined();
     expect(secondPage.items.map((painting) => painting.id)).toEqual(['painting-old']);
     expect(secondPage.items[0].files).toEqual({ input: ['old-input'], output: ['old-output'] });
@@ -149,15 +157,57 @@ describe('PaintingService integration', () => {
     expect(sqlite.prepare('SELECT COUNT(*) AS count FROM painting').get()).toEqual({ count: 1 });
   });
 
-  it('lists all painting ids with outputs in gallery order', async () => {
+  it('lists every painting id in gallery order so select-all matches what is on screen', async () => {
     insertPainting(sqlite, 'painting-first', 'a0', 3);
-    insertPainting(sqlite, 'painting-empty', 'a1', 2);
+    insertPainting(sqlite, 'painting-pending', 'a1', 2);
     insertPainting(sqlite, 'painting-last', 'a2', 1);
     insertFileAndRef(sqlite, 'first-output', 'painting-first', 'output', 3);
-    insertFileAndRef(sqlite, 'empty-input', 'painting-empty', 'input', 2);
+    insertFileAndRef(sqlite, 'pending-input', 'painting-pending', 'input', 2);
     insertFileAndRef(sqlite, 'last-output', 'painting-last', 'output', 1);
 
-    await expect(service.listAllIds()).resolves.toEqual(['painting-first', 'painting-last']);
+    await expect(service.listAllIds()).resolves.toEqual([
+      'painting-first',
+      'painting-pending',
+      'painting-last',
+    ]);
+  });
+
+  it('reuses an interrupted receipt: keeps its id, swaps inputs, moves it to the head', async () => {
+    insertPainting(sqlite, 'painting-retry', 'a5', 1);
+    insertFileAndRef(sqlite, 'stale-input', 'painting-retry', 'input', 1);
+    insertFile(sqlite, 'fresh-input', 2);
+
+    const retried = await service.resetForRetryTx(database, 'painting-retry', {
+      inputFileIds: ['fresh-input' as FileEntryId],
+      modelId: 'model-2',
+      prompt: 'retry prompt',
+      providerId: 'provider',
+    });
+
+    expect(retried).toMatchObject({
+      files: { input: ['fresh-input'], output: [] },
+      id: 'painting-retry',
+      modelId: 'provider::model-2',
+      orderKey: 'Zz',
+      prompt: 'retry prompt',
+    });
+    expect(sqlite.prepare('SELECT file_entry_id FROM painting_file_ref').all()).toEqual([
+      { file_entry_id: 'fresh-input' },
+    ]);
+  });
+
+  it('refuses to reuse a receipt that already holds outputs', async () => {
+    insertPainting(sqlite, 'painting-done', 'a0', 1);
+    insertFileAndRef(sqlite, 'done-output', 'painting-done', 'output', 1);
+
+    await expect(
+      service.resetForRetryTx(database, 'painting-done', {
+        inputFileIds: [],
+        modelId: 'model-2',
+        prompt: 'retry prompt',
+        providerId: 'provider',
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
   });
 });
 

--- a/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
+++ b/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
@@ -54,6 +54,7 @@ function createSubject() {
     },
     paintings: {
       createTx: jest.fn(async () => painting('painting-1')),
+      resetForRetryTx: jest.fn(async (_tx: Database, id: string) => painting(id)),
     },
     storage: {
       createInternalEntry: jest.fn(async () => internalEntry(inputFileId)),
@@ -79,19 +80,27 @@ const generationInput = {
   prompt: ' draw ',
 };
 
-const expectedSignature = JSON.stringify({
-  images: ['draft-1:file:///picked.png'],
-  mode: 'generate',
-  modelId,
-  paramValues: {},
-  prompt: 'draw',
-});
+function signatureFor(paintingId: string | null = null) {
+  return JSON.stringify({
+    images: ['draft-1:file:///picked.png'],
+    mode: 'generate',
+    modelId,
+    paintingId,
+    paramValues: {},
+    prompt: 'draw',
+  });
+}
+
+const expectedSignature = signatureFor();
 
 describe('createPaintingsModule', () => {
   it('creates the receipt and enqueues the job atomically inside one transaction', async () => {
     const { backend, dependencies } = createSubject();
 
-    await expect(backend.startGeneration(generationInput)).resolves.toEqual({ jobId: 'job-1' });
+    await expect(backend.startGeneration(generationInput)).resolves.toEqual({
+      jobId: 'job-1',
+      paintingId: 'painting-1',
+    });
 
     expect(dependencies.storage.createInternalEntry).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -146,9 +155,14 @@ describe('createPaintingsModule', () => {
 
   it('returns the active job on an idempotency hit and discards its fresh inputs', async () => {
     const { backend, dependencies } = createSubject();
-    jest.mocked(dependencies.jobs.findActiveGenerateTx).mockResolvedValue({ id: 'job-9' });
+    jest
+      .mocked(dependencies.jobs.findActiveGenerateTx)
+      .mockResolvedValue({ id: 'job-9', input: { paintingId: 'painting-9' } });
 
-    await expect(backend.startGeneration(generationInput)).resolves.toEqual({ jobId: 'job-9' });
+    await expect(backend.startGeneration(generationInput)).resolves.toEqual({
+      jobId: 'job-9',
+      paintingId: 'painting-9',
+    });
 
     expect(dependencies.jobs.findActiveGenerateTx).toHaveBeenCalledWith(tx, expectedSignature);
     expect(dependencies.paintings.createTx).not.toHaveBeenCalled();
@@ -156,6 +170,39 @@ describe('createPaintingsModule', () => {
     expect(dependencies.storage.discard).toHaveBeenCalledWith([
       expect.objectContaining({ id: inputFileId }),
     ]);
+  });
+
+  it('reuses the interrupted receipt when a paintingId is supplied instead of minting a new one', async () => {
+    const { backend, dependencies } = createSubject();
+
+    await expect(
+      backend.startGeneration({ ...generationInput, paintingId: 'painting-7' }),
+    ).resolves.toEqual({ jobId: 'job-1', paintingId: 'painting-7' });
+
+    expect(dependencies.paintings.createTx).not.toHaveBeenCalled();
+    expect(dependencies.paintings.resetForRetryTx).toHaveBeenCalledWith(tx, 'painting-7', {
+      inputFileIds: [inputFileId],
+      modelId,
+      prompt: 'draw',
+      providerId: 'openai',
+    });
+    expect(dependencies.jobs.enqueueGenerateTx).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ paintingId: 'painting-7' }),
+      { idempotencyKey: signatureFor('painting-7') },
+    );
+  });
+
+  it('keeps a retry and a fresh generation on distinct idempotency keys', async () => {
+    const { backend, dependencies } = createSubject();
+
+    await backend.startGeneration(generationInput);
+    await backend.startGeneration({ ...generationInput, paintingId: 'painting-7' });
+
+    const keys = jest
+      .mocked(dependencies.jobs.findActiveGenerateTx)
+      .mock.calls.map(([, idempotencyKey]) => idempotencyKey);
+    expect(new Set(keys).size).toBe(2);
   });
 
   it('discards created inputs when receipt persistence fails', async () => {

--- a/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
+++ b/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
@@ -2,13 +2,15 @@ import type { FileEntryId, InternalFileEntry } from '@cherrystudio/universal/dat
 import { createUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import type { Painting } from '@cherrystudio/universal/data/types/painting';
 
+import type { Database } from '@/backend/data/db/DbService';
 import type { PaintingsModule } from '@/shared/contracts';
 
 import { createPaintingsModule, type PaintingsModuleDependencies } from '../createPaintingsModule';
 
 const modelId = createUniqueModelId('openai', 'image-1');
 const inputFileId = '00000000-0000-4000-8000-000000000001' as FileEntryId;
-const outputFileId = '00000000-0000-4000-8000-000000000002' as FileEntryId;
+const existingFileId = '00000000-0000-4000-8000-000000000003' as FileEntryId;
+const tx = { sentinel: 'tx' } as unknown as Database;
 
 function painting(id: string, outputs: FileEntryId[] = []): Painting {
   return {
@@ -38,31 +40,24 @@ function internalEntry(id: FileEntryId): InternalFileEntry {
 }
 
 function createSubject() {
-  const receipt = painting('painting-1');
-  const completed = painting('painting-1', [outputFileId]);
-  const files = {
-    resolve: jest.fn(),
-  } satisfies PaintingsModuleDependencies['files'];
   const dependencies: PaintingsModuleDependencies = {
-    ai: {
-      generateImage: jest.fn(async () => ({
-        images: [{ base64: 'aW1hZ2U=', mediaType: 'image/png' }],
-      })),
+    db: {
+      withWriteTx: jest.fn(async (fn) => fn(tx)),
     },
-    files,
+    files: {
+      resolve: jest.fn(),
+    },
+    jobs: {
+      cancelGenerate: jest.fn(async () => undefined),
+      enqueueGenerateTx: jest.fn(async () => ({ id: 'job-1' })),
+      findActiveGenerateTx: jest.fn(async () => null),
+    },
     paintings: {
-      create: jest.fn(async () => receipt),
-      replaceOutputs: jest.fn(async () => completed),
+      createTx: jest.fn(async () => painting('painting-1')),
     },
     storage: {
-      createInternalEntry: jest.fn(async (input) =>
-        input.source === 'uri' ? internalEntry(inputFileId) : internalEntry(outputFileId),
-      ),
+      createInternalEntry: jest.fn(async () => internalEntry(inputFileId)),
       discard: jest.fn(async () => undefined),
-      readDataUrl: jest.fn(async () => 'data:image/png;base64,aW1hZ2U='),
-      getUri: jest.fn((entry) =>
-        entry.id === outputFileId ? 'file:///output.png' : 'file:///input.png',
-      ),
     },
   };
   const backend: PaintingsModule = createPaintingsModule(dependencies);
@@ -84,198 +79,110 @@ const generationInput = {
   prompt: ' draw ',
 };
 
-describe('createPaintingsModule', () => {
-  it('persists created input and output entries behind one session call', async () => {
-    const { backend, dependencies } = createSubject();
-    const session = backend.createGenerationSession();
+const expectedSignature = JSON.stringify({
+  images: ['draft-1:file:///picked.png'],
+  mode: 'generate',
+  modelId,
+  paramValues: {},
+  prompt: 'draw',
+});
 
-    await expect(session.generate(generationInput)).resolves.toEqual({
-      outputs: [{ fileEntryId: outputFileId, uri: 'file:///output.png' }],
-      painting: painting('painting-1', [outputFileId]),
-    });
-    expect(dependencies.paintings.create).toHaveBeenCalledWith(
+describe('createPaintingsModule', () => {
+  it('creates the receipt and enqueues the job atomically inside one transaction', async () => {
+    const { backend, dependencies } = createSubject();
+
+    await expect(backend.startGeneration(generationInput)).resolves.toEqual({ jobId: 'job-1' });
+
+    expect(dependencies.storage.createInternalEntry).toHaveBeenCalledWith(
       expect.objectContaining({
-        inputFileIds: [inputFileId],
-        prompt: 'draw',
-        providerId: 'openai',
+        cleanupPolicy: 'delete_when_unreferenced',
+        source: 'uri',
+        uri: 'file:///picked.png',
       }),
     );
-    expect(dependencies.ai.generateImage).toHaveBeenCalledWith(
-      expect.objectContaining({ prompt: 'draw', uniqueModelId: modelId }),
+    expect(dependencies.paintings.createTx).toHaveBeenCalledWith(tx, {
+      inputFileIds: [inputFileId],
+      modelId,
+      prompt: 'draw',
+      providerId: 'openai',
+    });
+    expect(dependencies.jobs.enqueueGenerateTx).toHaveBeenCalledWith(
+      tx,
+      {
+        images: [{ fileEntryId: inputFileId, mediaType: 'image/png', uri: 'file:///picked.png' }],
+        mode: 'generate',
+        modelId,
+        paintingId: 'painting-1',
+        paramValues: {},
+        prompt: 'draw',
+      },
+      { idempotencyKey: expectedSignature },
     );
-    expect(dependencies.paintings.replaceOutputs).toHaveBeenCalledWith('painting-1', [
-      outputFileId,
-    ]);
-    expect(dependencies.storage.createInternalEntry).toHaveBeenCalledWith(
-      expect.objectContaining({ cleanupPolicy: 'delete_when_unreferenced', source: 'uri' }),
-    );
-    expect(dependencies.storage.createInternalEntry).toHaveBeenCalledWith(
-      expect.objectContaining({ cleanupPolicy: 'delete_when_unreferenced', source: 'base64' }),
+    expect(dependencies.storage.discard).not.toHaveBeenCalled();
+  });
+
+  it('passes through images that already have a file entry without re-creating them', async () => {
+    const { backend, dependencies } = createSubject();
+
+    await backend.startGeneration({
+      ...generationInput,
+      images: [
+        {
+          fileEntryId: existingFileId,
+          id: 'attachment-1',
+          mediaType: 'image/png',
+          name: 'existing.png',
+          uri: 'file:///existing.png',
+        },
+      ],
+    });
+
+    expect(dependencies.storage.createInternalEntry).not.toHaveBeenCalled();
+    expect(dependencies.paintings.createTx).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ inputFileIds: [existingFileId] }),
     );
   });
 
-  it('reuses an incomplete receipt when the same generation is retried', async () => {
+  it('returns the active job on an idempotency hit and discards its fresh inputs', async () => {
     const { backend, dependencies } = createSubject();
-    jest
-      .mocked(dependencies.ai.generateImage)
-      .mockRejectedValueOnce(new Error('provider failed'))
-      .mockResolvedValueOnce({ images: [{ base64: 'aW1hZ2U=', mediaType: 'image/png' }] });
-    const session = backend.createGenerationSession();
+    jest.mocked(dependencies.jobs.findActiveGenerateTx).mockResolvedValue({ id: 'job-9' });
 
-    await expect(session.generate(generationInput)).rejects.toThrow('provider failed');
-    await session.generate(generationInput);
+    await expect(backend.startGeneration(generationInput)).resolves.toEqual({ jobId: 'job-9' });
 
-    expect(dependencies.paintings.create).toHaveBeenCalledTimes(1);
-  });
-
-  it('discards created inputs when receipt persistence fails', async () => {
-    const { backend, dependencies } = createSubject();
-    jest.mocked(dependencies.paintings.create).mockRejectedValue(new Error('database failed'));
-    const session = backend.createGenerationSession();
-
-    await expect(session.generate(generationInput)).rejects.toThrow('database failed');
+    expect(dependencies.jobs.findActiveGenerateTx).toHaveBeenCalledWith(tx, expectedSignature);
+    expect(dependencies.paintings.createTx).not.toHaveBeenCalled();
+    expect(dependencies.jobs.enqueueGenerateTx).not.toHaveBeenCalled();
     expect(dependencies.storage.discard).toHaveBeenCalledWith([
       expect.objectContaining({ id: inputFileId }),
     ]);
   });
 
-  it('discards created outputs when output reference persistence fails', async () => {
+  it('discards created inputs when receipt persistence fails', async () => {
     const { backend, dependencies } = createSubject();
-    jest
-      .mocked(dependencies.paintings.replaceOutputs)
-      .mockRejectedValue(new Error('database failed'));
-    const session = backend.createGenerationSession();
+    jest.mocked(dependencies.paintings.createTx).mockRejectedValue(new Error('database failed'));
 
-    await expect(session.generate(generationInput)).rejects.toThrow('database failed');
+    await expect(backend.startGeneration(generationInput)).rejects.toThrow('database failed');
     expect(dependencies.storage.discard).toHaveBeenCalledWith([
-      expect.objectContaining({ id: outputFileId }),
+      expect.objectContaining({ id: inputFileId }),
     ]);
   });
 
-  it('keeps referenced outputs when their URI cannot be resolved', async () => {
+  it('discards created inputs when the enqueue fails', async () => {
     const { backend, dependencies } = createSubject();
-    jest.mocked(dependencies.storage.getUri).mockReturnValue(undefined);
-    const session = backend.createGenerationSession();
+    jest.mocked(dependencies.jobs.enqueueGenerateTx).mockRejectedValue(new Error('enqueue failed'));
 
-    await expect(session.generate(generationInput)).rejects.toThrow(
-      `Generated painting file is unavailable: ${outputFileId}`,
-    );
-    expect(dependencies.paintings.replaceOutputs).toHaveBeenCalledWith('painting-1', [
-      outputFileId,
+    await expect(backend.startGeneration(generationInput)).rejects.toThrow('enqueue failed');
+    expect(dependencies.storage.discard).toHaveBeenCalledWith([
+      expect.objectContaining({ id: inputFileId }),
     ]);
-    expect(dependencies.storage.discard).not.toHaveBeenCalled();
   });
 
-  it('cancels the active call and reuses its receipt for the same input', async () => {
+  it('delegates cancellation to the job port', async () => {
     const { backend, dependencies } = createSubject();
-    let observedSignal: AbortSignal | undefined;
-    jest
-      .mocked(dependencies.ai.generateImage)
-      .mockImplementationOnce(
-        ({ requestOptions }) =>
-          new Promise((_resolve, reject) => {
-            observedSignal = requestOptions.signal;
-            requestOptions.signal.addEventListener(
-              'abort',
-              () => reject(requestOptions.signal.reason),
-              {
-                once: true,
-              },
-            );
-          }),
-      )
-      .mockResolvedValueOnce({ images: [{ base64: 'aW1hZ2U=', mediaType: 'image/png' }] });
-    const session = backend.createGenerationSession();
 
-    const firstGeneration = session.generate(generationInput);
-    await waitUntil(() => observedSignal !== undefined);
-    await expect(session.generate(generationInput)).rejects.toThrow(
-      'Painting generation is already in progress',
-    );
-    session.cancel();
+    await backend.cancelGeneration('job-1');
 
-    await expect(firstGeneration).rejects.toThrow('Painting generation cancelled');
-    expect(observedSignal?.aborted).toBe(true);
-    await session.generate(generationInput);
-    expect(dependencies.paintings.create).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps incomplete receipts isolated between sessions', async () => {
-    const { backend, dependencies } = createSubject();
-    jest.mocked(dependencies.ai.generateImage).mockRejectedValue(new Error('provider failed'));
-    const firstSession = backend.createGenerationSession();
-    const secondSession = backend.createGenerationSession();
-
-    await expect(firstSession.generate(generationInput)).rejects.toThrow('provider failed');
-    await expect(secondSession.generate(generationInput)).rejects.toThrow('provider failed');
-
-    expect(dependencies.paintings.create).toHaveBeenCalledTimes(2);
-  });
-
-  it('aborts on dispose and permanently rejects later generation', async () => {
-    const { backend, dependencies } = createSubject();
-    let observedSignal: AbortSignal | undefined;
-    jest.mocked(dependencies.ai.generateImage).mockImplementationOnce(
-      ({ requestOptions }) =>
-        new Promise((_resolve, reject) => {
-          observedSignal = requestOptions.signal;
-          requestOptions.signal.addEventListener(
-            'abort',
-            () => reject(requestOptions.signal.reason),
-            {
-              once: true,
-            },
-          );
-        }),
-    );
-    const session = backend.createGenerationSession();
-
-    const generation = session.generate(generationInput);
-    await waitUntil(() => observedSignal !== undefined);
-    session.dispose();
-
-    await expect(generation).rejects.toThrow('Painting generation session is disposed');
-    expect(observedSignal?.aborted).toBe(true);
-    await expect(session.generate(generationInput)).rejects.toThrow(
-      'Painting generation session is disposed',
-    );
-  });
-
-  it('does not revive a disposed session when receipt creation settles late', async () => {
-    const { backend, dependencies } = createSubject();
-    const receipt = createDeferred<Painting>();
-    jest.mocked(dependencies.paintings.create).mockReturnValueOnce(receipt.promise);
-    const session = backend.createGenerationSession();
-
-    const generation = session.generate(generationInput);
-    await waitUntil(() => jest.mocked(dependencies.paintings.create).mock.calls.length === 1);
-    session.dispose();
-    receipt.resolve(painting('painting-late'));
-
-    await expect(generation).rejects.toThrow('Painting generation session is disposed');
-    expect(dependencies.ai.generateImage).not.toHaveBeenCalled();
-    await expect(session.generate(generationInput)).rejects.toThrow(
-      'Painting generation session is disposed',
-    );
+    expect(dependencies.jobs.cancelGenerate).toHaveBeenCalledWith('job-1');
   });
 });
-
-function createDeferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  const promise = new Promise<T>((nextResolve) => {
-    resolve = nextResolve;
-  });
-
-  return { promise, resolve };
-}
-
-async function waitUntil(predicate: () => boolean) {
-  for (let index = 0; index < 20; index += 1) {
-    if (predicate()) {
-      return;
-    }
-    await Promise.resolve();
-  }
-
-  throw new Error('Timed out waiting for condition');
-}

--- a/src/backend/services/paintings/createPaintingsModule.ts
+++ b/src/backend/services/paintings/createPaintingsModule.ts
@@ -2,59 +2,62 @@ import type { FileEntryId, InternalFileEntry } from '@cherrystudio/universal/dat
 import { parseUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import type { Painting } from '@cherrystudio/universal/data/types/painting';
 
+import type { Database } from '@/backend/data/db/DbService';
 import type {
   PaintingGenerationInput,
-  PaintingGenerationResult,
-  PaintingGenerationSession as PaintingGenerationSessionContract,
+  PaintingGenerationStart,
   PaintingsModule,
   ResolvedFile,
   ResolvedPaintingFiles,
 } from '@/shared/contracts';
 
-import type { CreateInternalEntryInput } from '../file/fileStorage';
+import type {
+  PaintingFileStorage,
+  PaintingGenerateJobImage,
+  PaintingGenerateJobInput,
+} from './tasks/paintingGenerateJobHandler';
 
 type PaintingGenerationPersistence = {
-  create(input: {
-    inputFileIds: readonly FileEntryId[];
-    modelId: string;
-    prompt: string;
-    providerId: string;
-  }): Promise<Painting>;
-  replaceOutputs(id: string, outputFileIds: readonly FileEntryId[]): Promise<Painting>;
-};
-
-type PaintingAi = {
-  generateImage(input: {
-    inputImages: string[];
-    mode: PaintingGenerationInput['mode'];
-    paramValues: PaintingGenerationInput['paramValues'];
-    prompt: string;
-    requestOptions: { signal: AbortSignal };
-    uniqueModelId: PaintingGenerationInput['modelId'];
-  }): Promise<{ images: { base64: string; mediaType: string }[] }>;
-};
-
-type PaintingFileStorage = {
-  createInternalEntry(input: CreateInternalEntryInput): Promise<InternalFileEntry>;
-  discard(entries: readonly InternalFileEntry[]): Promise<void>;
-  readDataUrl(uri: string, mediaType: string): Promise<string>;
-  getUri(entry: InternalFileEntry): string | undefined;
+  createTx(
+    tx: Database,
+    input: {
+      inputFileIds: readonly FileEntryId[];
+      modelId: string;
+      prompt: string;
+      providerId: string;
+    },
+  ): Promise<Painting>;
 };
 
 type PaintingFileRepository = {
   resolve(id: FileEntryId): Promise<ResolvedFile | null>;
 };
 
+/**
+ * Painting-scoped slice of the job runtime, closed over the concrete type in
+ * composition so the module never touches the runtime or JobService directly.
+ */
+type PaintingJobsPort = {
+  cancelGenerate(jobId: string): Promise<void>;
+  enqueueGenerateTx(
+    tx: Database,
+    input: PaintingGenerateJobInput,
+    opts: { idempotencyKey: string },
+  ): Promise<{ id: string }>;
+  findActiveGenerateTx(tx: Database, idempotencyKey: string): Promise<{ id: string } | null>;
+};
+
 export type PaintingsModuleDependencies = {
-  ai: PaintingAi;
+  db: { withWriteTx<TValue>(fn: (tx: Database) => Promise<TValue>): Promise<TValue> };
   files: PaintingFileRepository;
+  jobs: PaintingJobsPort;
   paintings: PaintingGenerationPersistence;
-  storage: PaintingFileStorage;
+  storage: Pick<PaintingFileStorage, 'createInternalEntry' | 'discard'>;
 };
 
 export function createPaintingsModule(dependencies: PaintingsModuleDependencies): PaintingsModule {
   return {
-    createGenerationSession: () => new PaintingGenerationSession(dependencies),
+    cancelGeneration: (jobId) => dependencies.jobs.cancelGenerate(jobId),
     resolveFiles: async (painting: Painting): Promise<ResolvedPaintingFiles> => {
       const [inputs, outputs] = await Promise.all([
         resolveFileEntries(dependencies.files, painting.files.input),
@@ -62,164 +65,78 @@ export function createPaintingsModule(dependencies: PaintingsModuleDependencies)
       ]);
       return { inputs, outputs };
     },
+    startGeneration: (input) => startGeneration(dependencies, input),
   };
 }
 
-type IncompleteReceipt = {
-  id: string;
-  signature: string;
-};
-
-class PaintingGenerationSession implements PaintingGenerationSessionContract {
-  private activeController: AbortController | undefined;
-  private disposed = false;
-  private incompleteReceipt: IncompleteReceipt | undefined;
-
-  constructor(private readonly dependencies: PaintingsModuleDependencies) {}
-
-  cancel(): void {
-    this.activeController?.abort(new Error('Painting generation cancelled'));
-  }
-
-  dispose(): void {
-    if (this.disposed) {
-      return;
-    }
-
-    this.disposed = true;
-    this.activeController?.abort(new Error('Painting generation session is disposed'));
-    this.incompleteReceipt = undefined;
-  }
-
-  async generate(input: PaintingGenerationInput): Promise<PaintingGenerationResult> {
-    if (this.disposed) {
-      throw new Error('Painting generation session is disposed');
-    }
-    if (this.activeController) {
-      throw new Error('Painting generation is already in progress');
-    }
-
-    const controller = new AbortController();
-    const { signal } = controller;
-    this.activeController = controller;
-    try {
-      const prompt = input.prompt.trim();
-      const signature = generationSignature({ ...input, prompt });
-      let receiptId =
-        this.incompleteReceipt?.signature === signature ? this.incompleteReceipt.id : undefined;
-
-      if (!receiptId) {
-        receiptId = await this.createReceipt({ ...input, prompt }, signal);
-        if (!this.disposed) {
-          this.incompleteReceipt = { id: receiptId, signature };
-        }
-        throwIfAborted(signal);
-      }
-
-      const inputImages = await Promise.all(
-        input.images.map((image) =>
-          this.dependencies.storage.readDataUrl(image.uri, image.mediaType),
-        ),
-      );
-      throwIfAborted(signal);
-      const result = await this.dependencies.ai.generateImage({
-        inputImages,
-        mode: input.mode,
-        paramValues: input.paramValues,
-        prompt,
-        requestOptions: { signal },
-        uniqueModelId: input.modelId,
-      });
-      throwIfAborted(signal);
-
-      if (result.images.length === 0) {
-        throw new Error('Image provider returned no image');
-      }
-
-      const createdOutputs: InternalFileEntry[] = [];
-      let outputRefsCommitted = false;
-      try {
-        for (const image of result.images) {
-          createdOutputs.push(
-            await this.dependencies.storage.createInternalEntry({
-              cleanupPolicy: 'delete_when_unreferenced',
-              data: image.base64,
-              mediaType: image.mediaType,
-              source: 'base64',
-            }),
-          );
-        }
-        const painting = await this.dependencies.paintings.replaceOutputs(
-          receiptId,
-          createdOutputs.map((entry) => entry.id),
-        );
-        outputRefsCommitted = true;
-        throwIfAborted(signal);
-        const persistedOutputIds = new Set(painting.files.output);
-        const outputs = createdOutputs.map((entry) => {
-          if (!persistedOutputIds.has(entry.id)) {
-            throw new Error('Generated painting has a missing output file');
-          }
-          const uri = this.dependencies.storage.getUri(entry);
-          if (!uri) {
-            throw new Error(`Generated painting file is unavailable: ${entry.id}`);
-          }
-          return { fileEntryId: entry.id, uri };
+/**
+ * Creates the receipt and enqueues the `painting.generate` job in one write
+ * transaction — on rollback neither exists. Draft-only images are materialized
+ * into internal entries first (file IO cannot ride the transaction); the
+ * receipt's input refs pin them, and any entry left unreferenced on failure or
+ * on an idempotency hit is discarded before returning.
+ */
+async function startGeneration(
+  dependencies: PaintingsModuleDependencies,
+  input: PaintingGenerationInput,
+): Promise<PaintingGenerationStart> {
+  const prompt = input.prompt.trim();
+  const signature = generationSignature({ ...input, prompt });
+  const createdInputs: InternalFileEntry[] = [];
+  let createdInputsSettled = false;
+  try {
+    const images: PaintingGenerateJobImage[] = [];
+    for (const image of input.images) {
+      if (image.fileEntryId) {
+        images.push({ fileEntryId: image.fileEntryId, mediaType: image.mediaType, uri: image.uri });
+      } else {
+        const entry = await dependencies.storage.createInternalEntry({
+          cleanupPolicy: 'delete_when_unreferenced',
+          name: image.name,
+          source: 'uri',
+          uri: image.uri,
         });
-
-        this.incompleteReceipt = undefined;
-        return { outputs, painting };
-      } catch (error) {
-        if (!outputRefsCommitted) {
-          await this.dependencies.storage.discard(createdOutputs);
-        }
-        throw error;
-      }
-    } finally {
-      if (this.activeController === controller) {
-        this.activeController = undefined;
+        createdInputs.push(entry);
+        images.push({ fileEntryId: entry.id, mediaType: image.mediaType, uri: image.uri });
       }
     }
-  }
 
-  private async createReceipt(
-    input: PaintingGenerationInput,
-    signal: AbortSignal,
-  ): Promise<string> {
-    const createdInputs: InternalFileEntry[] = [];
-    let inputRefsCommitted = false;
-    try {
-      for (const image of input.images) {
-        if (!image.fileEntryId) {
-          throwIfAborted(signal);
-          createdInputs.push(
-            await this.dependencies.storage.createInternalEntry({
-              cleanupPolicy: 'delete_when_unreferenced',
-              name: image.name,
-              source: 'uri',
-              uri: image.uri,
-            }),
-          );
-        }
+    const { providerId } = parseUniqueModelId(input.modelId);
+    const result = await dependencies.db.withWriteTx(async (tx) => {
+      const existing = await dependencies.jobs.findActiveGenerateTx(tx, signature);
+      if (existing) {
+        return { jobId: existing.id, reusedActive: true };
       }
-      throwIfAborted(signal);
-      const { providerId } = parseUniqueModelId(input.modelId);
-      const receipt = await this.dependencies.paintings.create({
-        inputFileIds: [
-          ...input.images.flatMap((image) => (image.fileEntryId ? [image.fileEntryId] : [])),
-          ...createdInputs.map((entry) => entry.id),
-        ],
+      const receipt = await dependencies.paintings.createTx(tx, {
+        inputFileIds: images.map((image) => image.fileEntryId),
         modelId: input.modelId,
-        prompt: input.prompt,
+        prompt,
         providerId,
       });
-      inputRefsCommitted = true;
-      return receipt.id;
-    } catch (error) {
-      if (!inputRefsCommitted) {
-        await this.dependencies.storage.discard(createdInputs);
-      }
-      throw error;
+      const handle = await dependencies.jobs.enqueueGenerateTx(
+        tx,
+        {
+          images,
+          mode: input.mode,
+          modelId: input.modelId,
+          paintingId: receipt.id,
+          paramValues: input.paramValues,
+          prompt,
+        },
+        { idempotencyKey: signature },
+      );
+      return { jobId: handle.id, reusedActive: false };
+    });
+
+    if (result.reusedActive) {
+      // The active job's own receipt already pins its copies of these inputs.
+      await dependencies.storage.discard(createdInputs);
+    }
+    createdInputsSettled = true;
+    return { jobId: result.jobId };
+  } finally {
+    if (!createdInputsSettled) {
+      await dependencies.storage.discard(createdInputs);
     }
   }
 }
@@ -243,10 +160,4 @@ function sortRecord(values: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(values).sort(([left], [right]) => left.localeCompare(right)),
   );
-}
-
-function throwIfAborted(signal: AbortSignal): void {
-  if (signal.aborted) {
-    throw signal.reason ?? new Error('Painting generation aborted');
-  }
 }

--- a/src/backend/services/paintings/createPaintingsModule.ts
+++ b/src/backend/services/paintings/createPaintingsModule.ts
@@ -17,16 +17,16 @@ import type {
   PaintingGenerateJobInput,
 } from './tasks/paintingGenerateJobHandler';
 
+type PaintingReceiptInput = {
+  inputFileIds: readonly FileEntryId[];
+  modelId: string;
+  prompt: string;
+  providerId: string;
+};
+
 type PaintingGenerationPersistence = {
-  createTx(
-    tx: Database,
-    input: {
-      inputFileIds: readonly FileEntryId[];
-      modelId: string;
-      prompt: string;
-      providerId: string;
-    },
-  ): Promise<Painting>;
+  createTx(tx: Database, input: PaintingReceiptInput): Promise<Painting>;
+  resetForRetryTx(tx: Database, id: string, input: PaintingReceiptInput): Promise<Painting>;
 };
 
 type PaintingFileRepository = {
@@ -44,7 +44,10 @@ type PaintingJobsPort = {
     input: PaintingGenerateJobInput,
     opts: { idempotencyKey: string },
   ): Promise<{ id: string }>;
-  findActiveGenerateTx(tx: Database, idempotencyKey: string): Promise<{ id: string } | null>;
+  findActiveGenerateTx(
+    tx: Database,
+    idempotencyKey: string,
+  ): Promise<{ id: string; input: unknown } | null>;
 };
 
 export type PaintingsModuleDependencies = {
@@ -105,14 +108,21 @@ async function startGeneration(
     const result = await dependencies.db.withWriteTx(async (tx) => {
       const existing = await dependencies.jobs.findActiveGenerateTx(tx, signature);
       if (existing) {
-        return { jobId: existing.id, reusedActive: true };
+        return {
+          jobId: existing.id,
+          paintingId: activeJobPaintingId(existing.input),
+          reusedActive: true,
+        };
       }
-      const receipt = await dependencies.paintings.createTx(tx, {
+      const receiptInput = {
         inputFileIds: images.map((image) => image.fileEntryId),
         modelId: input.modelId,
         prompt,
         providerId,
-      });
+      };
+      const receipt = input.paintingId
+        ? await dependencies.paintings.resetForRetryTx(tx, input.paintingId, receiptInput)
+        : await dependencies.paintings.createTx(tx, receiptInput);
       const handle = await dependencies.jobs.enqueueGenerateTx(
         tx,
         {
@@ -125,7 +135,7 @@ async function startGeneration(
         },
         { idempotencyKey: signature },
       );
-      return { jobId: handle.id, reusedActive: false };
+      return { jobId: handle.id, paintingId: receipt.id, reusedActive: false };
     });
 
     if (result.reusedActive) {
@@ -133,7 +143,7 @@ async function startGeneration(
       await dependencies.storage.discard(createdInputs);
     }
     createdInputsSettled = true;
-    return { jobId: result.jobId };
+    return { jobId: result.jobId, paintingId: result.paintingId };
   } finally {
     if (!createdInputsSettled) {
       await dependencies.storage.discard(createdInputs);
@@ -146,11 +156,31 @@ async function resolveFileEntries(files: PaintingFileRepository, ids: readonly F
   return entries.filter((entry) => entry !== null);
 }
 
+/**
+ * The active job carries the receipt it writes into; an enqueued
+ * `painting.generate` always has one, so a missing id means the ledger row was
+ * written by something other than {@link startGeneration}.
+ */
+function activeJobPaintingId(jobInput: unknown): string {
+  const paintingId = (jobInput as Partial<PaintingGenerateJobInput> | null)?.paintingId;
+  if (typeof paintingId !== 'string' || paintingId.length === 0) {
+    throw new Error('Active painting.generate job has no paintingId in its input');
+  }
+  return paintingId;
+}
+
+/**
+ * `paintingId` participates so that retrying an interrupted receipt does not
+ * collide with generating the very same prompt as a brand-new painting — same
+ * inputs, different intent, and the idempotency hit would silently hand the
+ * caller back the wrong receipt.
+ */
 function generationSignature(input: PaintingGenerationInput): string {
   return JSON.stringify({
     images: input.images.map((image) => image.fileEntryId ?? `${image.id}:${image.uri}`),
     mode: input.mode,
     modelId: input.modelId,
+    paintingId: input.paintingId ?? null,
     paramValues: sortRecord(input.paramValues),
     prompt: input.prompt,
   });

--- a/src/backend/services/paintings/tasks/__tests__/paintingGenerateJobHandler.test.ts
+++ b/src/backend/services/paintings/tasks/__tests__/paintingGenerateJobHandler.test.ts
@@ -1,0 +1,200 @@
+import { randomUUID as mockRandomUUID } from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+
+import type { FileEntryId, InternalFileEntry } from '@cherrystudio/universal/data/types/file';
+import { createUniqueModelId } from '@cherrystudio/universal/data/types/model';
+import type { Painting } from '@cherrystudio/universal/data/types/painting';
+import { loggerService } from '@logger';
+
+import { createTestRuntime, type TestRuntime } from '@/backend/services/jobs/__tests__/_helpers';
+import { jobHandlerEntry } from '@/backend/services/jobs/JobRuntime';
+import type { JobContext } from '@/backend/services/jobs/types';
+
+import {
+  createPaintingGenerateJobHandler,
+  type PaintingGenerateJobDependencies,
+  type PaintingGenerateJobInput,
+} from '../paintingGenerateJobHandler';
+
+jest.mock('uuid', () => ({ v4: mockRandomUUID, v7: mockRandomUUID }));
+
+const modelId = createUniqueModelId('openai', 'image-1');
+const inputFileId = '00000000-0000-4000-8000-000000000001' as FileEntryId;
+const outputFileId = '00000000-0000-4000-8000-000000000002' as FileEntryId;
+
+function painting(id: string, outputs: FileEntryId[] = []): Painting {
+  return {
+    createdAt: '2026-01-01T00:00:00.000Z',
+    files: { input: [inputFileId], output: outputs },
+    id,
+    modelId,
+    orderKey: id,
+    prompt: 'draw',
+    providerId: 'openai',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function internalEntry(id: FileEntryId): InternalFileEntry {
+  return {
+    cleanupPolicy: 'delete_when_unreferenced',
+    contentHash: null,
+    createdAt: 1,
+    ext: 'png',
+    id,
+    name: 'image',
+    origin: 'internal',
+    size: 1,
+    updatedAt: 1,
+  };
+}
+
+function createDependencies(): PaintingGenerateJobDependencies {
+  return {
+    ai: {
+      generateImage: jest.fn(async () => ({
+        images: [{ base64: 'aW1hZ2U=', mediaType: 'image/png' }],
+      })),
+    },
+    paintings: {
+      replaceOutputs: jest.fn(async () => painting('painting-1', [outputFileId])),
+    },
+    storage: {
+      createInternalEntry: jest.fn(async () => internalEntry(outputFileId)),
+      discard: jest.fn(async () => undefined),
+      getUri: jest.fn(() => 'file:///output.png'),
+      readDataUrl: jest.fn(async () => 'data:image/png;base64,aW1hZ2U='),
+    },
+  };
+}
+
+const jobInput: PaintingGenerateJobInput = {
+  images: [{ fileEntryId: inputFileId, mediaType: 'image/png', uri: 'file:///picked.png' }],
+  mode: 'generate',
+  modelId,
+  paintingId: 'painting-1',
+  paramValues: {},
+  prompt: 'draw',
+};
+
+function createContext(
+  overrides: Partial<JobContext<PaintingGenerateJobInput>> = {},
+): JobContext<PaintingGenerateJobInput> {
+  return {
+    attempt: 0,
+    input: jobInput,
+    jobId: 'job-1',
+    logger: loggerService.withContext('PaintingGenerateTest'),
+    metadata: {},
+    parentId: null,
+    patchMetadata: async () => undefined,
+    reportProgress: () => undefined,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+describe('createPaintingGenerateJobHandler', () => {
+  it('generates, persists outputs onto the receipt, and returns the result', async () => {
+    const dependencies = createDependencies();
+    const handler = createPaintingGenerateJobHandler(dependencies);
+
+    await expect(handler.execute(createContext())).resolves.toEqual({
+      outputs: [{ fileEntryId: outputFileId, uri: 'file:///output.png' }],
+      painting: painting('painting-1', [outputFileId]),
+    });
+
+    expect(dependencies.storage.readDataUrl).toHaveBeenCalledWith(
+      'file:///picked.png',
+      'image/png',
+    );
+    expect(dependencies.ai.generateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputImages: ['data:image/png;base64,aW1hZ2U='],
+        prompt: 'draw',
+        uniqueModelId: modelId,
+      }),
+    );
+    expect(dependencies.paintings.replaceOutputs).toHaveBeenCalledWith('painting-1', [
+      outputFileId,
+    ]);
+  });
+
+  it('fails when the provider returns no image', async () => {
+    const dependencies = createDependencies();
+    jest.mocked(dependencies.ai.generateImage).mockResolvedValue({ images: [] });
+    const handler = createPaintingGenerateJobHandler(dependencies);
+
+    await expect(handler.execute(createContext())).rejects.toThrow(
+      'Image provider returned no image',
+    );
+  });
+
+  it('discards created outputs when output reference persistence fails', async () => {
+    const dependencies = createDependencies();
+    jest
+      .mocked(dependencies.paintings.replaceOutputs)
+      .mockRejectedValue(new Error('database failed'));
+    const handler = createPaintingGenerateJobHandler(dependencies);
+
+    await expect(handler.execute(createContext())).rejects.toThrow('database failed');
+    expect(dependencies.storage.discard).toHaveBeenCalledWith([
+      expect.objectContaining({ id: outputFileId }),
+    ]);
+  });
+
+  it('keeps referenced outputs when their URI cannot be resolved', async () => {
+    const dependencies = createDependencies();
+    jest.mocked(dependencies.storage.getUri).mockReturnValue(undefined);
+    const handler = createPaintingGenerateJobHandler(dependencies);
+
+    await expect(handler.execute(createContext())).rejects.toThrow(
+      `Generated painting file is unavailable: ${outputFileId}`,
+    );
+    expect(dependencies.storage.discard).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the abort reason instead of generating once the signal fires', async () => {
+    const dependencies = createDependencies();
+    const controller = new AbortController();
+    controller.abort(new Error('Job cancelled: user'));
+    const handler = createPaintingGenerateJobHandler(dependencies);
+
+    await expect(handler.execute(createContext({ signal: controller.signal }))).rejects.toThrow(
+      'Job cancelled: user',
+    );
+    expect(dependencies.ai.generateImage).not.toHaveBeenCalled();
+  });
+
+  describe('through the job runtime', () => {
+    let sqlite: DatabaseSync | undefined;
+    let ctx: TestRuntime | undefined;
+
+    afterEach(async () => {
+      await ctx?.runtime.dispose();
+      sqlite?.close();
+      ctx = undefined;
+      sqlite = undefined;
+    });
+
+    it('completes an enqueued painting.generate job with the generation result', async () => {
+      const dependencies = createDependencies();
+      sqlite = new DatabaseSync(':memory:');
+      ctx = createTestRuntime(sqlite, [
+        jobHandlerEntry('painting.generate', createPaintingGenerateJobHandler(dependencies)),
+      ]);
+
+      const handle = await ctx.runtime.enqueue('painting.generate', jobInput, {
+        idempotencyKey: 'signature-1',
+      });
+      const snapshot = await handle.finished;
+
+      expect(snapshot.status).toBe('completed');
+      expect(snapshot.queue).toBe('painting');
+      expect(snapshot.output).toEqual({
+        outputs: [{ fileEntryId: outputFileId, uri: 'file:///output.png' }],
+        painting: painting('painting-1', [outputFileId]),
+      });
+    });
+  });
+});

--- a/src/backend/services/paintings/tasks/paintingGenerateJobHandler.ts
+++ b/src/backend/services/paintings/tasks/paintingGenerateJobHandler.ts
@@ -1,0 +1,153 @@
+import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
+import type { FileEntryId, InternalFileEntry } from '@cherrystudio/universal/data/types/file';
+import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
+import type { Painting } from '@cherrystudio/universal/data/types/painting';
+
+import type { JobHandlerFor } from '@/backend/services/jobs/types';
+import type { PaintingGenerationResult } from '@/shared/contracts';
+
+import type { CreateInternalEntryInput } from '../../file/fileStorage';
+
+export const PAINTING_GENERATE_JOB_TYPE = 'painting.generate';
+export const PAINTING_JOB_QUEUE = 'painting';
+
+/**
+ * Input images always carry a fileEntryId: `startGeneration` materializes
+ * draft-only images into internal entries before the job is enqueued, and the
+ * receipt's painting_file_ref rows pin them for the job's lifetime. The uri is
+ * a same-process convenience for readDataUrl — an abandoned job never re-runs
+ * (recovery `'abandon'`, maxAttempts 1), so it is never read across restarts.
+ */
+export type PaintingGenerateJobImage = {
+  fileEntryId: FileEntryId;
+  mediaType: string;
+  uri: string;
+};
+
+export type PaintingGenerateJobInput = {
+  images: readonly PaintingGenerateJobImage[];
+  mode: ImageGenerationMode;
+  modelId: UniqueModelId;
+  paintingId: string;
+  paramValues: ParamValues;
+  prompt: string;
+};
+
+declare module '@/backend/services/jobs/jobRegistry' {
+  interface JobRegistry {
+    'painting.generate': PaintingGenerateJobInput;
+  }
+}
+
+export type PaintingAi = {
+  generateImage(input: {
+    inputImages: string[];
+    mode: ImageGenerationMode;
+    paramValues: ParamValues;
+    prompt: string;
+    requestOptions: { signal: AbortSignal };
+    uniqueModelId: UniqueModelId;
+  }): Promise<{ images: { base64: string; mediaType: string }[] }>;
+};
+
+export type PaintingFileStorage = {
+  createInternalEntry(input: CreateInternalEntryInput): Promise<InternalFileEntry>;
+  discard(entries: readonly InternalFileEntry[]): Promise<void>;
+  readDataUrl(uri: string, mediaType: string): Promise<string>;
+  getUri(entry: InternalFileEntry): string | undefined;
+};
+
+export type PaintingGenerateJobDependencies = {
+  ai: PaintingAi;
+  paintings: {
+    replaceOutputs(id: string, outputFileIds: readonly FileEntryId[]): Promise<Painting>;
+  };
+  storage: PaintingFileStorage;
+};
+
+/**
+ * Without a timeout a hung provider request would hold the queue's single
+ * concurrency slot until the next cold start; ten minutes is generous for the
+ * slowest image providers while still guaranteeing the slot comes back.
+ */
+const GENERATE_TIMEOUT_MS = 10 * 60_000;
+
+export function createPaintingGenerateJobHandler(
+  dependencies: PaintingGenerateJobDependencies,
+): JobHandlerFor<'painting.generate'> {
+  return {
+    defaultConcurrency: 1,
+    defaultQueue: () => PAINTING_JOB_QUEUE,
+    defaultRetryPolicy: { backoff: 'none', baseDelayMs: 0, maxAttempts: 1, maxDelayMs: 0 },
+    defaultTimeoutMs: GENERATE_TIMEOUT_MS,
+    executionClass: 'foreground-only',
+    recovery: 'abandon',
+    async execute(ctx): Promise<PaintingGenerationResult> {
+      const { images, mode, modelId, paintingId, paramValues, prompt } = ctx.input;
+      const { ai, paintings, storage } = dependencies;
+
+      const inputImages = await Promise.all(
+        images.map((image) => storage.readDataUrl(image.uri, image.mediaType)),
+      );
+      throwIfAborted(ctx.signal);
+      const result = await ai.generateImage({
+        inputImages,
+        mode,
+        paramValues,
+        prompt,
+        requestOptions: { signal: ctx.signal },
+        uniqueModelId: modelId,
+      });
+      throwIfAborted(ctx.signal);
+
+      if (result.images.length === 0) {
+        throw new Error('Image provider returned no image');
+      }
+
+      const createdOutputs: InternalFileEntry[] = [];
+      let outputRefsCommitted = false;
+      try {
+        for (const image of result.images) {
+          createdOutputs.push(
+            await storage.createInternalEntry({
+              cleanupPolicy: 'delete_when_unreferenced',
+              data: image.base64,
+              mediaType: image.mediaType,
+              source: 'base64',
+            }),
+          );
+        }
+        const painting = await paintings.replaceOutputs(
+          paintingId,
+          createdOutputs.map((entry) => entry.id),
+        );
+        outputRefsCommitted = true;
+        throwIfAborted(ctx.signal);
+        const persistedOutputIds = new Set(painting.files.output);
+        const outputs = createdOutputs.map((entry) => {
+          if (!persistedOutputIds.has(entry.id)) {
+            throw new Error('Generated painting has a missing output file');
+          }
+          const uri = storage.getUri(entry);
+          if (!uri) {
+            throw new Error(`Generated painting file is unavailable: ${entry.id}`);
+          }
+          return { fileEntryId: entry.id, uri };
+        });
+
+        return { outputs, painting };
+      } catch (error) {
+        if (!outputRefsCommitted) {
+          await storage.discard(createdOutputs);
+        }
+        throw error;
+      }
+    },
+  };
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw signal.reason ?? new Error('Painting generation aborted');
+  }
+}

--- a/src/bootstrap/composition/createBackend.ts
+++ b/src/bootstrap/composition/createBackend.ts
@@ -4,6 +4,7 @@ import { readUIMessageStream } from 'ai';
 
 import { ChatRuntime } from '@/backend/ai/streamManager/ChatRuntime';
 import type { McpServerMutations } from '@/backend/data/api/handlers/mcpServers';
+import type { DbService } from '@/backend/data/db/DbService';
 import { materializeRemoteModels } from '@/backend/data/services/materializeRemoteModels';
 import { canDeleteProvider } from '@/backend/data/services/ProviderService';
 import { CherryInClient } from '@/backend/services/cherryin/CherryInClient';
@@ -14,9 +15,15 @@ import {
   getInternalFileUri,
   imageUriToDataUrl,
 } from '@/backend/services/file/fileStorage';
+import {
+  createJobRuntime,
+  jobHandlerEntry,
+  type JobRuntime,
+} from '@/backend/services/jobs/JobRuntime';
 import { createMcpModule } from '@/backend/services/mcp/createMcpModule';
 import { createModelsModule } from '@/backend/services/models/createModelsModule';
 import { createPaintingsModule } from '@/backend/services/paintings/createPaintingsModule';
+import { createPaintingGenerateJobHandler } from '@/backend/services/paintings/tasks/paintingGenerateJobHandler';
 import { createPermissionsModule } from '@/backend/services/permissions/createPermissionsModule';
 import { createProfileModule } from '@/backend/services/profile/createProfileModule';
 import {
@@ -36,10 +43,15 @@ export type BackendComposition = {
   dataApiDependencies: {
     mcpServerMutations: McpServerMutations;
   };
+  jobRuntime: JobRuntime;
   dispose(): Promise<void>;
 };
 
-export function createBackend(services: BackendServices): BackendComposition {
+export function createBackend(
+  services: BackendServices,
+  infrastructure: { dbService: DbService },
+): BackendComposition {
+  const { dbService } = infrastructure;
   const cherryin = new CherryInClient({
     oauth: {
       authenticatedFetch: (providerId, buildRequest, doFetch, options) =>
@@ -91,16 +103,42 @@ export function createBackend(services: BackendServices): BackendComposition {
       update: (id, input) => services.provider.update(id, input),
     },
   });
+  const paintingStorage = {
+    createInternalEntry: (input: Parameters<typeof createInternalEntry>[1]) =>
+      createInternalEntry(services.fileEntry, input),
+    discard: (entries: Parameters<typeof discardInternalEntries>[1]) =>
+      discardInternalEntries(services.fileEntry, entries),
+    readDataUrl: imageUriToDataUrl,
+    getUri: getInternalFileUri,
+  };
+  const jobRuntime = createJobRuntime({
+    dbService,
+    handlers: [
+      jobHandlerEntry(
+        'painting.generate',
+        createPaintingGenerateJobHandler({
+          ai: services.ai,
+          paintings: services.painting,
+          storage: paintingStorage,
+        }),
+      ),
+    ],
+    jobService: services.job,
+  });
   const paintings = createPaintingsModule({
-    ai: services.ai,
+    db: { withWriteTx: (fn) => dbService.withWriteTx(fn) },
     files: services.fileContent,
-    paintings: services.painting,
-    storage: {
-      createInternalEntry: (input) => createInternalEntry(services.fileEntry, input),
-      discard: (entries) => discardInternalEntries(services.fileEntry, entries),
-      readDataUrl: imageUriToDataUrl,
-      getUri: getInternalFileUri,
+    jobs: {
+      cancelGenerate: async (jobId) => {
+        await jobRuntime.cancel(jobId);
+      },
+      enqueueGenerateTx: (tx, input, opts) =>
+        jobRuntime.enqueueTx(tx, 'painting.generate', input, opts),
+      findActiveGenerateTx: (tx, idempotencyKey) =>
+        services.job.findActiveByIdempotencyKeyTx(tx, idempotencyKey),
     },
+    paintings: services.painting,
+    storage: paintingStorage,
   });
   const mcp = createMcpModule({
     runtime: {
@@ -168,7 +206,12 @@ export function createBackend(services: BackendServices): BackendComposition {
     dataApiDependencies: {
       mcpServerMutations: mcp,
     },
+    jobRuntime,
     dispose: async () => {
+      // Jobs first: the drain gives in-flight handlers a bounded chance to land
+      // their terminal rows before the caller closes SQLite, and it keeps the
+      // oauth session alive for any authenticated request still in flight.
+      await jobRuntime.dispose();
       services.oauth.dispose();
       services.oauthSession.dispose();
       await chat.dispose();

--- a/src/bootstrap/runtime/__tests__/runPostReadyTasks.test.ts
+++ b/src/bootstrap/runtime/__tests__/runPostReadyTasks.test.ts
@@ -1,3 +1,4 @@
+import type { JobRuntime } from '@/backend/services/jobs/JobRuntime';
 import type { BackendServices } from '@/bootstrap/composition/createBackendServices';
 
 import { runPostReadyTasks } from '../runPostReadyTasks';
@@ -20,6 +21,10 @@ function createServices(
   } as unknown as BackendServices;
 }
 
+function createJobRuntimeStub(pump = jest.fn(async () => ({ claimed: 0 }))) {
+  return { jobRuntime: { pump } as unknown as JobRuntime, pump };
+}
+
 describe('runPostReadyTasks', () => {
   test('marks stale pending assistant messages as error', async () => {
     const settleCrashedMessages = jest.fn(async () => undefined);
@@ -28,7 +33,7 @@ describe('runPostReadyTasks', () => {
       settleCrashedMessages,
     });
 
-    await runPostReadyTasks(services);
+    await runPostReadyTasks(services, createJobRuntimeStub());
 
     expect(settleCrashedMessages).toHaveBeenCalledWith(['a', 'b']);
   });
@@ -40,9 +45,17 @@ describe('runPostReadyTasks', () => {
       settleCrashedMessages,
     });
 
-    await runPostReadyTasks(services);
+    await runPostReadyTasks(services, createJobRuntimeStub());
 
     expect(settleCrashedMessages).not.toHaveBeenCalled();
+  });
+
+  test('pumps the job runtime with the cold-start reason', async () => {
+    const { jobRuntime, pump } = createJobRuntimeStub();
+
+    await runPostReadyTasks(createServices(), { jobRuntime });
+
+    expect(pump).toHaveBeenCalledWith({ reason: 'cold-start' });
   });
 
   test('starts MCP prewarm without waiting for message reconciliation', async () => {
@@ -57,7 +70,7 @@ describe('runPostReadyTasks', () => {
         }),
     });
 
-    const tasks = runPostReadyTasks(services);
+    const tasks = runPostReadyTasks(services, createJobRuntimeStub());
     await Promise.resolve();
 
     expect(prewarmActiveServers).toHaveBeenCalledTimes(1);
@@ -72,6 +85,16 @@ describe('runPostReadyTasks', () => {
       },
     });
 
-    await expect(runPostReadyTasks(services)).resolves.toBeUndefined();
+    await expect(runPostReadyTasks(services, createJobRuntimeStub())).resolves.toBeUndefined();
+  });
+
+  test('does not throw when the cold-start pump rejects', async () => {
+    const { jobRuntime } = createJobRuntimeStub(
+      jest.fn(async () => {
+        throw new Error('pump failed');
+      }),
+    );
+
+    await expect(runPostReadyTasks(createServices(), { jobRuntime })).resolves.toBeUndefined();
   });
 });

--- a/src/bootstrap/runtime/createAppBootstrapRuntime.ts
+++ b/src/bootstrap/runtime/createAppBootstrapRuntime.ts
@@ -24,7 +24,12 @@ export function createAppBootstrapRuntime(): AppBootstrapRuntime {
   const cacheService = new CacheService();
   const dbService = new DbService();
   const services = createBackendServices(dbService, cacheService);
-  const { backend, dataApiDependencies, dispose: disposeBackend } = createBackend(services);
+  const {
+    backend,
+    dataApiDependencies,
+    dispose: disposeBackend,
+    jobRuntime,
+  } = createBackend(services, { dbService });
   let disposePromise: Promise<void> | undefined;
   const dataApi = new DataApiService(
     createDataApiHandlers({
@@ -83,6 +88,6 @@ export function createAppBootstrapRuntime(): AppBootstrapRuntime {
       await services.preference.init();
       await initializeAppRuntime(services);
     },
-    runPostReadyTasks: () => runPostReadyTasks(services),
+    runPostReadyTasks: () => runPostReadyTasks(services, { jobRuntime }),
   };
 }

--- a/src/bootstrap/runtime/runPostReadyTasks.ts
+++ b/src/bootstrap/runtime/runPostReadyTasks.ts
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger';
 
+import type { JobRuntime } from '@/backend/services/jobs/JobRuntime';
 import type { BackendServices } from '@/bootstrap/composition/createBackendServices';
 
 const logger = loggerService.withContext('runPostReadyTasks');
@@ -9,7 +10,10 @@ const logger = loggerService.withContext('runPostReadyTasks');
  * preferences — data repair and diagnostics belong here, not
  * in `initializeAppRuntime`. Best-effort: callers fire-and-forget and a failure
  * must not surface to the user. */
-export async function runPostReadyTasks(services: BackendServices) {
+export async function runPostReadyTasks(
+  services: BackendServices,
+  runtime: { jobRuntime: JobRuntime },
+) {
   // The catch lives here, not in callers: they `void` this promise, so a task
   // added below without its own handling would become an unhandled rejection.
   try {
@@ -17,6 +21,9 @@ export async function runPostReadyTasks(services: BackendServices) {
       reconcileStalePendingMessages(services),
       // The chat path is cache-only, so warm tools off the startup critical path.
       services.mcpRuntime.prewarmActiveServers(),
+      // The first pump also runs lazy startup recovery (abandon/retry/singleton
+      // sweeps over prior-process leftovers) and the cold-start GC sweep.
+      runtime.jobRuntime.pump({ reason: 'cold-start' }),
     ]);
   } catch (error) {
     logger.error('Post-ready tasks failed', error as Error);

--- a/src/frontend/data/hooks/useDataApi.ts
+++ b/src/frontend/data/hooks/useDataApi.ts
@@ -74,6 +74,14 @@ export function useQuery<TPath extends ApiPath>(
     /** Keep the previous key's data on screen while the new key loads. */
     keepPreviousData?: boolean;
     query?: QueryParamsForPath<TPath, 'GET'>;
+    /**
+     * Poll while mounted. A function form receives the latest data and returns
+     * the next delay, or `false` to stop (e.g. once a job reaches a terminal
+     * status).
+     */
+    refetchInterval?:
+      | number
+      | ((data: ResponseForPath<TPath, 'GET'> | undefined) => number | false);
     retry?: boolean | number;
     staleTime?: number;
   },
@@ -84,6 +92,7 @@ export function useQuery<TPath extends ApiPath>(
     ? resolveTemplate(path, options?.params as Record<string, string | number> | undefined)
     : path;
   const query = options?.query;
+  const refetchInterval = options?.refetchInterval;
   const result = useTanStackQuery<ResponseForPath<TPath, 'GET'>, Error>({
     enabled,
     placeholderData: options?.keepPreviousData ? keepPreviousData : undefined,
@@ -92,6 +101,15 @@ export function useQuery<TPath extends ApiPath>(
         query: query as QueryParamsForPath<ConcreteApiPaths, 'GET'>,
       }) as Promise<ResponseForPath<TPath, 'GET'>>,
     queryKey: buildQueryKey(resolvedPath, query),
+    ...(refetchInterval === undefined
+      ? {}
+      : {
+          refetchInterval:
+            typeof refetchInterval === 'function'
+              ? (tanStackQuery: { state: { data?: ResponseForPath<TPath, 'GET'> } }) =>
+                  refetchInterval(tanStackQuery.state.data)
+              : refetchInterval,
+        }),
     ...callerQueryOverrides(options),
   });
 

--- a/src/frontend/data/queryKeys/index.ts
+++ b/src/frontend/data/queryKeys/index.ts
@@ -1,6 +1,7 @@
 import { aiUsageRecordQueryKeys } from './aiUsageRecords';
 import { assistantQueryKeys } from './assistants';
 import { fileQueryKeys } from './files';
+import { jobQueryKeys } from './jobs';
 import { mcpServerQueryKeys } from './mcpServers';
 import { messageQueryKeys } from './messages';
 import { modelQueryKeys } from './models';
@@ -13,6 +14,7 @@ export const queryKeys = {
   aiUsageRecords: aiUsageRecordQueryKeys,
   assistants: assistantQueryKeys,
   files: fileQueryKeys,
+  jobs: jobQueryKeys,
   mcpServers: mcpServerQueryKeys,
   messages: messageQueryKeys,
   models: modelQueryKeys,

--- a/src/frontend/data/queryKeys/jobs.ts
+++ b/src/frontend/data/queryKeys/jobs.ts
@@ -1,0 +1,4 @@
+export const jobQueryKeys = {
+  all: () => ['/jobs'] as const,
+  detail: (jobId: string) => [`/jobs/${jobId}`] as const,
+};

--- a/src/frontend/features/paintings/DrawingList.tsx
+++ b/src/frontend/features/paintings/DrawingList.tsx
@@ -1,7 +1,7 @@
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
-import { useRouter } from 'expo-router';
-import { CheckIcon, ImageIcon } from 'lucide-uniwind/png';
+import { Link, useRouter } from 'expo-router';
+import { CheckIcon, ImageIcon, RotateCcwIcon } from 'lucide-uniwind/png';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -30,10 +30,11 @@ import {
 } from '@/frontend/components/messageTabs';
 import { Image } from '@/frontend/components/nativePrimitives';
 import { PaintingZoomLink } from '@/frontend/components/navigation';
+import { PaintingSkeleton } from '@/frontend/components/paintingSkeleton';
 
 import {
   type PaintingGalleryItem,
-  usePaintingGalleryItems,
+  usePaintingGalleryEntries,
   usePaintings,
 } from './hooks/usePaintings';
 import { usePaintingSelectionSource } from './hooks/usePaintingSelectionSource';
@@ -63,14 +64,14 @@ export function DrawingList() {
   const { width: windowWidth } = useWindowDimensions();
   const recentPhotos = useRecentPaintingPhotos(scope === 'drawings');
   const paintings = usePaintings();
-  const gallery = usePaintingGalleryItems(paintings.paintings);
+  const gallery = usePaintingGalleryEntries(paintings.paintings);
   const columnWidth = (windowWidth - pageEdge * 2 - galleryGap) / 2;
   const visibleGalleryItems = useMemo(
     () =>
       pendingDeletionIds.size === 0
-        ? (gallery.data ?? [])
-        : (gallery.data ?? []).filter((item) => !pendingDeletionIds.has(item.painting.id)),
-    [gallery.data, pendingDeletionIds],
+        ? gallery.items
+        : gallery.items.filter((item) => !pendingDeletionIds.has(item.painting.id)),
+    [gallery.items, pendingDeletionIds],
   );
   const columns = useMemo(() => distributeMasonryItems(visibleGalleryItems), [visibleGalleryItems]);
   const namedColumns = [
@@ -254,7 +255,9 @@ export function DrawingList() {
             <View className="flex-1 gap-1.5" key={column.key}>
               {column.items.map((item) => (
                 <DrawingGridItem
+                  generatingLabel={t('painting.status.generating')}
                   height={columnWidth / item.aspectRatio}
+                  interruptedLabel={t('painting.status.interrupted')}
                   isEditing={isEditing}
                   isSelected={selectedIds.has(item.painting.id)}
                   item={item}
@@ -277,7 +280,9 @@ export function DrawingList() {
 }
 
 type DrawingGridItemProps = {
+  generatingLabel: string;
   height: number;
+  interruptedLabel: string;
   isEditing: boolean;
   isSelected: boolean;
   item: PaintingGalleryItem;
@@ -286,29 +291,29 @@ type DrawingGridItemProps = {
 };
 
 function DrawingGridItem({
+  generatingLabel,
   height,
+  interruptedLabel,
   isEditing,
   isSelected,
   item,
   label,
   onToggle,
 }: DrawingGridItemProps) {
-  const image = (
-    <Image
-      cachePolicy="memory-disk"
-      contentFit="cover"
-      source={item.uri}
-      style={{ height: '100%', width: '100%' }}
-      transition={120}
-    />
-  );
+  const content = renderTileContent(item, generatingLabel, interruptedLabel);
+  const accessibilityLabel =
+    item.kind === 'output'
+      ? label
+      : item.kind === 'generating'
+        ? generatingLabel
+        : interruptedLabel;
 
   // A Link navigates on tap regardless of onPress, so editing mode must drop
-  // the PaintingZoomLink wrapper entirely to turn taps into selection.
+  // the link wrapper entirely to turn taps into selection.
   if (isEditing) {
     return (
       <Pressable
-        accessibilityLabel={label}
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="checkbox"
         accessibilityState={{ checked: isSelected }}
         className="overflow-hidden rounded-md bg-secondary active:opacity-75"
@@ -316,7 +321,7 @@ function DrawingGridItem({
         style={{ height }}
         testID={`painting-history-${item.key}`}
       >
-        {image}
+        {content}
         <Animated.View
           className="absolute top-1.5 right-1.5"
           entering={FadeIn.duration(160)}
@@ -334,18 +339,70 @@ function DrawingGridItem({
     );
   }
 
-  return (
+  const tile = (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      className="overflow-hidden rounded-md bg-secondary active:opacity-75"
+      style={{ height }}
+      testID={`painting-history-${item.key}`}
+    >
+      {content}
+    </Pressable>
+  );
+
+  // A receipt without images has nothing for the viewer to zoom into: tapping
+  // it goes back to the composer, which is where its progress — or its retry —
+  // lives.
+  return item.kind === 'output' ? (
     <PaintingZoomLink fileEntryId={item.fileEntryId} paintingId={item.painting.id}>
-      <Pressable
-        accessibilityLabel={label}
-        accessibilityRole="button"
-        className="overflow-hidden rounded-md bg-secondary active:opacity-75"
-        style={{ height }}
-        testID={`painting-history-${item.key}`}
-      >
-        {image}
-      </Pressable>
+      {tile}
     </PaintingZoomLink>
+  ) : (
+    <Link asChild href={{ pathname: '/paintings', params: { paintingId: item.painting.id } }}>
+      {tile}
+    </Link>
+  );
+}
+
+function renderTileContent(
+  item: PaintingGalleryItem,
+  generatingLabel: string,
+  interruptedLabel: string,
+) {
+  if (item.kind === 'output') {
+    return (
+      <Image
+        cachePolicy="memory-disk"
+        contentFit="cover"
+        source={item.uri}
+        style={{ height: '100%', width: '100%' }}
+        transition={120}
+      />
+    );
+  }
+
+  if (item.kind === 'generating') {
+    return (
+      <PaintingSkeleton
+        accessibilityLabel={generatingLabel}
+        testID={`painting-history-skeleton-${item.painting.id}`}
+      />
+    );
+  }
+
+  return (
+    <View className="flex-1 items-center justify-center gap-1 px-2">
+      <RotateCcwIcon className="size-5 text-foreground-tertiary" strokeWidth={1.5} />
+      <Text className="text-center font-medium text-foreground-secondary text-xs">
+        {interruptedLabel}
+      </Text>
+      {item.message ? (
+        <Text className="text-center text-foreground-tertiary text-xs" numberOfLines={2}>
+          {item.message}
+        </Text>
+      ) : null}
+    </View>
   );
 }
 

--- a/src/frontend/features/paintings/PaintingScreen.tsx
+++ b/src/frontend/features/paintings/PaintingScreen.tsx
@@ -25,10 +25,10 @@ export function PaintingScreen() {
   }>();
   const handoffToken = firstParam(params.handoff);
   const paintingId = firstParam(params.paintingId);
-  // Frozen at mount: once a generation started here writes its receipt id back
-  // into the route, re-entering the loading gate would tear the composer down
-  // mid-generation.
-  const [openedWithPaintingId] = useState(() => paintingId !== undefined);
+  // Frozen at mount: only the painting this screen opened with owns the loading
+  // gate. A generation writes a new receipt id into the route; letting that id
+  // re-enter the gate would tear the composer down mid-generation.
+  const [openedPaintingId] = useState(() => paintingId);
   const [handoff] = useState(() => consumePaintingDraftHandoff(handoffToken));
   const paintingQuery = usePainting(paintingId);
   const painting = paintingQuery.data;
@@ -39,7 +39,10 @@ export function PaintingScreen() {
   const filesQuery = useResolvedPaintingFiles(handoff ? undefined : painting);
   const paintingFiles = filesQuery.data ?? { inputs: [], outputs: [] };
   const insets = useSafeAreaInsets();
-  const isLoading = openedWithPaintingId && (paintingQuery.isLoading || filesQuery.isLoading);
+  const isLoading =
+    openedPaintingId !== undefined &&
+    paintingId === openedPaintingId &&
+    (paintingQuery.isLoading || filesQuery.isLoading);
   const backgroundColor = useThemeColor('background');
   const handleReceipt = useCallback(
     (receiptId: string | undefined) => navigation.setParams({ paintingId: receiptId }),

--- a/src/frontend/features/paintings/PaintingScreen.tsx
+++ b/src/frontend/features/paintings/PaintingScreen.tsx
@@ -1,5 +1,5 @@
-import { Stack, useLocalSearchParams } from 'expo-router';
-import { useState } from 'react';
+import { Stack, useLocalSearchParams, useNavigation } from 'expo-router';
+import { useCallback, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -11,12 +11,24 @@ import { usePainting, useResolvedPaintingFiles } from './hooks/usePaintings';
 import { consumePaintingDraftHandoff } from './utils/paintingDraftHandoff';
 
 export function PaintingScreen() {
+  // Screen-scoped rather than `router.setParams`: the receipt id can land after
+  // the user has already navigated away, and the router's version would write
+  // it into whatever route is focused by then.
+  // `RootParamList` is empty here (no generated route types), so the default
+  // `setParams` signature takes `undefined`; name the params this screen owns.
+  const navigation = useNavigation<{
+    setParams(params: { paintingId: string | undefined }): void;
+  }>();
   const params = useLocalSearchParams<{
     handoff?: string | string[];
     paintingId?: string | string[];
   }>();
   const handoffToken = firstParam(params.handoff);
   const paintingId = firstParam(params.paintingId);
+  // Frozen at mount: once a generation started here writes its receipt id back
+  // into the route, re-entering the loading gate would tear the composer down
+  // mid-generation.
+  const [openedWithPaintingId] = useState(() => paintingId !== undefined);
   const [handoff] = useState(() => consumePaintingDraftHandoff(handoffToken));
   const paintingQuery = usePainting(paintingId);
   const painting = paintingQuery.data;
@@ -27,8 +39,12 @@ export function PaintingScreen() {
   const filesQuery = useResolvedPaintingFiles(handoff ? undefined : painting);
   const paintingFiles = filesQuery.data ?? { inputs: [], outputs: [] };
   const insets = useSafeAreaInsets();
-  const isLoading = Boolean(paintingId) && (paintingQuery.isLoading || filesQuery.isLoading);
+  const isLoading = openedWithPaintingId && (paintingQuery.isLoading || filesQuery.isLoading);
   const backgroundColor = useThemeColor('background');
+  const handleReceipt = useCallback(
+    (receiptId: string | undefined) => navigation.setParams({ paintingId: receiptId }),
+    [navigation],
+  );
 
   return (
     <View className="flex-1 bg-background" style={{ paddingBottom: Math.max(insets.bottom, 8) }}>
@@ -48,7 +64,11 @@ export function PaintingScreen() {
           initialAttachments={handoff?.attachments ?? paintingFiles.inputs}
           initialDraft={handoff?.draft ?? painting?.prompt ?? ''}
         >
-          <PaintingComposer initialFiles={paintingFiles} painting={painting} />
+          <PaintingComposer
+            initialFiles={paintingFiles}
+            onReceipt={handleReceipt}
+            painting={painting}
+          />
         </ManagedComposerProvider>
       )}
     </View>

--- a/src/frontend/features/paintings/PaintingViewerScreen/hooks/__tests__/usePaintingViewerActions.test.tsx
+++ b/src/frontend/features/paintings/PaintingViewerScreen/hooks/__tests__/usePaintingViewerActions.test.tsx
@@ -5,7 +5,9 @@ import { useEffect } from 'react';
 import { Linking } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
+import { BackendProvider } from '@/frontend/data/BackendProvider';
 import { DataApiProvider } from '@/frontend/data/DataApiProvider';
+import type { Backend } from '@/shared/contracts';
 
 import { usePaintingViewerActions } from '../usePaintingViewerActions';
 
@@ -59,13 +61,19 @@ const painting = {
   id: '00000000-0000-7000-8000-000000000001',
   prompt: 'Draw a cherry',
 } as Painting;
+const mockCancelGeneration = jest.fn(async () => undefined);
 const dataApi = {
   delete: mockDelete,
-  get: jest.fn(),
+  // Deleting a painting stops any generation still writing into it, so the hook
+  // now reads the painting job list; nothing is running in these cases.
+  get: jest.fn(async () => []),
   patch: jest.fn(),
   post: jest.fn(),
   put: jest.fn(),
 } as unknown as ApiClient;
+const backend = {
+  paintings: { cancelGeneration: mockCancelGeneration },
+} as unknown as Backend;
 let queryClient: QueryClient;
 
 let actions: ReturnType<typeof usePaintingViewerActions> | undefined;
@@ -100,7 +108,9 @@ describe('usePaintingViewerActions', () => {
       renderer = create(
         <QueryClientProvider client={queryClient}>
           <DataApiProvider dataApi={dataApi}>
-            <Probe />
+            <BackendProvider backend={backend}>
+              <Probe />
+            </BackendProvider>
           </DataApiProvider>
         </QueryClientProvider>,
       );

--- a/src/frontend/features/paintings/__tests__/DrawingList.test.tsx
+++ b/src/frontend/features/paintings/__tests__/DrawingList.test.tsx
@@ -11,11 +11,22 @@ let mockSelectedIds: ReadonlySet<string> = new Set();
 
 const mockPaintingOne = { id: 'painting-1' } as Painting;
 const mockPaintingTwo = { id: 'painting-2' } as Painting;
-const defaultGalleryItems = [
+const mockPaintingPending = { id: 'painting-3' } as Painting;
+type MockGalleryItem = {
+  aspectRatio: number;
+  fileEntryId?: string;
+  key: string;
+  kind: 'generating' | 'interrupted' | 'output';
+  message?: string;
+  painting: Painting;
+  uri?: string;
+};
+const defaultGalleryItems: MockGalleryItem[] = [
   {
     aspectRatio: 1,
     fileEntryId: 'file-1',
     key: 'painting-1:file-1',
+    kind: 'output',
     painting: mockPaintingOne,
     uri: 'file:///file-1.png',
   },
@@ -23,6 +34,7 @@ const defaultGalleryItems = [
     aspectRatio: 1,
     fileEntryId: 'file-2',
     key: 'painting-1:file-2',
+    kind: 'output',
     painting: mockPaintingOne,
     uri: 'file:///file-2.png',
   },
@@ -30,6 +42,7 @@ const defaultGalleryItems = [
     aspectRatio: 1,
     fileEntryId: 'file-3',
     key: 'painting-2:file-3',
+    kind: 'output',
     painting: mockPaintingTwo,
     uri: 'file:///file-3.png',
   },
@@ -43,14 +56,23 @@ jest.mock('expo-image-picker', () => ({
 
 jest.mock('expo-media-library', () => ({
   addListener: jest.fn(() => ({ remove: jest.fn() })),
-  Asset: class {},
+  Asset: jest.fn(),
   getPermissionsAsync: jest.fn(async () => ({ canAskAgain: false, granted: false })),
   requestPermissionsAsync: jest.fn(async () => ({ canAskAgain: false, granted: false })),
 }));
 
-jest.mock('expo-router', () => ({
-  useRouter: () => ({ push: mockPush }),
-}));
+jest.mock('expo-router', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    Link: ({ children, href }: { children?: React.ReactNode; href: unknown }) => (
+      <MockView testID="painting-composer-link" testProps={href}>
+        {children}
+      </MockView>
+    ),
+    useRouter: () => ({ push: mockPush }),
+  };
+});
 
 jest.mock('@/frontend/components/AlertProvider', () => ({
   useAlert: () => ({ alert: { show: jest.fn() } }),
@@ -59,7 +81,14 @@ jest.mock('@/frontend/components/AlertProvider', () => ({
 jest.mock('lucide-uniwind/png', () => ({
   CheckIcon: () => null,
   ImageIcon: () => null,
+  RotateCcwIcon: () => null,
 }));
+
+jest.mock('@/frontend/components/paintingSkeleton', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return { PaintingSkeleton: ({ testID }: { testID?: string }) => <MockView testID={testID} /> };
+});
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -97,7 +126,7 @@ jest.mock('@/frontend/components/navigation', () => {
 });
 
 jest.mock('@/frontend/features/paintings/hooks/usePaintings', () => ({
-  usePaintingGalleryItems: () => ({ data: mockGalleryItems, isLoading: false }),
+  usePaintingGalleryEntries: () => ({ isLoading: false, items: mockGalleryItems }),
   usePaintings: () => ({
     isLoading: false,
     isLoadingMore: false,
@@ -239,6 +268,48 @@ describe('DrawingList', () => {
     expect(findHostsByTestID(tree, 'painting-history-painting-1:file-1')).toHaveLength(0);
     expect(findHostsByTestID(tree, 'painting-history-painting-1:file-2')).toHaveLength(0);
     expect(findHostsByTestID(tree, 'painting-history-painting-2:file-3')).toHaveLength(1);
+  });
+
+  it('shows a running generation as a skeleton tile that leads back to the composer', async () => {
+    mockGalleryItems = [
+      {
+        aspectRatio: 1,
+        key: 'painting-3:pending',
+        kind: 'generating',
+        painting: mockPaintingPending,
+      },
+    ];
+
+    const tree = await render();
+
+    expect(findHostsByTestID(tree, 'painting-history-skeleton-painting-3')).toHaveLength(1);
+    // No image to zoom into: the tile links to the composer, not the viewer.
+    expect(findHostsByTestID(tree, 'painting-zoom-link')).toHaveLength(0);
+    expect(findHostsByTestID(tree, 'painting-composer-link')[0]?.props.testProps).toEqual({
+      params: { paintingId: 'painting-3' },
+      pathname: '/paintings',
+    });
+  });
+
+  it("puts the provider's own words on an interrupted tile", async () => {
+    mockGalleryItems = [
+      {
+        aspectRatio: 1,
+        key: 'painting-3:pending',
+        kind: 'interrupted',
+        message: 'Invalid JSON response',
+        painting: mockPaintingPending,
+      },
+    ];
+
+    const tree = await render();
+    const texts = tree.root
+      .findAll((node) => typeof node.type === 'string' && node.type === 'Text')
+      .flatMap((node) => (Array.isArray(node.props.children) ? [] : [node.props.children]));
+
+    expect(texts).toContain('painting.status.interrupted');
+    expect(texts).toContain('Invalid JSON response');
+    expect(findHostsByTestID(tree, 'painting-history-painting-3:pending')).toHaveLength(1);
   });
 
   it('offers the same create action when the drawing history is empty', async () => {

--- a/src/frontend/features/paintings/__tests__/PaintingScreen.test.tsx
+++ b/src/frontend/features/paintings/__tests__/PaintingScreen.test.tsx
@@ -1,0 +1,148 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { PaintingScreen } from '../PaintingScreen';
+
+const mockSetParams = jest.fn();
+const mockConsumePaintingDraftHandoff = jest.fn();
+const mockUsePainting = jest.fn();
+const mockUseResolvedPaintingFiles = jest.fn();
+let mockParams: { handoff?: string; paintingId?: string } = {};
+let mockComposerProviderProps:
+  | {
+      initialAttachments?: readonly unknown[];
+      initialDraft?: string;
+    }
+  | undefined;
+let mockPaintingComposerProps:
+  | {
+      onReceipt?: (paintingId: string | undefined) => void;
+    }
+  | undefined;
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useLocalSearchParams: () => mockParams,
+  useNavigation: () => ({ setParams: mockSetParams }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0 }),
+}));
+
+jest.mock('@/frontend/components/composer', () => ({
+  ManagedComposerProvider: ({ children, ...props }: { children?: React.ReactNode }) => {
+    mockComposerProviderProps = props;
+    return children;
+  },
+}));
+
+jest.mock('@/frontend/hooks/useThemeColor', () => ({
+  useThemeColor: () => '#000000',
+}));
+
+jest.mock('../components/PaintingComposer', () => ({
+  PaintingComposer: (props: typeof mockPaintingComposerProps) => {
+    mockPaintingComposerProps = props;
+    return null;
+  },
+}));
+
+jest.mock('../hooks/usePaintings', () => ({
+  usePainting: (...args: unknown[]) => mockUsePainting(...args),
+  useResolvedPaintingFiles: (...args: unknown[]) => mockUseResolvedPaintingFiles(...args),
+}));
+
+jest.mock('../utils/paintingDraftHandoff', () => ({
+  consumePaintingDraftHandoff: (...args: unknown[]) => mockConsumePaintingDraftHandoff(...args),
+}));
+
+describe('PaintingScreen', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = {};
+    mockComposerProviderProps = undefined;
+    mockPaintingComposerProps = undefined;
+    mockUsePainting.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseResolvedPaintingFiles.mockReturnValue({ data: undefined, isLoading: false });
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('keeps the handoff composer mounted while its new receipt loads', () => {
+    const handoffAttachment = {
+      id: 'painting-file:source',
+      kind: 'image',
+      mediaType: 'image/png',
+      name: 'source.png',
+      uri: 'file:///source.png',
+    };
+    mockParams = { handoff: 'handoff-2', paintingId: 'source-1' };
+    mockConsumePaintingDraftHandoff.mockReturnValueOnce({
+      attachments: [handoffAttachment],
+      draft: '',
+    });
+    mockUsePainting.mockReturnValue({
+      data: { id: 'source-1', prompt: 'source prompt' },
+      isLoading: false,
+    });
+
+    act(() => {
+      renderer = create(<PaintingScreen />);
+    });
+
+    expect(mockPaintingComposerProps).toBeDefined();
+    expect(mockComposerProviderProps).toEqual({
+      initialAttachments: [handoffAttachment],
+      initialDraft: '',
+    });
+    act(() => {
+      mockPaintingComposerProps?.onReceipt?.('receipt-2');
+    });
+    expect(mockSetParams).toHaveBeenCalledWith({ paintingId: 'receipt-2' });
+
+    mockParams = { paintingId: 'receipt-2' };
+    mockPaintingComposerProps = undefined;
+    mockUsePainting.mockReturnValue({ data: undefined, isLoading: true });
+
+    act(() => {
+      renderer?.update(<PaintingScreen />);
+    });
+
+    expect(mockPaintingComposerProps).toBeDefined();
+  });
+
+  it('restores persisted inputs when opening a receipt without a handoff', () => {
+    const persistedInput = {
+      fileEntryId: '00000000-0000-7000-8000-000000000002',
+      id: 'painting-file:persisted',
+      kind: 'image',
+      mediaType: 'image/png',
+      name: 'persisted.png',
+      status: 'ready',
+      uri: 'file:///persisted.png',
+    };
+    mockParams = { paintingId: 'receipt-2' };
+    mockUsePainting.mockReturnValue({
+      data: { id: 'receipt-2', prompt: 'retry this edit' },
+      isLoading: false,
+    });
+    mockUseResolvedPaintingFiles.mockReturnValue({
+      data: { inputs: [persistedInput], outputs: [] },
+      isLoading: false,
+    });
+
+    act(() => {
+      renderer = create(<PaintingScreen />);
+    });
+
+    expect(mockComposerProviderProps).toEqual({
+      initialAttachments: [persistedInput],
+      initialDraft: 'retry this edit',
+    });
+  });
+});

--- a/src/frontend/features/paintings/components/PaintingCanvas.tsx
+++ b/src/frontend/features/paintings/components/PaintingCanvas.tsx
@@ -17,12 +17,14 @@ import type {
 type PaintingOutput = { fileEntryId: string; uri: string };
 
 export function PaintingCanvas({
+  aspectRatio,
   error,
   interruption,
   onRevealFinish,
   outputs,
   status,
 }: {
+  aspectRatio: number;
   error: Error | null;
   interruption: PaintingInterruption | null;
   onRevealFinish: () => void;
@@ -35,14 +37,12 @@ export function PaintingCanvas({
 
   return (
     <View className="min-h-0 flex-1 items-center justify-center px-4 pb-3 pt-2">
-      {/* Keep the skeleton / reveal / result in one centered ~half-height square
-          so the loading grid stays a compact preview rather than filling the
-          whole canvas, and the three states never jump in size between each
-          other. */}
+      {/* The request ratio sizes all three states before an output exists, so
+          decoding the generated image cannot reflow the canvas. */}
       <View
         className="overflow-hidden"
         onLayout={({ nativeEvent }) => setPreviewWidth(nativeEvent.layout.width)}
-        style={styles.preview}
+        style={[styles.preview, { aspectRatio }]}
       >
         {status === 'generating' ? (
           <PaintingSkeleton
@@ -146,9 +146,9 @@ const styles = StyleSheet.create({
   outputList: {
     alignItems: 'stretch',
   },
-  // Half the canvas height, kept square via aspectRatio so the width follows.
+  // Stay compact on portrait output and within the canvas on wide output.
   preview: {
-    aspectRatio: 1,
     height: '50%',
+    maxWidth: '100%',
   },
 });

--- a/src/frontend/features/paintings/components/PaintingCanvas.tsx
+++ b/src/frontend/features/paintings/components/PaintingCanvas.tsx
@@ -1,4 +1,5 @@
 import { useImage } from '@shopify/react-native-skia';
+import { RotateCcwIcon } from 'lucide-uniwind/png';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
@@ -8,17 +9,22 @@ import { Image } from '@/frontend/components/nativePrimitives';
 import { PaintingSkeleton } from '@/frontend/components/paintingSkeleton';
 import { paintingSkeleton } from '@/frontend/utils/constants';
 
-import type { PaintingGenerationStatus } from '../hooks/usePaintingGeneration';
+import type {
+  PaintingGenerationStatus,
+  PaintingInterruption,
+} from '../hooks/usePaintingGeneration';
 
 type PaintingOutput = { fileEntryId: string; uri: string };
 
 export function PaintingCanvas({
   error,
+  interruption,
   onRevealFinish,
   outputs,
   status,
 }: {
   error: Error | null;
+  interruption: PaintingInterruption | null;
   onRevealFinish: () => void;
   outputs: readonly PaintingOutput[];
   status: PaintingGenerationStatus;
@@ -71,9 +77,24 @@ export function PaintingCanvas({
               </View>
             ))}
           </ScrollView>
+        ) : interruption ? (
+          // The gallery tile truncates the provider's words to two lines; this
+          // is where they can be read in full, next to the input that retries.
+          <View
+            className="flex-1 items-center justify-center gap-2 px-6"
+            testID="painting-interrupted"
+          >
+            <RotateCcwIcon className="size-7 text-foreground-tertiary" strokeWidth={1.5} />
+            <Text className="text-center font-medium text-foreground-secondary text-sm">
+              {t('painting.status.interrupted')}
+            </Text>
+            <Text className="text-center text-foreground-tertiary text-xs">
+              {interruption.message ?? t('painting.status.interruptedHint')}
+            </Text>
+          </View>
         ) : null}
       </View>
-      {error ? (
+      {error && !interruption ? (
         <Text
           accessibilityRole="alert"
           className="pt-2 text-center text-destructive text-sm"

--- a/src/frontend/features/paintings/components/PaintingComposer.tsx
+++ b/src/frontend/features/paintings/components/PaintingComposer.tsx
@@ -43,6 +43,7 @@ export function PaintingComposer({
   return (
     <View className="flex-1 bg-background">
       <PaintingCanvas
+        aspectRatio={generation.aspectRatio}
         error={generation.error}
         interruption={generation.interruption}
         onRevealFinish={generation.finishReveal}

--- a/src/frontend/features/paintings/components/PaintingComposer.tsx
+++ b/src/frontend/features/paintings/components/PaintingComposer.tsx
@@ -6,27 +6,45 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getComposerKeyboardStickyOffset } from '@/frontend/components/composer/utils/composerLayout';
 
 import { usePaintingGeneration } from '../hooks/usePaintingGeneration';
+import { paintingJobParamValues, usePaintingJobs } from '../hooks/usePaintingJobs';
 import type { ResolvedPaintingFiles } from '../hooks/usePaintings';
 import { PaintingCanvas } from './PaintingCanvas';
 import { PaintingInput } from './PaintingInput';
 
 export function PaintingComposer({
   initialFiles,
+  onReceipt,
   painting,
 }: {
   initialFiles: ResolvedPaintingFiles;
+  onReceipt?: (paintingId: string | undefined) => void;
   painting?: Painting;
 }) {
   const { bottom } = useSafeAreaInsets();
   const keyboardInputOffset = getComposerKeyboardStickyOffset(bottom);
+  // Only an image-less receipt is this screen's to adopt or retry. One that
+  // already holds images is a source to work from (edit / resize), so a
+  // generation started here must mint its own painting instead.
+  const receiptId = painting && painting.files.output.length === 0 ? painting.id : undefined;
   const generation = usePaintingGeneration({
     initialOutputs: initialFiles.outputs,
+    onReceipt,
+    paintingId: receiptId,
   });
+  // Size, image count and the rest of a retried attempt live only in the job's
+  // input — the painting row never carried them.
+  const jobs = usePaintingJobs();
+  const initialParamValues = receiptId
+    ? paintingJobParamValues(
+        jobs.activeByPaintingId.get(receiptId) ?? jobs.interruptedByPaintingId.get(receiptId),
+      )
+    : undefined;
 
   return (
     <View className="flex-1 bg-background">
       <PaintingCanvas
         error={generation.error}
+        interruption={generation.interruption}
         onRevealFinish={generation.finishReveal}
         outputs={generation.outputs}
         status={generation.status}
@@ -34,6 +52,7 @@ export function PaintingComposer({
       <KeyboardStickyView offset={{ opened: keyboardInputOffset }}>
         <View className="px-3 pb-2" testID="painting-composer">
           <PaintingInput
+            initialParamValues={initialParamValues}
             onCancel={generation.cancel}
             onGenerate={generation.generate}
             painting={painting}

--- a/src/frontend/features/paintings/components/PaintingInput.tsx
+++ b/src/frontend/features/paintings/components/PaintingInput.tsx
@@ -14,7 +14,6 @@ import {
   ComposerModelPill,
   type ComposerSendPayload,
   ComposerSurface,
-  useComposerActions,
   useComposerFieldDismiss,
   useComposerState,
 } from '@/frontend/components/composer';
@@ -38,7 +37,6 @@ import {
   reconcileImageParamDraft,
   resolveImageGenerationMode,
 } from '../utils/imageGenerationParams';
-import { createPaintingOutputAttachmentDraft } from '../utils/paintingOutputAttachment';
 import { PaintingSettingsBottomSheet } from './PaintingSettingsBottomSheet';
 
 type PaintingInputProps = {
@@ -76,7 +74,6 @@ export function PaintingInput({
   } | null>(null);
   const [seedApplied, setSeedApplied] = useState(false);
   const { attachments, draft } = useComposerState();
-  const { setAttachments } = useComposerActions();
   const { model: selectedModel } = useModelById(selectedModelId);
   const { models: enabledImageModels } = useModels({
     capability: MODEL_CAPABILITY.IMAGE_GENERATION,
@@ -211,7 +208,6 @@ export function PaintingInput({
         paramValues: submittedValues,
         prompt: text,
       });
-      setAttachments(result.outputs.map(createPaintingOutputAttachmentDraft));
       onGenerated?.(result);
     },
     [
@@ -221,7 +217,6 @@ export function PaintingInput({
       paramValues,
       selectedModel?.imageGeneration,
       selectedModelId,
-      setAttachments,
     ],
   );
   const getSendErrorLabel = useCallback(

--- a/src/frontend/features/paintings/components/PaintingInput.tsx
+++ b/src/frontend/features/paintings/components/PaintingInput.tsx
@@ -42,6 +42,12 @@ import { createPaintingOutputAttachmentDraft } from '../utils/paintingOutputAtta
 import { PaintingSettingsBottomSheet } from './PaintingSettingsBottomSheet';
 
 type PaintingInputProps = {
+  /**
+   * Params to restore rather than derive — the settings an interrupted attempt
+   * ran with. They arrive a beat after mount (they live in the job ledger), so
+   * they are applied as a one-shot override of the model defaults.
+   */
+  initialParamValues?: ImageParamDraft;
   onCancel: () => void;
   onGenerate: (input: PaintingGenerationInput) => Promise<PaintingGenerationResult>;
   onGenerated?: (result: PaintingGenerationResult) => void;
@@ -50,6 +56,7 @@ type PaintingInputProps = {
 };
 
 export function PaintingInput({
+  initialParamValues,
   onCancel,
   onGenerate,
   onGenerated,
@@ -67,6 +74,7 @@ export function PaintingInput({
     modelId: UniqueModelId;
     values: ImageParamDraft;
   } | null>(null);
+  const [seedApplied, setSeedApplied] = useState(false);
   const { attachments, draft } = useComposerState();
   const { setAttachments } = useComposerActions();
   const { model: selectedModel } = useModelById(selectedModelId);
@@ -108,10 +116,21 @@ export function PaintingInput({
   // safe: reconcileImageParamDraft (already computed above as paramValues) is
   // idempotent, so once the draft settles the conditions stop matching and
   // setState is no longer called.
+  const pendingSeed = seedApplied ? undefined : initialParamValues;
   if (!selectedModelId) {
     if (paramState !== null) {
       setParamState(null);
     }
+  } else if (pendingSeed) {
+    // Restore branch, checked first: by the time the interrupted attempt's
+    // params load, the draft above has already reconciled to the model's
+    // defaults, so the equality guard would never let them through.
+    setSeedApplied(true);
+    setParamState({
+      mode: generationMode,
+      modelId: selectedModelId,
+      values: reconcileImageParamDraft(pendingSeed, resolvedMode),
+    });
   } else if (
     paramState?.modelId !== selectedModelId ||
     paramState.mode !== generationMode ||

--- a/src/frontend/features/paintings/components/PaintingSettingsBottomSheet.tsx
+++ b/src/frontend/features/paintings/components/PaintingSettingsBottomSheet.tsx
@@ -205,6 +205,7 @@ function PaintingSettingField({
     }
     case 'range': {
       const numericValue = typeof value === 'number' ? value : Number(value ?? field.spec.min);
+      const isFixed = field.spec.max <= field.spec.min;
       return (
         <View className="gap-3">
           <View className="flex-row items-center justify-between gap-3">
@@ -213,14 +214,16 @@ function PaintingSettingField({
               {numericValue}
             </Text>
           </View>
-          <Slider
-            accessibilityLabel={label}
-            max={field.spec.max}
-            min={field.spec.min}
-            onValueChange={(nextValue) => onValueChange(field.key, nextValue)}
-            step={field.spec.step ?? 1}
-            value={numericValue}
-          />
+          {isFixed ? null : (
+            <Slider
+              accessibilityLabel={label}
+              max={field.spec.max}
+              min={field.spec.min}
+              onValueChange={(nextValue) => onValueChange(field.key, nextValue)}
+              step={field.spec.step ?? 1}
+              value={numericValue}
+            />
+          )}
         </View>
       );
     }

--- a/src/frontend/features/paintings/components/__tests__/PaintingCanvas.test.tsx
+++ b/src/frontend/features/paintings/components/__tests__/PaintingCanvas.test.tsx
@@ -1,0 +1,56 @@
+import { StyleSheet } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { PaintingCanvas } from '../PaintingCanvas';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@shopify/react-native-skia', () => ({
+  useImage: () => null,
+}));
+
+jest.mock('lucide-uniwind/png', () => ({
+  RotateCcwIcon: () => null,
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  runOnJS: (callback: (...args: unknown[]) => unknown) => callback,
+  useSharedValue: (value: number) => ({ value }),
+  withTiming: (value: number) => value,
+}));
+
+jest.mock('@/frontend/components/paintingSkeleton', () => ({
+  PaintingSkeleton: () => null,
+}));
+
+describe('PaintingCanvas', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('uses the requested ratio for the loading and result frame', () => {
+    act(() => {
+      renderer = create(
+        <PaintingCanvas
+          aspectRatio={3 / 4}
+          error={null}
+          interruption={null}
+          onRevealFinish={jest.fn()}
+          outputs={[]}
+          status="generating"
+        />,
+      );
+    });
+
+    const preview = renderer!.root.find(
+      (node) => StyleSheet.flatten(node.props.style)?.aspectRatio !== undefined,
+    );
+
+    expect(StyleSheet.flatten(preview.props.style)?.aspectRatio).toBeCloseTo(3 / 4);
+  });
+});

--- a/src/frontend/features/paintings/components/__tests__/PaintingInput.test.tsx
+++ b/src/frontend/features/paintings/components/__tests__/PaintingInput.test.tsx
@@ -80,18 +80,6 @@ jest.mock('@cherrystudio/ui/components', () => ({
   },
 }));
 
-jest.mock('../../utils/paintingOutputAttachment', () => ({
-  createPaintingOutputAttachmentDraft: (output: { fileEntryId: string; uri: string }) => ({
-    fileEntryId: output.fileEntryId,
-    id: `painting-file:${output.fileEntryId}`,
-    kind: 'image',
-    mediaType: 'image/png',
-    name: 'generated.png',
-    status: 'ready',
-    uri: output.uri,
-  }),
-}));
-
 const painting = {
   modelId: 'provider::image-model',
 } as Painting;
@@ -128,7 +116,7 @@ describe('PaintingInput', () => {
     await act(async () => renderer?.unmount());
   });
 
-  it('seeds the generated output as the next ordinary attachment', async () => {
+  it('keeps generated outputs out of the next input attachments', async () => {
     await act(async () => {
       renderer = create(
         <PaintingInput
@@ -167,17 +155,7 @@ describe('PaintingInput', () => {
       paramValues: {},
       prompt: payload.text,
     });
-    expect(mockSetAttachments).toHaveBeenCalledWith([
-      {
-        fileEntryId: generationResult.outputs[0].fileEntryId,
-        id: `painting-file:${generationResult.outputs[0].fileEntryId}`,
-        kind: 'image',
-        mediaType: 'image/png',
-        name: 'generated.png',
-        status: 'ready',
-        uri: generationResult.outputs[0].uri,
-      },
-    ]);
+    expect(mockSetAttachments).not.toHaveBeenCalled();
     expect(mockOnGenerated).toHaveBeenCalledWith(generationResult);
   });
 

--- a/src/frontend/features/paintings/components/__tests__/PaintingSettingsBottomSheet.test.tsx
+++ b/src/frontend/features/paintings/components/__tests__/PaintingSettingsBottomSheet.test.tsx
@@ -74,7 +74,7 @@ jest.mock('@cherrystudio/ui/components', () => {
     Input: MockTextInput,
     Label: MockText,
     Section: MockSection,
-    Slider: (props: Record<string, unknown>) => <MockView {...props} />,
+    Slider: (props: Record<string, unknown>) => <MockView {...props} testID="mock-slider" />,
     Switch: (props: Record<string, unknown>) => <MockPressable {...props} />,
     TextField: MockView,
     useBottomSheet: () => ({
@@ -290,5 +290,29 @@ describe('PaintingSettingsBottomSheet', () => {
         .findAllByType(TextInput)
         .filter((input) => input.props.accessibilityLabel === 'painting.settings.width'),
     ).toHaveLength(0);
+  });
+
+  it('does not mount a native slider for a fixed range', () => {
+    const fixedRangeMode = {
+      definition: {
+        supports: {
+          numImages: { default: 1, max: 1, min: 1, type: 'range' },
+        },
+      },
+      mode: 'generate',
+    } satisfies ResolvedImageGenerationMode;
+
+    act(() => {
+      renderer = create(
+        <PaintingSettingsBottomSheet
+          onDismiss={jest.fn()}
+          onValueChange={jest.fn()}
+          resolvedMode={fixedRangeMode}
+          values={{ numImages: 1 }}
+        />,
+      );
+    });
+
+    expect(renderer?.root.findAllByProps({ testID: 'mock-slider' })).toHaveLength(0);
   });
 });

--- a/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
+++ b/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
@@ -200,6 +200,21 @@ describe('usePaintingGeneration', () => {
     expect(mockSyncPaintingQueries).toHaveBeenCalledWith(painting);
   });
 
+  it('keeps the requested aspect ratio through the reveal', async () => {
+    jobById.set(
+      'job-1',
+      jobSnapshot({ output: { outputs: [output], painting }, status: 'completed' }),
+    );
+    await mountProbe();
+
+    await act(async () => {
+      await api?.generate({ ...request, paramValues: { aspectRatio: '3:4' } });
+    });
+
+    expect(api?.aspectRatio).toBeCloseTo(3 / 4);
+    expect(api?.status).toBe('revealing');
+  });
+
   it('surfaces a failed job as frontend error state and allows a retry', async () => {
     mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-fail', paintingId: 'painting-1' });
     jobById.set(
@@ -283,10 +298,17 @@ describe('usePaintingGeneration', () => {
   });
 
   it("adopts this painting's still-active generation on mount and reveals its result", async () => {
-    activeJobs = [jobSnapshot({ input: { paintingId: 'painting-1' }, status: 'running' })];
+    activeJobs = [
+      jobSnapshot({
+        input: { paintingId: 'painting-1', paramValues: { aspectRatio: '3:4' } },
+        status: 'running',
+      }),
+    ];
     jobById.set('job-1', jobSnapshot({ status: 'running' }));
     await mountProbe('painting-1');
     await waitForCondition(() => api?.status === 'generating');
+
+    expect(api?.aspectRatio).toBeCloseTo(3 / 4);
 
     jobById.set(
       'job-1',
@@ -298,6 +320,7 @@ describe('usePaintingGeneration', () => {
     await waitForCondition(() => api?.status === 'revealing');
 
     expect(api?.outputs).toEqual([output]);
+    expect(api?.aspectRatio).toBeCloseTo(3 / 4);
     expect(mockSyncPaintingQueries).toHaveBeenCalledWith(painting);
   });
 

--- a/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
+++ b/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
@@ -1,9 +1,13 @@
+import type { JobSnapshot } from '@cherrystudio/universal/data/api/schemas/jobs';
+import type { ApiClient } from '@cherrystudio/universal/data/api/types';
 import type { Painting } from '@cherrystudio/universal/data/types/painting';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { BackendProvider } from '@/frontend/data';
-import type { Backend, PaintingGenerationSession } from '@/shared/contracts';
+import { DataApiProvider } from '@/frontend/data/DataApiProvider';
+import type { Backend } from '@/shared/contracts';
 
 import { usePaintingGeneration } from '../usePaintingGeneration';
 
@@ -21,22 +25,58 @@ const painting: Painting = {
   providerId: 'provider',
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
-const mockGenerate = jest.fn<
-  ReturnType<PaintingGenerationSession['generate']>,
-  Parameters<PaintingGenerationSession['generate']>
->();
-const mockCancel = jest.fn();
-const mockDispose = jest.fn();
-const session: PaintingGenerationSession = {
-  cancel: mockCancel,
-  dispose: mockDispose,
-  generate: mockGenerate,
-};
-const mockCreateGenerationSession = jest.fn(() => session);
+
+function jobSnapshot(overrides: Partial<JobSnapshot>): JobSnapshot {
+  return {
+    attempt: 1,
+    cancelRequested: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    error: null,
+    finishedAt: null,
+    id: 'job-1',
+    idempotencyKey: null,
+    input: null,
+    maxAttempts: 1,
+    metadata: {},
+    output: null,
+    parentId: null,
+    priority: 0,
+    queue: 'painting',
+    scheduledAt: '2026-01-01T00:00:00.000Z',
+    scheduleId: null,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    status: 'running',
+    timeoutMs: null,
+    type: 'painting.generate',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const mockStartGeneration = jest.fn(async () => ({ jobId: 'job-1' }));
+const mockCancelGeneration = jest.fn(async () => undefined);
 const backend = {
-  paintings: { createGenerationSession: mockCreateGenerationSession },
+  paintings: { cancelGeneration: mockCancelGeneration, startGeneration: mockStartGeneration },
 } as unknown as Backend;
 const mockSyncPaintingQueries = jest.fn(async () => undefined);
+
+/** Per-test ledger state served by the mocked Data API. */
+let activeJobs: JobSnapshot[] = [];
+let jobById = new Map<string, JobSnapshot>();
+
+const dataApi = {
+  delete: jest.fn(),
+  get: jest.fn(async (path: string) => {
+    if (path === '/jobs') return activeJobs;
+    const jobId = path.replace('/jobs/', '');
+    const job = jobById.get(jobId);
+    if (!job) throw new Error(`Job not found: ${jobId}`);
+    return job;
+  }),
+  patch: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+} as unknown as jest.Mocked<ApiClient>;
 
 jest.mock('@/frontend/features/paintings/hooks/usePaintings', () => ({
   useSyncPaintingQueries: () => mockSyncPaintingQueries,
@@ -45,6 +85,7 @@ jest.mock('@/frontend/features/paintings/hooks/usePaintings', () => ({
 type GenerationApi = ReturnType<typeof usePaintingGeneration>;
 let api: GenerationApi | undefined;
 let renderer: ReactTestRenderer | undefined;
+let queryClient: QueryClient;
 
 function Probe() {
   const generation = usePaintingGeneration({ initialOutputs: [] });
@@ -52,6 +93,37 @@ function Probe() {
     api = generation;
   }, [generation]);
   return null;
+}
+
+async function mountProbe() {
+  await act(async () => {
+    renderer = create(
+      <QueryClientProvider client={queryClient}>
+        <DataApiProvider dataApi={dataApi}>
+          <BackendProvider backend={backend}>
+            <Probe />
+          </BackendProvider>
+        </DataApiProvider>
+      </QueryClientProvider>,
+    );
+  });
+}
+
+/** Flush act passes until the condition holds. Each pass yields a macrotask:
+ * react-query batches observer notifications through `setTimeout(0)`, so
+ * microtask-only passes would race the commit and flake. */
+async function waitForCondition(predicate: () => boolean) {
+  for (let index = 0; index < 20; index += 1) {
+    if (predicate()) {
+      return;
+    }
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  }
+  throw new Error('Timed out waiting for condition');
 }
 
 const request = {
@@ -72,31 +144,36 @@ const request = {
   prompt: 'draw a cherry',
 };
 
-beforeEach(async () => {
+beforeEach(() => {
   jest.clearAllMocks();
   api = undefined;
-  mockGenerate.mockResolvedValue({ outputs: [output], painting });
-  await act(async () => {
-    renderer = create(
-      <BackendProvider backend={backend}>
-        <Probe />
-      </BackendProvider>,
-    );
+  activeJobs = [];
+  jobById = new Map();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: Infinity, retry: false } },
   });
 });
 
 afterEach(async () => {
   await act(async () => renderer?.unmount());
+  renderer = undefined;
+  queryClient.clear();
 });
 
 describe('usePaintingGeneration', () => {
-  it('maps image drafts into a backend session and reveals persisted outputs', async () => {
+  it('enqueues via the backend and reveals the outputs from the terminal job', async () => {
+    jobById.set(
+      'job-1',
+      jobSnapshot({ output: { outputs: [output], painting }, status: 'completed' }),
+    );
+    await mountProbe();
+
     let result: Awaited<ReturnType<GenerationApi['generate']>> | undefined;
     await act(async () => {
       result = await api?.generate(request);
     });
 
-    expect(mockGenerate).toHaveBeenCalledWith({
+    expect(mockStartGeneration).toHaveBeenCalledWith({
       images: [
         {
           fileEntryId: request.attachments[0].fileEntryId,
@@ -117,49 +194,111 @@ describe('usePaintingGeneration', () => {
     expect(mockSyncPaintingQueries).toHaveBeenCalledWith(painting);
   });
 
-  it('keeps workflow failure as frontend error state and reuses the same session', async () => {
-    mockGenerate.mockRejectedValueOnce(new Error('network failed'));
+  it('surfaces a failed job as frontend error state and allows a retry', async () => {
+    mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-fail' });
+    jobById.set(
+      'job-fail',
+      jobSnapshot({
+        error: { code: 'JOB_HANDLER_THREW', message: 'network failed', retryable: true },
+        id: 'job-fail',
+        status: 'failed',
+      }),
+    );
+    await mountProbe();
 
+    let settled: unknown;
     await act(async () => {
-      await expect(api?.generate(request)).rejects.toThrow('network failed');
+      settled = await api?.generate(request).catch((error: unknown) => error);
     });
+    expect(settled).toEqual(new Error('network failed'));
     expect(api?.error).toEqual(new Error('network failed'));
     expect(api?.status).toBe('idle');
 
-    await act(async () => {
-      await api?.generate(request);
-    });
-    expect(mockCreateGenerationSession).toHaveBeenCalledTimes(1);
-    expect(mockGenerate).toHaveBeenCalledTimes(2);
-  });
-
-  it('cancels the active backend session and disposes it on unmount', async () => {
-    let rejectGeneration: (error: Error) => void = () => undefined;
-    mockGenerate.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectGeneration = reject;
-        }),
+    mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-2' });
+    jobById.set(
+      'job-2',
+      jobSnapshot({ id: 'job-2', output: { outputs: [output], painting }, status: 'completed' }),
     );
-    mockCancel.mockImplementationOnce(() => {
-      rejectGeneration(new Error('Painting generation cancelled'));
-    });
-
-    let result: Promise<unknown> | undefined;
+    // Two act passes: the first lets `startGeneration` resolve and exits so act
+    // flushes the enqueue render (the poll query only subscribes then); awaiting
+    // the result inside that same act would deadlock on its own flush.
+    let retry: Promise<unknown> | undefined;
     await act(async () => {
-      result = api?.generate(request).catch((error) => error);
+      retry = api?.generate(request);
       await Promise.resolve();
     });
     await act(async () => {
+      await retry;
+    });
+    expect(api?.status).toBe('revealing');
+    expect(mockStartGeneration).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects the enqueue failure without touching the ledger', async () => {
+    mockStartGeneration.mockRejectedValueOnce(new Error('validation failed'));
+    await mountProbe();
+
+    let settled: unknown;
+    await act(async () => {
+      settled = await api?.generate(request).catch((error: unknown) => error);
+    });
+    expect(settled).toEqual(new Error('validation failed'));
+    expect(api?.error).toEqual(new Error('validation failed'));
+    expect(api?.status).toBe('idle');
+  });
+
+  it('cancels through the backend and settles when the job reports cancelled', async () => {
+    jobById.set('job-1', jobSnapshot({ status: 'running' }));
+    await mountProbe();
+
+    let settled: Promise<unknown> | undefined;
+    await act(async () => {
+      settled = api?.generate(request).catch((error) => error);
+      await Promise.resolve();
+    });
+    expect(api?.status).toBe('generating');
+
+    jobById.set(
+      'job-1',
+      jobSnapshot({
+        error: { code: 'JOB_CANCELLED', message: 'Cancelled by user', retryable: false },
+        status: 'cancelled',
+      }),
+    );
+    await act(async () => {
       api?.cancel();
-      await result;
+      await queryClient.refetchQueries();
+      await settled;
     });
 
-    expect(mockCancel).toHaveBeenCalledTimes(1);
-    expect(api?.error).toEqual(new Error('Painting generation cancelled'));
+    expect(mockCancelGeneration).toHaveBeenCalledWith('job-1');
+    expect(api?.error).toEqual(new Error('Cancelled by user'));
+    expect(api?.status).toBe('idle');
+  });
 
-    await act(async () => renderer?.unmount());
-    renderer = undefined;
-    expect(mockDispose).toHaveBeenCalledTimes(1);
+  it('adopts a still-active generation on mount and reveals its result', async () => {
+    activeJobs = [jobSnapshot({ status: 'running' })];
+    jobById.set('job-1', jobSnapshot({ status: 'running' }));
+    await mountProbe();
+    await waitForCondition(() => api?.status === 'generating');
+
+    jobById.set(
+      'job-1',
+      jobSnapshot({ output: { outputs: [output], painting }, status: 'completed' }),
+    );
+    await act(async () => {
+      await queryClient.refetchQueries();
+    });
+    await waitForCondition(() => api?.status === 'revealing');
+
+    expect(api?.outputs).toEqual([output]);
+    expect(mockSyncPaintingQueries).toHaveBeenCalledWith(painting);
+  });
+
+  it('does not adopt anything when the ledger has no active generation', async () => {
+    await mountProbe();
+
+    expect(api?.status).toBe('idle');
+    expect(dataApi.get).toHaveBeenCalledWith('/jobs', expect.anything());
   });
 });

--- a/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
+++ b/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
@@ -53,21 +53,25 @@ function jobSnapshot(overrides: Partial<JobSnapshot>): JobSnapshot {
   };
 }
 
-const mockStartGeneration = jest.fn(async () => ({ jobId: 'job-1' }));
+const mockStartGeneration = jest.fn(async () => ({ jobId: 'job-1', paintingId: 'painting-1' }));
 const mockCancelGeneration = jest.fn(async () => undefined);
 const backend = {
   paintings: { cancelGeneration: mockCancelGeneration, startGeneration: mockStartGeneration },
 } as unknown as Backend;
 const mockSyncPaintingQueries = jest.fn(async () => undefined);
+const mockDeletePaintings = jest.fn(async () => undefined);
 
 /** Per-test ledger state served by the mocked Data API. */
 let activeJobs: JobSnapshot[] = [];
+let interruptedJobs: JobSnapshot[] = [];
 let jobById = new Map<string, JobSnapshot>();
 
 const dataApi = {
   delete: jest.fn(),
-  get: jest.fn(async (path: string) => {
-    if (path === '/jobs') return activeJobs;
+  get: jest.fn(async (path: string, options?: { query?: { status?: string } }) => {
+    if (path === '/jobs') {
+      return options?.query?.status?.includes('running') ? activeJobs : interruptedJobs;
+    }
     const jobId = path.replace('/jobs/', '');
     const job = jobById.get(jobId);
     if (!job) throw new Error(`Job not found: ${jobId}`);
@@ -79,6 +83,7 @@ const dataApi = {
 } as unknown as jest.Mocked<ApiClient>;
 
 jest.mock('@/frontend/features/paintings/hooks/usePaintings', () => ({
+  useDeletePaintings: () => mockDeletePaintings,
   useSyncPaintingQueries: () => mockSyncPaintingQueries,
 }));
 
@@ -87,21 +92,21 @@ let api: GenerationApi | undefined;
 let renderer: ReactTestRenderer | undefined;
 let queryClient: QueryClient;
 
-function Probe() {
-  const generation = usePaintingGeneration({ initialOutputs: [] });
+function Probe({ paintingId }: { paintingId?: string }) {
+  const generation = usePaintingGeneration({ initialOutputs: [], paintingId });
   useEffect(() => {
     api = generation;
   }, [generation]);
   return null;
 }
 
-async function mountProbe() {
+async function mountProbe(paintingId?: string) {
   await act(async () => {
     renderer = create(
       <QueryClientProvider client={queryClient}>
         <DataApiProvider dataApi={dataApi}>
           <BackendProvider backend={backend}>
-            <Probe />
+            <Probe paintingId={paintingId} />
           </BackendProvider>
         </DataApiProvider>
       </QueryClientProvider>,
@@ -148,6 +153,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   api = undefined;
   activeJobs = [];
+  interruptedJobs = [];
   jobById = new Map();
   queryClient = new QueryClient({
     defaultOptions: { queries: { gcTime: Infinity, retry: false } },
@@ -195,7 +201,7 @@ describe('usePaintingGeneration', () => {
   });
 
   it('surfaces a failed job as frontend error state and allows a retry', async () => {
-    mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-fail' });
+    mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-fail', paintingId: 'painting-1' });
     jobById.set(
       'job-fail',
       jobSnapshot({
@@ -214,7 +220,7 @@ describe('usePaintingGeneration', () => {
     expect(api?.error).toEqual(new Error('network failed'));
     expect(api?.status).toBe('idle');
 
-    mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-2' });
+    mockStartGeneration.mockResolvedValueOnce({ jobId: 'job-2', paintingId: 'painting-1' });
     jobById.set(
       'job-2',
       jobSnapshot({ id: 'job-2', output: { outputs: [output], painting }, status: 'completed' }),
@@ -276,10 +282,10 @@ describe('usePaintingGeneration', () => {
     expect(api?.status).toBe('idle');
   });
 
-  it('adopts a still-active generation on mount and reveals its result', async () => {
-    activeJobs = [jobSnapshot({ status: 'running' })];
+  it("adopts this painting's still-active generation on mount and reveals its result", async () => {
+    activeJobs = [jobSnapshot({ input: { paintingId: 'painting-1' }, status: 'running' })];
     jobById.set('job-1', jobSnapshot({ status: 'running' }));
-    await mountProbe();
+    await mountProbe('painting-1');
     await waitForCondition(() => api?.status === 'generating');
 
     jobById.set(
@@ -295,10 +301,119 @@ describe('usePaintingGeneration', () => {
     expect(mockSyncPaintingQueries).toHaveBeenCalledWith(painting);
   });
 
-  it('does not adopt anything when the ledger has no active generation', async () => {
+  it('leaves a blank composer blank while another painting is generating', async () => {
+    activeJobs = [jobSnapshot({ input: { paintingId: 'painting-other' }, status: 'running' })];
+    jobById.set('job-1', jobSnapshot({ status: 'running' }));
     await mountProbe();
+    await waitForCondition(() => dataApi.get.mock.calls.length > 0);
 
     expect(api?.status).toBe('idle');
-    expect(dataApi.get).toHaveBeenCalledWith('/jobs', expect.anything());
+    expect(api?.interruption).toBeNull();
+  });
+
+  it("ignores another painting's generation even when bound to a receipt", async () => {
+    activeJobs = [jobSnapshot({ input: { paintingId: 'painting-other' }, status: 'running' })];
+    await mountProbe('painting-1');
+    await waitForCondition(() => api?.interruption !== null);
+
+    expect(api?.status).toBe('idle');
+  });
+
+  it('reports an image-less receipt with nothing running as interrupted, carrying the provider text', async () => {
+    interruptedJobs = [
+      jobSnapshot({
+        error: { code: 'JOB_HANDLER_THREW', message: 'Invalid JSON response', retryable: true },
+        input: { paintingId: 'painting-1' },
+        status: 'failed',
+      }),
+    ];
+    await mountProbe('painting-1');
+    await waitForCondition(() => api?.interruption !== null);
+
+    expect(api?.interruption).toEqual({ message: 'Invalid JSON response' });
+  });
+
+  it('keeps a cancelled job wordless: its message never went through i18n', async () => {
+    interruptedJobs = [
+      jobSnapshot({
+        error: {
+          code: 'JOB_CANCELLED',
+          message: 'Cancelled by startup recovery',
+          retryable: false,
+        },
+        input: { paintingId: 'painting-1' },
+        status: 'cancelled',
+      }),
+    ];
+    await mountProbe('painting-1');
+    await waitForCondition(() => api?.interruption !== null);
+
+    expect(api?.interruption).toEqual({ message: undefined });
+  });
+
+  it('retries into the interrupted receipt instead of minting a second painting', async () => {
+    interruptedJobs = [
+      jobSnapshot({
+        error: { code: 'JOB_HANDLER_THREW', message: 'boom', retryable: true },
+        input: { paintingId: 'painting-1' },
+        status: 'failed',
+      }),
+    ];
+    jobById.set(
+      'job-1',
+      jobSnapshot({ output: { outputs: [output], painting }, status: 'completed' }),
+    );
+    await mountProbe('painting-1');
+    await waitForCondition(() => api?.interruption !== null);
+
+    await act(async () => {
+      await api?.generate(request);
+    });
+
+    expect(mockStartGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ paintingId: 'painting-1' }),
+    );
+  });
+
+  it('starts a fresh painting from a blank composer', async () => {
+    jobById.set(
+      'job-1',
+      jobSnapshot({ output: { outputs: [output], painting }, status: 'completed' }),
+    );
+    await mountProbe();
+
+    await act(async () => {
+      await api?.generate(request);
+    });
+
+    expect(mockStartGeneration).toHaveBeenCalledWith(
+      expect.not.objectContaining({ paintingId: expect.anything() }),
+    );
+  });
+
+  it('discards the receipt when the user cancels, so no interrupted tile is left behind', async () => {
+    jobById.set('job-1', jobSnapshot({ status: 'running' }));
+    await mountProbe();
+
+    let settled: Promise<unknown> | undefined;
+    await act(async () => {
+      settled = api?.generate(request).catch((error) => error);
+      await Promise.resolve();
+    });
+
+    jobById.set(
+      'job-1',
+      jobSnapshot({
+        error: { code: 'JOB_CANCELLED', message: 'Cancelled by user', retryable: false },
+        status: 'cancelled',
+      }),
+    );
+    await act(async () => {
+      api?.cancel();
+      await queryClient.refetchQueries();
+      await settled;
+    });
+
+    expect(mockDeletePaintings).toHaveBeenCalledWith(['painting-1']);
   });
 });

--- a/src/frontend/features/paintings/hooks/__tests__/usePaintingJobs.test.tsx
+++ b/src/frontend/features/paintings/hooks/__tests__/usePaintingJobs.test.tsx
@@ -1,0 +1,184 @@
+import type { JobSnapshot } from '@cherrystudio/universal/data/api/schemas/jobs';
+import type { ApiClient } from '@cherrystudio/universal/data/api/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { DataApiProvider } from '@/frontend/data/DataApiProvider';
+
+import { paintingJobFailureMessage, usePaintingJobs } from '../usePaintingJobs';
+
+function jobSnapshot(overrides: Partial<JobSnapshot>): JobSnapshot {
+  return {
+    attempt: 1,
+    cancelRequested: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    error: null,
+    finishedAt: null,
+    id: 'job-1',
+    idempotencyKey: null,
+    input: null,
+    maxAttempts: 1,
+    metadata: {},
+    output: null,
+    parentId: null,
+    priority: 0,
+    queue: 'painting',
+    scheduledAt: '2026-01-01T00:00:00.000Z',
+    scheduleId: null,
+    startedAt: null,
+    status: 'running',
+    timeoutMs: null,
+    type: 'painting.generate',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+let activeJobs: JobSnapshot[] = [];
+let interruptedJobs: JobSnapshot[] = [];
+
+const dataApi = {
+  delete: jest.fn(),
+  get: jest.fn(async (path: string, options?: { query?: { status?: string } }) =>
+    path === '/jobs' && !options?.query?.status?.includes('running') ? interruptedJobs : activeJobs,
+  ),
+  patch: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+} as unknown as jest.Mocked<ApiClient>;
+
+let api: ReturnType<typeof usePaintingJobs> | undefined;
+let renderer: ReactTestRenderer | undefined;
+let queryClient: QueryClient;
+
+function Probe() {
+  const jobs = usePaintingJobs();
+  useEffect(() => {
+    api = jobs;
+  }, [jobs]);
+  return null;
+}
+
+async function mountProbe() {
+  await act(async () => {
+    renderer = create(
+      <QueryClientProvider client={queryClient}>
+        <DataApiProvider dataApi={dataApi}>
+          <Probe />
+        </DataApiProvider>
+      </QueryClientProvider>,
+    );
+  });
+}
+
+async function settle() {
+  for (let index = 0; index < 10; index += 1) {
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api = undefined;
+  activeJobs = [];
+  interruptedJobs = [];
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+  });
+});
+
+afterEach(async () => {
+  await act(async () => renderer?.unmount());
+  renderer = undefined;
+  queryClient.clear();
+});
+
+describe('usePaintingJobs', () => {
+  it('indexes jobs by the painting they write into', async () => {
+    activeJobs = [jobSnapshot({ id: 'job-a', input: { paintingId: 'painting-1' } })];
+    interruptedJobs = [
+      jobSnapshot({ id: 'job-b', input: { paintingId: 'painting-2' }, status: 'failed' }),
+    ];
+    await mountProbe();
+    await settle();
+
+    expect(api?.activeByPaintingId.get('painting-1')?.id).toBe('job-a');
+    expect(api?.interruptedByPaintingId.get('painting-2')?.id).toBe('job-b');
+    expect(api?.activeByPaintingId.get('painting-2')).toBeUndefined();
+  });
+
+  it('keeps the newest job per painting and skips rows with no receipt', async () => {
+    // The list arrives newest first, so the first hit per painting wins.
+    activeJobs = [
+      jobSnapshot({ id: 'job-new', input: { paintingId: 'painting-1' } }),
+      jobSnapshot({ id: 'job-old', input: { paintingId: 'painting-1' } }),
+      jobSnapshot({ id: 'job-orphan', input: null }),
+    ];
+    await mountProbe();
+    await settle();
+
+    expect(api?.activeByPaintingId.size).toBe(1);
+    expect(api?.activeByPaintingId.get('painting-1')?.id).toBe('job-new');
+  });
+
+  it('refreshes the gallery when a generation leaves the active set', async () => {
+    activeJobs = [jobSnapshot({ id: 'job-a', input: { paintingId: 'painting-1' } })];
+    await mountProbe();
+    await settle();
+    const invalidate = jest.spyOn(queryClient, 'invalidateQueries');
+
+    activeJobs = [];
+    await act(async () => {
+      await queryClient.refetchQueries();
+    });
+    await settle();
+
+    // Nothing else invalidates `/paintings` while the user sits on the list.
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['/paintings'] });
+  });
+
+  it('does not refresh the gallery while the same generation keeps running', async () => {
+    activeJobs = [jobSnapshot({ id: 'job-a', input: { paintingId: 'painting-1' } })];
+    await mountProbe();
+    await settle();
+    const invalidate = jest.spyOn(queryClient, 'invalidateQueries');
+
+    await act(async () => {
+      await queryClient.refetchQueries();
+    });
+    await settle();
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('paintingJobFailureMessage', () => {
+  it('repeats provider text but never the internal cancellation wording', () => {
+    expect(
+      paintingJobFailureMessage(
+        jobSnapshot({
+          error: { code: 'JOB_HANDLER_THREW', message: 'Invalid JSON response', retryable: true },
+          status: 'failed',
+        }),
+      ),
+    ).toBe('Invalid JSON response');
+    expect(
+      paintingJobFailureMessage(
+        jobSnapshot({
+          error: {
+            code: 'JOB_CANCELLED',
+            message: 'Cancelled by startup recovery',
+            retryable: false,
+          },
+          status: 'cancelled',
+        }),
+      ),
+    ).toBeUndefined();
+    expect(paintingJobFailureMessage(undefined)).toBeUndefined();
+  });
+});

--- a/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
+++ b/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
@@ -11,7 +11,12 @@ import type {
   PaintingGenerationOutput,
 } from '@/shared/contracts';
 
-import { paintingJobFailureMessage, usePaintingJobs } from './usePaintingJobs';
+import { imageParamsAspectRatio } from '../utils/imageGenerationParams';
+import {
+  paintingJobFailureMessage,
+  paintingJobParamValues,
+  usePaintingJobs,
+} from './usePaintingJobs';
 import { useDeletePaintings, useSyncPaintingQueries } from './usePaintings';
 
 export type PaintingGenerationStatus = 'idle' | 'generating' | 'revealing';
@@ -72,6 +77,7 @@ export function usePaintingGeneration({
   const syncPaintingQueries = useSyncPaintingQueries();
   const deletePaintings = useDeletePaintings();
   const jobs = usePaintingJobs();
+  const [aspectRatio, setAspectRatio] = useState(1);
   const [error, setError] = useState<Error | null>(null);
   const [outputs, setOutputs] = useState<PaintingOutput[]>(() => [...initialOutputs]);
   const [status, setStatus] = useState<PaintingGenerationStatus>('idle');
@@ -89,6 +95,7 @@ export function usePaintingGeneration({
   // idempotent, so the extra render pass converges immediately.
   if (activeJobId === null && adoptableJobId !== null) {
     setActiveJobId(adoptableJobId);
+    setAspectRatio(imageParamsAspectRatio(paintingJobParamValues(runningJob)));
     setStatus('generating');
   }
 
@@ -155,6 +162,7 @@ export function usePaintingGeneration({
         throw new Error('Painting generation is already in progress');
       }
       setError(null);
+      setAspectRatio(imageParamsAspectRatio(input.paramValues));
       setStatus('generating');
 
       try {
@@ -221,6 +229,7 @@ export function usePaintingGeneration({
   const finishReveal = useCallback(() => setStatus('idle'), []);
 
   return {
+    aspectRatio,
     cancel,
     error,
     finishReveal,

--- a/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
+++ b/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
@@ -1,18 +1,27 @@
 import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
 import { isTerminalStatus } from '@cherrystudio/universal/data/api/schemas/jobs';
 import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ComposerAttachmentDraft } from '@/frontend/components/composer/utils/composerAttachments';
-import { useBackendModule, useQuery } from '@/frontend/data';
+import { queryKeys, useBackendModule, useQuery } from '@/frontend/data';
 import type {
   PaintingGenerationResult as BackendPaintingGenerationResult,
   PaintingGenerationOutput,
 } from '@/shared/contracts';
 
-import { useSyncPaintingQueries } from './usePaintings';
+import { paintingJobFailureMessage, usePaintingJobs } from './usePaintingJobs';
+import { useDeletePaintings, useSyncPaintingQueries } from './usePaintings';
 
 export type PaintingGenerationStatus = 'idle' | 'generating' | 'revealing';
+
+/**
+ * The receipt exists but holds no images and nothing is running for it — the
+ * previous attempt died with the app, timed out, or the provider refused.
+ * `message` is provider text when there is any worth repeating.
+ */
+export type PaintingInterruption = { message?: string };
 
 export type PaintingOutput = PaintingGenerationOutput;
 
@@ -26,8 +35,6 @@ export type PaintingGenerationInput = {
 
 export type PaintingGenerationResult = BackendPaintingGenerationResult;
 
-const PAINTING_GENERATE_JOB_TYPE = 'painting.generate';
-const ACTIVE_JOB_STATUSES = 'pending,running,delayed';
 const JOB_POLL_INTERVAL_MS = 1000;
 
 type PendingSettle = {
@@ -38,43 +45,68 @@ type PendingSettle = {
 /**
  * Drives painting generation through the job ledger: `startGeneration` enqueues
  * a `painting.generate` job that outlives this hook, and the terminal snapshot
- * is observed by polling `GET /jobs/:id`. On mount the hook adopts a still
- * active generation left behind by a previous visit, so navigating away and
- * back keeps showing (and eventually reveals) the in-flight result.
+ * is observed by polling `GET /jobs/:id`.
+ *
+ * `paintingId` binds the screen to one receipt: the hook adopts that receipt's
+ * running job (so returning to it keeps showing progress) and reports it as
+ * interrupted when nothing is running and no image ever landed. A composer
+ * opened without one is a blank canvas and adopts nothing, however many other
+ * generations happen to be in flight.
  */
 export function usePaintingGeneration({
   initialOutputs,
+  onReceipt,
+  paintingId,
 }: {
   initialOutputs: readonly PaintingOutput[];
+  /**
+   * Fires with the receipt this screen is now bound to (and with `undefined`
+   * when a cancel discards it), so the route can carry the id and survive a
+   * remount.
+   */
+  onReceipt?: (paintingId: string | undefined) => void;
+  paintingId?: string;
 }) {
   const paintings = useBackendModule('paintings');
+  const queryClient = useQueryClient();
   const syncPaintingQueries = useSyncPaintingQueries();
+  const deletePaintings = useDeletePaintings();
+  const jobs = usePaintingJobs();
   const [error, setError] = useState<Error | null>(null);
   const [outputs, setOutputs] = useState<PaintingOutput[]>(() => [...initialOutputs]);
   const [status, setStatus] = useState<PaintingGenerationStatus>('idle');
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
-  const [adoptionSettled, setAdoptionSettled] = useState(false);
   const pendingSettleRef = useRef<PendingSettle | null>(null);
+  // A job stays in the active list for up to one poll after its terminal row
+  // lands; without this the settle effect would re-adopt what it just settled
+  // and replay the reveal.
+  const [settledJobIds, setSettledJobIds] = useState<ReadonlySet<string>>(() => new Set());
+  const receiptIdRef = useRef<string | undefined>(paintingId);
 
-  // Adoption is a one-shot mount decision: a screen that was already open when
-  // another screen enqueued a job must not hijack it later.
-  const restoreQuery = useQuery('/jobs', {
-    enabled: !adoptionSettled && activeJobId === null,
-    query: { limit: 1, status: ACTIVE_JOB_STATUSES, type: PAINTING_GENERATE_JOB_TYPE },
-    staleTime: 0,
-  });
-  const restoredJob = restoreQuery.data?.[0];
-  const restoreSettled = restoreQuery.data !== undefined || restoreQuery.isError;
-  // Render-phase adjustment (not an effect): once the restore query settles,
-  // adopt at most once. The `adoptionSettled` guard makes the setState
+  const runningJob = paintingId === undefined ? undefined : jobs.activeByPaintingId.get(paintingId);
+  const adoptableJobId = runningJob && !settledJobIds.has(runningJob.id) ? runningJob.id : null;
+  // Render-phase adjustment (not an effect): the guard makes the setState
   // idempotent, so the extra render pass converges immediately.
-  if (!adoptionSettled && activeJobId === null && restoreSettled) {
-    setAdoptionSettled(true);
-    if (restoredJob && !isTerminalStatus(restoredJob.status)) {
-      setActiveJobId(restoredJob.id);
-      setStatus('generating');
-    }
+  if (activeJobId === null && adoptableJobId !== null) {
+    setActiveJobId(adoptableJobId);
+    setStatus('generating');
   }
+
+  // Purely derived: a bound receipt with nothing running and nothing to show
+  // is one whose generation never landed. `jobs.isLoading` matters — before the
+  // active list arrives every in-flight painting would read as interrupted.
+  const isInterrupted =
+    paintingId !== undefined &&
+    !jobs.isLoading &&
+    !runningJob &&
+    activeJobId === null &&
+    status === 'idle' &&
+    outputs.length === 0;
+  const interruptedJob = paintingId ? jobs.interruptedByPaintingId.get(paintingId) : undefined;
+  const interruption: PaintingInterruption | null = useMemo(
+    () => (isInterrupted ? { message: paintingJobFailureMessage(interruptedJob) } : null),
+    [interruptedJob, isInterrupted],
+  );
 
   const jobQuery = useQuery('/jobs/:id', {
     enabled: activeJobId !== null,
@@ -96,6 +128,7 @@ export function usePaintingGeneration({
     }
     const settle = pendingSettleRef.current;
     pendingSettleRef.current = null;
+    setSettledJobIds((current) => new Set(current).add(job.id));
     setActiveJobId(null);
     if (job.status === 'completed') {
       const result = job.output as PaintingGenerationResult;
@@ -123,10 +156,9 @@ export function usePaintingGeneration({
       }
       setError(null);
       setStatus('generating');
-      setAdoptionSettled(true);
 
       try {
-        const { jobId } = await paintings.startGeneration({
+        const started = await paintings.startGeneration({
           images: input.attachments.flatMap((attachment) =>
             attachment.kind === 'image'
               ? [
@@ -142,12 +174,21 @@ export function usePaintingGeneration({
           ),
           mode: input.mode,
           modelId: input.modelId,
+          // Retrying reuses the interrupted receipt so its gallery tile flips in
+          // place; a receipt that already holds images is never passed here, and
+          // the backend rejects it if one ever is.
+          ...(interruption ? { paintingId } : {}),
           paramValues: input.paramValues,
           prompt: input.prompt,
         });
+        receiptIdRef.current = started.paintingId;
+        onReceipt?.(started.paintingId);
+        // The gallery's active-job poll stops once nothing is running, so a
+        // fresh enqueue has to wake it explicitly.
+        void queryClient.invalidateQueries({ queryKey: queryKeys.jobs.all() });
         return await new Promise<PaintingGenerationResult>((resolve, reject) => {
           pendingSettleRef.current = { reject, resolve };
-          setActiveJobId(jobId);
+          setActiveJobId(started.jobId);
         });
       } catch (generationError) {
         const normalized =
@@ -157,15 +198,26 @@ export function usePaintingGeneration({
         throw normalized;
       }
     },
-    [activeJobId, paintings],
+    [activeJobId, interruption, onReceipt, paintingId, paintings, queryClient],
   );
 
   const cancel = useCallback(() => {
     if (activeJobId === null) {
       return;
     }
-    void paintings.cancelGeneration(activeJobId);
-  }, [activeJobId, paintings]);
+    const receiptId = receiptIdRef.current ?? paintingId;
+    void paintings.cancelGeneration(activeJobId).then(async () => {
+      // Stopping on purpose is not the same as being interrupted: leaving the
+      // receipt behind would put an "interrupted, tap to retry" tile in the
+      // gallery for something the user just said they did not want.
+      if (receiptId === undefined) {
+        return;
+      }
+      receiptIdRef.current = undefined;
+      onReceipt?.(undefined);
+      await deletePaintings([receiptId]);
+    });
+  }, [activeJobId, deletePaintings, onReceipt, paintingId, paintings]);
   const finishReveal = useCallback(() => setStatus('idle'), []);
 
   return {
@@ -173,6 +225,7 @@ export function usePaintingGeneration({
     error,
     finishReveal,
     generate,
+    interruption,
     outputs,
     status,
   };

--- a/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
+++ b/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
@@ -1,9 +1,10 @@
 import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
+import { isTerminalStatus } from '@cherrystudio/universal/data/api/schemas/jobs';
 import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ComposerAttachmentDraft } from '@/frontend/components/composer/utils/composerAttachments';
-import { useBackendModule } from '@/frontend/data';
+import { useBackendModule, useQuery } from '@/frontend/data';
 import type {
   PaintingGenerationResult as BackendPaintingGenerationResult,
   PaintingGenerationOutput,
@@ -25,6 +26,22 @@ export type PaintingGenerationInput = {
 
 export type PaintingGenerationResult = BackendPaintingGenerationResult;
 
+const PAINTING_GENERATE_JOB_TYPE = 'painting.generate';
+const ACTIVE_JOB_STATUSES = 'pending,running,delayed';
+const JOB_POLL_INTERVAL_MS = 1000;
+
+type PendingSettle = {
+  reject: (error: Error) => void;
+  resolve: (result: PaintingGenerationResult) => void;
+};
+
+/**
+ * Drives painting generation through the job ledger: `startGeneration` enqueues
+ * a `painting.generate` job that outlives this hook, and the terminal snapshot
+ * is observed by polling `GET /jobs/:id`. On mount the hook adopts a still
+ * active generation left behind by a previous visit, so navigating away and
+ * back keeps showing (and eventually reveals) the in-flight result.
+ */
 export function usePaintingGeneration({
   initialOutputs,
 }: {
@@ -32,27 +49,85 @@ export function usePaintingGeneration({
 }) {
   const paintings = useBackendModule('paintings');
   const syncPaintingQueries = useSyncPaintingQueries();
-  const [session] = useState(() => paintings.createGenerationSession());
   const [error, setError] = useState<Error | null>(null);
   const [outputs, setOutputs] = useState<PaintingOutput[]>(() => [...initialOutputs]);
   const [status, setStatus] = useState<PaintingGenerationStatus>('idle');
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [adoptionSettled, setAdoptionSettled] = useState(false);
+  const pendingSettleRef = useRef<PendingSettle | null>(null);
 
-  useEffect(() => () => session.dispose(), [session]);
+  // Adoption is a one-shot mount decision: a screen that was already open when
+  // another screen enqueued a job must not hijack it later.
+  const restoreQuery = useQuery('/jobs', {
+    enabled: !adoptionSettled && activeJobId === null,
+    query: { limit: 1, status: ACTIVE_JOB_STATUSES, type: PAINTING_GENERATE_JOB_TYPE },
+    staleTime: 0,
+  });
+  const restoredJob = restoreQuery.data?.[0];
+  const restoreSettled = restoreQuery.data !== undefined || restoreQuery.isError;
+  // Render-phase adjustment (not an effect): once the restore query settles,
+  // adopt at most once. The `adoptionSettled` guard makes the setState
+  // idempotent, so the extra render pass converges immediately.
+  if (!adoptionSettled && activeJobId === null && restoreSettled) {
+    setAdoptionSettled(true);
+    if (restoredJob && !isTerminalStatus(restoredJob.status)) {
+      setActiveJobId(restoredJob.id);
+      setStatus('generating');
+    }
+  }
+
+  const jobQuery = useQuery('/jobs/:id', {
+    enabled: activeJobId !== null,
+    params: { id: activeJobId ?? '' },
+    refetchInterval: (job) => (job && isTerminalStatus(job.status) ? false : JOB_POLL_INTERVAL_MS),
+    staleTime: 0,
+  });
+
+  const job = jobQuery.data;
+  // This subscribes to an external store (the job ledger, via the poll query)
+  // rather than deriving a value: the terminal snapshot must settle the
+  // in-flight `generate` promise exactly once — a side effect that cannot run
+  // during render — and the state collapse must happen in the same step, since
+  // clearing `activeJobId` disables the query that carries the snapshot.
+  /* eslint-disable react-hooks/set-state-in-effect -- see above */
+  useEffect(() => {
+    if (!job || job.id !== activeJobId || !isTerminalStatus(job.status)) {
+      return;
+    }
+    const settle = pendingSettleRef.current;
+    pendingSettleRef.current = null;
+    setActiveJobId(null);
+    if (job.status === 'completed') {
+      const result = job.output as PaintingGenerationResult;
+      setOutputs(result.outputs);
+      setStatus('revealing');
+      void syncPaintingQueries(result.painting);
+      settle?.resolve(result);
+      return;
+    }
+    const failure = new Error(job.error?.message ?? 'Painting generation failed');
+    setStatus('idle');
+    if (settle) {
+      // `generate`'s catch records the error for its caller's throw path.
+      settle.reject(failure);
+    } else {
+      setError(failure);
+    }
+  }, [activeJobId, job, syncPaintingQueries]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const generate = useCallback(
-    async ({
-      attachments,
-      mode,
-      modelId,
-      paramValues,
-      prompt,
-    }: PaintingGenerationInput): Promise<PaintingGenerationResult> => {
+    async (input: PaintingGenerationInput): Promise<PaintingGenerationResult> => {
+      if (pendingSettleRef.current || activeJobId !== null) {
+        throw new Error('Painting generation is already in progress');
+      }
       setError(null);
       setStatus('generating');
+      setAdoptionSettled(true);
 
       try {
-        const result = await session.generate({
-          images: attachments.flatMap((attachment) =>
+        const { jobId } = await paintings.startGeneration({
+          images: input.attachments.flatMap((attachment) =>
             attachment.kind === 'image'
               ? [
                   {
@@ -65,15 +140,15 @@ export function usePaintingGeneration({
                 ]
               : [],
           ),
-          mode,
-          modelId,
-          paramValues,
-          prompt,
+          mode: input.mode,
+          modelId: input.modelId,
+          paramValues: input.paramValues,
+          prompt: input.prompt,
         });
-        setOutputs(result.outputs);
-        setStatus('revealing');
-        await syncPaintingQueries(result.painting);
-        return result;
+        return await new Promise<PaintingGenerationResult>((resolve, reject) => {
+          pendingSettleRef.current = { reject, resolve };
+          setActiveJobId(jobId);
+        });
       } catch (generationError) {
         const normalized =
           generationError instanceof Error ? generationError : new Error(String(generationError));
@@ -82,10 +157,15 @@ export function usePaintingGeneration({
         throw normalized;
       }
     },
-    [session, syncPaintingQueries],
+    [activeJobId, paintings],
   );
 
-  const cancel = useCallback(() => session.cancel(), [session]);
+  const cancel = useCallback(() => {
+    if (activeJobId === null) {
+      return;
+    }
+    void paintings.cancelGeneration(activeJobId);
+  }, [activeJobId, paintings]);
   const finishReveal = useCallback(() => setStatus('idle'), []);
 
   return {

--- a/src/frontend/features/paintings/hooks/usePaintingJobs.ts
+++ b/src/frontend/features/paintings/hooks/usePaintingJobs.ts
@@ -1,0 +1,117 @@
+import type { ParamValues } from '@cherrystudio/provider-registry';
+import type { JobSnapshot } from '@cherrystudio/universal/data/api/schemas/jobs';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { queryKeys, useQuery } from '@/frontend/data';
+
+export const PAINTING_GENERATE_JOB_TYPE = 'painting.generate';
+
+const ACTIVE_JOB_STATUSES = 'pending,running,delayed';
+const INTERRUPTED_JOB_STATUSES = 'failed,cancelled';
+const JOB_POLL_INTERVAL_MS = 1000;
+/**
+ * Only the newest job per painting is ever read, so this bounds the fan-in
+ * rather than the coverage — a painting whose last failure fell off the end has
+ * long since been buried under a hundred newer generations.
+ */
+const INTERRUPTED_JOB_LIMIT = 100;
+
+export type PaintingJobs = {
+  /** Newest still-running job per painting; a painting listed here is generating. */
+  activeByPaintingId: ReadonlyMap<string, JobSnapshot>;
+  isLoading: boolean;
+  /**
+   * Newest non-completed job per painting, used for the interruption copy and
+   * for restoring the params a retry should start from. A painting missing from
+   * both maps was interrupted so long ago that job GC already collected it.
+   */
+  interruptedByPaintingId: ReadonlyMap<string, JobSnapshot>;
+};
+
+/**
+ * The gallery's live view of `painting.generate`. An output-less painting is
+ * "generating" when it appears in {@link PaintingJobs.activeByPaintingId} and
+ * "interrupted" otherwise — deriving the interrupted state from the absence of
+ * an active job (rather than from a terminal row) keeps it correct even after
+ * job GC drops the row that explains why.
+ *
+ * Polling only runs while something is actually in flight; the list is woken
+ * back up by {@link queryKeys.jobs} invalidation when a generation is enqueued.
+ */
+export function usePaintingJobs(): PaintingJobs {
+  const queryClient = useQueryClient();
+  const activeQuery = useQuery('/jobs', {
+    query: { status: ACTIVE_JOB_STATUSES, type: PAINTING_GENERATE_JOB_TYPE },
+    refetchInterval: (jobs) => (jobs && jobs.length > 0 ? JOB_POLL_INTERVAL_MS : false),
+    staleTime: 0,
+  });
+  const interruptedQuery = useQuery('/jobs', {
+    query: {
+      limit: INTERRUPTED_JOB_LIMIT,
+      status: INTERRUPTED_JOB_STATUSES,
+      type: PAINTING_GENERATE_JOB_TYPE,
+    },
+    staleTime: 0,
+  });
+
+  const activeJobs = activeQuery.data;
+  const activeByPaintingId = useMemo(() => indexByPaintingId(activeJobs), [activeJobs]);
+  const interruptedByPaintingId = useMemo(
+    () => indexByPaintingId(interruptedQuery.data),
+    [interruptedQuery.data],
+  );
+
+  // A job leaving the active set is the only signal the gallery gets that a
+  // generation landed — nothing else invalidates `/paintings` while the user
+  // sits on the list, so without this the finished image never appears.
+  const previousActiveIds = useRef<ReadonlySet<string>>(new Set());
+  useEffect(() => {
+    if (!activeJobs) {
+      return;
+    }
+    const currentIds = new Set(activeJobs.map((job) => job.id));
+    const settled = [...previousActiveIds.current].some((id) => !currentIds.has(id));
+    previousActiveIds.current = currentIds;
+    if (!settled) {
+      return;
+    }
+    void queryClient.invalidateQueries({ queryKey: queryKeys.paintings.all() });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.jobs.all() });
+  }, [activeJobs, queryClient]);
+
+  return {
+    activeByPaintingId,
+    isLoading: activeQuery.isLoading || interruptedQuery.isLoading,
+    interruptedByPaintingId,
+  };
+}
+
+/**
+ * Provider text worth putting in front of the user. A cancelled job carries an
+ * internal English string (`Cancelled by startup recovery`, `Cancelled by
+ * user`) that never went through i18n, so only genuine failures speak for
+ * themselves; the caller supplies its own copy for the rest.
+ */
+export function paintingJobFailureMessage(job: JobSnapshot | undefined): string | undefined {
+  return job?.status === 'failed' ? job.error?.message : undefined;
+}
+
+export function paintingJobParamValues(job: JobSnapshot | undefined): ParamValues | undefined {
+  const paramValues = (job?.input as { paramValues?: unknown } | null)?.paramValues;
+  return paramValues && typeof paramValues === 'object' ? (paramValues as ParamValues) : undefined;
+}
+
+/** `list` orders by `createdAt` descending, so the first hit per painting is the newest. */
+function indexByPaintingId(
+  jobs: readonly JobSnapshot[] | undefined,
+): ReadonlyMap<string, JobSnapshot> {
+  const byPaintingId = new Map<string, JobSnapshot>();
+  for (const job of jobs ?? []) {
+    const paintingId = (job.input as { paintingId?: unknown } | null)?.paintingId;
+    if (typeof paintingId === 'string' && !byPaintingId.has(paintingId)) {
+      byPaintingId.set(paintingId, job);
+    }
+  }
+  return byPaintingId;
+}

--- a/src/frontend/features/paintings/hooks/usePaintings.ts
+++ b/src/frontend/features/paintings/hooks/usePaintings.ts
@@ -26,16 +26,41 @@ import {
 } from '@/frontend/data/utils/optimisticQueryUpdate';
 import { imageMediaTypeFromExtension } from '@/shared/utils/imageFileTypes';
 
+import { imageParamsAspectRatio } from '../utils/imageGenerationParams';
+import {
+  paintingJobFailureMessage,
+  paintingJobParamValues,
+  usePaintingJobs,
+} from './usePaintingJobs';
+
 const pageSize = 20;
 type PaintingListData = InfiniteData<CursorPaginationResponse<Painting>, string | undefined>;
 
-export type PaintingGalleryItem = {
+export type PaintingOutputGalleryItem = {
   aspectRatio: number;
   fileEntryId: FileEntryId;
   key: string;
+  kind: 'output';
   painting: Painting;
   uri: string;
 };
+
+/**
+ * A receipt with no images yet: either `painting.generate` is still running or
+ * it stopped without producing any. Both keep the painting's place in the
+ * gallery — the tile is the only way back to a running generation and the only
+ * handle on an abandoned one.
+ */
+export type PaintingPendingGalleryItem = {
+  aspectRatio: number;
+  key: string;
+  kind: 'generating' | 'interrupted';
+  /** Provider failure text; absent when there is nothing user-facing to say. */
+  message?: string;
+  painting: Painting;
+};
+
+export type PaintingGalleryItem = PaintingOutputGalleryItem | PaintingPendingGalleryItem;
 
 export type ResolvedPaintingAttachment = ComposerAttachmentReady;
 
@@ -65,6 +90,8 @@ export function usePaintingIds({ enabled }: { enabled: boolean }) {
 
 export function useDeletePaintings() {
   const queryClient = useQueryClient();
+  const paintingsBackend = useBackendModule('paintings');
+  const { activeByPaintingId } = usePaintingJobs();
   const mutation = useMutation('DELETE', '/paintings', {
     onMutate: async (variables) => {
       const ids = new Set(variables?.query?.ids ?? []);
@@ -96,13 +123,21 @@ export function useDeletePaintings() {
         return;
       }
 
+      // Stop first: a generation that lands after its receipt is gone fails on
+      // the write and burns the provider call for images nobody can reach.
+      await Promise.all(
+        uniqueIds.flatMap((id) => {
+          const job = activeByPaintingId.get(id);
+          return job ? [paintingsBackend.cancelGeneration(job.id)] : [];
+        }),
+      );
       await deletePaintings({ query: { ids: uniqueIds } });
       for (const id of uniqueIds) {
         // Drop rather than invalidate: refetching a deleted painting would throw.
         queryClient.removeQueries({ queryKey: queryKeys.paintings.detail(id) });
       }
     },
-    [deletePaintings, queryClient],
+    [activeByPaintingId, deletePaintings, paintingsBackend, queryClient],
   );
 }
 
@@ -154,7 +189,7 @@ export function usePaintingGalleryItems(paintings: readonly Painting[]) {
     // regeneration) mints a fresh key. Keep the previous resolved items visible
     // until the new set resolves so the masonry never blinks to empty mid-scroll.
     placeholderData: keepPreviousData,
-    queryFn: async (): Promise<PaintingGalleryItem[]> => {
+    queryFn: async (): Promise<PaintingOutputGalleryItem[]> => {
       const items = (
         await Promise.all(
           paintings.map(async (painting) => ({
@@ -171,29 +206,74 @@ export function usePaintingGalleryItems(paintings: readonly Painting[]) {
       );
       return await Promise.all(
         items.map(async ({ fileEntryId, painting, uri }) => {
+          const base = {
+            fileEntryId,
+            key: `${painting.id}:${fileEntryId}`,
+            kind: 'output' as const,
+            painting,
+            uri,
+          };
           try {
             const image = await ExpoImage.loadAsync(uri);
             return {
+              ...base,
               aspectRatio: image.width > 0 && image.height > 0 ? image.width / image.height : 1,
-              fileEntryId,
-              key: `${painting.id}:${fileEntryId}`,
-              painting,
-              uri,
             };
           } catch {
-            return {
-              aspectRatio: 1,
-              fileEntryId,
-              key: `${painting.id}:${fileEntryId}`,
-              painting,
-              uri,
-            };
+            return { ...base, aspectRatio: 1 };
           }
         }),
       );
     },
     queryKey: ['painting-gallery-files', ...paintings.map((painting) => painting.updatedAt)],
   });
+}
+
+/**
+ * The gallery in painting order, with an output-less receipt standing in for
+ * its own tile. Placeholders are merged here rather than inside
+ * {@link usePaintingGalleryItems} so that the once-per-second job poll never
+ * re-runs the image measuring pass behind it.
+ */
+export function usePaintingGalleryEntries(paintings: readonly Painting[]) {
+  const outputs = usePaintingGalleryItems(paintings);
+  const jobs = usePaintingJobs();
+  const outputItems = outputs.data;
+
+  const items = useMemo(() => {
+    const byPaintingId = new Map<string, PaintingOutputGalleryItem[]>();
+    for (const item of outputItems ?? []) {
+      const existing = byPaintingId.get(item.painting.id);
+      if (existing) {
+        existing.push(item);
+      } else {
+        byPaintingId.set(item.painting.id, [item]);
+      }
+    }
+
+    return paintings.flatMap((painting): PaintingGalleryItem[] => {
+      const resolved = byPaintingId.get(painting.id);
+      if (resolved && resolved.length > 0) {
+        return resolved;
+      }
+      const activeJob = jobs.activeByPaintingId.get(painting.id);
+      const interruptedJob = jobs.interruptedByPaintingId.get(painting.id);
+      return [
+        {
+          aspectRatio: imageParamsAspectRatio(paintingJobParamValues(activeJob ?? interruptedJob)),
+          // No file entry to key on, and exactly one placeholder per painting:
+          // a multi-image request still shows a single tile until its outputs
+          // land and the real count is known.
+          key: `${painting.id}:pending`,
+          kind: activeJob ? 'generating' : 'interrupted',
+          message: activeJob ? undefined : paintingJobFailureMessage(interruptedJob),
+          painting,
+        },
+      ];
+    });
+  }, [jobs.activeByPaintingId, jobs.interruptedByPaintingId, outputItems, paintings]);
+
+  return { isLoading: outputs.isLoading || jobs.isLoading, items };
 }
 
 export function useSyncPaintingQueries() {

--- a/src/frontend/features/paintings/utils/__tests__/imageGenerationParams.test.ts
+++ b/src/frontend/features/paintings/utils/__tests__/imageGenerationParams.test.ts
@@ -1,6 +1,7 @@
 import type { ImageGenerationSupport } from '@cherrystudio/provider-registry';
 
 import {
+  imageParamsAspectRatio,
   isImageParamDraftValid,
   prepareImageParamValues,
   reconcileImageParamDraft,
@@ -125,5 +126,23 @@ describe('image generation parameter drafts', () => {
       'Invalid custom image size',
     );
     expect(prepareImageParamValues({ seed: 4 }, undefined, undefined)).toEqual({});
+  });
+});
+
+describe('placeholder tile sizing', () => {
+  it('prefers an explicit ratio, then a pixel size, and squares off when neither is set', () => {
+    expect(imageParamsAspectRatio({ aspectRatio: '16:9' })).toBeCloseTo(16 / 9);
+    expect(imageParamsAspectRatio({ size: '1024x768' })).toBeCloseTo(4 / 3);
+    expect(imageParamsAspectRatio({ imageResolution: '512X1024' })).toBeCloseTo(0.5);
+    // Ratio wins: `size` may be the provider's own pixel spelling of it.
+    expect(imageParamsAspectRatio({ aspectRatio: '1:2', size: '1024x1024' })).toBeCloseTo(0.5);
+    expect(imageParamsAspectRatio(undefined)).toBe(1);
+    expect(imageParamsAspectRatio({})).toBe(1);
+  });
+
+  it('falls back to square rather than trusting junk from the ledger', () => {
+    expect(imageParamsAspectRatio({ aspectRatio: 'auto' })).toBe(1);
+    expect(imageParamsAspectRatio({ size: '0x1024' })).toBe(1);
+    expect(imageParamsAspectRatio({ size: '1024' })).toBe(1);
   });
 });

--- a/src/frontend/features/paintings/utils/imageGenerationParams.ts
+++ b/src/frontend/features/paintings/utils/imageGenerationParams.ts
@@ -42,6 +42,38 @@ export function resolveImageGenerationMode(
     : undefined;
 }
 
+/**
+ * Shape of the image a request will produce, read back from the params that
+ * asked for it. A placeholder tile has no image to measure, so this is the only
+ * way to size it before the generation lands — and every key here is optional
+ * in the registry, hence the square fallback.
+ */
+export function imageParamsAspectRatio(values: ParamValues | undefined): number {
+  const ratio = parseRatio(values?.aspectRatio);
+  if (ratio !== undefined) {
+    return ratio;
+  }
+  const size = parseSize(values?.size) ?? parseSize(values?.imageResolution);
+  return size ?? 1;
+}
+
+function parseRatio(value: unknown): number | undefined {
+  return typeof value === 'string' ? toRatio(value.split(':')) : undefined;
+}
+
+function parseSize(value: unknown): number | undefined {
+  return typeof value === 'string' ? toRatio(value.toLowerCase().split('x')) : undefined;
+}
+
+function toRatio(parts: string[]): number | undefined {
+  if (parts.length !== 2) {
+    return undefined;
+  }
+  const width = Number(parts[0]);
+  const height = Number(parts[1]);
+  return width > 0 && height > 0 ? width / height : undefined;
+}
+
 export function getImageParamFields(
   resolvedMode: ResolvedImageGenerationMode | undefined,
 ): ImageParamField[] {

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -706,6 +706,8 @@
   "painting.selection.deleteTitle": "Delete selected drawings?",
   "painting.status.failed": "Generation failed. Try again.",
   "painting.status.generating": "Generating image",
+  "painting.status.interrupted": "Interrupted",
+  "painting.status.interruptedHint": "The last generation did not finish. Try again.",
   "painting.status.revealing": "Revealing image",
   "painting.templates.close": "Close template details",
   "painting.templates.item": "Open {{title}} template",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -705,6 +705,8 @@
   "painting.selection.deleteTitle": "删除所选绘图？",
   "painting.status.failed": "生成失败，请重试",
   "painting.status.generating": "正在生成图片",
+  "painting.status.interrupted": "已中断",
+  "painting.status.interruptedHint": "上次生成未完成，可以重新生成",
   "painting.status.revealing": "正在显示图片",
   "painting.templates.close": "关闭模板详情",
   "painting.templates.item": "打开 {{title}} 模板",

--- a/src/shared/contracts/paintings.ts
+++ b/src/shared/contracts/paintings.ts
@@ -36,13 +36,18 @@ export type ResolvedPaintingFiles = {
   outputs: ResolvedFile[];
 };
 
-export interface PaintingGenerationSession {
-  cancel(): void;
-  dispose(): void;
-  generate(input: PaintingGenerationInput): Promise<PaintingGenerationResult>;
-}
+export type PaintingGenerationStart = {
+  jobId: string;
+};
 
 export interface PaintingsModule {
-  createGenerationSession(): PaintingGenerationSession;
+  cancelGeneration(jobId: string): Promise<void>;
   resolveFiles(painting: Painting): Promise<ResolvedPaintingFiles>;
+  /**
+   * Creates the painting receipt and enqueues a `painting.generate` job
+   * atomically. The generation outlives the calling screen; observe the job's
+   * ledger row (`GET /jobs/:id`) for progress and the terminal
+   * {@link PaintingGenerationResult} in its output.
+   */
+  startGeneration(input: PaintingGenerationInput): Promise<PaintingGenerationStart>;
 }

--- a/src/shared/contracts/paintings.ts
+++ b/src/shared/contracts/paintings.ts
@@ -17,6 +17,12 @@ export type PaintingGenerationInput = {
   images: readonly PaintingSourceImage[];
   mode: ImageGenerationMode;
   modelId: UniqueModelId;
+  /**
+   * Retry an interrupted receipt in place rather than minting a new one. The
+   * receipt must have no outputs — passing a finished painting is rejected,
+   * since reusing it would delete the images it already holds.
+   */
+  paintingId?: string;
   paramValues: ParamValues;
   prompt: string;
 };
@@ -38,6 +44,12 @@ export type ResolvedPaintingFiles = {
 
 export type PaintingGenerationStart = {
   jobId: string;
+  /**
+   * The receipt this job writes into — the caller has no other way to learn it
+   * for a fresh generation, and it is what makes the screen restorable (the
+   * job is found again by painting, not by the id it happened to be handed).
+   */
+  paintingId: string;
 };
 
 export interface PaintingsModule {


### PR DESCRIPTION
Moves painting generation onto JobRuntime so requests survive navigation and cold-start recovery, with idempotent enqueueing and receipt-aware retries.

Shows generating/interrupted receipts in the gallery, supports retry/cancel/delete lifecycle, and keeps the composer bound only to its own job.

Adds Kolors URL-result support and fixes fixed-range params, 3:4 skeleton/output stability, generated attachment leakage, and composer height/edit-attachment remount issues.

Validation: `pnpm typecheck`, `pnpm lint` (0 errors), 361 Jest suites / 2946 tests, plus iPhone 17 Pro agent-device checks with CherryIN Kolors.