### PR TITLE
feat(lifecycle): adopt the desktop lifecycle framework (stage A)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,10 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
+      // Must precede class-property transforms. Legacy mode matches the desktop
+      // lifecycle decorators, which pass every argument explicitly and therefore
+      // need neither the 2023-11 proposal nor emitDecoratorMetadata.
+      ['@babel/plugin-proposal-decorators', { version: 'legacy' }],
       './babel-plugins/lucide-png-deep-import',
       ['inline-import', { extensions: ['.sql'] }],
       [

--- a/docs/references/architecture-overview.md
+++ b/docs/references/architecture-overview.md
@@ -74,6 +74,7 @@ compatibility adapter or generic frontend selector for persistence services.
 - [Universal Package](./universal-package.md): `@cherrystudio/universal` scope, admission criteria, aliasing, and desktop sync.
 - [Storage Engine](./data/storage-engine.md): current SQLite constraints and migration criteria.
 - [Runtime Ownership](./runtime-ownership.md): app bootstrap, runtimes, sessions, cleanup, and startup gates.
+- [Lifecycle](./lifecycle/README.md): service container, hosts, phases, and resource-scope coordination (designed; landing in stages).
 - [AI Provider Integration](./ai/provider-integration.md): provider/model records and AI adapters.
 - [Chat Streaming And Rendering](./chat/streaming-and-rendering.md): `ChatRuntime`, overlay, and persistence.
 - [Web Search](./web-search.md): external providers versus provider-native web search.

--- a/docs/references/lifecycle/README.md
+++ b/docs/references/lifecycle/README.md
@@ -1,0 +1,78 @@
+# Lifecycle
+
+> Status: Design complete, not yet wired. Stage A ships the framework only; no existing module is
+> migrated by it.
+> Desktop source: `CherryHQ/cherry-studio@12498d68` — `src/main/core/lifecycle/`,
+> `src/main/core/application/`, `docs/references/lifecycle/`
+> Supersedes: the "no service registry, no lifecycle framework" stance previously recorded in
+> [runtime-ownership.md](../runtime-ownership.md), `src/bootstrap/README.md`, and
+> `src/bootstrap/composition/README.md`. Those documents are rewritten in Stage B.
+
+Mobile adopts Desktop's lifecycle framework rather than a mobile-specific invention. Business code
+reads identically on both platforms — `application.get('DbService')`, `@Injectable('ChatRuntime')`,
+`@DependsOn([...])` — and the framework diverges only where a mobile runtime physically differs
+from an Electron main process.
+
+Two subsystems have no desktop counterpart and are designed here for the first time:
+`ApplicationHost` (swappable service generations, for tests and Fast Refresh) and
+`ResourceScopeCoordinator` (deleting a domain resource terminates the work running under it).
+Desktop lacks the second one too — its topic deletion does not abort live streams — so it is a gap
+fill on both platforms, not a port.
+
+## Documents
+
+| Document | Contents |
+| --- | --- |
+| [lifecycle-overview.md](./lifecycle-overview.md) | Framework interfaces, phases, service states, startup/shutdown sequences, failure and timeout semantics, `application.get()` rules |
+| [resource-scope.md](./resource-scope.md) | `ResourceScopeCoordinator`, the five-step deletion sequence, the four-legged correctness model for process kills, and Chat/Job/Activity integration |
+| [lifecycle-migration.md](./lifecycle-migration.md) | Stage A→B→D→C commit plan, lint and ownership rules, testing requirements, acceptance walkthroughs |
+
+## Admission: does a module belong in lifecycle?
+
+Lifecycle manages **resources**, not logic. A class named `*Service` does not qualify by virtue of
+its name.
+
+Register a module as a lifecycle service when it owns at least one of:
+
+| Category | Mobile examples |
+| --- | --- |
+| A connection or handle outliving one call | SQLite (`DbService`), MCP clients, OAuth sessions |
+| A timer or scheduled loop | job delayed-promotion timer, cache rotation |
+| A subscription or listener | `AppState` subscribers, preference change subscriptions |
+| A native surface | Live Activity presenters, the keep-alive audio session |
+| In-memory runtime state that must be released | active chat turns, in-flight job executions, API-key rotation state |
+| Work that continues after the caller returns | chat turns, job executions, OAuth flows |
+
+Do **not** register:
+
+| Case | Where it lives instead |
+| --- | --- |
+| CRUD data services (`TopicService`, `MessageService`, `PaintingService`, …) | Module singletons that resolve `application.get('DbService')` per call — same shape as desktop |
+| Pure functions and stateless transforms | Plain modules |
+| Resources released before the method returns | The method itself |
+| React state, navigation, React Query cache, toasts | Frontend owners; see [runtime-ownership.md](../runtime-ownership.md) |
+| Per-screen listeners and timers | The React component that created them |
+
+Stateful data services are the exception to the CRUD rule: `PreferenceService` (cache plus async
+init) and `providerRegistryService` (catalog cache) hold per-generation state and therefore register
+as services.
+
+## Divergence from desktop
+
+Every deviation is deliberate and load-bearing; the rationale for each lives in the linked section.
+
+| Desktop | Mobile | Reason |
+| --- | --- | --- |
+| `BeforeReady` / `Background` / `WhenReady` | `Gate` / `PostReady` | Desktop's three phases are defined relative to Electron `app.whenReady()`, which has no mobile equivalent. The real mobile boundary is the first-paint gate. See [phases](./lifecycle-overview.md#phases) |
+| `BaseService.ipcHandle` / `ipcOn` | Removed | No `ipcMain` in a React Native runtime |
+| `BaseService` WeakSet forbidding a second instantiation | Container-level "at most one live instance per host" | Each host generation must re-instantiate its services; the desktop guard assumes one instantiation per process. See [ApplicationHost](./lifecycle-overview.md#applicationhost) |
+| — | `BaseService.registerAppStateListener` | Mobile-only signal with no desktop analogue |
+| `@Conditional` + `getOptional()` dual track | Always register; select a no-op implementation | Mobile's platform differences are light (iOS-only surfaces), and no-op adapters already exist. Removes the get/getOptional split and transitive exclusion entirely. See [conditional capability](./lifecycle-overview.md#conditional-capability) |
+| 30s `process.exit(1)` shutdown fuse | Not ported | The OS owns process death on mobile; a JS-side force-exit buys nothing |
+| Topic deletion does not abort live streams | `ResourceScopeCoordinator` | A desktop gap, not a desktop feature. See [resource-scope.md](./resource-scope.md) |
+
+## Related
+
+- [runtime-ownership.md](../runtime-ownership.md) — ownership of long-lived resources and startup work
+- [job-manager-design.md](../job-manager-design.md) — the durable job ledger this design builds on
+- [architecture-overview.md](../architecture-overview.md) — the frontend/backend seam

--- a/docs/references/lifecycle/lifecycle-migration.md
+++ b/docs/references/lifecycle/lifecycle-migration.md
@@ -1,0 +1,174 @@
+# Lifecycle Migration
+
+> Status: Stage A in progress; B, D, C not started.
+> Interfaces: [lifecycle-overview.md](./lifecycle-overview.md) ·
+> [resource-scope.md](./resource-scope.md)
+
+## Stage order
+
+Skeleton first: the framework lands before the fix that motivated it.
+
+| Stage | Content | Why here |
+| --- | --- | --- |
+| **A** | Toolchain + `src/backend/core/lifecycle/` + `src/backend/core/application/` | Pure addition. Nothing is wired, so app behaviour cannot change |
+| **B** | Migrate the ~18 runtime modules to `@Injectable` classes; `AppBootstrapProvider` installs a host | The mechanical bulk. Behaviour-preserving, reviewable module by module |
+| **D** | `ResourceScopeCoordinator`, Chat/Job/Activity registration, Data API routing, write-path guard tests | The correctness fix. Needs B's services to register against |
+| **C** | CRUD services become module singletons; every test moves to a test host | Largest mechanical volume, lowest risk, and it blocks nothing |
+
+Stage D is the reason this work exists, but it is not first: the coordinator is registered like any
+other service, so building it before the container means writing its wiring twice. B before D also
+means D's integration points already exist as lifecycle services.
+
+## Where the code lives
+
+```text
+src/backend/core/lifecycle/     framework — depends only on shared
+  types.ts  decorators.ts  BaseService.ts  ServiceContainer.ts
+  DependencyResolver.ts  LifecycleManager.ts  event.ts  signal.ts
+src/backend/core/application/   orchestrator
+  Application.ts       the `application` constant and get()/install()
+  ApplicationHost.ts   one service generation
+  serviceRegistry.ts   the central `services` object
+```
+
+This mirrors desktop's `src/main/core/lifecycle/` and `src/main/core/application/`, and the location
+is forced rather than stylistic. CRUD data services in `src/backend/data/` must call
+`application.get('DbService')`, and the existing `backendLayer` eslint rule forbids
+`src/backend/**` from importing `@/bootstrap`. Putting the framework under `bootstrap` would make
+the very call pattern this design is built on a lint error.
+
+Two constraints follow:
+
+- **No barrel.** Import `@/backend/core/application/Application` directly, as desktop imports
+  `@application` straight at `Application.ts`. A barrel re-exporting `serviceRegistry` would pull
+  the whole service graph into every consumer and create an import cycle.
+- **`serviceRegistry.ts` is the one exception to the layer rule** — it imports concrete classes from
+  `backend/ai`, `backend/services`, and `backend/data` because registration *is* assembly. It gets a
+  file-scoped eslint exemption. `Application.ts` reaches the `ServiceRegistry` type through
+  `import type`, which erases at compile time and therefore creates no runtime cycle.
+
+## Lint and ownership rules
+
+| Rule | Mechanism | Status |
+| --- | --- | --- |
+| Frontend may not call `application.get()` | Existing `frontendLayer` already bans `@/backend/*` from `src/frontend/**` | Free — no new rule |
+| `backend/core` may not import `backend/ai`, `backend/services`, `backend/data` | New `backendCoreLayer` pattern | Stage A |
+| `serviceRegistry.ts` exempt from the above | File-scoped block | Stage A |
+| Undeclared dependency resolved during init | Container warns in dev/test | Stage A |
+| Service classes are never exported as instances | Review; the registry only holds constructors | Stage B |
+
+Three README files assert the opposite of this design and are rewritten in Stage B:
+`src/bootstrap/README.md` ("Do not introduce service locators, lifecycle phase registries"),
+`src/bootstrap/composition/README.md` ("must not introduce a general registry, service locator, or
+lifecycle framework"), and the principles section of
+[runtime-ownership.md](../runtime-ownership.md) ("Mobile does not port the desktop lifecycle
+framework, service registry, or phase graph"). Leaving them in place would leave the repository
+contradicting itself.
+
+## Stage A commits
+
+1. **Toolchain** — add `reflect-metadata` and `@babel/plugin-proposal-decorators` (legacy), enable
+   `experimentalDecorators`, import `reflect-metadata` once from preboot. Verify a decorator
+   compiles under both Metro and jest-expo before anything depends on it.
+2. **Primitives** — `event.ts` (`Disposable`, `Emitter`, `toDisposable`), `signal.ts`, `types.ts`
+   (`Phase`, `LifecycleState`, `TeardownOutcome`, `ServiceMetadata`, `Pausable`, `Activatable`).
+3. **Decorators** — `@Injectable`, `@DependsOn`, `@Priority`, `@ServicePhase`, `@ErrorHandling`,
+   `@AppStatePolicy`, plus their metadata readers.
+4. **BaseService** — desktop's, minus IPC sugar and the WeakSet guard, plus
+   `registerAppStateListener`.
+5. **DependencyResolver** — topological sort, cycle detection, layered parallelism, priority
+   ordering within a layer.
+6. **ServiceContainer** — registration, lazy singleton creation, constructor injection, one live
+   instance per host, dev-mode undeclared-dependency warning.
+7. **LifecycleManager** — phase startup, `stopAll`/`destroyAll` in reverse order, the 5s per-service
+   ceiling, `TeardownSummary`.
+8. **Application + ApplicationHost** — `get()`, serialized `install()`/`uninstall()`, two-stage
+   host construction, `HostProfile` overrides.
+9. **Lint + docs** — `backendCoreLayer`, the registry exemption, and this document's status line.
+
+Every commit carries its own tests. Stage A ships an empty `services` object: the framework is
+present and tested, no module is registered, and the app's runtime graph is untouched.
+
+## Stage B outline
+
+Migrate in dependency order so each commit leaves a working app: `CacheService` → `DbService` →
+`PreferenceService` → `KeepAliveCoordinator` → `BackgroundActivityManager` → `WebSearchService` →
+`McpRuntimeService` → OAuth services → `ChatRuntime` → `JobRuntime` → feature modules.
+
+Per module: extend `BaseService`, add decorators, move `initialize`-style work into `onInit`, move
+`dispose()` into `onStop`/`onDestroy`, replace hand-rolled `AppState` subscriptions with
+`registerAppStateListener`, and delete the module's construction from `createBackend.ts`.
+
+Closing commits: `AppBootstrapProvider` builds and installs an `ApplicationHost` instead of calling
+`createAppBootstrapRuntime()`; factory-shaped modules (`createJobRuntime`, `createMcpModule`, …)
+become classes; `JobRuntime`'s `liveRuntimesByDb` WeakMap is removed in favour of the container
+guard; `providerRegistryService` stops being a module-level escape and registers as a service.
+
+## Stage D outline
+
+1. `ResourceScopeCoordinator` with unit tests (fencing, multi-scope dedup, drain timeout,
+   registration during fence, idempotent release).
+2. `ChatRuntime` registers turns under their topic scope.
+3. The painting job handler registers executions under their painting scope.
+4. Data API topic/message/assistant/painting handlers route destructive mutations through
+   `delete()` / `invalidate()`.
+5. Delete `onTopicsDeleted` and its plumbing through `createBackend.ts` and `apiHandlers.ts`.
+6. Write-path guard tests: late writes against a deleted topic and a deleted painting.
+
+## Stage C outline
+
+CRUD services drop constructor injection and resolve `application.get('DbService')` per call, and
+each exports a module singleton — matching desktop's `export const topicService = new TopicService()`.
+Their tests move to an installed test host backed by the existing in-memory SQLite harness. Batch by
+service family (topics/messages, paintings, providers/models, jobs, …) so each commit is reviewable.
+
+## Testing
+
+### Test host
+
+```typescript
+const host = await installTestHost({ DbService: createInMemoryDbService() })
+// afterEach
+await application.uninstall()
+```
+
+The existing harness in `src/backend/data/serviceTestDatabase.ts` — `node:sqlite` `:memory:` plus
+real migrations plus a duck-typed `DbService` that reproduces the `writeTail` serialization —
+becomes the standard `DbService` override rather than a per-test construction argument. A test that
+forgets to install a host gets a loud throw from `get()`, not a silent stale instance.
+
+### Required coverage
+
+Framework: dependency ordering and layered parallelism, cycle detection, `Gate` fail-fast vs
+`PostReady` graceful, teardown reverse order, per-service timeout producing `timed_out` rather than
+success, destroy skipped under an in-flight stop, serialized host replacement, `get()` throwing with
+no host and between generations, undeclared-dependency warning.
+
+Coordinator: repeated cancel and release, registration racing invalidation, batch scopes that
+overlap, late callbacks after release, a `cancel()` callback that throws, drain timeout leaving the
+scope unfenced and the mutation unrun, and disposal concurrent with a user cancel.
+
+## Acceptance walkthroughs
+
+The nine scenarios from the requirement note, resolved against the designed mechanism:
+
+| # | Scenario | Resolution |
+| --- | --- | --- |
+| 1 | Delete the message being generated | `invalidate([topic])` cancels the turn, awaits settle, then deletes. No late write, Activity, or lease |
+| 2 | Assistant cascade deletes several topics | One `delete()` call carrying every scope; overlapping operations cancelled once |
+| 3 | Painting deleted mid-generation through any Data API caller | Handler-level `delete()` cancels the job first — no dependency on a frontend hook |
+| 4 | Cleanup rejects or times out | `ScopeDrainTimeoutError` naming stragglers; mutation never runs; scope unfenced |
+| 5 | New operation starts during invalidation | `register()` throws `ScopeFencedError`; the operation never crosses the fence |
+| 6 | Host disposal races a user cancel | Both paths idempotent; `release()` and `cancel()` tolerate repetition; no double-finalize |
+| 7 | Foreground/background round trip | `AppState` drives no service transition; presentation and keep-alive change per owner policy |
+| 8 | Process killed, then cold start | Job ledger resumes, pending messages repaired, Live Activity orphans swept, write guards reject stale writes |
+| 9 | Android without iOS surfaces | No-op implementations resolve under the same keys; no registration leaks |
+
+Scenarios 1–5 are Stage D; 6–7 are Stage B; 8–9 hold today and gain the guard tests in Stage D.
+
+## Verification per stage
+
+Each commit: `pnpm typecheck`, the targeted `pnpm test:app -- <pattern>`, lint, format. Full
+`pnpm test:app` once before opening each PR. Stage A additionally requires a cold start on a
+simulator to confirm the untouched runtime graph still boots — the framework being inert is the
+claim, and only running the app proves it.

--- a/docs/references/lifecycle/lifecycle-migration.md
+++ b/docs/references/lifecycle/lifecycle-migration.md
@@ -1,6 +1,7 @@
 # Lifecycle Migration
 
-> Status: Stage A in progress; B, D, C not started.
+> Status: Stage A landed — the framework exists and is tested, and the `services` registry is
+> empty, so no module runs through it yet. B, D, and C are not started.
 > Interfaces: [lifecycle-overview.md](./lifecycle-overview.md) ·
 > [resource-scope.md](./resource-scope.md)
 
@@ -65,29 +66,32 @@ lifecycle framework"), and the principles section of
 framework, service registry, or phase graph"). Leaving them in place would leave the repository
 contradicting itself.
 
-## Stage A commits
+## Stage A contents (landed)
 
-1. **Toolchain** — add `reflect-metadata` and `@babel/plugin-proposal-decorators` (legacy), enable
-   `experimentalDecorators`, import `reflect-metadata` once from preboot. Verify a decorator
-   compiles under both Metro and jest-expo before anything depends on it.
-2. **Primitives** — `event.ts` (`Disposable`, `Emitter`, `toDisposable`), `signal.ts`, `types.ts`
-   (`Phase`, `LifecycleState`, `TeardownOutcome`, `ServiceMetadata`, `Pausable`, `Activatable`).
-3. **Decorators** — `@Injectable`, `@DependsOn`, `@Priority`, `@ServicePhase`, `@ErrorHandling`,
-   `@AppStatePolicy`, plus their metadata readers.
-4. **BaseService** — desktop's, minus IPC sugar and the WeakSet guard, plus
-   `registerAppStateListener`.
-5. **DependencyResolver** — topological sort, cycle detection, layered parallelism, priority
-   ordering within a layer.
-6. **ServiceContainer** — registration, lazy singleton creation, constructor injection, one live
-   instance per host, dev-mode undeclared-dependency warning.
-7. **LifecycleManager** — phase startup, `stopAll`/`destroyAll` in reverse order, the 5s per-service
-   ceiling, `TeardownSummary`.
-8. **Application + ApplicationHost** — `get()`, serialized `install()`/`uninstall()`, two-stage
-   host construction, `HostProfile` overrides.
-9. **Lint + docs** — `backendCoreLayer`, the registry exemption, and this document's status line.
+| Piece | What shipped |
+| --- | --- |
+| Toolchain | `reflect-metadata` plus `@babel/plugin-proposal-decorators`. The installed plugin is v8, which takes `version: 'legacy'` — v7's `legacy: true` fails to load. `reflect-metadata` is imported by `decorators.ts` itself rather than from preboot, so no global setup ordering is implied |
+| Primitives | `types.ts` (`Phase`, `LifecycleState`, `TeardownOutcome`, `ServiceMetadata`, `Pausable`, `Activatable`), `event.ts` (`Disposable`, `Emitter`, `toDisposable`) |
+| Decorators | `@Injectable`, `@DependsOn`, `@Priority`, `@ServicePhase`, `@ErrorHandling`, `@AppStatePolicy` and their readers. The error strategy defaults from the phase, so most services declare none |
+| BaseService | Desktop's, minus IPC sugar and the WeakSet guard, plus `registerAppStateListener` |
+| DependencyResolver | Layered topological sort, cycle detection, priority ordering, `hoistGateDependencies` |
+| ServiceContainer | Registration, lazy singletons, constructor injection, overrides, dev-mode undeclared-dependency warning |
+| LifecycleManager | Phase startup, `runAllReady`, reverse-order `stopAll`/`destroyAll`, the 5s ceiling, `TeardownSummary` |
+| Application + ApplicationHost | `get()`, serialized `install()`/`uninstall()`, two-stage construction, `HostProfile` overrides |
+| Lint | `backendCoreLayer` plus the `serviceRegistry.ts` exemption |
 
-Every commit carries its own tests. Stage A ships an empty `services` object: the framework is
-present and tested, no module is registered, and the app's runtime graph is untouched.
+`signal.ts` was not ported: nothing consumes a one-shot signal yet. It comes with the first service
+that needs one, most likely `ChatRuntime`'s reconciliation gate in Stage B.
+
+68 unit tests cover the framework. The `services` object is empty, so the app's runtime graph is
+untouched — confirmed by a simulator cold start that reaches the topic list exactly as before.
+
+The toolchain was proven end to end rather than by a green build alone. A temporary decorated class
+wired into the app entry compiled to Hermes bytecode in a production export, and on a simulator it
+read its own `@Injectable` name, `@DependsOn` list, and default phase back out of
+`reflect-metadata`. That last leg is worth doing once: `reflect-metadata` falls back to the
+`Function` constructor to find a global object, and Hermes rejects that constructor — the fallback
+is unreachable only because `globalThis` is checked first.
 
 ## Stage B outline
 
@@ -169,6 +173,5 @@ Scenarios 1–5 are Stage D; 6–7 are Stage B; 8–9 hold today and gain the gu
 ## Verification per stage
 
 Each commit: `pnpm typecheck`, the targeted `pnpm test:app -- <pattern>`, lint, format. Full
-`pnpm test:app` once before opening each PR. Stage A additionally requires a cold start on a
-simulator to confirm the untouched runtime graph still boots — the framework being inert is the
-claim, and only running the app proves it.
+`pnpm test:app` once before opening each PR. Stage A additionally required a simulator cold start —
+the framework being inert is the claim, and only running the app proves it.

--- a/docs/references/lifecycle/lifecycle-overview.md
+++ b/docs/references/lifecycle/lifecycle-overview.md
@@ -1,0 +1,335 @@
+# Lifecycle Overview
+
+> Status: Design complete, not yet wired.
+> Desktop source: `CherryHQ/cherry-studio@12498d68` — `src/main/core/lifecycle/`,
+> `src/main/core/application/`
+> Admission rules and the desktop divergence index live in [README.md](./README.md).
+
+## Architecture
+
+Four layers, mirroring desktop's split between `core/lifecycle` (the framework) and
+`core/application` (the orchestrator):
+
+```text
+application                 stable global reference; owns `get()` and host installation
+    │ holds one
+ApplicationHost             one generation of services: container + lifecycle manager
+    │ contains
+ServiceContainer            registration, conditional resolution, singleton instances
+LifecycleManager            phase ordering, dependency graph, teardown and its outcomes
+```
+
+`application` is a module-level constant that never changes identity. The `ApplicationHost` behind
+it is replaceable, which is what makes per-test service graphs and Fast Refresh possible. Production
+installs exactly one host and never replaces it.
+
+Code lives in `src/backend/core/lifecycle/` (framework) and `src/backend/core/application/`
+(orchestrator), mirroring desktop's `src/main/core/`. The location is forced, not stylistic: CRUD
+data services under `src/backend/data/` must resolve `DbService` through `application`, and the
+existing `backendLayer` lint rule forbids `src/backend/**` from importing `@/bootstrap`. See
+[where the code lives](./lifecycle-migration.md#where-the-code-lives) for the no-barrel rule and the
+one registry exemption that follow.
+
+## Phases
+
+```typescript
+export enum Phase {
+  /** Blocks first paint. Failures abort startup and surface the error screen. */
+  Gate = 'gate',
+  /** Runs after the gate opens. Fire-and-forget; failures are logged only. */
+  PostReady = 'postReady'
+}
+```
+
+Desktop's `BeforeReady` / `Background` / `WhenReady` are all defined relative to Electron
+`app.whenReady()`. Mobile has no such event; its only real boundary is the first-paint gate, so the
+enum carries mobile's boundary instead of a renamed Electron one. Within a phase, services are
+dependency-sorted and peers initialize in parallel — that layering algorithm is ported unchanged.
+
+`Gate` holds what a correct first render requires: `CacheService`, `DbService` (migration and
+seeding), `PreferenceService`. Boot theme and i18n remain app-level steps performed by
+`AppBootstrapProvider` after `host.start()` resolves — they are frontend concerns and do not become
+backend services.
+
+`PostReady` holds crash-orphan message repair, MCP prewarm, and the job runtime's cold-start pump.
+
+## Service states and hooks
+
+The state machine is ported verbatim:
+
+```text
+Created → Initializing → Ready ⇄ Paused
+               ↑           ↓
+               │        Stopping → Stopped → (restart) → Initializing
+               │                      ↓
+               └──────────────── Destroyed
+```
+
+| Hook | When |
+| --- | --- |
+| `onInit()` | Service is initializing; dependencies are already `Ready` |
+| `onReady()` | This service finished initializing |
+| `onAllReady()` | Every service in every phase finished; at most once per instance. Schedule work here, do not perform it — see [the PostReady rule](#the-onallready-rule) |
+| `onStop()` | Shutdown, reverse dependency order. Disposables are released afterwards |
+| `onDestroy()` | After all `onStop()` passes complete |
+| `onPause()` / `onResume()` | Optional `Pausable` capability. Not driven by `AppState`; reserved for database snapshot/restore |
+| `onActivate()` / `onDeactivate()` | Optional `Activatable` capability. Heavy resources behind a preference or feature gate |
+
+`Pausable` and `Activatable` stay type-guard capability interfaces rather than base-class members,
+as on desktop. Neither has a consumer in Stage A; `Activatable` is the intended home for the
+background-reply preference gate when that module migrates.
+
+## BaseService
+
+Ported from desktop with three changes, all forced by the runtime rather than chosen:
+
+```typescript
+export abstract class BaseService {
+  get state(): LifecycleState
+  get isReady(): boolean
+  get isDestroyed(): boolean
+  get isStopped(): boolean
+  get isActivated(): boolean
+
+  protected onInit(): Promise<void> | void
+  protected onReady(): Promise<void> | void
+  protected onAllReady(): Promise<void> | void
+  protected onStop(): Promise<void> | void
+  protected onDestroy(): Promise<void> | void
+
+  /** Auto-released after onStop/onDestroy. Accepts a Disposable or a cleanup function. */
+  protected registerDisposable<T extends Disposable>(disposable: T): T
+  protected registerDisposable(dispose: () => void): Disposable
+
+  /** Recurring timer scoped to this service; rejections are logged, the loop survives. */
+  protected registerInterval(callback: () => void | Promise<void>, intervalMs: number): Disposable
+
+  /** Mobile-only. Subscribes to AppState and releases the subscription on stop. */
+  protected registerAppStateListener(listener: (status: AppStateStatus) => void): Disposable
+}
+```
+
+| Desktop member | Mobile | Why |
+| --- | --- | --- |
+| `ipcHandle()` / `ipcOn()` | Removed | `ipcMain` does not exist here |
+| `private static instances = new WeakSet()` rejecting a second `new` | Removed; the container enforces one live instance **per host** | Every host generation re-instantiates its services. The desktop guard encodes "one instantiation per process", which is false for tests and Fast Refresh |
+| — | `registerAppStateListener()` | Five call sites currently hand-roll `AppState.addEventListener` plus `subscription.remove()`; the sugar removes the leak class |
+
+`registerInterval` drops desktop's `handle.unref()` — a Node-only API absent from Hermes. The timer
+is cleared by the same disposable path regardless.
+
+## Registration
+
+Two-part, exactly as on desktop: decorators carry metadata, a central object performs registration
+and derives the types.
+
+```typescript
+@Injectable('JobRuntime')
+@ServicePhase(Phase.Gate)
+@DependsOn(['DbService', 'KeepAliveCoordinator'])
+@AppStatePolicy('continue')
+export class JobRuntime extends BaseService {
+  constructor(private dbService: DbService, private keepAlive: KeepAliveCoordinator) { super() }
+
+  protected async onStop(): Promise<void> {
+    await this.drainInFlight({ timeoutMs: DISPOSE_DRAIN_TIMEOUT_MS })
+  }
+}
+```
+
+```typescript
+// src/bootstrap/application/serviceRegistry.ts
+export const services = {
+  CacheService, DbService, PreferenceService, ProviderRegistryService,
+  KeepAliveCoordinator, BackgroundActivityManager, ResourceScopeCoordinator,
+  ChatRuntime, JobRuntime, McpRuntimeService, WebSearchService, /* … */
+} as const
+
+export type ServiceRegistry = { [K in keyof typeof services]: InstanceType<(typeof services)[K]> }
+export const serviceList = Object.values(services) as ServiceConstructor[]
+```
+
+Adding a service is one import plus one line; `application.get()` key types follow automatically.
+The name passed to `@Injectable` must match its key here — bundlers mangle `class.name`, so the
+explicit string is mandatory, same as desktop.
+
+Decorators require `@babel/plugin-proposal-decorators` (legacy) and `reflect-metadata`. Desktop's
+decorators all take explicit arguments, so `emitDecoratorMetadata` and constructor type reflection
+are not needed.
+
+`@AppStatePolicy` is mobile-only and purely declarative — `'continue'`,
+`'background-presentation'`, or `'not-applicable'`. It drives no behaviour; it makes "what does this
+service do when the app backgrounds" auditable without reading each implementation.
+
+## Conditional capability
+
+Desktop excludes a service at registration when `@Conditional` fails, which forces every consumer
+onto `getOptional()` and forces the container to transitively exclude dependents. Mobile registers
+every service unconditionally and selects a no-op implementation instead:
+
+```typescript
+// Android and web resolve the same key; the instance simply does nothing.
+const lease = application.get('KeepAliveCoordinator').acquire('job.painting.generate')
+```
+
+Call sites carry no platform branches and no `?.`. `getOptional()`, the get/getOptional mutual
+exclusion, and transitive exclusion are all unported. The metadata slot for `@Conditional` stays
+reserved for a future heavyweight service that must not even be constructed.
+
+## `application.get()`
+
+```typescript
+class Application {
+  get<K extends keyof ServiceRegistry>(name: K): ServiceRegistry[K]
+  install(host: ApplicationHost): Promise<void>
+  uninstall(): Promise<TeardownSummary>
+  get hasHost(): boolean
+}
+
+export const application = new Application()
+```
+
+### Who may call it
+
+| Layer | Allowed | Mechanism |
+| --- | --- | --- |
+| `src/backend/**` | Yes | Direct |
+| `src/bootstrap/**` | Yes | Direct |
+| CRUD module singletons | Yes | Resolve `DbService` per call |
+| `src/frontend/**`, `src/app/**` | **No** | `useBackendModule()`, Data API hooks, preference hooks |
+
+The frontend ban is the mobile equivalent of desktop's renderer/IPC boundary, which enforces the
+same separation physically. It is enforced by an eslint layer rule, not convention — see
+[lifecycle-migration.md](./lifecycle-migration.md#lint-and-ownership-rules).
+
+### Timing semantics
+
+| Moment | Result |
+| --- | --- |
+| No host installed | Throws. This is what makes a module-scope `application.get()` fail loudly instead of capturing a stale instance |
+| Between `uninstall()` and the next `install()` | Throws |
+| During host startup | Resolves; services are created lazily, so a `Gate` service may resolve a dependency mid-startup |
+| During host disposal | Resolves, so `onStop()` can reach collaborators while tearing down |
+| A late callback after disposal completes | Resolves against the *current* host if one exists, otherwise throws |
+
+`get()` deliberately has no readiness gate — it never asks "is this service `Ready`?". That matches
+desktop, and correctness for late callbacks comes from scope fencing plus write-path guards
+(see [resource-scope.md](./resource-scope.md)), not from making every resolution defensive.
+
+### Undeclared dependencies
+
+Resolving a service that is not in `@DependsOn` is legal at **runtime** — desktop relies on it to
+break the `AiStreamManager` ↔ `AiService` cycle. It is a bug during **initialization**, because it
+silently escapes the ordering graph.
+
+The container therefore records resolutions made while a service's `onInit`/`onReady` is executing
+and warns when one was not declared. Dev and test only; zero production cost; a warning rather than
+an error because the runtime back-edge pattern is legitimate and only the init window is unsafe.
+
+## ApplicationHost
+
+A host is one generation of services. It exists because mobile must be able to swap an entire
+service graph inside a single process — production never does, but tests and Fast Refresh do.
+
+```typescript
+type HostProfile = {
+  readonly services: readonly ServiceConstructor[]
+  /** Test seam: pre-built instances that win over construction. */
+  readonly overrides?: Partial<ServiceRegistry>
+}
+
+class ApplicationHost {
+  constructor(profile: HostProfile)          // constructs nothing; claims nothing
+  start(): Promise<void>                     // runs the Gate phase
+  runPostReady(): void                       // fire-and-forget PostReady phase
+  dispose(): Promise<TeardownSummary>        // reverse-order stop, then destroy
+  readonly container: ServiceContainer
+  readonly state: HostState                  // 'created' | 'starting' | 'ready' | 'disposing' | 'disposed'
+}
+```
+
+### Two-stage construction
+
+Construction allocates no resource: no database is opened, no job is claimed, no audio session
+starts. Only `start()` does that. This formalizes a rule bootstrap already follows — composition
+builds, runtime starts — and it is what makes replacement safe.
+
+`application.install(host)` serializes generations internally: the previous host's `dispose()` is
+awaited to completion before the new host's `start()` begins. Two hosts therefore never hold the
+SQLite connection or a job claim at once, which is exactly the failure `JobRuntime`'s
+`liveRuntimesByDb` WeakMap was added to detect. That guard is removed once the container enforces
+one live instance per host.
+
+### Who installs a host
+
+| Context | Owner |
+| --- | --- |
+| Interactive app | `AppBootstrapProvider` — creates and installs on mount, uninstalls on unmount |
+| Tests | The test itself, via a helper that installs a host with an in-memory database and disposes it in `afterEach` |
+| Headless task | Type slot only. No mobile headless entry point exists today (no `TaskManager`/`registerTaskAsync` anywhere); the profile type keeps the design from foreclosing one |
+
+Fast Refresh remounts the provider, which disposes the old host and installs a new one. There is no
+dev-only host reuse cache — a rebuild costs a cold start in development and keeps one honest code
+path in production.
+
+## Startup sequence
+
+```text
+AppBootstrapProvider mount
+  └─ new ApplicationHost({ services: serviceList })        constructs, claims nothing
+  └─ application.install(host)
+       └─ host.start()                                     Gate phase
+            ├─ dependency-sort Gate services, layer them
+            ├─ per layer, in parallel: _doInit() → onInit() → Ready → onReady()
+            └─ any failure rejects: startup aborts, provider shows the error screen
+  └─ apply boot theme, initialize i18n                     app-level, still pre-gate
+  └─ status = ready → AppBootstrapGate renders children
+  └─ host.runPostReady()                                   fire-and-forget
+       ├─ _doAllReady() on every service, at most once each
+       └─ PostReady services initialize; failures are logged, never fatal
+```
+
+### The `onAllReady` rule
+
+`onAllReady` must **schedule**, not perform. Desktop's `JobManager` sets a 60s timer there and
+returns synchronously; performing long work inside the hook stalls the phase and collides with the
+teardown ceiling. Mobile keeps the same rule: register the timer via `registerInterval` or a
+disposable `setTimeout`, and join it in `onStop`.
+
+## Shutdown sequence
+
+```text
+application.uninstall()  (provider unmount, or install() of a replacement)
+  └─ host.dispose()
+       ├─ stopAll():    reverse initialization order, per service ceiling 5s
+       │                 onStop() → release disposables → Stopped
+       ├─ destroyAll(): reverse order again, same ceiling
+       └─ TeardownSummary { timedOut: string[], failed: string[] }
+```
+
+Reverse-order teardown means consumers stop before the infrastructure they use: `JobRuntime` and
+`ChatRuntime` drain before `DbService` closes, because they declared it as a dependency.
+
+## Failure, timeout, and concurrency semantics
+
+| Concern | Rule |
+| --- | --- |
+| Gate failure | `fail-fast`. Startup aborts; the provider surfaces the error. No `custom` strategy is ported — it has no mobile use |
+| PostReady failure | `graceful`. Logged, startup unaffected |
+| Circular dependency | `CircularDependencyError` naming the cycle, thrown during resolution |
+| Init timeout | None. A hung `Gate` service hangs startup, as it does today; a diagnostic watchdog logs the culprit but changes no behaviour |
+| Teardown timeout | 5s per service per pass. On expiry the framework stops *waiting* — it does not cancel. The hook keeps running and the service is reported as `timed_out` |
+| Destroy under an in-flight stop | Skipped, and reported as `failed`. Tearing down resources beneath live work is worse than leaking them during shutdown |
+| Overall shutdown fuse | Not ported. Desktop force-exits after 30s because Electron owns process death; mobile's OS does |
+| Concurrent `install()` | Serialized; the second waits for the first generation's disposal |
+| `dispose()` called twice | Idempotent, returns the same promise — matches every existing mobile runtime |
+
+A `timed_out` outcome is reported honestly rather than folded into success: the summary distinguishes
+`completed`, `timed_out`, and `failed`, and a non-clean shutdown is logged as such.
+
+## Observability
+
+Structured logs carry owner, operation kind, resource scope, transition and reason, duration, and
+outcome. They never carry prompts, tokens, or message payloads. The vocabulary distinguishes normal
+completion, user cancellation, resource invalidation, host disposal, OS recovery, timeout, and
+implementation error — a shutdown that timed out must not read like a clean one.

--- a/docs/references/lifecycle/resource-scope.md
+++ b/docs/references/lifecycle/resource-scope.md
@@ -1,0 +1,235 @@
+# Resource Scope Lifecycle
+
+> Status: Design complete, not yet wired. Lands in Stage D.
+> Framework interfaces live in [lifecycle-overview.md](./lifecycle-overview.md).
+
+## The gap
+
+Deleting a domain resource does not stop the work running under it.
+
+`onTopicsDeleted` — the only coordination hook that exists today — is wired to exactly one consumer:
+
+```typescript
+// src/bootstrap/composition/createBackend.ts
+onTopicsDeleted: (topicIds) => {
+  for (const topicId of topicIds) backgroundReply.clearTopic(topicId)
+}
+```
+
+That ends the Live Activity presentation. It does not abort the stream. `chat.abort(topicId)` has
+exactly one caller in the entire repository — the frontend stop button — and `jobRuntime.cancel()`
+has exactly one — the painting cancel action. Neither is on any deletion path. So deleting a topic
+mid-generation leaves the turn streaming into a topic that no longer exists, and deleting a painting
+mid-generation leaves its job running.
+
+Desktop has the same hole: its topic deletion handler calls `TopicService.delete` and never reaches
+`AiStreamManager.abort`, and its painting deletion relies on the renderer cancelling first. The
+closest thing to a correct precedent on either platform is desktop's knowledge-base deletion, which
+cancels the base's active jobs *outside* the lock, then deletes. This subsystem generalizes that
+shape.
+
+## Model
+
+A **scope** is a domain resource that owns work. An **operation** is cancellable work that belongs
+to one or more scopes.
+
+```typescript
+export type ScopeKind = 'topic' | 'assistant' | 'painting'
+
+export type ResourceScope = {
+  readonly kind: ScopeKind
+  readonly id: string
+}
+
+export type OperationRegistration = {
+  /** Diagnostic identity, e.g. 'chat.turn', 'job.painting.generate'. */
+  readonly kind: string
+  /** Every scope this operation belongs to. Any one of them invalidating cleans it up once. */
+  readonly scopes: readonly ResourceScope[]
+  /** Idempotent, synchronous, non-throwing. Requests termination; does not await it. */
+  cancel(reason: CancelReason): void
+  /** Resolves when the operation has actually stopped and written its terminal state. */
+  readonly settled: Promise<unknown>
+}
+
+export type OperationHandle = {
+  /** Idempotent. Must be called on every terminal path. */
+  release(): void
+}
+```
+
+The coordinator is a plain lifecycle service that understands none of this domain vocabulary beyond
+the scope kinds — it stores registrations and calls the callbacks it was handed. It does not import
+`ChatRuntime`, `JobRuntime`, or `BackgroundActivityManager`, so adding a new kind of cancellable
+work requires no change to it.
+
+```typescript
+@Injectable('ResourceScopeCoordinator')
+@ServicePhase(Phase.Gate)
+export class ResourceScopeCoordinator extends BaseService {
+  /** Throws ScopeFencedError if any target scope is already fenced. */
+  register(registration: OperationRegistration): OperationHandle
+
+  /** Context is invalid but the scope survives: cleanup, mutate, then reopen. */
+  invalidate<T>(scopes: readonly ResourceScope[], mutate: () => Promise<T>, options?: MutationOptions): Promise<T>
+
+  /** Resource is gone: cleanup, mutate, then seal against further registration. */
+  delete<T>(scopes: readonly ResourceScope[], mutate: () => Promise<T>, options?: MutationOptions): Promise<T>
+
+  /** Diagnostics only. Not a pre-flight check — see the race note below. */
+  listActive(scope: ResourceScope): readonly ActiveOperation[]
+}
+```
+
+## The deletion sequence
+
+`delete()` and `invalidate()` run the same five steps; they differ only in the final one.
+
+```text
+1. Fence      every target scope rejects new registrations from this moment
+2. Cancel     call cancel() on every operation registered under any target scope, once each
+3. Drain      await Promise.allSettled(settled) with a bounded ceiling
+4. Mutate     run the caller's persistence mutation
+5. Settle     delete: seal the scope    invalidate: unfence the scope
+```
+
+Failure handling is what makes the ordering worth having:
+
+- **Drain times out** → step 4 never runs. The mutation fails with a diagnosable result naming the
+  straggling operations, and the scope is unfenced. Already-cancelled work is not resurrected.
+- **Mutation throws** → the scope is unfenced (`invalidate`) or left fenced and reported
+  (`delete`), and the error propagates. Cancelled work stays cancelled.
+- **A `cancel()` callback throws** → logged and treated as best effort; it cannot block the pass,
+  because a throwing canceller must not strand the resource forever.
+
+```typescript
+export type MutationOptions = {
+  /** Ceiling for step 3. Default 5000ms, matching the teardown ceiling. */
+  readonly drainTimeoutMs?: number
+  readonly reason?: CancelReason
+}
+
+export type StragglerInfo = { readonly kind: string; readonly scopes: readonly ResourceScope[] }
+export class ScopeDrainTimeoutError extends Error { readonly stragglers: readonly StragglerInfo[] }
+export class ScopeFencedError extends Error { readonly scope: ResourceScope }
+```
+
+### Transaction ordering
+
+Steps 1–3 must complete **before** any write transaction opens. `withWriteTx` is not reentrant —
+its `writeTail` promise chain plus `BEGIN IMMEDIATE` means a nested call deadlocks — and a cancelled
+operation's terminal write needs the write lock to settle. Cancelling inside the transaction would
+therefore deadlock: the drain waits for a write that waits for the transaction that is waiting on
+the drain. Desktop hit exactly this and documents "cancel outside the lock" in its knowledge-base
+deletion.
+
+The rule: `mutate` opens the transaction; the coordinator never does.
+
+### Batch and cascade
+
+A batch deletion resolves its full scope set up front, deduplicates operations that belong to
+several of them, cancels each exactly once, and drains once. Deleting an assistant with its topics
+passes every affected scope in a single call, so an operation registered under both the assistant
+and one of its topics is cleaned up once — not once per scope, and not left behind by a partial
+pass.
+
+### Registration races
+
+`register()` is the atomic gate; there is no check-then-act. A caller does not ask "is this scope
+fenced?" and then register — it registers, and handles `ScopeFencedError`. `listActive()` exists for
+diagnostics and logging only.
+
+An operation must register **before** it starts any external side effect, and release on every
+terminal path — success, error, cancellation, and host disposal alike.
+
+## Integration
+
+### Chat turn
+
+```typescript
+// ChatRuntime, when a turn starts
+const handle = this.scopes.register({
+  kind: 'chat.turn',
+  scopes: [{ kind: 'topic', id: topicId }],
+  cancel: () => activeTurn.abortController.abort(),
+  settled: turnSettled
+})
+// every terminal path
+handle.release()
+```
+
+The Live Activity and the keep-alive lease need no separate registration: they are owned by the
+turn, so aborting the turn releases them through the paths that already exist
+(`clearTopic` → `session.cancel()` → lease release). The coordinator guarantees they are gone by
+awaiting `settled`, not by knowing what they are.
+
+### Painting job
+
+```typescript
+// the painting.generate handler, at execution start
+const handle = this.scopes.register({
+  kind: 'job.painting.generate',
+  scopes: [{ kind: 'painting', id: input.paintingId }],
+  cancel: () => this.jobRuntime.cancel(jobId, 'painting-deleted'),
+  settled: executionSettled
+})
+```
+
+### Data API handlers
+
+```typescript
+// DELETE /paintings
+await coordinator.delete(
+  ids.map((id) => ({ kind: 'painting', id }) as const),
+  () => paintingService.deleteMany(ids)
+)
+
+// DELETE /messages/:id — the topic survives, so this invalidates
+await coordinator.invalidate(
+  [{ kind: 'topic', id: message.topicId }],
+  () => messageService.delete(id)
+)
+```
+
+This is the guarantee the current design lacks: every Data API caller gets cancellation, not just
+the ones that remembered to call a frontend hook first. `onTopicsDeleted` is deleted once the topic
+and message handlers route through the coordinator — renaming it or keeping it alongside would leave
+two cleanup paths, which is the defect being removed.
+
+## Correctness when the process is killed
+
+The coordinator only works while the process lives. iOS and Android kill apps without running any
+teardown, so it is one leg of four:
+
+| Leg | Mechanism | Covers |
+| --- | --- | --- |
+| 1. In-process registry | This document | Active cancellation while the app runs |
+| 2. Durable job ledger | SQLite rows are the source of truth; intent is persisted before irreversible work | Jobs resume, retry, or abandon on cold start |
+| 3. Cold-start sweep | Live Activity `clearOrphans()`, crash-orphaned pending message repair | Native surfaces and rows that outlived the process |
+| 4. Write-path guards | **Formalized here** | Late writes after the registry is gone |
+
+Leg 4 exists today by accident and becomes a contract. Topics are soft-deleted, and the message
+service's queries — including its write paths — filter on `isNull(deletedAt)`, so a late write
+against a deleted topic already fails in most paths. Nothing tests that, so any SQL edit can
+silently remove it.
+
+The contract: **a write targeting a deleted resource must fail or no-op, never resurrect it.**
+Guard tests delete the resource, then drive a late write, and assert nothing lands. Paintings are
+hard-deleted, so their equivalent guard is an existence check when a receipt is persisted.
+
+Legs 1 and 4 are complementary, not redundant: leg 1 makes deletion clean while the app is alive;
+leg 4 makes it safe after the app has died and restarted.
+
+## Boundaries
+
+- **App shutdown does not use the coordinator.** Host teardown stops services in reverse dependency
+  order and each owner drains its own operations — `ChatRuntime.dispose()` already aborts and awaits
+  every turn. Two drain paths for one event would double-wait and double-report.
+- **Registrations are per-process.** Anything needing cross-process recovery uses the durable job
+  ledger. The registry is never persisted.
+- **Manager-wide quiesce is not built.** Desktop's `pause()` + `drainInFlight()` exists for database
+  snapshot/restore, hand-copied across `AiStreamManager` and `JobManager`. Mobile has no such
+  feature, and the fence/drain contract here is per scope. If snapshot/restore ever lands, a
+  manager-level hold is added then.
+- **The coordinator stays domain-neutral.** It never learns what a topic is, never touches native
+  surfaces, and never invalidates a React Query cache.

--- a/docs/references/runtime-ownership.md
+++ b/docs/references/runtime-ownership.md
@@ -6,7 +6,10 @@ Terms follow [Domain Language](./domain-language.md).
 
 ## Principles
 
-- Mobile does not port the desktop lifecycle framework, service registry, or phase graph.
+- Mobile adopts the desktop lifecycle framework, service registry, and a mobile-specific phase pair;
+  see [Lifecycle](./lifecycle/README.md). This document describes the current explicit-composition
+  wiring, which that design replaces stage by stage — where the two disagree, Lifecycle is the
+  target state and this document is the present one.
 - A runtime owner exists only for state or resources that outlive one call.
 - Every owner defines creation, disposal, and abort behavior.
 - Backgrounding is not a reliable execution window for chat or painting generation.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,6 +160,16 @@ const backendDataLayer = {
   message: 'Backend data modules must not depend on AI or general backend services.',
 };
 
+// The lifecycle core sits below every backend module: data services resolve
+// `DbService` through `application`, so anything the core imported would become
+// a cycle. `serviceRegistry.ts` is exempted below because registration *is*
+// assembly — it is the one place that names concrete classes.
+const backendCoreLayer = {
+  group: aliasRoots(['backend/ai', 'backend/data', 'backend/services']),
+  message:
+    'The lifecycle core must not depend on the modules it manages. Register concrete services in serviceRegistry.ts instead.',
+};
+
 const frontendLayer = layerPattern(
   ['app', 'backend', 'bootstrap'],
   'Frontend may depend only on frontend and shared modules. Use Data API hooks for resources, preference hooks for settings, and useBackendModule() for workflows.',
@@ -277,6 +287,10 @@ module.exports = defineConfig([
   restrictedImports(['src/backend/**/*.{ts,tsx}'], [backendLayer]),
   restrictedImports(['src/backend/services/**/*.{ts,tsx}'], [backendLayer, backendServicesLayer]),
   restrictedImports(['src/backend/data/**/*.{ts,tsx}'], [backendLayer, backendDataLayer]),
+  restrictedImports(['src/backend/core/**/*.{ts,tsx}'], [backendLayer, backendCoreLayer]),
+  // Registration is assembly: this file names every concrete service class, so
+  // it keeps only the outer backend layer rule.
+  restrictedImports(['src/backend/core/application/serviceRegistry.ts'], [backendLayer]),
   restrictedImports(['src/frontend/**/*.{ts,tsx}'], [frontendLayer]),
   restrictedImports(sharedFrontendDirectories, [frontendLayer, frontendSharedLayer]),
   restrictedImports(['src/frontend/features/**/*.{ts,tsx}'], [frontendLayer, frontendFeatureLayer]),

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.16.1",
     "react-native-worklets": "0.10.2",
+    "reflect-metadata": "^0.2.2",
     "remend": "1.3.0",
     "rn-expo-emoji-picker": "^0.1.0",
     "tailwind-merge": "^3.6.0",
@@ -163,6 +164,7 @@
   },
   "devDependencies": {
     "@babel/generator": "^7.29.7",
+    "@babel/plugin-proposal-decorators": "^8.0.2",
     "@babel/preset-typescript": "^7.27.1",
     "@babel/traverse": "^7.29.7",
     "@gorhom/bottom-sheet": "5.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       react-native-worklets:
         specifier: 0.10.2
         version: 0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       remend:
         specifier: 1.3.0
         version: 1.3.0
@@ -375,6 +378,9 @@ importers:
       '@babel/generator':
         specifier: ^7.29.7
         version: 7.29.7
+      '@babel/plugin-proposal-decorators':
+        specifier: ^8.0.2
+        version: 8.0.2(@babel/core@7.29.7)
       '@babel/preset-typescript':
         specifier: ^7.27.1
         version: 7.29.7(@babel/core@7.29.7)
@@ -900,6 +906,10 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
@@ -912,6 +922,10 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/generator@8.0.0-rc.2':
     resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -919,6 +933,10 @@ packages:
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
@@ -929,6 +947,12 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-create-class-features-plugin@8.0.1':
+    resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-create-regexp-features-plugin@7.29.7':
     resolution: {integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==}
@@ -945,9 +969,17 @@ packages:
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-member-expression-to-functions@7.29.7':
     resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
@@ -963,9 +995,19 @@ packages:
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-optimise-call-expression@8.0.0':
+    resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@8.0.1':
+    resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-remap-async-to-generator@7.29.7':
     resolution: {integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==}
@@ -979,13 +1021,27 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-replace-supers@8.0.1':
+    resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-string-parser@8.0.0-rc.5':
     resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
@@ -998,6 +1054,10 @@ packages:
   '@babel/helper-validator-identifier@8.0.0-rc.2':
     resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
@@ -1021,11 +1081,22 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
   '@babel/plugin-proposal-decorators@7.29.0':
     resolution: {integrity: sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-decorators@8.0.2':
+    resolution: {integrity: sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-proposal-export-default-from@7.29.7':
     resolution: {integrity: sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==}
@@ -1059,6 +1130,12 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@8.0.1':
+    resolution: {integrity: sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-syntax-dynamic-import@7.8.3':
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -1359,9 +1436,17 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@8.0.4':
+    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -1370,6 +1455,10 @@ packages:
   '@babel/types@8.0.0-rc.2':
     resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -6876,6 +6965,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -8125,6 +8217,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -9429,6 +9524,11 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.29.7': {}
 
   '@babel/core@7.29.7':
@@ -9459,6 +9559,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0-rc.2':
     dependencies:
       '@babel/parser': 8.0.0-rc.2
@@ -9471,6 +9580,10 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -9493,6 +9606,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/helper-replace-supers': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+      '@babel/traverse': 8.0.4
+      semver: 7.8.5
+
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -9513,12 +9637,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
+  '@babel/helper-globals@8.0.0': {}
+
   '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
@@ -9540,7 +9671,15 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/helper-optimise-call-expression@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
+
   '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-plugin-utils@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
 
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9560,6 +9699,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/traverse': 8.0.4
+
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7
@@ -9567,13 +9713,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-string-parser@8.0.0': {}
 
   '@babel/helper-string-parser@8.0.0-rc.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.2': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -9598,6 +9753,10 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.2
 
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+
   '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -9606,6 +9765,13 @@ snapshots:
       '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-proposal-decorators@8.0.2(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9636,6 +9802,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-decorators@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)':
     dependencies:
@@ -9972,6 +10143,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -9984,6 +10161,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.4':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.1
+
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
@@ -9993,6 +10180,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.5
       '@babel/helper-validator-identifier': 8.0.0-rc.2
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -15554,6 +15746,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -16922,6 +17116,8 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:

--- a/src/backend/core/application/Application.ts
+++ b/src/backend/core/application/Application.ts
@@ -1,0 +1,114 @@
+import type { TeardownSummary } from '../lifecycle/types';
+import type { ApplicationHost } from './ApplicationHost';
+import type { ServiceRegistry } from './serviceRegistry';
+
+/**
+ * The stable reference every service resolves through.
+ *
+ * `application` never changes identity; the `ApplicationHost` behind it does.
+ * That indirection is what lets a CRUD module singleton hold no state — it
+ * resolves the *current* host's `DbService` on every call — and what lets a test
+ * swap the entire graph without touching the code under test.
+ *
+ * Import this module directly rather than through a barrel. Desktop's
+ * `@application` alias points straight at its `Application.ts` for the same
+ * reason: a barrel that also re-exported the registry would drag the whole
+ * service graph into every consumer and close an import cycle.
+ */
+class Application {
+  private host: ApplicationHost | null = null;
+
+  /** Serializes install/uninstall so two generations never overlap. */
+  private transition: Promise<unknown> = Promise.resolve();
+
+  /**
+   * Resolve a service from the installed host.
+   *
+   * Throws when no host is installed, which is deliberate: it turns a
+   * module-scope `application.get()` — evaluated at import time, before any host
+   * exists — into a loud failure instead of a silently captured stale instance.
+   *
+   * There is no readiness gate. Resolution during host startup is normal
+   * (services are created lazily) and resolution during disposal is normal
+   * (`onStop` reaches its collaborators). Correctness for late callbacks comes
+   * from scope fencing and write-path guards, not from making every call site
+   * defensive.
+   */
+  get<K extends keyof ServiceRegistry>(name: K): ServiceRegistry[K] {
+    if (!this.host) {
+      throw new Error(
+        `[Application] Cannot resolve '${String(name)}': no ApplicationHost is installed. ` +
+          `Resolve services inside a method rather than at module scope, and install a test host in tests.`,
+      );
+    }
+    return this.host.container.get<ServiceRegistry[K]>(name as string);
+  }
+
+  /**
+   * Install a host, replacing any current one.
+   *
+   * The outgoing host is disposed to completion before the incoming one starts,
+   * so a database connection or job claim is never held by two generations at
+   * once. Concurrent calls queue rather than interleave.
+   *
+   * If `start()` rejects, no host is installed and the error propagates.
+   */
+  async install(host: ApplicationHost): Promise<void> {
+    await this.enqueue(async () => {
+      const outgoing = this.host;
+      this.host = null;
+      if (outgoing) {
+        await outgoing.dispose();
+      }
+
+      await host.start();
+      this.host = host;
+    });
+  }
+
+  /** Dispose the installed host. Returns an empty summary when none is installed. */
+  async uninstall(): Promise<TeardownSummary> {
+    let summary: TeardownSummary = { failed: [], timedOut: [] };
+
+    await this.enqueue(async () => {
+      const outgoing = this.host;
+      this.host = null;
+      if (outgoing) {
+        summary = await outgoing.dispose();
+      }
+    });
+
+    return summary;
+  }
+
+  get hasHost(): boolean {
+    return this.host !== null;
+  }
+
+  /** The installed host. For bootstrap and tests; services use `get()`. */
+  get current(): ApplicationHost | null {
+    return this.host;
+  }
+
+  private async enqueue(work: () => Promise<void>): Promise<void> {
+    const previous = this.transition;
+    let release: () => void = () => {};
+    this.transition = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // A failed predecessor must not poison the queue — it already reported to
+    // its own caller.
+    await previous.catch(() => {});
+
+    try {
+      await work();
+    } finally {
+      release();
+    }
+  }
+}
+
+export const application = new Application();
+
+export type { Application };

--- a/src/backend/core/application/ApplicationHost.ts
+++ b/src/backend/core/application/ApplicationHost.ts
@@ -1,0 +1,115 @@
+import { loggerService } from '@logger';
+
+import { LifecycleManager } from '../lifecycle/LifecycleManager';
+import { ServiceContainer } from '../lifecycle/ServiceContainer';
+import { Phase, type ServiceConstructor, type TeardownSummary } from '../lifecycle/types';
+
+const logger = loggerService.withContext('Lifecycle');
+
+export type HostProfile = {
+  /** Service constructors to register. Usually `serviceList`. */
+  readonly services: readonly ServiceConstructor[];
+  /**
+   * Pre-built instances that win over construction and receive no lifecycle
+   * callbacks. The test seam: an in-memory `DbService` fake goes here and does
+   * not have to extend `BaseService`.
+   */
+  readonly overrides?: Readonly<Record<string, unknown>>;
+};
+
+export type HostState = 'created' | 'starting' | 'ready' | 'disposing' | 'disposed';
+
+/**
+ * One generation of services: a container, a lifecycle manager, and the
+ * instances they hold.
+ *
+ * This has no desktop counterpart — a desktop process has exactly one service
+ * graph for its whole life. Mobile needs the graph to be replaceable inside one
+ * process: every test installs its own, and Fast Refresh replaces the app's.
+ *
+ * **Construction claims nothing.** No database is opened, no job is claimed, no
+ * audio session starts until `start()` runs. That is what makes replacement
+ * safe: `application.install()` awaits the outgoing host's disposal before
+ * starting the incoming one, so two generations never hold the same SQLite
+ * connection or job claim at once.
+ */
+export class ApplicationHost {
+  readonly container: ServiceContainer;
+
+  private readonly lifecycle: LifecycleManager;
+  private hostState: HostState = 'created';
+  private disposal: Promise<TeardownSummary> | null = null;
+
+  constructor(profile: HostProfile) {
+    this.container = new ServiceContainer(profile.overrides);
+    this.container.registerAll(profile.services);
+    this.lifecycle = new LifecycleManager(this.container);
+  }
+
+  get state(): HostState {
+    return this.hostState;
+  }
+
+  /**
+   * Run the `Gate` phase.
+   *
+   * Rejects if a fail-fast service fails, leaving the host in `starting`; the
+   * caller is expected to dispose it. Nothing here blocks on `PostReady` work.
+   */
+  async start(): Promise<void> {
+    if (this.hostState !== 'created') {
+      throw new Error(`[ApplicationHost] Cannot start a host in state '${this.hostState}'`);
+    }
+
+    this.hostState = 'starting';
+    await this.lifecycle.startPhase(Phase.Gate);
+    this.hostState = 'ready';
+  }
+
+  /**
+   * Start `PostReady` services and run every service's `onAllReady`.
+   *
+   * Fire-and-forget by contract: this runs after the gate has opened, so it
+   * swallows its own failures rather than surfacing them to the UI.
+   */
+  runPostReady(): void {
+    if (this.hostState !== 'ready') {
+      logger.warn(`Skipping post-ready work: host is '${this.hostState}'`);
+      return;
+    }
+
+    void (async () => {
+      try {
+        await this.lifecycle.startPhase(Phase.PostReady);
+        await this.lifecycle.runAllReady();
+      } catch (error) {
+        logger.error('Post-ready work failed', error as Error);
+      }
+    })();
+  }
+
+  /**
+   * Stop then destroy every service, in reverse initialization order.
+   *
+   * Idempotent: concurrent and repeated calls share one promise, matching the
+   * disposal contract every existing mobile runtime already follows.
+   */
+  dispose(): Promise<TeardownSummary> {
+    this.disposal ??= this.runDisposal();
+    return this.disposal;
+  }
+
+  private async runDisposal(): Promise<TeardownSummary> {
+    this.hostState = 'disposing';
+
+    const stopped = await this.lifecycle.stopAll();
+    const destroyed = await this.lifecycle.destroyAll();
+
+    this.hostState = 'disposed';
+
+    return {
+      failed: [...stopped.failed, ...destroyed.failed],
+      timedOut: [...stopped.timedOut, ...destroyed.timedOut],
+    };
+  }
+}

--- a/src/backend/core/application/__tests__/ApplicationHost.test.ts
+++ b/src/backend/core/application/__tests__/ApplicationHost.test.ts
@@ -1,0 +1,220 @@
+import { BaseService } from '../../lifecycle/BaseService';
+import { Injectable, ServicePhase } from '../../lifecycle/decorators';
+import { Phase } from '../../lifecycle/types';
+import { application } from '../Application';
+import { ApplicationHost } from '../ApplicationHost';
+
+jest.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() }),
+  },
+}));
+
+let journal: string[] = [];
+
+@Injectable('Connection')
+class Connection extends BaseService {
+  open = false;
+
+  protected onInit(): void {
+    this.open = true;
+    journal.push('Connection:open');
+  }
+
+  protected onStop(): void {
+    this.open = false;
+    journal.push('Connection:close');
+  }
+}
+
+@Injectable('LateWork')
+@ServicePhase(Phase.PostReady)
+class LateWork extends BaseService {
+  protected onInit(): void {
+    journal.push('LateWork:init');
+  }
+}
+
+/** Resolves only when the test releases it, so overlap is observable. */
+class SlowClose extends BaseService {
+  static release: (() => void) | undefined;
+
+  protected onStop(): Promise<void> {
+    journal.push('SlowClose:closing');
+    return new Promise<void>((resolve) => {
+      SlowClose.release = () => {
+        journal.push('SlowClose:closed');
+        resolve();
+      };
+    });
+  }
+}
+Injectable('SlowClose')(SlowClose);
+
+beforeEach(() => {
+  journal = [];
+  SlowClose.release = undefined;
+});
+
+afterEach(async () => {
+  await application.uninstall();
+});
+
+describe('ApplicationHost construction', () => {
+  it('claims nothing until start', async () => {
+    const host = new ApplicationHost({ services: [Connection] });
+
+    expect(host.state).toBe('created');
+    expect(host.container.peek('Connection')).toBeUndefined();
+    expect(journal).toEqual([]);
+
+    await host.start();
+
+    expect(host.state).toBe('ready');
+    expect(host.container.peek<Connection>('Connection')?.open).toBe(true);
+  });
+
+  it('refuses to start twice', async () => {
+    const host = new ApplicationHost({ services: [Connection] });
+    await host.start();
+
+    await expect(host.start()).rejects.toThrow(/Cannot start a host in state 'ready'/);
+  });
+
+  it('leaves post-ready services alone until runPostReady', async () => {
+    const host = new ApplicationHost({ services: [Connection, LateWork] });
+
+    await host.start();
+    expect(journal).toEqual(['Connection:open']);
+
+    host.runPostReady();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(journal).toEqual(['Connection:open', 'LateWork:init']);
+    await host.dispose();
+  });
+
+  it('shares one promise across repeated disposals', async () => {
+    const host = new ApplicationHost({ services: [Connection] });
+    await host.start();
+
+    const first = host.dispose();
+    const second = host.dispose();
+
+    expect(first).toBe(second);
+    await first;
+    expect(host.state).toBe('disposed');
+    expect(journal.filter((entry) => entry === 'Connection:close')).toHaveLength(1);
+  });
+
+  it('passes overrides through to consumers without managing them', async () => {
+    const fake = { open: true } as Connection;
+    const host = new ApplicationHost({
+      overrides: { Connection: fake },
+      services: [Connection],
+    });
+
+    await host.start();
+
+    expect(host.container.get('Connection')).toBe(fake);
+    // The fake never received onInit, so nothing was journalled for it.
+    expect(journal).toEqual([]);
+  });
+});
+
+describe('application.get', () => {
+  it('throws when no host is installed', () => {
+    expect(() => application.get('Connection' as never)).toThrow(/no ApplicationHost is installed/);
+  });
+
+  it('resolves from the installed host', async () => {
+    await application.install(new ApplicationHost({ services: [Connection] }));
+
+    expect(application.get('Connection' as never)).toBeInstanceOf(Connection);
+  });
+
+  it('throws again after uninstall', async () => {
+    await application.install(new ApplicationHost({ services: [Connection] }));
+    await application.uninstall();
+
+    expect(() => application.get('Connection' as never)).toThrow(/no ApplicationHost is installed/);
+    expect(application.hasHost).toBe(false);
+  });
+});
+
+describe('application.install', () => {
+  it('disposes the outgoing host before starting the incoming one', async () => {
+    await application.install(new ApplicationHost({ services: [SlowClose] }));
+
+    const incoming = new ApplicationHost({ services: [Connection] });
+    const installing = application.install(incoming);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The replacement must not have opened anything while the old host is
+    // still closing — that overlap is what would let two generations hold the
+    // same SQLite connection or job claim.
+    expect(journal).toEqual(['SlowClose:closing']);
+    expect(incoming.state).toBe('created');
+
+    SlowClose.release?.();
+    await installing;
+
+    expect(journal).toEqual(['SlowClose:closing', 'SlowClose:closed', 'Connection:open']);
+    expect(incoming.state).toBe('ready');
+  });
+
+  it('serializes concurrent installs', async () => {
+    const first = new ApplicationHost({ services: [Connection] });
+    const second = new ApplicationHost({ services: [Connection] });
+
+    await Promise.all([application.install(first), application.install(second)]);
+
+    expect(application.current).toBe(second);
+    expect(first.state).toBe('disposed');
+    expect(journal).toEqual(['Connection:open', 'Connection:close', 'Connection:open']);
+  });
+
+  it('installs no host when startup fails', async () => {
+    @Injectable('FailsToStart')
+    class FailsToStart extends BaseService {
+      protected onInit(): void {
+        throw new Error('migration failed');
+      }
+    }
+
+    await expect(
+      application.install(new ApplicationHost({ services: [FailsToStart] })),
+    ).rejects.toThrow(/migration failed/);
+
+    expect(application.hasHost).toBe(false);
+  });
+
+  it('keeps accepting installs after a failed one', async () => {
+    @Injectable('AlsoFails')
+    class AlsoFails extends BaseService {
+      protected onInit(): void {
+        throw new Error('nope');
+      }
+    }
+
+    await expect(
+      application.install(new ApplicationHost({ services: [AlsoFails] })),
+    ).rejects.toThrow();
+
+    await application.install(new ApplicationHost({ services: [Connection] }));
+
+    expect(application.get('Connection' as never)).toBeInstanceOf(Connection);
+  });
+});
+
+describe('application.uninstall', () => {
+  it('reports a clean teardown', async () => {
+    await application.install(new ApplicationHost({ services: [Connection] }));
+
+    expect(await application.uninstall()).toEqual({ failed: [], timedOut: [] });
+  });
+
+  it('is safe with no host installed', async () => {
+    expect(await application.uninstall()).toEqual({ failed: [], timedOut: [] });
+  });
+});

--- a/src/backend/core/application/serviceRegistry.ts
+++ b/src/backend/core/application/serviceRegistry.ts
@@ -1,0 +1,26 @@
+import type { ServiceConstructor } from '../lifecycle/types';
+
+/**
+ * The central service registry.
+ *
+ * Adding a service is one import plus one line here; the `ServiceRegistry` type
+ * and therefore the `application.get()` keys follow automatically. The name a
+ * class passes to `@Injectable` must match its key in this object.
+ *
+ * This is the one file allowed to import concrete classes from `backend/ai`,
+ * `backend/services`, and `backend/data`: registration is assembly, so the layer
+ * rule is relaxed here and nowhere else.
+ *
+ * Stage A registers nothing. The framework ships inert — present, tested, and
+ * wired to no module — so that migrating the existing runtime graph is a
+ * separate, reviewable change that cannot be conflated with framework bugs.
+ */
+export const services = {} as const;
+
+/** Service name to instance type, derived from `services`. */
+export type ServiceRegistry = {
+  [K in keyof typeof services]: InstanceType<(typeof services)[K]>;
+};
+
+/** Constructors to register with a host, in declaration order. */
+export const serviceList: readonly ServiceConstructor[] = Object.values(services);

--- a/src/backend/core/lifecycle/BaseService.ts
+++ b/src/backend/core/lifecycle/BaseService.ts
@@ -1,0 +1,293 @@
+import { loggerService } from '@logger';
+import { AppState, type AppStateStatus } from 'react-native';
+
+import { getServiceName } from './decorators';
+import { type Disposable, toDisposable } from './event';
+import { isActivatable, isPausable, LifecycleState, type ServiceConstructor } from './types';
+
+const logger = loggerService.withContext('Lifecycle');
+
+/**
+ * Base class for every lifecycle-managed service.
+ *
+ * Ported from Cherry Desktop `src/main/core/lifecycle/BaseService.ts` with three
+ * changes, each forced by the runtime rather than chosen:
+ *
+ * - `ipcHandle`/`ipcOn` are gone. There is no `ipcMain` here.
+ * - The WeakSet that rejected a second instantiation is gone. It encodes "one
+ *   instantiation per process", which is false on mobile: every ApplicationHost
+ *   generation re-instantiates its services, and tests install a host per case.
+ *   The container enforces one live instance per host instead.
+ * - `registerAppStateListener` is added. Five call sites currently hand-roll
+ *   `AppState.addEventListener` plus a matching `remove()`; routing them through
+ *   the disposable bag removes that leak class.
+ *
+ * Hooks are protected and default to no-ops. The framework calls the `_do*`
+ * methods; services never call them directly.
+ */
+export abstract class BaseService {
+  private lifecycleState: LifecycleState = LifecycleState.Created;
+
+  /** Ensures `onAllReady` runs at most once per instance, even across restarts. */
+  private allReadyCalled = false;
+
+  private disposables: Disposable[] = [];
+
+  private activated = false;
+
+  /** Guards against concurrent activate/deactivate. */
+  private activating = false;
+
+  /**
+   * Whether `_doStop()` is currently running. Distinct from
+   * `state === Stopping`, which a rejected `onStop()` also leaves behind — see
+   * `_doDestroy()`.
+   */
+  private stopInFlight = false;
+
+  get state(): LifecycleState {
+    return this.lifecycleState;
+  }
+
+  get isReady(): boolean {
+    return this.lifecycleState === LifecycleState.Ready;
+  }
+
+  get isDestroyed(): boolean {
+    return this.lifecycleState === LifecycleState.Destroyed;
+  }
+
+  get isPaused(): boolean {
+    return this.lifecycleState === LifecycleState.Paused;
+  }
+
+  get isStopped(): boolean {
+    return this.lifecycleState === LifecycleState.Stopped;
+  }
+
+  /** Only meaningful for `Activatable` services; always false otherwise. */
+  get isActivated(): boolean {
+    return this.activated;
+  }
+
+  protected setState(state: LifecycleState): void {
+    this.lifecycleState = state;
+  }
+
+  /**
+   * Register a resource for automatic release after `onStop`/`onDestroy`.
+   * Accepts a `Disposable` or a plain cleanup function, and returns it so it can
+   * be assigned inline.
+   */
+  protected registerDisposable<T extends Disposable>(disposable: T): T;
+  protected registerDisposable(dispose: () => void): Disposable;
+  protected registerDisposable<T extends Disposable>(
+    disposableOrFn: T | (() => void),
+  ): T | Disposable {
+    const disposable =
+      typeof disposableOrFn === 'function' ? toDisposable(disposableOrFn) : disposableOrFn;
+    this.disposables.push(disposable);
+    return disposable;
+  }
+
+  /**
+   * Register a recurring timer scoped to this service.
+   *
+   * Rejections are logged and the loop survives them. Desktop additionally
+   * `unref()`s the handle to keep Node from staying alive for it; Hermes has no
+   * such API and no such problem.
+   *
+   * Not suitable for a timer that should follow activation rather than the
+   * service lifetime — manage those inside `onActivate`/`onDeactivate`.
+   */
+  protected registerInterval(callback: () => void | Promise<void>, intervalMs: number): Disposable {
+    const handle = setInterval(async () => {
+      try {
+        await callback();
+      } catch (error) {
+        logger.error(`[${this.serviceName}] registerInterval callback failed`, error as Error);
+      }
+    }, intervalMs);
+    return this.registerDisposable(() => clearInterval(handle));
+  }
+
+  /**
+   * Subscribe to foreground/background transitions for this service's lifetime.
+   *
+   * The framework itself does nothing on `AppState` changes: the five existing
+   * subscribers want mutually incompatible things (query refocus, audio restart,
+   * native surface rebuild, one-shot return waiter), so there is no correct
+   * default. A service declares its intent with `@AppStatePolicy` and implements
+   * it here.
+   */
+  protected registerAppStateListener(listener: (status: AppStateStatus) => void): Disposable {
+    const subscription = AppState.addEventListener('change', listener);
+    return this.registerDisposable(() => subscription.remove());
+  }
+
+  private releaseDisposables(): void {
+    for (const disposable of this.disposables) {
+      try {
+        disposable.dispose();
+      } catch (error) {
+        logger.error(`[${this.serviceName}] disposable failed to release`, error as Error);
+      }
+    }
+    this.disposables = [];
+  }
+
+  private get serviceName(): string {
+    return getServiceName(this.constructor as ServiceConstructor);
+  }
+
+  /** Dependencies are `Ready` by the time this runs. */
+  protected onInit(): Promise<void> | void {}
+
+  /** This service finished initializing. */
+  protected onReady(): Promise<void> | void {}
+
+  /**
+   * Every service in every phase finished initializing, so any service may be
+   * resolved regardless of `@DependsOn`.
+   *
+   * Schedule work here; do not perform it. A long await stalls the phase and
+   * collides with the teardown ceiling — register a timer and join it in
+   * `onStop` instead.
+   */
+  protected onAllReady(): Promise<void> | void {}
+
+  /** Release work and let in-flight operations settle. Disposables are released afterwards. */
+  protected onStop(): Promise<void> | void {}
+
+  /** Final release, after every service has stopped. */
+  protected onDestroy(): Promise<void> | void {}
+
+  /** Framework entry point. Runs `onInit` then `onReady`. */
+  async _doInit(): Promise<void> {
+    this.lifecycleState = LifecycleState.Initializing;
+    await this.onInit();
+    this.lifecycleState = LifecycleState.Ready;
+    await this.onReady();
+  }
+
+  /** Framework entry point. At most once per instance. */
+  async _doAllReady(): Promise<void> {
+    if (this.allReadyCalled) return;
+    this.allReadyCalled = true;
+    await this.onAllReady();
+  }
+
+  /** Framework entry point. Auto-deactivates, runs `onStop`, then releases disposables. */
+  async _doStop(): Promise<void> {
+    this.lifecycleState = LifecycleState.Stopping;
+    this.stopInFlight = true;
+    try {
+      if (this.activated && isActivatable(this)) {
+        try {
+          await this.onDeactivate();
+        } catch {
+          // Best effort — the service logs its own failure, and it must not
+          // block onStop.
+        }
+        this.activated = false;
+      }
+      await this.onStop();
+    } finally {
+      this.stopInFlight = false;
+      this.releaseDisposables();
+    }
+    this.lifecycleState = LifecycleState.Stopped;
+  }
+
+  /** Framework entry point. Idempotent. */
+  async _doDestroy(): Promise<void> {
+    if (this.lifecycleState === LifecycleState.Destroyed) {
+      return;
+    }
+
+    // An abandoned `_doStop()` keeps running after the ceiling expires.
+    // Destroying underneath it would tear down the resources that work is still
+    // using, so skip; the caller turns the unchanged state into a non-completed
+    // outcome.
+    //
+    // Keyed on the in-flight flag rather than on `Stopping`: a rejected
+    // `onStop()` also leaves the state at `Stopping`, but it has already settled
+    // and already released its disposables, so nothing is running underneath it.
+    if (this.stopInFlight) {
+      logger.warn(`Skipping destroy for '${this.serviceName}' — stop still in flight`);
+      return;
+    }
+
+    if (this.activated && isActivatable(this)) {
+      try {
+        await this.onDeactivate();
+      } catch {
+        // Best effort.
+      }
+      this.activated = false;
+    }
+
+    await this.onDestroy();
+    this.releaseDisposables();
+    this.lifecycleState = LifecycleState.Destroyed;
+  }
+
+  /** Framework entry point. Idempotent; returns the resulting activation state. */
+  async _doActivate(): Promise<boolean> {
+    if (!isActivatable(this)) return false;
+    if (this.activated || this.activating) return this.activated;
+    if (this.lifecycleState !== LifecycleState.Ready) return false;
+
+    this.activating = true;
+    try {
+      await this.onActivate();
+      this.activated = true;
+      return true;
+    } finally {
+      this.activating = false;
+    }
+  }
+
+  /** Framework entry point. Idempotent. */
+  async _doDeactivate(): Promise<boolean> {
+    if (!isActivatable(this)) return false;
+    if (!this.activated || this.activating) return !this.activated;
+
+    this.activating = true;
+    try {
+      await this.onDeactivate();
+      this.activated = false;
+      return true;
+    } finally {
+      this.activating = false;
+    }
+  }
+
+  /** Self-activation, for use inside the service. External callers go through the host. */
+  protected async activate(): Promise<boolean> {
+    return this._doActivate();
+  }
+
+  /** Self-deactivation, for use inside the service. */
+  protected async deactivate(): Promise<boolean> {
+    return this._doDeactivate();
+  }
+
+  /** Framework entry point. Returns false when the service is not `Pausable`. */
+  async _doPause(): Promise<boolean> {
+    if (!isPausable(this)) return false;
+    this.lifecycleState = LifecycleState.Pausing;
+    await this.onPause();
+    this.lifecycleState = LifecycleState.Paused;
+    return true;
+  }
+
+  /** Framework entry point. Returns false when the service is not `Pausable`. */
+  async _doResume(): Promise<boolean> {
+    if (!isPausable(this)) return false;
+    this.lifecycleState = LifecycleState.Resuming;
+    await this.onResume();
+    this.lifecycleState = LifecycleState.Ready;
+    return true;
+  }
+}

--- a/src/backend/core/lifecycle/DependencyResolver.ts
+++ b/src/backend/core/lifecycle/DependencyResolver.ts
@@ -1,0 +1,175 @@
+import { loggerService } from '@logger';
+
+import { CircularDependencyError, type DependencyNode, Phase } from './types';
+
+const logger = loggerService.withContext('Lifecycle');
+
+const DEFAULT_PRIORITY = 100;
+
+export type PhaseAdjustment = {
+  serviceName: string;
+  from: Phase;
+  to: Phase;
+  reason: string;
+};
+
+/**
+ * Resolves service initialization order.
+ *
+ * Ported from Cherry Desktop `src/main/core/lifecycle/DependencyResolver.ts`.
+ * The layering algorithm (Kahn's, with priority ordering inside a layer) is
+ * unchanged; the phase validation is rewritten because mobile has two phases
+ * instead of Desktop's three and the correct repair runs the other way — see
+ * `hoistGateDependencies`.
+ *
+ * Desktop's `getDependents`/`getDependencies` are not ported: they exist to
+ * cascade single-service start/stop, and mobile only starts and stops whole
+ * hosts.
+ */
+export class DependencyResolver {
+  /**
+   * Group services into layers that can initialize in parallel.
+   *
+   * Every service in layer N depends only on services in layers < N. Within a
+   * layer, services are ordered by `@Priority` — which matters only for the
+   * sequencing of their synchronous prologues, since the layer runs
+   * concurrently.
+   */
+  resolveLayered(nodes: DependencyNode[]): string[][] {
+    const nodeMap = new Map(nodes.map((node) => [node.name, node]));
+    const inDegree = new Map<string, number>();
+    const dependents = new Map<string, string[]>();
+
+    for (const node of nodes) {
+      inDegree.set(node.name, 0);
+      dependents.set(node.name, []);
+    }
+
+    for (const node of nodes) {
+      for (const dependency of node.dependencies) {
+        // Dependencies outside this node set (a different phase, typically)
+        // are already initialized and impose no ordering here.
+        if (!nodeMap.has(dependency)) continue;
+        dependents.get(dependency)?.push(node.name);
+        inDegree.set(node.name, (inDegree.get(node.name) ?? 0) + 1);
+      }
+    }
+
+    const layers: string[][] = [];
+    let remaining = nodes.length;
+
+    while (remaining > 0) {
+      const layer: string[] = [];
+      for (const [name, degree] of inDegree) {
+        if (degree === 0) layer.push(name);
+      }
+
+      if (layer.length === 0) {
+        throw new CircularDependencyError(this.findCycle(nodes));
+      }
+
+      this.sortByPriority(layer, nodeMap);
+      layers.push(layer);
+
+      for (const name of layer) {
+        inDegree.set(name, -1);
+        for (const dependent of dependents.get(name) ?? []) {
+          inDegree.set(dependent, (inDegree.get(dependent) ?? 0) - 1);
+        }
+      }
+
+      remaining -= layer.length;
+    }
+
+    return layers;
+  }
+
+  /**
+   * Promote every `PostReady` service that a `Gate` service depends on.
+   *
+   * Desktop demotes the *dependent* to the later phase. That is wrong here:
+   * `Gate` means "first paint needs this", so a `Gate` service demoted to
+   * `PostReady` would silently stop blocking the gate it was declared to block.
+   * Promoting the dependency preserves both the ordering and the intent.
+   *
+   * Mutates `nodes` and iterates to a fixed point so a chain of dependencies is
+   * promoted in full. Returns what it changed so the caller can log it.
+   */
+  hoistGateDependencies(nodes: DependencyNode[]): PhaseAdjustment[] {
+    const nodeMap = new Map(nodes.map((node) => [node.name, node]));
+    const adjustments: PhaseAdjustment[] = [];
+
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const node of nodes) {
+        if (node.phase !== Phase.Gate) continue;
+
+        for (const dependencyName of node.dependencies) {
+          const dependency = nodeMap.get(dependencyName);
+          if (!dependency || dependency.phase === Phase.Gate) continue;
+
+          adjustments.push({
+            serviceName: dependency.name,
+            from: dependency.phase,
+            to: Phase.Gate,
+            reason: `required by gate service '${node.name}'`,
+          });
+          dependency.phase = Phase.Gate;
+          changed = true;
+        }
+      }
+    }
+
+    for (const adjustment of adjustments) {
+      logger.warn(
+        `Service '${adjustment.serviceName}' declared ${adjustment.from} but is ${adjustment.reason}; promoted to ${adjustment.to}`,
+      );
+    }
+
+    return adjustments;
+  }
+
+  private sortByPriority(names: string[], nodeMap: Map<string, DependencyNode>): void {
+    names.sort((a, b) => {
+      const priorityA = nodeMap.get(a)?.priority ?? DEFAULT_PRIORITY;
+      const priorityB = nodeMap.get(b)?.priority ?? DEFAULT_PRIORITY;
+      return priorityA - priorityB;
+    });
+  }
+
+  /** Depth-first search for a cycle, used only to build the error message. */
+  private findCycle(nodes: DependencyNode[]): string[] {
+    const nodeMap = new Map(nodes.map((node) => [node.name, node]));
+    const visited = new Set<string>();
+    const stack = new Set<string>();
+
+    const walk = (name: string, path: string[]): string[] | null => {
+      if (stack.has(name)) {
+        return [...path.slice(path.indexOf(name)), name];
+      }
+      if (visited.has(name)) return null;
+
+      visited.add(name);
+      stack.add(name);
+      path.push(name);
+
+      for (const dependency of nodeMap.get(name)?.dependencies ?? []) {
+        if (!nodeMap.has(dependency)) continue;
+        const cycle = walk(dependency, path);
+        if (cycle) return cycle;
+      }
+
+      stack.delete(name);
+      path.pop();
+      return null;
+    };
+
+    for (const node of nodes) {
+      const cycle = walk(node.name, []);
+      if (cycle) return cycle;
+    }
+
+    return ['unknown cycle'];
+  }
+}

--- a/src/backend/core/lifecycle/LifecycleManager.ts
+++ b/src/backend/core/lifecycle/LifecycleManager.ts
@@ -1,0 +1,283 @@
+import { loggerService } from '@logger';
+
+import type { BaseService } from './BaseService';
+import { DependencyResolver } from './DependencyResolver';
+import type { ServiceContainer } from './ServiceContainer';
+import {
+  LifecycleState,
+  Phase,
+  ServiceInitError,
+  type TeardownOutcome,
+  type TeardownSummary,
+} from './types';
+
+const logger = loggerService.withContext('Lifecycle');
+
+/** Ceiling for one service's `onStop` or `onDestroy`. Matches desktop. */
+export const SERVICE_TEARDOWN_TIMEOUT_MS = 5000;
+
+/**
+ * Race a teardown against a ceiling.
+ *
+ * The loser is **not** cancelled — it keeps running, overlapping whatever the
+ * pass does next. That is accepted: no service may pin its correctness on
+ * `onStop`, because the OS kills mobile apps without running it at all.
+ *
+ * The timer must be cleared, or one leaked multi-second timer per service
+ * outlives an otherwise instant teardown.
+ */
+async function raceWithTimeout(
+  run: Promise<TeardownOutcome>,
+  timeoutMs: number,
+): Promise<TeardownOutcome> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<TeardownOutcome>((resolve) => {
+    timer = setTimeout(() => resolve('timed_out'), timeoutMs);
+  });
+  try {
+    return await Promise.race([run, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Log one teardown pass.
+ *
+ * A clean pass says so; any other pass must not, because that line is the first
+ * thing read when diagnosing a bad shutdown and claiming success over a starved
+ * service is the false signal this mechanism exists to remove.
+ */
+function logTeardownSummary(
+  pass: 'stop' | 'destroy',
+  summary: TeardownSummary,
+  durationMs: number,
+): void {
+  const elapsed = `${durationMs.toFixed(1)}ms`;
+  if (summary.timedOut.length === 0 && summary.failed.length === 0) {
+    logger.info(`All services ${pass === 'stop' ? 'stopped' : 'destroyed'} (${elapsed})`);
+    return;
+  }
+  logger.warn(
+    `Service ${pass} pass finished with ${summary.timedOut.length} timeout(s), ${summary.failed.length} failure(s) (${elapsed})`,
+    { failed: summary.failed, timedOut: summary.timedOut },
+  );
+}
+
+/**
+ * Drives services through their lifecycle for one host generation.
+ *
+ * Ported from Cherry Desktop `src/main/core/lifecycle/LifecycleManager.ts`,
+ * minus the pieces that do not apply: it is not a singleton (one per host), it
+ * emits no lifecycle event bus (nothing consumes it), it carries no CPU profiler
+ * or event-loop lag sampler (Node-only), and it has no cascade pause/stop
+ * bookkeeping (mobile starts and stops whole hosts, never single services).
+ */
+export class LifecycleManager {
+  private readonly resolver = new DependencyResolver();
+  private readonly initializationOrder: string[] = [];
+  private readonly serviceTiming = new Map<string, number>();
+  private phasesValidated = false;
+
+  constructor(private readonly container: ServiceContainer) {}
+
+  /**
+   * Promote `PostReady` services that a `Gate` service depends on.
+   * Idempotent; runs once before the first phase starts.
+   */
+  validatePhases(): void {
+    if (this.phasesValidated) return;
+
+    const graph = this.container.buildDependencyGraph();
+    for (const adjustment of this.resolver.hoistGateDependencies(graph)) {
+      this.container.updatePhase(adjustment.serviceName, adjustment.to);
+    }
+    this.phasesValidated = true;
+  }
+
+  /**
+   * Initialize every service in a phase, layer by layer.
+   *
+   * Layers run in sequence; peers inside a layer run in parallel. A rejection
+   * from any peer aborts the phase — `handleError` only rethrows for fail-fast
+   * services, so a graceful failure never reaches here.
+   */
+  async startPhase(phase: Phase): Promise<void> {
+    this.validatePhases();
+
+    const graph = this.container.buildDependencyGraph(phase);
+    if (graph.length === 0) {
+      logger.debug(`No services registered for phase '${phase}'`);
+      return;
+    }
+
+    const layers = this.resolver.resolveLayered(graph);
+    const order = layers.map((layer) => `[${layer.join(', ')}]`).join(' -> ');
+    logger.info(`--- ${phase} start (${layers.flat().length} services) --- ${order}`);
+
+    const startedAt = performance.now();
+
+    for (const layer of layers) {
+      const results = await Promise.allSettled(
+        layer.map((serviceName) => this.initializeService(serviceName)),
+      );
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          throw result.reason;
+        }
+      }
+      this.initializationOrder.push(...layer);
+    }
+
+    logger.info(`--- ${phase} complete (${(performance.now() - startedAt).toFixed(1)}ms) ---`);
+  }
+
+  /**
+   * Run `onAllReady` on every initialized service, at most once each.
+   *
+   * Failures are isolated: this runs after the gate has opened, so one service's
+   * scheduling mistake must not take down the others.
+   */
+  async runAllReady(): Promise<void> {
+    for (const serviceName of this.initializationOrder) {
+      const instance = this.container.peek<BaseService>(serviceName);
+      if (!instance) continue;
+
+      try {
+        await instance._doAllReady();
+      } catch (error) {
+        logger.error(`Service '${serviceName}' failed in onAllReady`, error as Error);
+      }
+    }
+  }
+
+  /**
+   * Stop every service in reverse initialization order.
+   *
+   * Each service gets its own ceiling, so one stuck `onStop` cannot starve the
+   * services queued behind it. What this guarantees is that stops are
+   * *initiated* in reverse order and that no single async wait exceeds the
+   * ceiling — not that the pass is strictly serial (an abandoned teardown keeps
+   * running) and not a hard wall-clock bound (a synchronously blocking `onStop`
+   * cannot be preempted by a timer).
+   */
+  async stopAll(): Promise<TeardownSummary> {
+    const summary: TeardownSummary = { failed: [], timedOut: [] };
+    const startedAt = performance.now();
+
+    for (const serviceName of [...this.initializationOrder].reverse()) {
+      const outcome = await this.stopService(serviceName);
+      if (outcome === 'timed_out') summary.timedOut.push(serviceName);
+      else if (outcome === 'failed') summary.failed.push(serviceName);
+    }
+
+    logTeardownSummary('stop', summary, performance.now() - startedAt);
+    return summary;
+  }
+
+  /** Destroy every service in reverse order, with the same ceiling and guarantees as {@link stopAll}. */
+  async destroyAll(): Promise<TeardownSummary> {
+    const summary: TeardownSummary = { failed: [], timedOut: [] };
+    const startedAt = performance.now();
+
+    for (const serviceName of [...this.initializationOrder].reverse()) {
+      const outcome = await this.destroyService(serviceName);
+      if (outcome === 'timed_out') summary.timedOut.push(serviceName);
+      else if (outcome === 'failed') summary.failed.push(serviceName);
+    }
+
+    this.initializationOrder.length = 0;
+    logTeardownSummary('destroy', summary, performance.now() - startedAt);
+    return summary;
+  }
+
+  /** Per-service initialization duration, for startup diagnostics. */
+  getTimings(): ReadonlyMap<string, number> {
+    return this.serviceTiming;
+  }
+
+  private async initializeService(serviceName: string): Promise<void> {
+    const metadata = this.container.getMetadata(serviceName);
+    if (!metadata) return;
+
+    try {
+      const instance = this.container.get<BaseService>(serviceName);
+      const startedAt = performance.now();
+
+      this.container.beginInitWindow(serviceName);
+      try {
+        await instance._doInit();
+      } finally {
+        this.container.endInitWindow();
+      }
+
+      const duration = performance.now() - startedAt;
+      this.serviceTiming.set(serviceName, duration);
+      logger.debug(`Service '${serviceName}' initialized (${duration.toFixed(1)}ms)`);
+    } catch (error) {
+      this.handleInitError(serviceName, error as Error);
+    }
+  }
+
+  /**
+   * Fail-fast rethrows as `ServiceInitError`, aborting the phase. Graceful logs
+   * and returns, leaving the service in whatever state it reached.
+   */
+  private handleInitError(serviceName: string, error: Error): void {
+    const strategy = this.container.getMetadata(serviceName)?.errorStrategy ?? 'graceful';
+
+    if (strategy === 'fail-fast') {
+      logger.error(`Service '${serviceName}' failed to initialize (fail-fast)`, error);
+      throw new ServiceInitError(serviceName, error);
+    }
+
+    logger.error(`Service '${serviceName}' failed to initialize (continuing)`, error);
+  }
+
+  private async stopService(serviceName: string): Promise<TeardownOutcome> {
+    const instance = this.container.peek<BaseService>(serviceName);
+    if (!instance) return 'completed';
+
+    const run = instance
+      ._doStop()
+      .then((): TeardownOutcome => 'completed')
+      .catch((error: unknown): TeardownOutcome => {
+        logger.error(`Service '${serviceName}' failed to stop`, error as Error);
+        return 'failed';
+      });
+
+    const outcome = await raceWithTimeout(run, SERVICE_TEARDOWN_TIMEOUT_MS);
+    if (outcome === 'timed_out') {
+      logger.warn(
+        `Service '${serviceName}' stop exceeded ${SERVICE_TEARDOWN_TIMEOUT_MS}ms; moving on`,
+      );
+    }
+    return outcome;
+  }
+
+  private async destroyService(serviceName: string): Promise<TeardownOutcome> {
+    const instance = this.container.peek<BaseService>(serviceName);
+    if (!instance) return 'completed';
+
+    const run = instance
+      ._doDestroy()
+      .then((): TeardownOutcome => {
+        // `_doDestroy` skips itself when a stop is still in flight, so a
+        // fulfilled promise does not prove the service was destroyed. Reporting
+        // that as success would hide exactly the case worth surfacing.
+        return instance.state === LifecycleState.Destroyed ? 'completed' : 'failed';
+      })
+      .catch((error: unknown): TeardownOutcome => {
+        logger.error(`Service '${serviceName}' failed to destroy`, error as Error);
+        return 'failed';
+      });
+
+    const outcome = await raceWithTimeout(run, SERVICE_TEARDOWN_TIMEOUT_MS);
+    if (outcome === 'timed_out') {
+      logger.warn(
+        `Service '${serviceName}' destroy exceeded ${SERVICE_TEARDOWN_TIMEOUT_MS}ms; moving on`,
+      );
+    }
+    return outcome;
+  }
+}

--- a/src/backend/core/lifecycle/ServiceContainer.ts
+++ b/src/backend/core/lifecycle/ServiceContainer.ts
@@ -1,0 +1,216 @@
+import { loggerService } from '@logger';
+
+import {
+  getAppStatePolicy,
+  getDependencies,
+  getErrorStrategy,
+  getPhase,
+  getPriority,
+  getServiceName,
+} from './decorators';
+import type {
+  DependencyNode,
+  Phase,
+  ServiceConstructor,
+  ServiceEntry,
+  ServiceMetadata,
+  ServiceToken,
+} from './types';
+
+const logger = loggerService.withContext('Lifecycle');
+
+/**
+ * Registration and resolution for one ApplicationHost generation.
+ *
+ * Ported from Cherry Desktop `src/main/core/lifecycle/ServiceContainer.ts` with
+ * two structural changes:
+ *
+ * - It is **not** a singleton. Desktop's container is process-global because a
+ *   desktop process has exactly one service graph; mobile needs a graph per host
+ *   so tests and Fast Refresh can replace one wholesale.
+ * - Conditional registration is gone. A capability unavailable on a platform
+ *   registers a no-op implementation, so there is no exclusion set, no
+ *   `getOptional()`, and no transitive exclusion pass.
+ *
+ * Overrides are the test seam: an instance supplied here wins over construction
+ * and never receives lifecycle callbacks, so a duck-typed fake (the in-memory
+ * `DbService`, for instance) does not have to extend `BaseService`.
+ */
+export class ServiceContainer {
+  private readonly services = new Map<string, ServiceEntry>();
+  private readonly overrides: ReadonlyMap<string, unknown>;
+
+  /**
+   * Service whose `onInit`/`onReady` is currently running, for the undeclared
+   * dependency check. Null while constructing instances, because constructor
+   * injection resolves declared dependencies by definition.
+   */
+  private initializingService: string | null = null;
+
+  constructor(overrides: Readonly<Record<string, unknown>> = {}) {
+    this.overrides = new Map(Object.entries(overrides));
+  }
+
+  register<T>(target: ServiceConstructor<T>): void {
+    const name = getServiceName(target);
+
+    if (this.services.has(name)) {
+      logger.warn(`Service '${name}' is already registered, skipping`);
+      return;
+    }
+
+    const metadata: ServiceMetadata = {
+      name,
+      dependencies: getDependencies(target),
+      priority: getPriority(target),
+      errorStrategy: getErrorStrategy(target),
+      phase: getPhase(target),
+      appStatePolicy: getAppStatePolicy(target),
+    };
+
+    this.services.set(name, { metadata, useClass: target });
+  }
+
+  registerAll(targets: readonly ServiceConstructor[]): void {
+    for (const target of targets) {
+      this.register(target);
+    }
+  }
+
+  /**
+   * Resolve a service, constructing it on first use.
+   *
+   * Every service is a singleton within its host. Resolving a name that was not
+   * registered throws — including from module scope before any host exists,
+   * which is what stops a module-level `application.get()` from capturing a
+   * stale instance.
+   */
+  get<T>(token: ServiceToken<T>): T {
+    const name = typeof token === 'string' ? token : getServiceName(token);
+
+    this.checkUndeclaredResolution(name);
+
+    const override = this.overrides.get(name);
+    if (override !== undefined) {
+      return override as T;
+    }
+
+    const entry = this.services.get(name);
+    if (!entry) {
+      throw new Error(`[ServiceContainer] Service '${name}' is not registered`);
+    }
+
+    if (entry.instance !== undefined) {
+      return entry.instance as T;
+    }
+
+    // Constructor injection resolves declared dependencies, so suspend the
+    // undeclared-dependency check for the duration.
+    const outerTracking = this.initializingService;
+    this.initializingService = null;
+    try {
+      const instance = this.createInstance(entry);
+      entry.instance = instance;
+      return instance as T;
+    } finally {
+      this.initializingService = outerTracking;
+    }
+  }
+
+  has(token: ServiceToken): boolean {
+    const name = typeof token === 'string' ? token : getServiceName(token);
+    return this.services.has(name) || this.overrides.has(name);
+  }
+
+  /** The already-constructed instance, if any. Does not construct. */
+  peek<T>(token: ServiceToken<T>): T | undefined {
+    const name = typeof token === 'string' ? token : getServiceName(token);
+    const override = this.overrides.get(name);
+    if (override !== undefined) return override as T;
+    return this.services.get(name)?.instance as T | undefined;
+  }
+
+  getMetadata(token: ServiceToken): ServiceMetadata | undefined {
+    const name = typeof token === 'string' ? token : getServiceName(token);
+    return this.services.get(name)?.metadata;
+  }
+
+  /** Names of services the lifecycle manages — overridden ones are excluded. */
+  getManagedNames(): string[] {
+    return [...this.services.keys()].filter((name) => !this.overrides.has(name));
+  }
+
+  isOverridden(name: string): boolean {
+    return this.overrides.has(name);
+  }
+
+  /** Dependency graph nodes, optionally for one phase only. Overridden services are excluded. */
+  buildDependencyGraph(phase?: Phase): DependencyNode[] {
+    const nodes: DependencyNode[] = [];
+
+    for (const entry of this.services.values()) {
+      const { metadata } = entry;
+      if (this.overrides.has(metadata.name)) continue;
+      if (phase !== undefined && metadata.phase !== phase) continue;
+
+      nodes.push({
+        name: metadata.name,
+        dependencies: metadata.dependencies,
+        priority: metadata.priority,
+        phase: metadata.phase,
+      });
+    }
+
+    return nodes;
+  }
+
+  /** Applied after `DependencyResolver.hoistGateDependencies` adjusts a node. */
+  updatePhase(name: string, phase: Phase): void {
+    const entry = this.services.get(name);
+    if (entry) {
+      entry.metadata.phase = phase;
+    }
+  }
+
+  /**
+   * Mark the window in which a service's `onInit`/`onReady` runs.
+   *
+   * Resolving an undeclared service is legal at runtime — it is how a
+   * dependency cycle is broken — but during initialization it escapes the
+   * ordering graph, so it is reported.
+   */
+  beginInitWindow(name: string): void {
+    this.initializingService = name;
+  }
+
+  endInitWindow(): void {
+    this.initializingService = null;
+  }
+
+  private checkUndeclaredResolution(resolved: string): void {
+    const isDevelopment = typeof __DEV__ !== 'undefined' && __DEV__;
+    if (!isDevelopment || this.initializingService === null) return;
+    if (this.initializingService === resolved) return;
+
+    const declared = this.services.get(this.initializingService)?.metadata.dependencies ?? [];
+    if (declared.includes(resolved)) return;
+
+    logger.warn(
+      `Service '${this.initializingService}' resolved '${resolved}' during initialization without declaring it. ` +
+        `Add it to @DependsOn, or move the resolution out of onInit/onReady if it is a deliberate runtime back-edge.`,
+    );
+  }
+
+  private createInstance(entry: ServiceEntry): unknown {
+    const dependencies = entry.metadata.dependencies.map((name) => {
+      if (!this.has(name)) {
+        throw new Error(
+          `[ServiceContainer] Dependency '${name}' of service '${entry.metadata.name}' is not registered`,
+        );
+      }
+      return this.get(name);
+    });
+
+    return new entry.useClass(...(dependencies as never[]));
+  }
+}

--- a/src/backend/core/lifecycle/__tests__/BaseService.test.ts
+++ b/src/backend/core/lifecycle/__tests__/BaseService.test.ts
@@ -1,0 +1,287 @@
+import { AppState } from 'react-native';
+
+import { BaseService } from '../BaseService';
+import { Injectable } from '../decorators';
+import { Emitter } from '../event';
+import { type Activatable, LifecycleState } from '../types';
+
+jest.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() }),
+  },
+}));
+
+@Injectable('Recorder')
+class Recorder extends BaseService {
+  readonly calls: string[] = [];
+
+  protected onInit(): void {
+    this.calls.push('onInit');
+  }
+
+  protected onReady(): void {
+    this.calls.push('onReady');
+  }
+
+  protected onAllReady(): void {
+    this.calls.push('onAllReady');
+  }
+
+  protected onStop(): void {
+    this.calls.push('onStop');
+  }
+
+  protected onDestroy(): void {
+    this.calls.push('onDestroy');
+  }
+
+  track(cleanup: () => void): void {
+    this.registerDisposable(cleanup);
+  }
+
+  trackInterval(callback: () => void, ms: number): void {
+    this.registerInterval(callback, ms);
+  }
+
+  trackAppState(listener: () => void): void {
+    this.registerAppStateListener(listener);
+  }
+}
+
+describe('BaseService lifecycle', () => {
+  it('runs onInit then onReady and lands in Ready', async () => {
+    const service = new Recorder();
+    expect(service.state).toBe(LifecycleState.Created);
+
+    await service._doInit();
+
+    expect(service.calls).toEqual(['onInit', 'onReady']);
+    expect(service.isReady).toBe(true);
+  });
+
+  it('runs onAllReady at most once', async () => {
+    const service = new Recorder();
+    await service._doInit();
+
+    await service._doAllReady();
+    await service._doAllReady();
+
+    expect(service.calls.filter((call) => call === 'onAllReady')).toHaveLength(1);
+  });
+
+  it('stops then destroys', async () => {
+    const service = new Recorder();
+    await service._doInit();
+
+    await service._doStop();
+    expect(service.isStopped).toBe(true);
+
+    await service._doDestroy();
+    expect(service.isDestroyed).toBe(true);
+    expect(service.calls).toEqual(['onInit', 'onReady', 'onStop', 'onDestroy']);
+  });
+
+  it('ignores a repeated destroy', async () => {
+    const service = new Recorder();
+    await service._doInit();
+    await service._doDestroy();
+    await service._doDestroy();
+
+    expect(service.calls.filter((call) => call === 'onDestroy')).toHaveLength(1);
+  });
+});
+
+describe('BaseService disposables', () => {
+  it('releases registered cleanups after onStop', async () => {
+    const service = new Recorder();
+    const cleanup = jest.fn();
+    service.track(cleanup);
+
+    await service._doInit();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    await service._doStop();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases them even when onStop throws', async () => {
+    @Injectable('Exploding')
+    class Exploding extends BaseService {
+      protected onStop(): void {
+        throw new Error('boom');
+      }
+
+      track(cleanup: () => void): void {
+        this.registerDisposable(cleanup);
+      }
+    }
+
+    const service = new Exploding();
+    const cleanup = jest.fn();
+    service.track(cleanup);
+
+    await expect(service._doStop()).rejects.toThrow('boom');
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps releasing after one disposable throws', async () => {
+    const service = new Recorder();
+    const survivor = jest.fn();
+    service.track(() => {
+      throw new Error('bad cleanup');
+    });
+    service.track(survivor);
+
+    await service._doStop();
+
+    expect(survivor).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears an interval on stop', async () => {
+    jest.useFakeTimers();
+    const service = new Recorder();
+    const tick = jest.fn();
+    service.trackInterval(tick, 1000);
+
+    jest.advanceTimersByTime(2000);
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    await service._doStop();
+    jest.advanceTimersByTime(5000);
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
+  it('removes an AppState subscription on stop', async () => {
+    const remove = jest.fn();
+    const addEventListener = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValue({ remove } as never);
+
+    const service = new Recorder();
+    service.trackAppState(jest.fn());
+    expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    await service._doStop();
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    addEventListener.mockRestore();
+  });
+
+  it('disposes an Emitter registered as a disposable', async () => {
+    const service = new Recorder();
+    const emitter = new Emitter<string>();
+    service.track(() => emitter.dispose());
+
+    await service._doStop();
+
+    expect(emitter.isDisposed).toBe(true);
+  });
+});
+
+describe('BaseService destroy under an in-flight stop', () => {
+  it('skips destroy so it cannot tear down resources live work still uses', async () => {
+    let releaseStop: (() => void) | undefined;
+
+    @Injectable('SlowStop')
+    class SlowStop extends BaseService {
+      destroyed = false;
+
+      protected onStop(): Promise<void> {
+        return new Promise<void>((resolve) => {
+          releaseStop = resolve;
+        });
+      }
+
+      protected onDestroy(): void {
+        this.destroyed = true;
+      }
+    }
+
+    const service = new SlowStop();
+    const stopping = service._doStop();
+    await Promise.resolve();
+
+    await service._doDestroy();
+    expect(service.destroyed).toBe(false);
+    expect(service.state).not.toBe(LifecycleState.Destroyed);
+
+    releaseStop?.();
+    await stopping;
+
+    // Once the stop settles, destroy is allowed again.
+    await service._doDestroy();
+    expect(service.destroyed).toBe(true);
+  });
+
+  it('still destroys after a rejected stop, which has already settled and released', async () => {
+    @Injectable('RejectingStop')
+    class RejectingStop extends BaseService {
+      destroyed = false;
+
+      protected onStop(): Promise<void> {
+        return Promise.reject(new Error('stop failed'));
+      }
+
+      protected onDestroy(): void {
+        this.destroyed = true;
+      }
+    }
+
+    const service = new RejectingStop();
+    await expect(service._doStop()).rejects.toThrow('stop failed');
+
+    await service._doDestroy();
+
+    expect(service.destroyed).toBe(true);
+  });
+});
+
+describe('BaseService activation', () => {
+  @Injectable('Heavy')
+  class Heavy extends BaseService implements Activatable {
+    activations = 0;
+    deactivations = 0;
+
+    onActivate(): void {
+      this.activations += 1;
+    }
+
+    onDeactivate(): void {
+      this.deactivations += 1;
+    }
+  }
+
+  it('activates only when Ready and is idempotent', async () => {
+    const service = new Heavy();
+
+    expect(await service._doActivate()).toBe(false);
+
+    await service._doInit();
+    expect(await service._doActivate()).toBe(true);
+    await service._doActivate();
+
+    expect(service.activations).toBe(1);
+    expect(service.isActivated).toBe(true);
+  });
+
+  it('auto-deactivates on stop', async () => {
+    const service = new Heavy();
+    await service._doInit();
+    await service._doActivate();
+
+    await service._doStop();
+
+    expect(service.deactivations).toBe(1);
+    expect(service.isActivated).toBe(false);
+  });
+
+  it('reports false for a service that is not activatable', async () => {
+    const service = new Recorder();
+    await service._doInit();
+
+    expect(await service._doActivate()).toBe(false);
+    expect(service.isActivated).toBe(false);
+  });
+});

--- a/src/backend/core/lifecycle/__tests__/DependencyResolver.test.ts
+++ b/src/backend/core/lifecycle/__tests__/DependencyResolver.test.ts
@@ -1,0 +1,122 @@
+import { DependencyResolver } from '../DependencyResolver';
+import { CircularDependencyError, type DependencyNode, Phase } from '../types';
+
+const node = (
+  name: string,
+  dependencies: string[] = [],
+  overrides: Partial<DependencyNode> = {},
+): DependencyNode => ({
+  dependencies,
+  name,
+  phase: Phase.Gate,
+  priority: 100,
+  ...overrides,
+});
+
+describe('DependencyResolver.resolveLayered', () => {
+  it('places a dependency in an earlier layer than its dependent', () => {
+    const layers = new DependencyResolver().resolveLayered([
+      node('Chat', ['Db']),
+      node('Db'),
+      node('Jobs', ['Db']),
+    ]);
+
+    expect(layers).toEqual([['Db'], expect.arrayContaining(['Chat', 'Jobs'])]);
+    expect(layers[1]).toHaveLength(2);
+  });
+
+  it('orders peers within a layer by priority', () => {
+    const layers = new DependencyResolver().resolveLayered([
+      node('Late', [], { priority: 200 }),
+      node('Early', [], { priority: 10 }),
+      node('Default', []),
+    ]);
+
+    expect(layers).toEqual([['Early', 'Default', 'Late']]);
+  });
+
+  it('ignores dependencies outside the node set', () => {
+    // A gate service already initialized in an earlier phase imposes no
+    // ordering on the phase being resolved.
+    const layers = new DependencyResolver().resolveLayered([
+      node('PostReadyOnly', ['GateService']),
+    ]);
+
+    expect(layers).toEqual([['PostReadyOnly']]);
+  });
+
+  it('reports the cycle rather than looping forever', () => {
+    const resolve = () =>
+      new DependencyResolver().resolveLayered([
+        node('A', ['C']),
+        node('B', ['A']),
+        node('C', ['B']),
+      ]);
+
+    expect(resolve).toThrow(CircularDependencyError);
+    try {
+      resolve();
+    } catch (error) {
+      // The message must name the participants; "a cycle exists" is not
+      // actionable at 2am.
+      expect((error as CircularDependencyError).cycle.length).toBeGreaterThan(1);
+      expect((error as CircularDependencyError).message).toContain('A');
+    }
+  });
+
+  it('detects a service depending on itself', () => {
+    expect(() => new DependencyResolver().resolveLayered([node('Selfish', ['Selfish'])])).toThrow(
+      CircularDependencyError,
+    );
+  });
+});
+
+describe('DependencyResolver.hoistGateDependencies', () => {
+  it('promotes a post-ready service that a gate service depends on', () => {
+    const nodes = [node('Gate', ['Late']), node('Late', [], { phase: Phase.PostReady })];
+
+    const adjustments = new DependencyResolver().hoistGateDependencies(nodes);
+
+    expect(adjustments).toEqual([
+      {
+        from: Phase.PostReady,
+        reason: expect.stringContaining('Gate'),
+        serviceName: 'Late',
+        to: Phase.Gate,
+      },
+    ]);
+    expect(nodes[1]?.phase).toBe(Phase.Gate);
+  });
+
+  it('promotes transitively', () => {
+    const nodes = [
+      node('Gate', ['Middle']),
+      node('Middle', ['Deep'], { phase: Phase.PostReady }),
+      node('Deep', [], { phase: Phase.PostReady }),
+    ];
+
+    new DependencyResolver().hoistGateDependencies(nodes);
+
+    expect(nodes.map((n) => n.phase)).toEqual([Phase.Gate, Phase.Gate, Phase.Gate]);
+  });
+
+  it('leaves a post-ready service alone when only post-ready services need it', () => {
+    const nodes = [
+      node('LateConsumer', ['LateDependency'], { phase: Phase.PostReady }),
+      node('LateDependency', [], { phase: Phase.PostReady }),
+    ];
+
+    expect(new DependencyResolver().hoistGateDependencies(nodes)).toEqual([]);
+    expect(nodes.every((n) => n.phase === Phase.PostReady)).toBe(true);
+  });
+
+  it('never demotes a gate service to keep it with its dependency', () => {
+    // Desktop adjusts the dependent; doing that here would silently stop a gate
+    // service from blocking the gate it was declared to block.
+    const nodes = [node('Gate', ['Late']), node('Late', [], { phase: Phase.PostReady })];
+
+    new DependencyResolver().hoistGateDependencies(nodes);
+
+    expect(nodes[0]?.phase).toBe(Phase.Gate);
+  });
+});

--- a/src/backend/core/lifecycle/__tests__/LifecycleManager.test.ts
+++ b/src/backend/core/lifecycle/__tests__/LifecycleManager.test.ts
@@ -1,0 +1,292 @@
+import { BaseService } from '../BaseService';
+import { DependsOn, ErrorHandling, Injectable, ServicePhase } from '../decorators';
+import { LifecycleManager, SERVICE_TEARDOWN_TIMEOUT_MS } from '../LifecycleManager';
+import { ServiceContainer } from '../ServiceContainer';
+import { Phase, ServiceInitError } from '../types';
+
+jest.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() }),
+  },
+}));
+
+/** Shared across service instances within one test, so ordering is observable. */
+let journal: string[] = [];
+
+@Injectable('Storage')
+class Storage extends BaseService {
+  protected onInit(): void {
+    journal.push('Storage:init');
+  }
+
+  protected onStop(): void {
+    journal.push('Storage:stop');
+  }
+
+  protected onDestroy(): void {
+    journal.push('Storage:destroy');
+  }
+}
+
+@Injectable('Writer')
+@DependsOn(['Storage'])
+class Writer extends BaseService {
+  constructor(readonly storage: Storage) {
+    super();
+  }
+
+  protected onInit(): void {
+    journal.push('Writer:init');
+  }
+
+  protected onStop(): void {
+    journal.push('Writer:stop');
+  }
+
+  protected onDestroy(): void {
+    journal.push('Writer:destroy');
+  }
+}
+
+@Injectable('Reporter')
+@ServicePhase(Phase.PostReady)
+class Reporter extends BaseService {
+  protected onInit(): void {
+    journal.push('Reporter:init');
+  }
+
+  protected onAllReady(): void {
+    journal.push('Reporter:allReady');
+  }
+}
+
+const build = (services: readonly (new (...args: never[]) => BaseService)[]) => {
+  const container = new ServiceContainer();
+  container.registerAll(services);
+  return { container, manager: new LifecycleManager(container) };
+};
+
+beforeEach(() => {
+  journal = [];
+});
+
+describe('LifecycleManager.startPhase', () => {
+  it('initializes dependencies before dependents', async () => {
+    const { manager } = build([Writer, Storage]);
+
+    await manager.startPhase(Phase.Gate);
+
+    expect(journal).toEqual(['Storage:init', 'Writer:init']);
+  });
+
+  it('only starts services belonging to the phase', async () => {
+    const { manager } = build([Storage, Reporter]);
+
+    await manager.startPhase(Phase.Gate);
+    expect(journal).toEqual(['Storage:init']);
+
+    await manager.startPhase(Phase.PostReady);
+    expect(journal).toEqual(['Storage:init', 'Reporter:init']);
+  });
+
+  it('runs peers in the same layer concurrently', async () => {
+    const started: string[] = [];
+    const makeSlowPeer = (name: string) => {
+      @Injectable(name)
+      class Peer extends BaseService {
+        protected async onInit(): Promise<void> {
+          started.push(`${name}:enter`);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          started.push(`${name}:exit`);
+        }
+      }
+      return Peer;
+    };
+
+    const { manager } = build([makeSlowPeer('PeerA'), makeSlowPeer('PeerB')]);
+
+    await manager.startPhase(Phase.Gate);
+
+    // Both enter before either exits — sequential execution would interleave
+    // as enter/exit/enter/exit.
+    expect(started).toEqual(['PeerA:enter', 'PeerB:enter', 'PeerA:exit', 'PeerB:exit']);
+  });
+
+  it('aborts the phase when a fail-fast service throws', async () => {
+    @Injectable('Broken')
+    class Broken extends BaseService {
+      protected onInit(): void {
+        throw new Error('cannot open database');
+      }
+    }
+
+    const { manager } = build([Broken]);
+
+    await expect(manager.startPhase(Phase.Gate)).rejects.toThrow(ServiceInitError);
+    await expect(manager.startPhase(Phase.Gate)).rejects.toThrow(/cannot open database/);
+  });
+
+  it('continues past a graceful failure', async () => {
+    @Injectable('BestEffort')
+    @ErrorHandling('graceful')
+    class BestEffort extends BaseService {
+      protected onInit(): void {
+        throw new Error('optional warmup failed');
+      }
+    }
+
+    const { manager } = build([BestEffort, Storage]);
+
+    await expect(manager.startPhase(Phase.Gate)).resolves.toBeUndefined();
+    expect(journal).toEqual(['Storage:init']);
+  });
+
+  it('treats post-ready failures as graceful by default', async () => {
+    @Injectable('LateBroken')
+    @ServicePhase(Phase.PostReady)
+    class LateBroken extends BaseService {
+      protected onInit(): void {
+        throw new Error('prewarm failed');
+      }
+    }
+
+    const { manager } = build([LateBroken]);
+
+    await expect(manager.startPhase(Phase.PostReady)).resolves.toBeUndefined();
+  });
+
+  it('promotes a post-ready service that a gate service depends on', async () => {
+    @Injectable('LateDependency')
+    @ServicePhase(Phase.PostReady)
+    class LateDependency extends BaseService {
+      protected onInit(): void {
+        journal.push('LateDependency:init');
+      }
+    }
+
+    @Injectable('GateConsumer')
+    @DependsOn(['LateDependency'])
+    class GateConsumer extends BaseService {
+      constructor(readonly dependency: LateDependency) {
+        super();
+      }
+
+      protected onInit(): void {
+        journal.push('GateConsumer:init');
+      }
+    }
+
+    const { manager } = build([GateConsumer, LateDependency]);
+
+    await manager.startPhase(Phase.Gate);
+
+    expect(journal).toEqual(['LateDependency:init', 'GateConsumer:init']);
+  });
+});
+
+describe('LifecycleManager.runAllReady', () => {
+  it('runs after every phase and survives a failing hook', async () => {
+    @Injectable('NoisyAllReady')
+    class NoisyAllReady extends BaseService {
+      protected onAllReady(): void {
+        throw new Error('scheduling failed');
+      }
+    }
+
+    const { manager } = build([NoisyAllReady, Reporter]);
+    await manager.startPhase(Phase.Gate);
+    await manager.startPhase(Phase.PostReady);
+
+    await expect(manager.runAllReady()).resolves.toBeUndefined();
+    expect(journal).toContain('Reporter:allReady');
+  });
+});
+
+describe('LifecycleManager teardown', () => {
+  it('stops and destroys in reverse initialization order', async () => {
+    const { manager } = build([Writer, Storage]);
+    await manager.startPhase(Phase.Gate);
+    journal = [];
+
+    const stopped = await manager.stopAll();
+    const destroyed = await manager.destroyAll();
+
+    expect(journal).toEqual(['Writer:stop', 'Storage:stop', 'Writer:destroy', 'Storage:destroy']);
+    expect(stopped).toEqual({ failed: [], timedOut: [] });
+    expect(destroyed).toEqual({ failed: [], timedOut: [] });
+  });
+
+  it('records a throwing onStop as failed without stopping the pass', async () => {
+    @Injectable('FailingStop')
+    class FailingStop extends BaseService {
+      protected onStop(): void {
+        throw new Error('stop exploded');
+      }
+    }
+
+    const { manager } = build([FailingStop, Storage]);
+    await manager.startPhase(Phase.Gate);
+    journal = [];
+
+    const summary = await manager.stopAll();
+
+    expect(summary.failed).toEqual(['FailingStop']);
+    expect(journal).toContain('Storage:stop');
+  });
+
+  it('abandons a hanging stop at the ceiling and moves on', async () => {
+    @Injectable('Hanging')
+    class Hanging extends BaseService {
+      protected onStop(): Promise<void> {
+        return new Promise<void>(() => {});
+      }
+    }
+
+    const { manager } = build([Hanging, Storage]);
+    await manager.startPhase(Phase.Gate);
+    journal = [];
+
+    jest.useFakeTimers();
+    const stopping = manager.stopAll();
+    await jest.advanceTimersByTimeAsync(SERVICE_TEARDOWN_TIMEOUT_MS);
+    const summary = await stopping;
+    jest.useRealTimers();
+
+    expect(summary.timedOut).toEqual(['Hanging']);
+    // The service behind the stuck one still got its turn.
+    expect(journal).toContain('Storage:stop');
+  });
+
+  it('reports a skipped destroy as failed rather than completed', async () => {
+    // `_doDestroy` skips itself while a stop is still in flight, so a resolved
+    // promise does not prove the service was destroyed.
+    @Injectable('StuckStop')
+    class StuckStop extends BaseService {
+      protected onStop(): Promise<void> {
+        return new Promise<void>(() => {});
+      }
+    }
+
+    const { manager } = build([StuckStop]);
+    await manager.startPhase(Phase.Gate);
+
+    jest.useFakeTimers();
+    const stopping = manager.stopAll();
+    await jest.advanceTimersByTimeAsync(SERVICE_TEARDOWN_TIMEOUT_MS);
+    await stopping;
+
+    const destroying = manager.destroyAll();
+    await jest.advanceTimersByTimeAsync(SERVICE_TEARDOWN_TIMEOUT_MS);
+    const summary = await destroying;
+    jest.useRealTimers();
+
+    expect(summary.failed).toEqual(['StuckStop']);
+  });
+
+  it('records per-service initialization timings', async () => {
+    const { manager } = build([Storage]);
+    await manager.startPhase(Phase.Gate);
+
+    expect(manager.getTimings().has('Storage')).toBe(true);
+  });
+});

