### PR TITLE
feat(settings): fade between themes with a native snapshot transition

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -129,6 +129,16 @@ jest.mock('react-native-mmkv', () => {
   return { createMMKV };
 });
 
+// react-native-nitro-theme-transition is another Nitro HybridObject. The library
+// already degrades to "just run the callback" when the native side is missing, so
+// this is not about avoiding a crash — it is about not dragging
+// react-native-nitro-modules into every suite whose import chain reaches
+// useSettingPreferences. Running the callback inline keeps the theme swap
+// synchronous, which is what the real thing does under the snapshot.
+jest.mock('react-native-nitro-theme-transition', () => ({
+  withThemeTransition: (applyTheme: () => void) => applyTheme(),
+}));
+
 // gesture-handler 真模块在 jest 下要求 Reanimated.default.createAnimatedComponent，
 // 而 jest 环境的 reanimated 没有这个 API。GestureDetector 透传 children，
 // Gesture.* 返回任意链式调用都指向自身的构建器。

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "react-native-nitro-healthkit": "1.0.0",
     "react-native-nitro-image": "0.15.1",
     "react-native-nitro-modules": "0.35.9",
+    "react-native-nitro-theme-transition": "^1.0.0",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       react-native-nitro-modules:
         specifier: 0.35.9
         version: 0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-nitro-theme-transition:
