### PR TITLE
fix(chat-input): keep effort slider centered

### DIFF
--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -85,9 +85,10 @@ Two consequences to take seriously:
       needle rotates across the same normalized stop positions as the slider.
 - [ ] The model pill has no effort suffix, and the model picker has no effort footer: the gauge is the
       only entry point.
-- [ ] Tapping the gauge grows the discrete slider leftward from the gauge into the composer's
-      toolbar footprint. The composer keeps its size and stays mounted behind the blur, so the
-      draft, attachments, selected tool, keyboard, and focus remain unchanged.
+- [ ] Tapping the gauge grows the discrete slider from the gauge into a viewport-centered panel.
+      Its label and track stay centered when the keyboard moves the composer. The composer keeps
+      its size and stays mounted behind the blur, so the draft, attachments, selected tool,
+      keyboard, and focus remain unchanged.
 - [ ] The floating label contains the selected model name and localized effort name; crossing a stop
       updates it immediately and fires the slider's selection haptic.
 - [ ] Tapping outside closes the slider. The transparent dismissal regions do not cover its track,

--- a/src/frontend/features/chat/input/components/ChatInputEffortOverlay.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputEffortOverlay.tsx
@@ -37,7 +37,7 @@ const AnimatedBlurView = createAnimatedComponent(BlurView);
 const openDurationMs = 150;
 const closeDurationMs = 120;
 const appBlurIntensity = 30;
