### PR TITLE
feat: support reasoning effort control for DeepSeek V4 models

### DIFF
--- a/src/aiCore/utils/reasoning.ts
+++ b/src/aiCore/utils/reasoning.ts
@@ -525,6 +525,7 @@ export function getXAIReasoningParams(assistant: Assistant, model: Model): Pick<
     case 'high':
       return { reasoningEffort }
     case 'xhigh':
+    case 'max':
       return { reasoningEffort: 'high' }
   }
 }

--- a/src/config/models/__tests__/reasoning.test.ts
+++ b/src/config/models/__tests__/reasoning.test.ts
@@ -1,0 +1,87 @@
+import type { Model } from '@/types/assistant'
+
+// `vision.ts` / `websearch.ts` pull in `@/services/ProviderService`, whose module
+// graph opens expo-sqlite (unavailable in jest). Mock it so the pure model
+// classification logic below can be tested directly.
+jest.mock('@/services/ProviderService', () => ({
+  getProviderByModel: jest.fn()
+}))
+
+import {
+  getThinkModelType,
+  isDeepSeekHybridInferenceModel,
+  isDeepSeekV4Model,
+  isReasoningModel,
+  MODEL_SUPPORTED_OPTIONS,
+  MODEL_SUPPORTED_REASONING_EFFORT
+} from '../reasoning'
+
+const makeModel = (id: string, provider = 'deepseek'): Model => ({
+  id,
+  provider,
+  name: id,
+  group: ''
+})
+
+describe('DeepSeek V4 reasoning support', () => {
+  describe('isDeepSeekV4Model', () => {
+    it.each([
+      'deepseek-v4-flash',
+      'deepseek-v4-flash-latest',
+      'deepseek-v4-pro',
+      'deepseek/deepseek-v4-flash',
+      'deepseek/deepseek-v4-pro'
+    ])('matches %s', id => {
+      expect(isDeepSeekV4Model(makeModel(id))).toBe(true)
+    })
+
+    it.each(['deepseek-v3.1', 'deepseek-v3-2', 'deepseek-chat-v3.1', 'deepseek-chat', 'deepseek-r1', 'gpt-4o'])(
+      'does not match %s',
+      id => {
+        expect(isDeepSeekV4Model(makeModel(id))).toBe(false)
+      }
+    )
+  })
+
+  describe('isDeepSeekHybridInferenceModel', () => {
+    it('still matches V3 hybrid models only', () => {
+      expect(isDeepSeekHybridInferenceModel(makeModel('deepseek-v3-1'))).toBe(true)
+      expect(isDeepSeekHybridInferenceModel(makeModel('deepseek-chat-v3.1'))).toBe(true)
+      expect(isDeepSeekHybridInferenceModel(makeModel('deepseek-v4-flash'))).toBe(false)
+    })
+  })
+
+  describe('isReasoningModel', () => {
+    it('recognizes DeepSeek V4 models as reasoning models', () => {
+      expect(isReasoningModel(makeModel('deepseek-v4-flash'))).toBe(true)
+      expect(isReasoningModel(makeModel('deepseek-v4-flash-latest'))).toBe(true)
+      expect(isReasoningModel(makeModel('deepseek-v4-pro'))).toBe(true)
+    })
+
+    it('keeps non-reasoning models negative', () => {
+      expect(isReasoningModel(makeModel('deepseek-chat'))).toBe(false)
+    })
+  })
+
+  describe('getThinkModelType', () => {
+    it('maps DeepSeek V4 to deepseek_v4 type', () => {
+      expect(getThinkModelType(makeModel('deepseek-v4-flash'))).toBe('deepseek_v4')
+      expect(getThinkModelType(makeModel('deepseek-v4-pro'))).toBe('deepseek_v4')
+    })
+
+    it('keeps DeepSeek V3 hybrid models on deepseek_hybrid type', () => {
+      expect(getThinkModelType(makeModel('deepseek-v3-1'))).toBe('deepseek_hybrid')
+    })
+  })
+
+  describe('effort options', () => {
+    it('exposes selectable reasoning effort levels for V4', () => {
+      expect(MODEL_SUPPORTED_REASONING_EFFORT.deepseek_v4).toEqual(['none', 'low', 'high', 'max', 'xhigh'])
+      expect(MODEL_SUPPORTED_OPTIONS.deepseek_v4).toEqual(['none', 'low', 'high', 'max', 'xhigh'])
+    })
+
+    it('keeps V3 hybrid models to a simple on/off toggle', () => {
+      expect(MODEL_SUPPORTED_OPTIONS.deepseek_hybrid).toEqual(['none', 'auto'])
+    })
+  })
+})