+        specifier: ^1.0.0
+        version: 1.0.0(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.0
         version: 4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -8065,6 +8068,13 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-nitro-theme-transition@1.0.0:
+    resolution: {integrity: sha512-wCmcR+Bzsth6yHhQvAS6UGWBD6DzQWb84VgYTKYJE8YsQsrCdSYxOVGNajRFM++/TAtneoZVTeC60N33mG0Afg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+      react-native-nitro-modules: '>=0.36.0'
 
   react-native-reanimated@4.5.0:
     resolution: {integrity: sha512-+iPfvK34PKKYP/p/4TaBliFkbfvjGDIvXuiiaxvISP5ip7sWegvlacwU/uAV6zNDSSmX0tDyER7PurPMKGDipA==}
@@ -16920,6 +16930,12 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+
+  react-native-nitro-theme-transition@1.0.0(react-native-nitro-modules@0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+      react-native-nitro-modules: 0.35.9(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
 
   react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/frontend/features/settings/hooks/__tests__/useSettingPreferences.test.tsx
+++ b/src/frontend/features/settings/hooks/__tests__/useSettingPreferences.test.tsx
@@ -1,0 +1,174 @@
+import { ThemeMode } from '@cherrystudio/universal/data/preference';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { useSettingPreferences } from '../useSettingPreferences';
+
+type SettingPreferences = ReturnType<typeof useSettingPreferences>;
+
+const mockApplyThemeMode = jest.fn();
+const mockAlertShow = jest.fn();
+const mockWithThemeTransition = jest.fn((applyTheme: () => void, _config: unknown) => applyTheme());
+const mockSetPreferences = jest.fn(async () => undefined);
+
+let mockPreferences: { language: string; themeMode: ThemeMode };
+
+jest.mock('@/frontend/data/hooks', () => ({
+  useMultiplePreferences: () => [mockPreferences, mockSetPreferences],
+}));
+
+jest.mock('@/frontend/utils/theme', () => ({
+  applyThemeModePreference: (themeMode: unknown) => mockApplyThemeMode(themeMode),
+}));
+
+jest.mock('@/frontend/i18n', () => ({
+  initI18n: jest.fn(),
+  resolveLanguage: (language: string) => language,
+}));
+
+jest.mock('@/frontend/components/AlertProvider', () => ({
+  useAlert: () => ({ alert: { show: mockAlertShow } }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Overrides the inline stub in jest.setup.ts so the config handed to the native side
+// can be asserted. Still runs the callback synchronously — that is the contract the
+// library documents, and the reason the theme swap had to stop awaiting the write.
+jest.mock('react-native-nitro-theme-transition', () => ({
+  withThemeTransition: (applyTheme: () => void, config: unknown) =>
+    mockWithThemeTransition(applyTheme, config),
+}));
+
+describe('useSettingPreferences', () => {
+  let renderer: ReactTestRenderer | undefined;
+  let preferences: SettingPreferences | undefined;
+
+  function Probe() {
+    preferences = useSettingPreferences();
+    return null;
+  }
+
+  function mount() {
+    act(() => {
+      renderer = create(<Probe />);
+    });
+
+    return current();
+  }
+
+  // The store pushes preference writes back through a subscription, so a committed
+  // write re-renders this hook with the new mode.
+  function pushThemeMode(themeMode: ThemeMode) {
+    mockPreferences = { ...mockPreferences, themeMode };
+    act(() => {
+      renderer?.update(<Probe />);
+    });
+  }
+
+  function current() {
+    if (!preferences) {
+      throw new Error('Setting preferences were not rendered.');
+    }
+
+    return preferences;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPreferences = { language: 'en-US', themeMode: ThemeMode.light };
+    mockSetPreferences.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+    preferences = undefined;
+  });
+
+  test('applies the theme synchronously, before the write is even issued', () => {
+    const settings = mount();
+
+    act(() => settings.theme.onValueChange(ThemeMode.dark));
+
+    // No await anywhere above: the whole point of the change is that the theme is
+    // live by the time the handler returns, rather than one SQLite round trip later.
+    expect(mockApplyThemeMode).toHaveBeenCalledWith(ThemeMode.dark);
+    expect(mockApplyThemeMode.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSetPreferences.mock.invocationCallOrder[0] as number,
+    );
+    expect(mockSetPreferences).toHaveBeenCalledWith(
+      { themeMode: ThemeMode.dark },
+      { optimistic: true },
+    );
+  });
+
+  test('swaps the theme inside the transition callback, not around it', () => {
+    // Holding the callback instead of running it is the only way to tell "swapped
+    // inside the transition" apart from "swapped next to it". The library invokes it
+    // while a snapshot of the old screen covers the app, so a swap on either side of
+    // that window reads as a jump rather than a fade.
+    mockWithThemeTransition.mockImplementationOnce(() => undefined);
+    const settings = mount();
+
+    act(() => settings.theme.onValueChange(ThemeMode.dark));
+
+    expect(mockApplyThemeMode).not.toHaveBeenCalled();
+
+    act(() => mockWithThemeTransition.mock.calls[0]?.[0]());
+
+    expect(mockApplyThemeMode).toHaveBeenCalledWith(ThemeMode.dark);
+  });
+
+  test('ignores a tap on the mode that is already selected', () => {
+    const settings = mount();
+
+    act(() => settings.theme.onValueChange(ThemeMode.light));
+
+    // `getChangedKeys` would drop the write anyway, but only after a fade had
+    // already played over an unchanged screen.
+    expect(mockWithThemeTransition).not.toHaveBeenCalled();
+    expect(mockApplyThemeMode).not.toHaveBeenCalled();
+    expect(mockSetPreferences).not.toHaveBeenCalled();
+  });
+
+  test('restores the previous mode when the write fails', async () => {
+    mockSetPreferences.mockRejectedValueOnce(new Error('write failed'));
+    const settings = mount();
+
+    await act(async () => {
+      settings.theme.onValueChange(ThemeMode.dark);
+    });
+
+    expect(mockApplyThemeMode.mock.calls).toEqual([[ThemeMode.dark], [ThemeMode.light]]);
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'settings.appearance.saveFailed' });
+    // The rollback is deliberately not animated: a failed write should not read as
+    // another polished crossfade.
+    expect(mockWithThemeTransition).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not roll back when a newer change has already superseded the failure', async () => {
+    let rejectFirstWrite: ((error: Error) => void) | undefined;
+    mockSetPreferences.mockReturnValueOnce(
+      new Promise<undefined>((_resolve, reject) => {
+        rejectFirstWrite = reject;
+      }),
+    );
+
+    const settings = mount();
+
+    act(() => settings.theme.onValueChange(ThemeMode.dark));
+    pushThemeMode(ThemeMode.dark);
+    act(() => current().theme.onValueChange(ThemeMode.system));
+
+    await act(async () => {
+      rejectFirstWrite?.(new Error('write failed'));
+    });
+
+    // The stale failure must not drag the app back to light after the user has
+    // already moved on to system.
+    expect(mockApplyThemeMode.mock.calls).toEqual([[ThemeMode.dark], [ThemeMode.system]]);
+    expect(mockAlertShow).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/features/settings/hooks/useSettingPreferences.ts
+++ b/src/frontend/features/settings/hooks/useSettingPreferences.ts
@@ -1,9 +1,12 @@
 import { type LanguageVarious, ThemeMode } from '@cherrystudio/universal/data/preference';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { withThemeTransition } from 'react-native-nitro-theme-transition';
 
+import { useAlert } from '@/frontend/components/AlertProvider';
 import { useMultiplePreferences } from '@/frontend/data/hooks';
 import { initI18n, resolveLanguage } from '@/frontend/i18n';
+import { themeTransition } from '@/frontend/utils/constants';
 import { applyThemeModePreference } from '@/frontend/utils/theme';
 
 import type { SettingOption } from '../settingOptions';
@@ -15,7 +18,9 @@ const preferenceMapping = {
 
 export function useSettingPreferences() {
   const { t } = useTranslation();
+  const { alert } = useAlert();
   const [preferences, setPreferences] = useMultiplePreferences(preferenceMapping);
+  const persistenceVersionRef = useRef(0);
   const languageValue = resolveLanguage(preferences.language);
 
   const languageOptions = useMemo<SettingOption<LanguageVarious>[]>(
@@ -28,11 +33,40 @@ export function useSettingPreferences() {
 
   const handleThemeModeChange = useCallback(
     (nextThemeMode: ThemeMode) => {
-      void setPreferences({ themeMode: nextThemeMode }).then(() => {
-        applyThemeModePreference(nextThemeMode);
+      // `getChangedKeys` drops no-op writes as well, but by the time it runs the
+      // snapshot is already up — re-tapping the current swatch would play a fade
+      // over nothing.
+      if (nextThemeMode === preferences.themeMode) {
+        return;
+      }
+
+      // Read rather than snapshotted into a ref because `enqueueUpdate` chains
+      // `runUpdate` onto `updateTail`: even the optimistic cache write lands a
+      // microtask later, so this closure still sees the pre-tap value. It can drift
+      // from the service's own `previousValues` only when two writes fail back to
+      // back with a tap in between, the same exposure `FontSizeSettingsScreen` has.
+      const previousThemeMode = preferences.themeMode;
+      const persistenceVersion = ++persistenceVersionRef.current;
+
+      // Has to be synchronous: the callback runs while a snapshot of the old screen
+      // covers the app and the reveal is scheduled off native frame callbacks, so an
+      // async swap would land after the fade had already uncovered the new theme.
+      withThemeTransition(() => applyThemeModePreference(nextThemeMode), themeTransition);
+
+      void setPreferences({ themeMode: nextThemeMode }, { optimistic: true }).catch(() => {
+        if (persistenceVersion !== persistenceVersionRef.current) {
+          return;
+        }
+
+        // Deliberately not wrapped in a transition. A failed write should read as a
+        // failure, not as another polished crossfade, and `alert.show` puts up a
+        // UIAlertController — a system window no snapshot can contain, so it would
+        // land on top of a frozen copy of the app while that copy faded underneath.
+        applyThemeModePreference(previousThemeMode);
+        alert.show({ title: t('settings.appearance.saveFailed') });
       });
     },
-    [setPreferences],
+    [alert, preferences.themeMode, setPreferences, t],
   );
 
   const handleLanguageChange = useCallback(

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -233,6 +233,7 @@
   "settings.about.title": "About",
   "settings.about.website.title": "Official Website",
   "settings.appearance.automatic": "Automatic",
+  "settings.appearance.saveFailed": "Failed to save theme",
   "settings.appearance.title": "Appearance",
   "settings.app.title": "App",
   "settings.data.appData.title": "App data",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -232,6 +232,7 @@
   "settings.about.title": "关于",
   "settings.about.website.title": "官方网站",
   "settings.appearance.automatic": "自动",
+  "settings.appearance.saveFailed": "主题设置保存失败",
   "settings.appearance.title": "外观设置",
   "settings.app.title": "应用",
   "settings.data.appData.title": "应用数据",

--- a/src/frontend/utils/constants.ts
+++ b/src/frontend/utils/constants.ts
@@ -29,6 +29,37 @@ export const screenBottomActionInset = 16;
 // focus() call landing before that is silently ignored by UIKit.
 export const searchBarAutoFocusDelayMs = 100;
 
+// Native transition played over a theme switch (react-native-nitro-theme-transition).
+// The theme itself is instant — Uniwind commits it to the shadow tree in C++ — so
+// what animates is a GPU snapshot of the old screen fading out over the new one.
+//
+// `fade` is the only kind that needs no "did the resolved theme actually change"
+// guard: an opaque snapshot going alpha 1 -> 0 over an identical screen composites
+// to that screen at every step, so switching to `system` on a device already in
+// that scheme is invisible rather than a flicker. Every reveal-shaped kind would
+// draw a visible edge there.
+//
+// Duration is the only knob: the curve is compiled into the library, which is
+// deliberate on its part — `(0.4, 0, 0.2, 1)` is shared by both platforms so they look
+// identical, and the author's comment on it explains that he already tried a snappier,
+// front-loaded curve and backed it out. Changing it would mean patching two native
+// files with nothing tying them to `easing.settle` in packages/ui/src/motion.ts.
+//
+// 800ms, a shade above the library's 650ms default, picked by eye. Tap-to-settled
+// measured on a debug build: 389ms with the transition bypassed entirely, 379ms with it
+// but `durationMs: 0`, 735ms at 650ms, 945ms at 1000ms. The snapshot itself is therefore
+// free — what it covers is the ~390ms `Uniwind.setTheme` already costs (recomputing every
+// CSS variable and committing the shadow tree), which without it is just the screen
+// sitting still. Past roughly the default, the duration stops hiding that cost and starts
+// adding to it, so this is the slow end of the usable range rather than a free choice.
+//
+// The floor for `fade` is 200ms, but 350ms bunches most of the luminance travel into the
+// middle ~150ms and reads as a flicker rather than as a crossfade.
+//
+// `settleFrames` is left at the library default of 2. That is calibrated for theme
+// systems that apply synchronously, which is exactly what `Uniwind.setTheme` is.
+export const themeTransition = { kind: 'fade', durationMs: 800 } as const;
+
 // Tuning knobs for the GitHub-style AI usage calendars.
 // Sizes and spring feel replicate the reference contribution-graph animation
 // 1:1 — adjust here, not in the AI usage components. The heat scale is not


### PR DESCRIPTION
Switching theme changed the screen between two frames, because Uniwind applies a theme in a single C++ shadow-tree commit — there was no interpolation to hook into and nothing to animate. `react-native-nitro-theme-transition` sidesteps that: it pins a GPU snapshot of the old screen over the app in an overlay window, lets the swap happen underneath, then fades the snapshot out on the render server. The animation is decoupled from the JS thread entirely.

`useSettingPreferences` is the only theme-mode write funnel in the app, so the change lands there. The handler had to stop awaiting the write — the library calls back while the snapshot is up and schedules the reveal off native frame callbacks, so an async swap lands *after* the fade has already uncovered the new theme. It now applies optimistically and rolls back on failure, the shape `FontSizeSettingsScreen` already uses, plus a version counter so a stale rejection cannot drag the app back after the user has moved on. The rollback is deliberately not animated: a failed write should read as a failure, and `alert.show` puts up a `UIAlertController` — a system window no snapshot can contain, so it would land on top of a frozen copy of the app while that copy faded underneath.

`preferences.themeMode` joins the dependency array. `setPreferences` is permanently stable, so the old `[setPreferences]` never rebuilt the callback and would have frozen the pre-tap value the moment anything read it — which the no-op guard and the rollback both now do.

## Why fade only, and hardcoded

`fade` is the one kind that needs no "did the resolved theme actually change" guard. An opaque snapshot going alpha 1 → 0 over an identical screen composites to that screen at every step, so turning off 自动 on a device already in that scheme is invisible rather than a flicker. Every reveal-shaped kind would draw a visible edge there, and guarding against it would mean dragging `useUniwind()` into the hook.

The curve is left as upstream ships it. It is compiled into both native sides on purpose so the platforms match, and the author's comment records that he already tried a snappier front-loaded curve and backed it out. Aligning it with `easing.settle` would mean patching two native files with nothing tying them back to `packages/ui/src/motion.ts`.

## Cost

Tap-to-settled on a debug build: **389ms** with the transition bypassed entirely, **379ms** with it at `durationMs: 0`. The snapshot itself is free. What it covers is the ~390ms `Uniwind.setTheme` already cost — recomputing every CSS variable and committing the shadow tree — which without it was just the screen sitting still. 800ms was picked by eye, a shade above the library's 650ms default; past roughly there the duration stops hiding that cost and starts adding to it.

`settleFrames` stays at the default of 2, which is calibrated for theme systems that apply synchronously — exactly what `Uniwind.setTheme` is.

## Dependency

`react-native-nitro-theme-transition@1.0.0` (MIT) declares `react-native-nitro-modules >= 0.36.0` against this repo's pinned `0.35.9`. The peer warning is left in place rather than papered over: pnpm cannot override an already-declared peerDep, and a patch just to silence a warning is worse than the warning. It compiles — the library's `.nitro.ts` spec uses only plain string-union enums, records, `Promise<void>`, boolean and number, never 0.36.0's union-with-payload variants — and `pod install` plus a full Xcode build were verified against mmkv, nitro-image and nitro-healthkit.

## Tests

New hook suite, five cases, each written to fail only on a real defect per the rule added in #517: sync-apply-before-persist, the swap happening *inside* the transition callback rather than next to it (verified by mutation — moving the swap out fails that case and only that case), the no-op guard, rollback-plus-alert with the rollback unanimated, and the version guard. No assertion on `durationMs` — retuning it is not a defect.

Jest 305/305 suites, 2876 tests. typecheck, lint, format:check, doc-links clean.

Verified by hand on an iPhone 17 Pro simulator. Note for anyone reproducing: `simctl io recordVideo` does **not** capture the intermediate composited state of an overlay window, so screen recordings show a frozen screen and then a jump. `simctl io screenshot` and the human eye both see the fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)