-const keyboardBlurIntensity = 7;
+const keyboardBlurIntensity = 30;
 const isIOS = process.env.EXPO_OS === 'ios';
 
 type ActiveEffortLayout = ChatInputEffortOverlayLayout & {
@@ -130,6 +130,7 @@ export function ChatInputEffortOverlay({
         const nextLayout = getChatInputEffortOverlayLayout(
           { height, left, top, width },
           gaugeFrame,
+          { height: viewportHeight, left: 0, top: 0, width: viewportWidth },
         );
         if (!nextLayout) {
           return;

--- a/src/frontend/features/chat/input/effortSlider/README.md
+++ b/src/frontend/features/chat/input/effortSlider/README.md
@@ -21,6 +21,8 @@ model renders 5–6 detents.
   a centered 44dp progress pill, a 36dp white thumb, and 10dp stop dots. Stop
   dots share the thumb's endpoint centers, derived by
   `getEffortSliderTrackGeometry`, so two-stop and six-stop models stay aligned.
+  The chat overlay centers its label-and-track panel in the live viewport, so
+  keyboard and composer movement do not shift its resting position.
 - **Visuals** — the progress pill uses the sampled reference blue (`#3995ff`),
   with translucent white dots over the blue and dark portions of the track.
 

--- a/src/frontend/features/chat/input/utils/__tests__/chatInputEffortLayout.test.ts
+++ b/src/frontend/features/chat/input/utils/__tests__/chatInputEffortLayout.test.ts
@@ -1,42 +1,62 @@
 import {
   chatInputEffortLabelGap,
   chatInputEffortLabelHeight,
+  chatInputEffortPanelHeight,
   chatInputEffortTrackHeight,
   chatInputEffortTrackInset,
   getChatInputEffortOverlayLayout,
 } from '../chatInputEffortLayout';
 
 describe('getChatInputEffortOverlayLayout', () => {
-  it('expands from the measured gauge into the inset composer toolbar track', () => {
+  it('expands from the measured gauge into a viewport-centered panel', () => {
     const gaugeFrame = { height: 32, left: 320, top: 704, width: 32 };
+    const viewportFrame = { height: 874, left: 0, top: 0, width: 402 };
+    const sliderWidth = 361 - chatInputEffortTrackInset * 2;
+    const panelTop = (viewportFrame.height - chatInputEffortPanelHeight) / 2;
     const layout = getChatInputEffortOverlayLayout(
       { height: 96, left: 16, top: 640, width: 361 },
       gaugeFrame,
+      viewportFrame,
     );
 
     expect(layout).toEqual({
       gaugeFrame,
       labelFrame: {
         height: chatInputEffortLabelHeight,
-        left: 16,
-        top:
-          gaugeFrame.top +
-          (gaugeFrame.height - chatInputEffortTrackHeight) / 2 -
-          chatInputEffortLabelGap -
-          chatInputEffortLabelHeight,
-        width: 361,
+        left: (viewportFrame.width - sliderWidth) / 2,
+        top: panelTop,
+        width: sliderWidth,
       },
       sliderFrame: {
         height: chatInputEffortTrackHeight,
-        left: 16 + chatInputEffortTrackInset,
-        top: gaugeFrame.top + (gaugeFrame.height - chatInputEffortTrackHeight) / 2,
-        width: 361 - chatInputEffortTrackInset * 2,
+        left: (viewportFrame.width - sliderWidth) / 2,
+        top: panelTop + chatInputEffortLabelHeight + chatInputEffortLabelGap,
+        width: sliderWidth,
       },
     });
   });
 
-  it('rejects invalid measurements and composers narrower than one track height', () => {
+  it('keeps the panel centered when the keyboard moves the composer and gauge', () => {
+    const viewportFrame = { height: 874, left: 0, top: 0, width: 402 };
+    const composerFrame = { height: 96, left: 16, top: 640, width: 361 };
+    const closedLayout = getChatInputEffortOverlayLayout(
+      composerFrame,
+      { height: 32, left: 320, top: 704, width: 32 },
+      viewportFrame,
+    );
+    const keyboardLayout = getChatInputEffortOverlayLayout(
+      { ...composerFrame, top: 343 },
+      { height: 32, left: 320, top: 407, width: 32 },
+      viewportFrame,
+    );
+
+    expect(keyboardLayout?.labelFrame).toEqual(closedLayout?.labelFrame);
+    expect(keyboardLayout?.sliderFrame).toEqual(closedLayout?.sliderFrame);
+  });
+
+  it('rejects invalid measurements and frames too small for the centered panel', () => {
     const gaugeFrame = { height: 32, left: 10, top: 10, width: 32 };
+    const viewportFrame = { height: 874, left: 0, top: 0, width: 402 };
 
     expect(
       getChatInputEffortOverlayLayout(
@@ -47,10 +67,21 @@ describe('getChatInputEffortOverlayLayout', () => {
           width: chatInputEffortTrackInset * 2 + chatInputEffortTrackHeight - 1,
         },
         gaugeFrame,
+        viewportFrame,
       ),
     ).toBeNull();
     expect(
-      getChatInputEffortOverlayLayout({ height: 0, left: 0, top: 0, width: 361 }, gaugeFrame),
+      getChatInputEffortOverlayLayout(
+        { height: 0, left: 0, top: 0, width: 361 },
+        gaugeFrame,
+        viewportFrame,
+      ),
+    ).toBeNull();
+    expect(
+      getChatInputEffortOverlayLayout({ height: 96, left: 0, top: 0, width: 361 }, gaugeFrame, {
+        ...viewportFrame,
+        height: chatInputEffortPanelHeight - 1,
+      }),
     ).toBeNull();
   });
 });

--- a/src/frontend/features/chat/input/utils/chatInputEffortLayout.ts
+++ b/src/frontend/features/chat/input/utils/chatInputEffortLayout.ts
@@ -17,6 +17,8 @@ export const chatInputEffortTrackHeight = effortSliderTrackHeight;
 export const chatInputEffortTrackInset = 24;
 export const chatInputEffortLabelGap = 16;
 export const chatInputEffortLabelHeight = 24;
+export const chatInputEffortPanelHeight =
+  chatInputEffortLabelHeight + chatInputEffortLabelGap + chatInputEffortTrackHeight;
 
 function isValidFrame(frame: ChatInputEffortFrame): boolean {
   return (
@@ -29,24 +31,30 @@ function isValidFrame(frame: ChatInputEffortFrame): boolean {
   );
 }
 
-/** Geometry for the floating slider, derived from the live composer and gauge. */
+/** Gauge-anchored morph geometry with a viewport-centered resting panel. */
 export function getChatInputEffortOverlayLayout(
   composerFrame: ChatInputEffortFrame,
   gaugeFrame: ChatInputEffortFrame,
+  viewportFrame: ChatInputEffortFrame,
 ): ChatInputEffortOverlayLayout | null {
-  if (!isValidFrame(composerFrame) || !isValidFrame(gaugeFrame)) {
+  if (!isValidFrame(composerFrame) || !isValidFrame(gaugeFrame) || !isValidFrame(viewportFrame)) {
     return null;
   }
 
-  const sliderWidth = composerFrame.width - chatInputEffortTrackInset * 2;
-  if (sliderWidth < chatInputEffortTrackHeight) {
+  const sliderWidth =
+    Math.min(composerFrame.width, viewportFrame.width) - chatInputEffortTrackInset * 2;
+  if (
+    sliderWidth < chatInputEffortTrackHeight ||
+    viewportFrame.height < chatInputEffortPanelHeight
+  ) {
     return null;
   }
 
+  const panelTop = viewportFrame.top + (viewportFrame.height - chatInputEffortPanelHeight) / 2;
   const sliderFrame = {
     height: chatInputEffortTrackHeight,
-    left: composerFrame.left + chatInputEffortTrackInset,
-    top: gaugeFrame.top + (gaugeFrame.height - chatInputEffortTrackHeight) / 2,
+    left: viewportFrame.left + (viewportFrame.width - sliderWidth) / 2,
+    top: panelTop + chatInputEffortLabelHeight + chatInputEffortLabelGap,
     width: sliderWidth,
   };
 
@@ -54,9 +62,9 @@ export function getChatInputEffortOverlayLayout(
     gaugeFrame,
     labelFrame: {
       height: chatInputEffortLabelHeight,
-      left: composerFrame.left,
-      top: sliderFrame.top - chatInputEffortLabelGap - chatInputEffortLabelHeight,
-      width: composerFrame.width,
+      left: sliderFrame.left,
+      top: panelTop,
+      width: sliderWidth,
     },
     sliderFrame,
   };


### PR DESCRIPTION
Centers the expanded reasoning-effort label and track in the live viewport while preserving composer-derived width, so keyboard and gauge movement no longer shift the resting panel. Raises the iOS keyboard blur intensity to 30 and updates the behavior documentation and pure layout coverage. Validation passed the three focused layout tests, typecheck, and format; lint reports zero errors with 38 existing warnings, and iPhone 17 Pro checks covered keyboard shown/hidden plus backdrop dismissal.