--- a/src/backend/core/lifecycle/__tests__/ServiceContainer.test.ts
+++ b/src/backend/core/lifecycle/__tests__/ServiceContainer.test.ts
@@ -1,0 +1,224 @@
+import { BaseService } from '../BaseService';
+import { DependsOn, Injectable, Priority, ServicePhase } from '../decorators';
+import { ServiceContainer } from '../ServiceContainer';
+import { Phase } from '../types';
+
+const mockLoggerWarn = jest.fn();
+
+jest.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    }),
+  },
+}));
+
+@Injectable('Database')
+class Database extends BaseService {
+  readonly rows: string[] = [];
+}
+
+@Injectable('Chat')
+@DependsOn(['Database'])
+class Chat extends BaseService {
+  constructor(readonly database: Database) {
+    super();
+  }
+}
+
+@Injectable('Sneaky')
+class Sneaky extends BaseService {
+  resolved: Database | null = null;
+
+  constructor(private readonly container: ServiceContainer) {
+    super();
+  }
+
+  protected onInit(): void {
+    // Resolving something it never declared — legal at runtime, reportable here.
+    this.resolved = this.container.get<Database>('Database');
+  }
+}
+
+beforeEach(() => {
+  mockLoggerWarn.mockClear();
+});
+
+describe('ServiceContainer resolution', () => {
+  it('returns the same instance on every resolution', () => {
+    const container = new ServiceContainer();
+    container.register(Database);
+
+    expect(container.get('Database')).toBe(container.get('Database'));
+  });
+
+  it('injects declared dependencies through the constructor', () => {
+    const container = new ServiceContainer();
+    container.registerAll([Database, Chat]);
+
+    const chat = container.get<Chat>('Chat');
+
+    expect(chat.database).toBe(container.get('Database'));
+  });
+
+  it('throws for an unregistered service', () => {
+    expect(() => new ServiceContainer().get('Missing')).toThrow(/not registered/);
+  });
+
+  it('names the dependent when a declared dependency is missing', () => {
+    const container = new ServiceContainer();
+    container.register(Chat);
+
+    expect(() => container.get('Chat')).toThrow(/'Database'.+'Chat'/);
+  });
+
+  it('does not construct anything until first resolution', () => {
+    const container = new ServiceContainer();
+    container.register(Database);
+
+    expect(container.peek('Database')).toBeUndefined();
+    container.get('Database');
+    expect(container.peek('Database')).toBeDefined();
+  });
+
+  it('reads metadata from decorators', () => {
+    const container = new ServiceContainer();
+    container.registerAll([Database, Chat]);
+
+    expect(container.getMetadata('Chat')).toEqual({
+      appStatePolicy: 'not-applicable',
+      dependencies: ['Database'],
+      errorStrategy: 'fail-fast',
+      name: 'Chat',
+      phase: Phase.Gate,
+      priority: 100,
+    });
+  });
+
+  it('ignores a duplicate registration rather than replacing the first', () => {
+    const container = new ServiceContainer();
+    container.register(Database);
+    const first = container.get('Database');
+
+    container.register(Database);
+
+    expect(container.get('Database')).toBe(first);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('already registered'));
+  });
+});
+
+describe('ServiceContainer overrides', () => {
+  it('returns the override instead of constructing the real service', () => {
+    const fake = { rows: ['fake'] };
+    const container = new ServiceContainer({ Database: fake });
+    container.register(Database);
+
+    expect(container.get('Database')).toBe(fake);
+  });
+
+  it('injects an override into a dependent', () => {
+    const fake = { rows: ['fake'] };
+    const container = new ServiceContainer({ Database: fake });
+    container.registerAll([Database, Chat]);
+
+    expect(container.get<Chat>('Chat').database).toBe(fake);
+  });
+
+  it('excludes overridden services from lifecycle management', () => {
+    // A duck-typed fake does not extend BaseService, so driving it through
+    // init/stop would crash. It is the test's own responsibility.
+    const container = new ServiceContainer({ Database: { rows: [] } });
+    container.registerAll([Database, Chat]);
+
+    expect(container.getManagedNames()).toEqual(['Chat']);
+    expect(container.buildDependencyGraph().map((n) => n.name)).toEqual(['Chat']);
+    expect(container.isOverridden('Database')).toBe(true);
+  });
+
+  it('reports an override as present', () => {
+    const container = new ServiceContainer({ Database: { rows: [] } });
+
+    expect(container.has('Database')).toBe(true);
+  });
+});
+
+describe('ServiceContainer undeclared dependency detection', () => {
+  it('warns when a service resolves something it did not declare during init', async () => {
+    const container = new ServiceContainer();
+    container.register(Database);
+    container.register(Sneaky);
+    // Sneaky takes the container itself, which is not a registered service.
+    const sneaky = new Sneaky(container);
+
+    container.beginInitWindow('Sneaky');
+    await sneaky._doInit();
+    container.endInitWindow();
+
+    expect(sneaky.resolved).toBeDefined();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved 'Database' during initialization without declaring it"),
+    );
+  });
+
+  it('stays quiet for a declared dependency', () => {
+    const container = new ServiceContainer();
+    container.registerAll([Database, Chat]);
+
+    container.beginInitWindow('Chat');
+    container.get('Database');
+    container.endInitWindow();
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for constructor injection of a transitive dependency', () => {
+    // Constructing Chat resolves Database. That is declared ordering, not an
+    // escape, and must not be reported while Chat's own init window is open.
+    const container = new ServiceContainer();
+    container.registerAll([Database, Chat]);
+
+    container.beginInitWindow('Chat');
+    container.get('Chat');
+    container.endInitWindow();
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet outside an init window', () => {
+    const container = new ServiceContainer();
+    container.registerAll([Database, Chat]);
+
+    container.get('Database');
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+});
+
+describe('ServiceContainer dependency graph', () => {
+  @Injectable('LateService')
+  @ServicePhase(Phase.PostReady)
+  @Priority(5)
+  class LateService extends BaseService {}
+
+  it('filters by phase and carries decorator metadata into nodes', () => {
+    const container = new ServiceContainer();
+    container.registerAll([Database, LateService]);
+
+    expect(container.buildDependencyGraph(Phase.PostReady)).toEqual([
+      { dependencies: [], name: 'LateService', phase: Phase.PostReady, priority: 5 },
+    ]);
+    expect(container.buildDependencyGraph(Phase.Gate).map((n) => n.name)).toEqual(['Database']);
+  });
+
+  it('applies a phase update', () => {
+    const container = new ServiceContainer();
+    container.register(LateService);
+
+    container.updatePhase('LateService', Phase.Gate);
+
+    expect(container.getMetadata('LateService')?.phase).toBe(Phase.Gate);
+  });
+});

--- a/src/backend/core/lifecycle/decorators.ts
+++ b/src/backend/core/lifecycle/decorators.ts
@@ -1,0 +1,131 @@
+import 'reflect-metadata';
+import {
+  type AppStatePolicyValue,
+  type ErrorStrategy,
+  Phase,
+  type ServiceConstructor,
+} from './types';
+
+/**
+ * Service metadata decorators.
+ *
+ * Ported from Cherry Desktop `src/main/core/lifecycle/decorators.ts`. Every
+ * decorator takes its arguments explicitly, so `emitDecoratorMetadata` and
+ * constructor type reflection are not required — only `experimentalDecorators`
+ * plus `@babel/plugin-proposal-decorators` in legacy mode.
+ *
+ * Desktop's `@Conditional` is not ported; see types.ts for why.
+ */
+
+const METADATA_KEYS = {
+  INJECTABLE: 'lifecycle:injectable',
+  SERVICE_NAME: 'lifecycle:serviceName',
+  DEPENDENCIES: 'lifecycle:dependencies',
+  PRIORITY: 'lifecycle:priority',
+  ERROR_STRATEGY: 'lifecycle:errorStrategy',
+  PHASE: 'lifecycle:phase',
+  APP_STATE_POLICY: 'lifecycle:appStatePolicy',
+} as const;
+
+const DEFAULT_PRIORITY = 100;
+
+/**
+ * Mark a class as a lifecycle service.
+ *
+ * @param name Explicit service name. Required rather than derived from
+ *   `target.name` because bundlers mangle class names. It must match the key
+ *   used in the service registry, `application.get(name)`, and `@DependsOn`.
+ */
+export function Injectable(name: string): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(METADATA_KEYS.INJECTABLE, true, target);
+    Reflect.defineMetadata(METADATA_KEYS.SERVICE_NAME, name, target);
+  };
+}
+
+/**
+ * Declare the services this one needs.
+ *
+ * Dependencies are constructed and initialized first, and torn down after.
+ * Resolving an undeclared service at runtime is legal — it is how a dependency
+ * cycle is broken — but doing so during `onInit` escapes the ordering graph and
+ * the container warns about it in development.
+ */
+export function DependsOn(dependencies: string[]): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(METADATA_KEYS.DEPENDENCIES, dependencies, target);
+  };
+}
+
+/** Ordering within a dependency layer; lower runs earlier. Defaults to 100. */
+export function Priority(priority: number): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(METADATA_KEYS.PRIORITY, priority, target);
+  };
+}
+
+/**
+ * Override the error strategy implied by the phase.
+ *
+ * Rarely needed: `Gate` services are fail-fast and `PostReady` services are
+ * graceful by default. Use this for a `Gate` service that must initialize early
+ * but whose failure should not abort startup.
+ */
+export function ErrorHandling(strategy: ErrorStrategy): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(METADATA_KEYS.ERROR_STRATEGY, strategy, target);
+  };
+}
+
+/** Set the bootstrap phase. Defaults to `Phase.Gate`. */
+export function ServicePhase(phase: Phase): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(METADATA_KEYS.PHASE, phase, target);
+  };
+}
+
+/**
+ * Declare what this service does when the app leaves the foreground.
+ *
+ * Documentation and audit only — the framework drives no AppState behaviour.
+ * Services that care subscribe through `BaseService.registerAppStateListener`.
+ */
+export function AppStatePolicy(policy: AppStatePolicyValue): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(METADATA_KEYS.APP_STATE_POLICY, policy, target);
+  };
+}
+
+export function isInjectable(target: ServiceConstructor): boolean {
+  return Reflect.getMetadata(METADATA_KEYS.INJECTABLE, target) === true;
+}
+
+export function getServiceName(target: ServiceConstructor): string {
+  return Reflect.getMetadata(METADATA_KEYS.SERVICE_NAME, target) || target.name;
+}
+
+export function getDependencies(target: ServiceConstructor): string[] {
+  return Reflect.getMetadata(METADATA_KEYS.DEPENDENCIES, target) || [];
+}
+
+export function getPriority(target: ServiceConstructor): number {
+  return Reflect.getMetadata(METADATA_KEYS.PRIORITY, target) ?? DEFAULT_PRIORITY;
+}
+
+export function getPhase(target: ServiceConstructor): Phase {
+  return Reflect.getMetadata(METADATA_KEYS.PHASE, target) || Phase.Gate;
+}
+
+/** Explicit `@ErrorHandling` wins; otherwise the phase decides. */
+export function getErrorStrategy(target: ServiceConstructor): ErrorStrategy {
+  const explicit: ErrorStrategy | undefined = Reflect.getMetadata(
+    METADATA_KEYS.ERROR_STRATEGY,
+    target,
+  );
+  if (explicit) return explicit;
+  return getPhase(target) === Phase.Gate ? 'fail-fast' : 'graceful';
+}
+
+export function getAppStatePolicy(target: ServiceConstructor): AppStatePolicyValue {
+  return Reflect.getMetadata(METADATA_KEYS.APP_STATE_POLICY, target) || 'not-applicable';
+}

