### PR TITLE
fix(android-menu): preserve React-managed child layout

### DIFF
--- a/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
+++ b/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
@@ -38,6 +38,11 @@ private class MenuFrameLayout(context: Context) : FrameLayout(context) {
         gestureDetector.onTouchEvent(event)
         return super.dispatchTouchEvent(event)
     }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        // React Native's UIManager lays out children when the view manager does not opt into
+        // custom child layout. Letting FrameLayout run here would overwrite those Yoga positions.
+    }
 }
 
 @DoNotStrip


### PR DESCRIPTION
## Summary

- preserve React Native's Yoga-computed child layout inside Android `CherryMenuView`
- prevent `FrameLayout.onLayout` from overwriting padding and child positions
- keep the existing native long-press menu behavior unchanged

## Root cause

`CherryMenuViewManager` returns `needsCustomLayoutForChildren() = false`, so React Native's UIManager owns child layout. `MenuFrameLayout` inherited `FrameLayout.onLayout`, which recursively laid out the child again and overwrote the positions computed by Yoga. This made the user-message bubble visually lose its `p-2` padding.

## Impact

User-message bubbles wrapped by the native Android menu retain their expected internal padding. Long-press still opens the Copy/Edit menu.

## Validation

- `pnpm exec jest packages/ui/src/components/menu/__tests__/menu.test.tsx --runInBand` — 3 tests passed
- `./gradlew :cherrystudio_ui:compileDebugKotlin` — `BUILD SUCCESSFUL`
- Android emulator benchmark fixture: measured left inset changed from 1 px before the fix to 22 px after the fix
- Android emulator long-press check: Copy/Edit menu remained available
- `git diff --check`
