### PR TITLE
feat(markdown): upgrade enriched-markdown to 1.0.1 and turn on code highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-native": "0.86.0",
     "react-native-bottom-tabs": "1.4.0",
     "react-native-chart-kit": "7.0.2",
-    "react-native-enriched-markdown": "0.7.3",
+    "react-native-enriched-markdown": "1.0.1",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-keyboard-controller": "^1.21.13",
     "react-native-mmkv": "4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,8 +300,8 @@ importers:
         specifier: 7.0.2
         version: 7.0.2(react-native-svg@15.15.4(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-enriched-markdown:
-        specifier: 0.7.3
-        version: 0.7.3(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: 1.0.1
+        version: 1.0.1(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -334,7 +334,7 @@ importers:
         version: 4.25.2(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-streamdown:
         specifier: 0.2.0
-        version: 0.2.0(react-native-enriched-markdown@0.7.3(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(remend@1.3.0)
+        version: 0.2.0(react-native-enriched-markdown@1.0.1(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(remend@1.3.0)
       react-native-svg:
         specifier: 15.15.4
         version: 15.15.4(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -8165,8 +8165,8 @@ packages:
       react-native-gesture-handler: '>= 2.0.0'
       react-native-reanimated: '>= 2.0.0'
 
-  react-native-enriched-markdown@0.7.3:
-    resolution: {integrity: sha512-+RP3r3bveVpMbT8GLt5GRZl8L2an5hrUMPHHLZ8z4ivtICql26D7T+DDXVSph+vZc7rbPbP5/5RsouDOPaDXWg==}
+  react-native-enriched-markdown@1.0.1:
+    resolution: {integrity: sha512-Wh23zYIjZmrJ5/dbezS1Ldc2k0tp++Y3cZrhJ4aRBfsfQpyxBtRNgvkfkWYFSlCCwX9RlCf/iyCDcG1Okp7F6g==}
     peerDependencies:
       '@expo/config-plugins': '>=50.0.0'
       katex: '>=0.16.0'
@@ -17286,7 +17286,7 @@ snapshots:
       react-native-reanimated: 4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-enriched-markdown@0.7.3(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+  react-native-enriched-markdown@1.0.1(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
@@ -17378,11 +17378,11 @@ snapshots:
 
   react-native-skia-apple-tvos@147.1.0: {}
 
-  react-native-streamdown@0.2.0(react-native-enriched-markdown@0.7.3(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(remend@1.3.0):
+  react-native-streamdown@0.2.0(react-native-enriched-markdown@1.0.1(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(remend@1.3.0):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
-      react-native-enriched-markdown: 0.7.3(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-enriched-markdown: 1.0.1(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-worklets: 0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       remend: 1.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,9 @@ allowBuilds:
   core-js: true
   '@j178/prek': true
   '@shopify/react-native-skia': true
+  # 1.0.0 起把 tree-sitter 语法和 RaTeX XCFramework 挪到 postinstall 下载，
+  # 不放行就装不出代码高亮和数学公式所需的原生产物。
+  react-native-enriched-markdown: true
 
 patchedDependencies:
   '@opeoginni/github-copilot-openai-compatible@1.0.0': patches/@opeoginni__github-copilot-openai-compatible@1.0.0.patch
@@ -91,6 +94,6 @@ minimumReleaseAgeExclude:
   - expo-linking@57.0.1
   - expo-splash-screen@57.0.1
   - heroui-native@1.0.5
-  - react-native-enriched-markdown@0.7.3
+  - react-native-enriched-markdown@1.0.1
   - expo-camera@57.0.3
   - '@legendapp/list@3.3.3'

--- a/src/frontend/components/markdown/README.md
+++ b/src/frontend/components/markdown/README.md
@@ -2,3 +2,13 @@
 
 Shared Markdown rendering for chat content and non-chat previews. The public `MarkdownText`
 component owns renderer selection, theme colors, links, and the global typography preference.
+
+## Code blocks
+
+Syntax highlighting is native (tree-sitter, compiled into the binary) and math is rendered by
+RaTeX, both enabled by default in react-native-enriched-markdown. Neither is reachable from JS
+alone: highlighting draws every token type without a color in the plain code color, so the
+palettes in `components/syntaxColors.ts` are what makes it visible. Only the grammars compiled
+into the build highlight at all — the curated default set covers 14 languages, and `cpp`, `swift`,
+`php`, `ruby`, and `c-sharp` are opt-in through the library's Expo config plugin. A language that
+is not compiled in renders as plain code rather than failing.

--- a/src/frontend/components/markdown/components/MarkdownText.tsx
+++ b/src/frontend/components/markdown/components/MarkdownText.tsx
@@ -6,12 +6,15 @@ import {
   type MarkdownStyle,
 } from 'react-native-enriched-markdown';
 import { StreamdownText } from 'react-native-streamdown';
+import { useUniwind } from 'uniwind';
 
 import { usePreference } from '@/frontend/data/hooks';
 import { useThemeColor } from '@/frontend/hooks/useThemeColor';
 import { monoFontFamily } from '@/frontend/utils/constants';
 import { openExternalUrl } from '@/frontend/utils/openExternalUrl';
 import { resolveTypographyScale } from '@/frontend/utils/typographyScale';
+
+import { resolveSyntaxColors } from './syntaxColors';
 
 type MarkdownTextProps = {
   fontSizeStep?: FontSizeStep;
@@ -47,6 +50,7 @@ function createMarkdownTypographyStyle(fontSizeStep: FontSizeStep): MarkdownStyl
 
 export function MarkdownText({ fontSizeStep, isStreaming = false, markdown }: MarkdownTextProps) {
   const [storedFontSizeStep] = usePreference('ui.font_size_step');
+  const { theme } = useUniwind();
   const [
     foreground,
     background,
@@ -110,6 +114,7 @@ export function MarkdownText({ fontSizeStep, isStreaming = false, markdown }: Ma
         backgroundColor: codeBlock,
         borderColor: border,
         color: foreground,
+        syntaxColors: resolveSyntaxColors(theme, mutedForeground),
       },
       link: { color: link },
       strong: { color: foreground },
@@ -151,6 +156,7 @@ export function MarkdownText({ fontSizeStep, isStreaming = false, markdown }: Ma
     mutedForeground,
     resolvedStep,
     secondary,
+    theme,
   ]);
 
   return (

--- a/src/frontend/components/markdown/components/__tests__/MarkdownText.test.tsx
+++ b/src/frontend/components/markdown/components/__tests__/MarkdownText.test.tsx
@@ -29,7 +29,17 @@ jest.mock('react-native-streamdown', () => {
   };
 });
 
+let mockTheme = 'light';
+
+jest.mock('uniwind', () => ({
+  useUniwind: () => ({ theme: mockTheme }),
+}));
+
 describe('MarkdownText', () => {
+  beforeEach(() => {
+    mockTheme = 'light';
+  });
+
   test.each([
     [true, 'StreamdownText', 'EnrichedMarkdownText'],
     [false, 'EnrichedMarkdownText', 'StreamdownText'],
@@ -66,19 +76,38 @@ describe('MarkdownText', () => {
             color: 'inline-code-foreground',
             fontFamily: 'GeistMono-Regular',
           },
-          codeBlock: {
+          codeBlock: expect.objectContaining({
             backgroundColor: 'code-block',
             borderColor: 'border',
             color: 'foreground',
             fontFamily: 'GeistMono-Regular',
             fontSize: 18,
             lineHeight: 28,
-          },
+          }),
         }),
       );
       expect(renderer.root.findAllByType(excluded)).toHaveLength(0);
     },
   );
+
+  // Native syntax highlighting draws every token type it was not given a color
+  // for in the plain code color, so an absent or half-filled `syntaxColors`
+  // silently renders as no highlighting at all.
+  test.each(['light', 'dark'] as const)('%s mode highlights code with its own palette', (mode) => {
+    mockTheme = mode;
+    const renderer = render(<MarkdownText markdown="Hello" />);
+    const { syntaxColors } =
+      renderer.root.findByType('EnrichedMarkdownText').props.markdownStyle.codeBlock;
+
+    expect(syntaxColors).toEqual(
+      expect.objectContaining({
+        keyword: mode === 'dark' ? '#C792EA' : '#A626A4',
+        // Both upstream themes pick a comment gray against their own editor
+        // background that lands near 2:1 on ours, so this one slot is a token.
+        comment: 'muted-foreground',
+      }),
+    );
+  });
 });
 
 function render(element: ReactElement): ReactTestRenderer {

--- a/src/frontend/components/markdown/components/syntaxColors.ts
+++ b/src/frontend/components/markdown/components/syntaxColors.ts
@@ -1,0 +1,63 @@
+import type { MarkdownStyle } from 'react-native-enriched-markdown';
+
+type SyntaxColors = NonNullable<NonNullable<MarkdownStyle['codeBlock']>['syntaxColors']>;
+
+/**
+ * Code-block syntax highlighting is native (tree-sitter) as of
+ * react-native-enriched-markdown 1.0, but every token type left unset is drawn
+ * in the plain code color — so an unconfigured `syntaxColors` renders a code
+ * block that looks exactly like the unhighlighted one. These two palettes are
+ * what actually turns the feature on.
+ *
+ * They mirror the desktop app's Shiki defaults (`one-light` in light mode,
+ * `material-theme-darker` in dark) so a snippet reads the same on both ends.
+ * Alignment stops at contrast: a handful of the upstream colors fall below 3:1
+ * on our `code-block` surface, and those are corrected rather than copied.
+ *
+ * `operator` and `punctuation` are deliberately absent from the light palette,
+ * and `variable` from the dark one — both source themes leave those at the
+ * body text color, which is what omitting them already produces.
+ */
+
+/** One Light. `string` and `type` are darkened from #50A14F/#C18401 (2.9:1). */
+const LIGHT_SYNTAX_COLORS: SyntaxColors = {
+  keyword: '#A626A4',
+  string: '#3D7F3C',
+  number: '#986801',
+  constant: '#986801',
+  function: '#4078F2',
+  type: '#A16C00',
+  variable: '#E45649',
+  property: '#E45649',
+  tag: '#E45649',
+  attribute: '#986801',
+  embedded: '#CA1243',
+};
+
+/** Material Theme Darker, unmodified apart from the comment color. */
+const DARK_SYNTAX_COLORS: SyntaxColors = {
+  keyword: '#C792EA',
+  operator: '#89DDFF',
+  punctuation: '#89DDFF',
+  string: '#C3E88D',
+  number: '#F78C6C',
+  constant: '#FF9CAC',
+  function: '#82AAFF',
+  type: '#FFCB6B',
+  property: '#F07178',
+  tag: '#F07178',
+  attribute: '#C792EA',
+  embedded: '#89DDFF',
+};
+
+/**
+ * Both source themes pick a comment gray against their own editor background,
+ * which lands at 2.3:1 on ours — illegible. `muted-foreground` is the token
+ * that already means "de-emphasized but readable", so comments defer to it
+ * instead of to the upstream value.
+ */
+export function resolveSyntaxColors(theme: string, mutedForeground: string): SyntaxColors {
+  const palette = theme === 'dark' ? DARK_SYNTAX_COLORS : LIGHT_SYNTAX_COLORS;
+
+  return { ...palette, comment: mutedForeground };
+}


### PR DESCRIPTION
## What

Upgrades `react-native-enriched-markdown` **0.7.3 → 1.0.1** and wires up the native syntax highlighting it introduces.

npm still tags **0.7.4** as `latest`, but [v1.0.1](https://github.com/software-mansion/react-native-enriched-markdown/releases/tag/v1.0.1) is the newest GitHub release (non-prerelease) — the tag just hasn't been moved.

## Why the version bump isn't enough

The library draws every token type it was **not** given a color for in the plain code color. So an unconfigured `syntaxColors` compiles the grammars into the binary and still renders a code block that looks exactly like the unhighlighted one. `components/syntaxColors.ts` is what actually turns the feature on.

The palettes mirror the desktop app's Shiki defaults (`one-light` in light mode, `material-theme-darker` in dark) so a snippet reads the same on both ends. **Alignment stops at contrast:** both upstream themes pick their comment gray against their own editor background, which measures 2.3:1 on our `code-block` surface. Comments defer to `muted-foreground` instead, and light-mode `string`/`type` are darkened from 2.9:1. Copying those would be aligning on a defect.

## Build-level change

1.0 moved the tree-sitter grammars and the RaTeX XCFramework out of the npm tarball into a **postinstall download**, so the package needs an `allowBuilds` entry — without it the native assets never land and both highlighting and math silently degrade. `node_modules` for this package goes from ~3MB to ~231MB on disk; only the 14 default grammars (~32MB of C source) are compiled in.

## Verification

- iOS full build passes
- `nm` confirms the 14 default `tree_sitter_*` grammars and RaTeX are linked into the binary
- Simulator run: highlighted TypeScript and Python, LaTeX math (block + inline), and plain-text C++ — an opt-in grammar, confirming absent languages degrade rather than fail
- typecheck / tests / lint / format / `--frozen-lockfile` all clean


**Android is not verified** — only iOS was built.

## Follow-ups worth a decision (not in this PR)

1. **Opt-in grammars.** `cpp`, `swift`, `php`, `ruby`, and `c-sharp` are not compiled in by default. C++/C# are common in chat; enabling them means registering the library's Expo config plugin and grows the compiled C source from 32MB toward 152MB (swift alone is 48MB).
2. **Supply-chain gap.** RaTeX and the tree-sitter runtime are sha256-verified, but the 19 grammar packages are fetched from the npm registry at postinstall with **no integrity check**. Versions are pinned and the transport is HTTPS, but this path bypasses the lockfile, `minimumReleaseAge`, and `trustPolicy` entirely. CI pays the download on each of the three jobs.

Note: **the dev client must be rebuilt** — the native surface changed substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