--- a/src/config/models/reasoning.ts
+++ b/src/config/models/reasoning.ts
@@ -40,7 +40,8 @@ export const MODEL_SUPPORTED_REASONING_EFFORT: ReasoningEffortConfig = {
   hunyuan: ['auto'] as const,
   zhipu: ['auto'] as const,
   perplexity: ['low', 'medium', 'high'] as const,
-  deepseek_hybrid: ['auto'] as const
+  deepseek_hybrid: ['auto'] as const,
+  deepseek_v4: ['none', 'low', 'high', 'max', 'xhigh'] as const
 } as const
 
 // 模型类型到支持选项的映射表
@@ -65,7 +66,8 @@ export const MODEL_SUPPORTED_OPTIONS: ThinkingOptionConfig = {
   hunyuan: ['none', ...MODEL_SUPPORTED_REASONING_EFFORT.hunyuan] as const,
   zhipu: ['none', ...MODEL_SUPPORTED_REASONING_EFFORT.zhipu] as const,
   perplexity: MODEL_SUPPORTED_REASONING_EFFORT.perplexity,
-  deepseek_hybrid: ['none', ...MODEL_SUPPORTED_REASONING_EFFORT.deepseek_hybrid] as const
+  deepseek_hybrid: ['none', ...MODEL_SUPPORTED_REASONING_EFFORT.deepseek_hybrid] as const,
+  deepseek_v4: MODEL_SUPPORTED_REASONING_EFFORT.deepseek_v4
 } as const
 
 const withModelIdAndNameAsId = <T>(model: Model, fn: (model: Model) => T): { idResult: T; nameResult: T } => {
@@ -124,6 +126,7 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
   } else if (isSupportedThinkingTokenHunyuanModel(model)) thinkingModelType = 'hunyuan'
   else if (isSupportedReasoningEffortPerplexityModel(model)) thinkingModelType = 'perplexity'
   else if (isSupportedThinkingTokenZhipuModel(model)) thinkingModelType = 'zhipu'
+  else if (isDeepSeekV4Model(model)) thinkingModelType = 'deepseek_v4'
   else if (isDeepSeekHybridInferenceModel(model)) thinkingModelType = 'deepseek_hybrid'
   return thinkingModelType
 }
@@ -451,6 +454,16 @@ export const isDeepSeekHybridInferenceModel = (model: Model) => {
   return /deepseek-v3(?:\.\d|-\d)(?:(\.|-)\w+)?$/.test(modelId) || modelId.includes('deepseek-chat-v3.1')
 }
 
