### PR TITLE
fix(model-list): align provider pull with desktop catalog merge

### DIFF
--- a/src/backend/ai/AiService.ts
+++ b/src/backend/ai/AiService.ts
@@ -38,6 +38,10 @@ import {
 } from '@/backend/data/services/AiUsageRecordService';
 import { assistantService, type AssistantService } from '@/backend/data/services/AssistantService';
 import { modelService, type ModelService } from '@/backend/data/services/ModelService';
+import {
+  providerRegistryService,
+  type ProviderRegistryService,
+} from '@/backend/data/services/ProviderRegistryService';
 import { providerService, type ProviderService } from '@/backend/data/services/ProviderService';
 import { fileContent } from '@/backend/services/file/fileContent';
 import { COPILOT_PROVIDER_ID } from '@/backend/services/oauth/authorization/adapters/CopilotOAuthAdapter';
@@ -92,7 +96,23 @@ export interface AiServiceDependencies extends BuildAgentParamsDependencies {
   model: Pick<ModelService, 'getById'>;
   provider: BuildAgentParamsDependencies['provider'] &
     Pick<ProviderService, 'getByProviderId' | 'getRotatedApiKey'>;
+  providerRegistry: Pick<ProviderRegistryService, 'listProviderRegistryModels'>;
   vertexAuth: Pick<VertexAuthClient, 'getAuthorizationHeaders'>;
+}
+
+function bareModelKey(model: Partial<Model>): string {
+  const modelId = model.apiModelId ?? model.modelId ?? '';
+  const afterSlash = modelId.includes('/') ? modelId.slice(modelId.lastIndexOf('/') + 1) : modelId;
+  return afterSlash.toLowerCase();
+}
+
+export function mergeProviderModelsWithRegistry(
+  remote: Partial<Model>[],
+  registry: Model[],
+): Partial<Model>[] {
+  const seen = new Set(remote.map(bareModelKey));
+  const missing = registry.filter((model) => !seen.has(bareModelKey(model)));
+  return missing.length > 0 ? [...remote, ...missing] : remote;
 }
 
 /** `auto` is the picker's "let the model decide" sentinel, not a wire value. */
@@ -219,6 +239,7 @@ export class AiService extends BaseService {
       oauth: overrides.oauth ?? hostOAuth,
       preference: overrides.preference ?? application.get('PreferenceService'),
       provider: overrides.provider ?? providerService,
+      providerRegistry: overrides.providerRegistry ?? providerRegistryService,
       tools: overrides.tools ?? this.getToolResolver(),
       vertexAuth: overrides.vertexAuth ?? this.getVertexAuth(),
     };