--- a/src/backend/core/lifecycle/event.ts
+++ b/src/backend/core/lifecycle/event.ts
@@ -1,0 +1,97 @@
+/**
+ * Typed events for inter-service communication.
+ *
+ * Ported verbatim from Cherry Desktop `src/main/core/lifecycle/event.ts`.
+ * Producers own an `Emitter<T>` and expose its `Event<T>`; consumers subscribe
+ * and receive a `Disposable`.
+ *
+ * @example
+ * // Producer
+ * private readonly _onTurnSettled = new Emitter<string>();
+ * readonly onTurnSettled: Event<string> = this._onTurnSettled.event;
+ *
+ * // Consumer
+ * this.registerDisposable(chatRuntime.onTurnSettled((topicId) => { ... }));
+ */
+
+/**
+ * A resource with deterministic cleanup.
+ *
+ * Register one via `BaseService.registerDisposable()` to have it released when
+ * the service stops.
+ */
+export type Disposable = {
+  dispose(): void;
+};
+
+/**
+ * Wrap a cleanup function as a `Disposable`.
+ *
+ * Bridges APIs that return `() => void` — React Native's
+ * `AppState.addEventListener().remove`, preference subscriptions — into the
+ * interface `registerDisposable()` expects. Disposal is idempotent.
+ */
+export function toDisposable(fn: () => void): Disposable {
+  let disposed = false;
+  return {
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      fn();
+    },
+  };
+}
+
+/** Subscribe to a typed event; the returned `Disposable` unsubscribes. */
+export type Event<T> = (listener: (e: T) => void) => Disposable;
+
+/**
+ * Type-safe event emitter.
+ *
+ * `fire()` is synchronous and error-isolated: one throwing listener cannot
+ * prevent the others from running. A disposed emitter ignores `fire()` and
+ * hands back a no-op subscription.
+ */
+export class Emitter<T> implements Disposable {
+  private readonly listeners = new Set<(e: T) => void>();
+  private disposed = false;
+
+  readonly event: Event<T> = (listener: (e: T) => void): Disposable => {
+    if (this.disposed) {
+      return { dispose: () => {} };
+    }
+
+    this.listeners.add(listener);
+    return {
+      dispose: () => {
+        this.listeners.delete(listener);
+      },
+    };
+  };
+
+  /** Notify every current listener. The set is snapshotted, so a listener may subscribe or unsubscribe during delivery. */
+  fire(event: T): void {
+    if (this.disposed) return;
+
+    for (const listener of [...this.listeners]) {
+      try {
+        listener(event);
+      } catch {
+        // Error isolation: one bad listener must not break the others.
+      }
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.listeners.clear();
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}

--- a/src/backend/core/lifecycle/types.ts
+++ b/src/backend/core/lifecycle/types.ts
@@ -1,0 +1,203 @@
+/**
+ * Lifecycle framework types.
+ *
+ * Ported from Cherry Desktop `src/main/core/lifecycle/types.ts`. Two deliberate
+ * differences, both documented in docs/references/lifecycle/README.md:
+ *
+ * - Phases are `Gate`/`PostReady` rather than Desktop's three Electron-relative
+ *   phases; mobile's only real boundary is the first-paint gate.
+ * - Desktop's `@Conditional` machinery is not ported. A capability that is
+ *   unavailable on a platform registers a no-op implementation instead, so there
+ *   is no exclusion set and no `getOptional()` twin.
+ *
+ * Enums are expressed as const objects because this repository uses no
+ * TypeScript `enum`.
+ */
+
+/**
+ * Bootstrap phase. Determines when a service initializes relative to the
+ * first-paint gate.
+ */
+export const Phase = {
+  /** Blocks first paint. A failure here aborts startup. */
+  Gate: 'gate',
+  /** Runs after the gate opens. Fire-and-forget; failures are logged only. */
+  PostReady: 'postReady',
+} as const;
+
+export type Phase = (typeof Phase)[keyof typeof Phase];
+
+/** Phase ordering for comparison (lower runs earlier). */
+export const PhaseOrder: Record<Phase, number> = {
+  [Phase.Gate]: 0,
+  [Phase.PostReady]: 1,
+};
+
+/**
+ * Lifecycle state of a single service.
+ *
+ * Created → Initializing → Ready ⇄ Paused
+ *                ↑           ↓
+ *                │        Stopping → Stopped → (restart) → Initializing
+ *                │                      ↓
+ *                └──────────────── Destroyed
+ *
+ * Activation is orthogonal: a Ready service may be activated or not, and
+ * toggling it does not change this state.
+ */
+export const LifecycleState = {
+  Created: 'created',
+  Initializing: 'initializing',
+  Ready: 'ready',
+  Pausing: 'pausing',
+  Paused: 'paused',
+  Resuming: 'resuming',
+  Stopping: 'stopping',
+  Stopped: 'stopped',
+  Destroyed: 'destroyed',
+} as const;
+
+export type LifecycleState = (typeof LifecycleState)[keyof typeof LifecycleState];
+
+/**
+ * How one service's teardown pass (`onStop` / `onDestroy`) ended.
+ *
+ * Orthogonal to `LifecycleState`, which does not encode it: anything but
+ * `completed` leaves the state where it was. The state says where the service
+ * is; this says how the framework's attempt ended.
+ */
+export type TeardownOutcome = 'completed' | 'timed_out' | 'failed';
+
+/** Aggregate result of a `stopAll()` / `destroyAll()` pass. Empty on both counts means clean. */
+export type TeardownSummary = {
+  /** Services whose teardown exceeded the per-service ceiling and was abandoned. */
+  timedOut: string[];
+  /** Services whose teardown threw, or was skipped because their stop was still in flight. */
+  failed: string[];
+};
+
+/**
+ * Error handling strategy.
+ *
+ * Desktop's third option, `custom`, routes failures to a `SERVICE_ERROR` event
+ * listener. It has no mobile use, so it is not ported: `Gate` services are
+ * fail-fast and `PostReady` services are graceful.
+ */
+export type ErrorStrategy = 'fail-fast' | 'graceful';
+
+/** Thrown when a fail-fast service fails to initialize. */
+export class ServiceInitError extends Error {
+  constructor(
+    readonly serviceName: string,
+    override readonly cause: Error,
+  ) {
+    super(`Service '${serviceName}' failed to initialize: ${cause.message}`);
+    this.name = 'ServiceInitError';
+  }
+}
+
+/** Thrown when the dependency graph contains a cycle. */
+export class CircularDependencyError extends Error {
+  constructor(readonly cycle: string[]) {
+    super(`Circular dependency detected: ${cycle.join(' -> ')}`);
+    this.name = 'CircularDependencyError';
+  }
+}
+
+/**
+ * Declarative record of what a service does when the app leaves the foreground.
+ *
+ * Mobile-only and purely descriptive: the framework drives no AppState
+ * behaviour. It exists so "what happens to this service in the background" is
+ * auditable without reading every implementation.
+ */
+export type AppStatePolicyValue =
+  /** Keeps working; the owner arranges its own execution window if it needs one. */
+  | 'continue'
+  /** Owns a native background surface (Live Activity, keep-alive audio). */
+  | 'background-presentation'
+  /** Holds nothing that background transitions affect. */
+  | 'not-applicable';
+
+/** Service metadata, assembled from decorators at registration time. */
+export type ServiceMetadata = {
+  name: string;
+  dependencies: string[];
+  /** Ordering within a dependency layer; lower runs earlier. */
+  priority: number;
+  errorStrategy: ErrorStrategy;
+  phase: Phase;
+  appStatePolicy: AppStatePolicyValue;
+};
+
+export type ServiceConstructor<T = unknown> = new (...args: never[]) => T;
+
+/** A service is addressed by its registered name or by its constructor. */
+export type ServiceToken<T = unknown> = string | ServiceConstructor<T>;
+
+export type ServiceEntry<T = unknown> = {
+  metadata: ServiceMetadata;
+  useClass: ServiceConstructor<T>;
+  /** Populated on first resolution; every service is a singleton within its host. */
+  instance?: T;
+};
+
+/** Node in the dependency graph used for topological sorting. */
+export type DependencyNode = {
+  name: string;
+  dependencies: string[];
+  priority: number;
+  phase: Phase;
+};
+
+/**
+ * Services that support pause/resume.
+ *
+ * Not driven by AppState — mobile services subscribe to that themselves. This
+ * exists for deliberate, caller-initiated suspension such as a database
+ * snapshot.
+ */
+export type Pausable = {
+  onPause(): Promise<void> | void;
+  onResume(): Promise<void> | void;
+};
+
+export function isPausable(service: unknown): service is Pausable {
+  return (
+    typeof service === 'object' &&
+    service !== null &&
+    'onPause' in service &&
+    'onResume' in service &&
+    typeof (service as Pausable).onPause === 'function' &&
+    typeof (service as Pausable).onResume === 'function'
+  );
+}
+
+/**
+ * Services whose heavy resources sit behind a preference or feature gate.
+ *
+ * Unlike a platform capability — which registers a no-op implementation — an
+ * activatable service is always registered and initialized, and only its
+ * expensive resources come and go. Supports repeated cycles.
+ */
+export type Activatable = {
+  /**
+   * Load heavy resources. If this throws after partially allocating, it must
+   * release what it allocated first: activation may be retried, because
+   * `isActivated` stays false on failure.
+   */
+  onActivate(): Promise<void> | void;
+  /** Release heavy resources. Safe even if `onActivate` never ran or failed. */
+  onDeactivate(): Promise<void> | void;
+};
+
+export function isActivatable(service: unknown): service is Activatable {
+  return (
+    typeof service === 'object' &&
+    service !== null &&
+    'onActivate' in service &&
+    'onDeactivate' in service &&
+    typeof (service as Activatable).onActivate === 'function' &&
+    typeof (service as Activatable).onDeactivate === 'function'
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "experimentalDecorators": true,
     "types": ["jest"],
     "paths": {
       "@cherrystudio/provider-registry": ["./packages/provider-registry/src/index.ts"],


### PR DESCRIPTION
## Why

Deleting a domain resource does not stop the work running against it. `onTopicsDeleted` only ends
the Live Activity presentation, so deleting a topic mid-generation leaves the chat stream writing
into a deleted topic and leaves any associated job running. Painting deletion is safe today only
because a frontend hook happens to cancel first — every other Data API caller bypasses it.

Fixing that needs somewhere for a domain-neutral deletion coordinator to live and something to own
its lifetime. Mobile has explicit composition wiring in `src/bootstrap` and no service lifecycle at
all, so this stack starts by adopting the desktop lifecycle framework and builds the fix on top.

## What this PR contains

Stage A of a four-stage migration: the framework, wired to nothing.

- `docs/references/lifecycle/` — the design: admission rules, final interfaces, the resource-scope
  coordinator, and the staged migration plan
- `src/backend/core/lifecycle/` — `ServiceContainer`, `LifecycleManager`, `DependencyResolver`,
  `BaseService`, the decorators, and the event primitives
- `src/backend/core/application/` — `application`, `ApplicationHost`, and an empty `serviceRegistry`
- Toolchain: `reflect-metadata` and `@babel/plugin-proposal-decorators`, plus
  `experimentalDecorators`
- One new eslint layer rule and its single deliberate exemption

`services` is empty, so nothing runs through the framework yet and app behaviour is unchanged.

## Divergence from desktop

Each deviation is recorded with its reason in `docs/references/lifecycle/README.md`: two mobile
phases instead of three Electron ones, no IPC sugar, no permanent-singleton `WeakSet` (host
generations must be able to re-instantiate), no `@Conditional` (unavailable capabilities register
no-op implementations instead), no 30s `process.exit` fuse, and an added `registerAppStateListener`.

One repair direction is inverted rather than ported. Desktop demotes a dependent into its
dependency's later phase; here that would silently stop a `Gate` service from blocking the gate it
was declared to block, so the dependency is promoted instead.

## Verification

- 68 new unit tests; full suite 3014 passing
- typecheck, lint, format, and doc links clean
- A production `expo export` compiles to Hermes bytecode, and a temporary decorated class read its
  own `@Injectable` name, `@DependsOn` list, and phase back out of `reflect-metadata` on a
  simulator — the decorator toolchain is verified on Hermes, not just in jest
- Simulator cold start reaches the topic list unchanged

## Stack

This is the bottom of a stack. Layers above it:

1. **#509** — stage B/C/D: the ~18 runtime modules become services, CRUD services
   become module singletons, and `ResourceScopeCoordinator` lands with the deletion fix
2. #473 (background activities) rebases on top once this is stable

This supersedes #505, which had the same content on a fork-hosted branch. GitHub requires a PR's
base branch to live in the base repository, so a branch on `eeee0717` can never be the base of the
layer above it. Both branches now live on `CherryHQ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