+/**
+ * DeepSeek V4 series (deepseek-v4-flash / deepseek-v4-pro / deepseek-v4-flash-latest).
+ * Unlike the V3 hybrid models, V4 is a single model with thinking enabled by default
+ * and a selectable `reasoning_effort` (none/low/high/max/xhigh) on the wire.
+ */
+export const isDeepSeekV4Model = (model: Model): boolean => {
+  const modelId = getLowerBaseModelName(model.id, '/')
+  return /deepseek-v4(?:-\w+)?(?:-latest)?$/.test(modelId) || modelId.includes('deepseek-chat-v4')
+}
+
 export const isLingReasoningModel = (model?: Model): boolean => {
   if (!model) {
     return false
@@ -518,6 +531,7 @@ export function isReasoningModel(model?: Model): boolean {
     isZhipuReasoningModel(model) ||
     isStepReasoningModel(model) ||
     isDeepSeekHybridInferenceModel(model) ||
+    isDeepSeekV4Model(model) ||
     isLingReasoningModel(model) ||
     isMiniMaxReasoningModel(model) ||
     modelId.includes('magistral') ||

--- a/src/types/assistant.ts
+++ b/src/types/assistant.ts
@@ -51,10 +51,11 @@ const ThinkModelTypes = [
   'hunyuan',
   'zhipu',
   'perplexity',
-  'deepseek_hybrid'
+  'deepseek_hybrid',
+  'deepseek_v4'
 ] as const
 
-export type ReasoningEffortOption = NonNullable<OpenAI.ReasoningEffort> | 'auto' | 'none'
+export type ReasoningEffortOption = NonNullable<OpenAI.ReasoningEffort> | 'auto' | 'none' | 'max'
 export type ThinkingOption = ReasoningEffortOption | 'off'
 export type ThinkingModelType = (typeof ThinkModelTypes)[number]
 export type ThinkingOptionConfig = Record<ThinkingModelType, ThinkingOption[]>
@@ -72,6 +73,7 @@ export const EFFORT_RATIO: EffortRatio = {
   medium: 0.5,
   high: 0.8,
   xhigh: 0.9,
+  max: 0.95,
   auto: 2
 }
 export type AssistantSettings = {

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -78,9 +78,9 @@ type OpenAIParamsPurified = Omit<OpenAI.Chat.Completions.ChatCompletionCreatePar
 export type ReasoningEffortOptionalParams = {
   thinking?: { type: 'disabled' | 'enabled' | 'auto'; budget_tokens?: number }
   reasoning?: { max_tokens?: number; exclude?: boolean; effort?: string; enabled?: boolean } | OpenAI.Reasoning
-  reasoningEffort?: OpenAI.Chat.Completions.ChatCompletionCreateParams['reasoning_effort'] | 'none' | 'auto' | 'xhigh'
+  reasoningEffort?: OpenAI.Chat.Completions.ChatCompletionCreateParams['reasoning_effort'] | 'none' | 'auto' | 'xhigh' | 'max'
   // WARN: This field will be overwrite to undefined by aisdk if the provider is openai-compatible. Use reasoningEffort instead.
-  reasoning_effort?: OpenAI.Chat.Completions.ChatCompletionCreateParams['reasoning_effort'] | 'none' | 'auto' | 'xhigh'
+  reasoning_effort?: OpenAI.Chat.Completions.ChatCompletionCreateParams['reasoning_effort'] | 'none' | 'auto' | 'xhigh' | 'max'
   enable_thinking?: boolean
   thinking_budget?: number
   incremental_output?: boolean


### PR DESCRIPTION
## Summary

DeepSeek V4 (`deepseek-v4-flash` / `deepseek-v4-pro` / `deepseek-v4-flash-latest`) was released after the hardcoded reasoning whitelist in `src/config/models/reasoning.ts` was written, so these models are currently **not recognized as reasoning models at all** on mobile: the Think button is hidden and `reasoning_effort` cannot be adjusted.

The desktop app (CherryHQ/cherry-studio) already supports this via its data-driven provider registry (DeepSeek V4 declares selectable efforts `[none, low, high, max, xhigh]`). This PR ports the same capability into the mobile app's model-classification layer.

## Changes

- **`src/config/models/reasoning.ts`**
  - New `isDeepSeekV4Model()` matcher (also handles `deepseek/deepseek-v4-*` provider-prefixed ids and `-latest` aliases).
  - New `deepseek_v4` think type with selectable efforts `['none', 'low', 'high', 'max', 'xhigh']`, matching the desktop registry's `supportedEfforts` for `deepseek-v4-flash`.
  - `isReasoningModel()` and `getThinkModelType()` now route V4 models through it; V3 hybrid models (`deepseek_hybrid`, `none/auto` toggle) are untouched.
- **`src/types/assistant.ts`** — added `'max'` to `ReasoningEffortOption` (and its `EFFORT_RATIO` entry). `'xhigh'` was already present.
- **`src/types/sdk.ts`** — pass-through types accept `'max'` as well.
- **`src/aiCore/utils/reasoning.ts`** — XAI fallback switch handles `'max'` (maps to `'high'`).
- **Tests** — new `src/config/models/__tests__/reasoning.test.ts` (18 cases): V4 matching (incl. prefixed/latest ids), V3 regression, think-type mapping, effort options.

## Transport

No request-path change needed: `getOpenAIReasoningParams()` already passes `reasoning_effort` straight through for non-OpenAI models, and the DeepSeek API accepts `none/low/high/max` (with `xhigh` mapped server-side).

## Verification

- `tsc --noEmit`: no new type errors vs. `main` (pre-existing env-only errors unchanged).
- Jest: 18/18 new tests pass; full `src/config` + `src/utils` + ModelSheet suites: 139/139 pass.