@@ -370,7 +391,15 @@ export class AiService extends BaseService {
 
   async listModels(request: ListModelsRequest): Promise<Partial<Model>[]> {
     const provider = await this.getProviderForListModels(request);
-    return listProviderModels(
+    const registryModels = this.services.providerRegistry.listProviderRegistryModels({
+      presetProviderId: provider.presetProviderId ?? null,
+      providerId: provider.id,
+    });
+    if (provider.modelListSource === 'registry') {
+      return registryModels;
+    }
+
+    const remoteModels = await listProviderModels(
       provider,
       {
         getAuthConfig: async (providerId) =>
@@ -383,6 +412,7 @@ export class AiService extends BaseService {
       request.requestOptions?.signal,
       { throwOnError: request.throwOnError },
     );
+    return mergeProviderModelsWithRegistry(remoteModels, registryModels);
   }
 
   // ── Image generation ──

--- a/src/backend/ai/__tests__/AiService.test.ts
+++ b/src/backend/ai/__tests__/AiService.test.ts
@@ -124,6 +124,84 @@ describe('AiService.listModels authentication adapters', () => {
   });
 });
 
+describe('AiService.listModels catalog merge', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the registry catalog without requesting the upstream API', async () => {
+    const provider = createProvider({
+      id: 'login-provider',
+      modelListSource: 'registry',
+      presetProviderId: 'login-provider',
+    });
+    const registryModel = createModel('registry-model', { providerId: provider.id });
+    const listProviderRegistryModels = jest.fn(() => [registryModel]);
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const services = {
+      ...createServices({ provider }),
+      providerRegistry: { listProviderRegistryModels },
+    } as unknown as AiServiceDependencies;
+
+    await expect(new AiService(services).listModels({ providerId: provider.id })).resolves.toEqual([
+      registryModel,
+    ]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(listProviderRegistryModels).toHaveBeenCalledWith({
+      presetProviderId: 'login-provider',
+      providerId: 'login-provider',
+    });
+  });
+
+  it('appends registry-only models and deduplicates publisher-prefixed twins', async () => {
+    const provider = createProvider({ id: 'ppio', presetProviderId: 'ppio' });
+    const registryTwin = createModel('qwen/qwen3', {
+      apiModelId: 'qwen/qwen3',
+      providerId: provider.id,
+    });
+    const registryOnly = createModel('z-image-turbo', {
+      apiModelId: 'z-image-turbo',
+      providerId: provider.id,
+    });
+    const listProviderRegistryModels = jest.fn(() => [registryTwin, registryOnly]);
+    jest.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'qwen3', name: 'Qwen3 from API' }],
+          }),
+          { status: 200 },
+        ),
+    );
+    const services = {
+      ...createServices({ provider }),
+      providerRegistry: { listProviderRegistryModels },
+    } as unknown as AiServiceDependencies;
+
+    const result = await new AiService(services).listModels({
+      providerId: provider.id,
+      throwOnError: true,
+    });
+
+    expect(result.map((model) => model.apiModelId)).toEqual(['qwen3', 'z-image-turbo']);
+    expect(result[0]?.name).toBe('qwen3');
+  });
+
+  it('preserves upstream failures instead of falling back to the registry catalog', async () => {
+    const provider = createProvider({ id: 'openai', presetProviderId: 'openai' });
+    const registryModel = createModel('registry-model', { providerId: provider.id });
+    jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('upstream unavailable'));
+    const services = {
+      ...createServices({ provider }),
+      providerRegistry: { listProviderRegistryModels: jest.fn(() => [registryModel]) },
+    } as unknown as AiServiceDependencies;
+
+    await expect(
+      new AiService(services).listModels({ providerId: provider.id, throwOnError: true }),
+    ).rejects.toThrow('upstream unavailable');
+  });
+});
+
 describe('AiService.generateImage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1115,6 +1193,9 @@ function createServices({
           ? { attribution: 'unknown' as const }
           : { attribution: 'explicit' as const, id: 'key-1', masked: 'ro****ey' },
       })),
+    },
+    providerRegistry: {
+      listProviderRegistryModels: jest.fn(() => []),
     },
     tools,
     vertexAuth: {

--- a/src/backend/data/services/ProviderRegistryService.ts
+++ b/src/backend/data/services/ProviderRegistryService.ts
@@ -72,6 +72,7 @@ export type ProviderDisplayMetadata = {
 
 export type ListProviderRegistryModelsOptions = {
   disabled?: boolean;
+  presetProviderId?: string | null;
   providerId?: string;
 };
 
@@ -567,8 +568,16 @@ export class ProviderRegistryService {
   }
 
   listProviderRegistryModels(options: ListProviderRegistryModelsOptions = {}): Model[] {
-    const overrides = options.providerId
-      ? this.loader.getOverridesForProvider(options.providerId)
+    const targetProviderId = options.providerId;
+    const sourceProviderId = targetProviderId
+      ? (this.loader.findProvider(targetProviderId)?.id ?? options.presetProviderId)
+      : undefined;
+    if (targetProviderId && !sourceProviderId) {
+      return [];
+    }
+
+    const overrides = sourceProviderId
+      ? this.loader.getOverridesForProvider(sourceProviderId)
       : this.loader.loadProviderModels();
     const includeDisabled = options.disabled ?? false;
     const results: Model[] = [];
@@ -580,12 +589,13 @@ export class ProviderRegistryService {
 
       const presetModel =
         this.loader.findModel(override.modelId) ?? synthesizePresetFromOverride(override);
-      const provider = this.loader.findProvider(override.providerId);
+      const providerId = targetProviderId ?? override.providerId;
+      const provider = this.loader.findProvider(sourceProviderId ?? override.providerId);
       const reasoningProfile = this.resolveProfileForModelData(
         {
           defaultChatEndpoint: provider?.defaultChatEndpoint,
-          id: override.providerId,
-          presetProviderId: provider?.presetProviderId,
+          id: providerId,
+          presetProviderId: sourceProviderId ?? provider?.presetProviderId,
         },
         presetModel,
         override,
@@ -594,7 +604,7 @@ export class ProviderRegistryService {
       const model = mergePresetModel(
         presetModel,
         override,
-        override.providerId,
+        providerId,
         reasoningProfile.wire,
         reasoningProfile.support,
       );
@@ -602,8 +612,10 @@ export class ProviderRegistryService {
       results.push({
         ...model,
         apiModelId,
-        id: createUniqueModelId(override.providerId, apiModelId),
+        id: createUniqueModelId(providerId, apiModelId),
+        modelId: apiModelId,
         presetModelId: presetModel.id,
+        providerId,
       });
     }
 

--- a/src/backend/data/services/__tests__/ProviderRegistryService.test.ts
+++ b/src/backend/data/services/__tests__/ProviderRegistryService.test.ts
@@ -96,6 +96,26 @@ describe('provider-registry-service', () => {
     ]);
   });
 
+  test('projects a preset provider catalog onto a copied provider id', () => {
+    const models = providerRegistryService.listProviderRegistryModels({
+      presetProviderId: 'zhipu',
+      providerId: 'copied-zhipu',
+    });
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.every((model) => model.providerId === 'copied-zhipu')).toBe(true);
+    expect(models.every((model) => model.id.startsWith('copied-zhipu::'))).toBe(true);
+  });
+
+  test('does not inherit a catalog for a fully custom provider', () => {
+    expect(
+      providerRegistryService.listProviderRegistryModels({
+        presetProviderId: null,
+        providerId: 'fully-custom',
+      }),
+    ).toEqual([]);
+  });
+
   test('loads Radeon Cloud after CherryIN', () => {
     const providerIds = providerRegistryService.loadProviders().map(({ id }) => id);
 

--- a/src/backend/data/services/__tests__/materializeRemoteModels.test.ts
+++ b/src/backend/data/services/__tests__/materializeRemoteModels.test.ts
@@ -51,6 +51,29 @@ describe('materializeRemoteModels', () => {
     });
   });
 
+  it('uses apiModelId as the persisted provider model id when modelId is absent', () => {
+    const result = materializeRemoteModels(provider, [
+      {
+        apiModelId: 'vendor/model-v1',
+        name: 'Model V1',
+      },
+    ]);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        apiModelId: 'vendor/model-v1',
+        id: 'cherryin::vendor/model-v1',
+        modelId: 'vendor/model-v1',
+        name: 'Model V1',
+      }),
+    ]);
+    expect(providerRegistryService.lookupModel).toHaveBeenCalledWith(
+      'cherryin',
+      'vendor/model-v1',
+      expect.any(Object),
+    );
+  });
+
   it('enriches remote rows with registry metadata', () => {
     jest.mocked(providerRegistryService.lookupModel).mockReturnValue({
       presetModel: {

--- a/src/backend/data/services/materializeRemoteModels.ts
+++ b/src/backend/data/services/materializeRemoteModels.ts
@@ -18,7 +18,7 @@ export function materializeRemoteModels(
   const models: Model[] = [];
 
   for (const remoteModel of remoteModels) {
-    const modelId = remoteModel.modelId?.trim();
+    const modelId = (remoteModel.apiModelId ?? remoteModel.modelId)?.trim();
     if (!modelId) {
       continue;
     }

--- a/src/backend/services/models/__tests__/createModelsModule.test.ts
+++ b/src/backend/services/models/__tests__/createModelsModule.test.ts
@@ -70,6 +70,19 @@ describe('createModelsModule', () => {
     expect(dependencies.models.reconcile).not.toHaveBeenCalled();
   });
 
+  it('reports a remote addition when the only local model is custom', async () => {
+    const local = model('custom');
+    const remote = model('remote');
+    const { backend, dependencies } = createSubject();
+    jest.mocked(dependencies.models.list).mockResolvedValue([local]);
+    jest.mocked(dependencies.ai.listModels).mockResolvedValue([remote]);
+
+    await expect(backend.pull('openai')).resolves.toEqual({
+      preview: { added: [remote], missing: [] },
+      status: 'changes',
+    });
+  });
+
   it('enables a disabled provider after an up-to-date pull with local models', async () => {
     const current = model('current');
     const { backend, dependencies } = createSubject();


### PR DESCRIPTION
## Summary

- materialize fetched provider models from `apiModelId` so valid remote results are not dropped
- align mobile model listing with desktop by handling registry-only providers and merging API results with registry-only models
- project preset catalogs onto copied providers while keeping fully custom providers isolated

## Validation

- `pnpm packages:build`
- `pnpm jest src/backend/ai/__tests__/AiService.test.ts src/backend/data/services/__tests__/materializeRemoteModels.test.ts src/backend/data/services/__tests__/ProviderRegistryService.test.ts src/backend/services/models/__tests__/createModelsModule.test.ts --runInBand` (60 tests)
- `pnpm typecheck:app`

Desktop behavior source: `CherryHQ/cherry-studio@12498d68ecb4fb261670843ca7a8e4e64a37526a`.