### PR TITLE
fix(chat-input): theme effort slider colors

### DIFF
--- a/src/frontend/features/chat/input/components/ChatInputEffortGauge.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputEffortGauge.tsx
@@ -13,7 +13,6 @@ import {
 import { useThemeColor } from '@/frontend/hooks/useThemeColor';
 
 import { effortGaugeNeedleAngle } from '../effortSlider/utils/effortSliderMath';
-import { effortSliderAccentColor } from '../effortSlider/utils/effortSliderVisual';
 import type { ChatInputEffortFrame } from '../utils/chatInputEffortLayout';
 
 const gaugeSize = 20;
@@ -34,7 +33,7 @@ export function ChatInputEffortGauge({
   stopCount,
   valueIndex,
 }: ChatInputEffortGaugeProps) {
-  const foregroundColor = useThemeColor('foreground');
+  const [brandColor, foregroundColor] = useThemeColor(['brand', 'foreground']);
   const reducedMotion = useReducedMotion();
   const needleAngle = useSharedValue(effortGaugeNeedleAngle(valueIndex, stopCount));
   const footprintRef = useRef<View>(null);
@@ -80,13 +79,13 @@ export function ChatInputEffortGauge({
             style="stroke"
           />
           <Line
-            color={effortSliderAccentColor}
+            color={brandColor}
             p1={gaugeCenter}
             p2={needleEnd}
             strokeCap="round"
             strokeWidth={1.8}
           />
-          <Circle color={effortSliderAccentColor} cx={gaugeCenter.x} cy={gaugeCenter.y} r={1.4} />
+          <Circle color={brandColor} cx={gaugeCenter.x} cy={gaugeCenter.y} r={1.4} />
         </Canvas>
       </Composer.Action>
     </View>

--- a/src/frontend/features/chat/input/effortSlider/README.md
+++ b/src/frontend/features/chat/input/effortSlider/README.md
@@ -1,7 +1,7 @@
 # effortSlider
 
 Discrete effort-level slider used by the chat composer's gauge overlay. Its
-two-layer capsule, blue fill, stop dots, and circular thumb follow the ChatGPT
+two-layer capsule, brand fill, stop dots, and circular thumb follow the ChatGPT
 iOS interaction reference.
 
 The number of stops is entirely driven by `options` — i.e. by how many
@@ -25,8 +25,8 @@ model renders 5–6 detents.
   keyboard and composer movement do not shift its resting position.
 - **Visuals** — the neutral outer capsule and its exposed stop dots use the
   theme's `secondary`/`secondary-foreground` pair, so the track is light in the
-  light theme and near-black in the dark theme. The progress pill retains the
-  sampled reference blue (`#3995ff`) with translucent white dots.
+  light theme and near-black in the dark theme. The progress pill and gauge
+  pointer use the shared `brand` token with translucent white dots over the pill.
 
 ## Theming & accessibility
 

--- a/src/frontend/features/chat/input/effortSlider/README.md
+++ b/src/frontend/features/chat/input/effortSlider/README.md
@@ -17,14 +17,16 @@ model renders 5–6 detents.
   ease-out snap to the nearest stop on release, and a light `expo-haptics`
   selection tick on every crossed stop. Commit fires as soon as the active
   stop changes.
-- **Geometry** — the sampled reference is a 64dp near-black outer capsule with
-  a centered 44dp progress pill, a 36dp white thumb, and 10dp stop dots. Stop
+- **Geometry** — the sampled reference is a 64dp outer capsule with a centered
+  44dp progress pill, a 36dp white thumb, and 10dp stop dots. Stop
   dots share the thumb's endpoint centers, derived by
   `getEffortSliderTrackGeometry`, so two-stop and six-stop models stay aligned.
   The chat overlay centers its label-and-track panel in the live viewport, so
   keyboard and composer movement do not shift its resting position.
-- **Visuals** — the progress pill uses the sampled reference blue (`#3995ff`),
-  with translucent white dots over the blue and dark portions of the track.
+- **Visuals** — the neutral outer capsule and its exposed stop dots use the
+  theme's `secondary`/`secondary-foreground` pair, so the track is light in the
+  light theme and near-black in the dark theme. The progress pill retains the
+  sampled reference blue (`#3995ff`) with translucent white dots.
 
 ## Theming & accessibility
 

--- a/src/frontend/features/chat/input/effortSlider/components/EffortSlider.tsx
+++ b/src/frontend/features/chat/input/effortSlider/components/EffortSlider.tsx
@@ -4,8 +4,6 @@ import { type AccessibilityActionEvent, type LayoutChangeEvent, View } from 'rea
 import { GestureDetector } from 'react-native-gesture-handler';
 import { useReducedMotion, withTiming } from 'react-native-reanimated';
 
-import { useThemeColor } from '@/frontend/hooks/useThemeColor';
-
 import { useEffortSliderGesture } from '../hooks/useEffortSliderGesture';
 import { effortSliderSnapTiming } from '../utils/constants';
 import { stopFraction } from '../utils/effortSliderMath';
@@ -50,7 +48,6 @@ export function EffortSlider({
   testID,
 }: EffortSliderProps) {
   const reducedMotion = useReducedMotion();
-  const [constantBlack, constantWhite] = useThemeColor(['constant-black', 'constant-white']);
   // 0 until the first onLayout lands: with travelDistance 0 the thumb/fill
   // would paint at the left edge, then teleport once measured — hide the
   // track for those frames (the panel's fade-in covers the gap).
@@ -133,8 +130,6 @@ export function EffortSlider({
         testID={testID}
       >
         <EffortSliderTrack
-          constantBlack={constantBlack}
-          constantWhite={constantWhite}
           measuredWidth={measuredWidth}
           position={position}
           stopCount={stopCount}

--- a/src/frontend/features/chat/input/effortSlider/components/EffortSliderTrack.tsx
+++ b/src/frontend/features/chat/input/effortSlider/components/EffortSliderTrack.tsx
@@ -5,7 +5,6 @@ import { useThemeColor } from '@/frontend/hooks/useThemeColor';
 
 import { getEffortSliderTrackGeometry, stopFraction } from '../utils/effortSliderMath';
 import {
-  effortSliderAccentColor,
   effortSliderProgressHeight,
   effortSliderThumbInset,
   effortSliderThumbSize,
@@ -23,9 +22,9 @@ type EffortSliderTrackProps = {
 };
 
 /**
- * The reference uses a 64dp neutral capsule around a 44dp blue progress pill.
- * The capsule and exposed ticks follow the active theme. The thumb sits inside
- * the blue end cap, leaving its four-pixel blue ring visible at the endpoints.
+ * A 64dp neutral capsule surrounds a 44dp brand progress pill. The capsule and
+ * exposed ticks follow the active theme. The thumb sits inside the progress end
+ * cap, leaving its four-pixel brand ring visible at the endpoints.
  */
 export function EffortSliderTrack({
   trackHeight,
@@ -33,12 +32,14 @@ export function EffortSliderTrack({
   position,
   measuredWidth,
 }: EffortSliderTrackProps) {
-  const [trackColor, trackForegroundColor, constantBlack, constantWhite] = useThemeColor([
-    'secondary',
-    'secondary-foreground',
-    'constant-black',
-    'constant-white',
-  ]);
+  const [brandColor, trackColor, trackForegroundColor, constantBlack, constantWhite] =
+    useThemeColor([
+      'brand',
+      'secondary',
+      'secondary-foreground',
+      'constant-black',
+      'constant-white',
+    ]);
   const scale = trackHeight / effortSliderTrackHeight;
   const progressHeight = effortSliderProgressHeight * scale;
   const thumbInset = effortSliderThumbInset * scale;
@@ -93,7 +94,7 @@ export function EffortSliderTrack({
           className="absolute overflow-hidden"
           style={[
             {
-              backgroundColor: effortSliderAccentColor,
+              backgroundColor: brandColor,
               borderRadius: progressHeight / 2,
               height: progressHeight,
               left: progressInset,

--- a/src/frontend/features/chat/input/effortSlider/components/EffortSliderTrack.tsx
+++ b/src/frontend/features/chat/input/effortSlider/components/EffortSliderTrack.tsx
@@ -1,6 +1,8 @@
 import { View } from 'react-native';
 import Animated, { type SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 
+import { useThemeColor } from '@/frontend/hooks/useThemeColor';
+
 import { getEffortSliderTrackGeometry, stopFraction } from '../utils/effortSliderMath';
 import {
   effortSliderAccentColor,
@@ -8,7 +10,6 @@ import {
   effortSliderThumbInset,
   effortSliderThumbSize,
   effortSliderTickSize,
-  effortSliderTrackColor,
   effortSliderTrackHeight,
 } from '../utils/effortSliderVisual';
 
@@ -19,23 +20,25 @@ type EffortSliderTrackProps = {
   position: SharedValue<number>;
   /** Measured track width in dp (React state, for tick layout). */
   measuredWidth: number;
-  constantBlack: string;
-  constantWhite: string;
 };
 
 /**
- * The reference uses a 64dp dark capsule around a 44dp blue progress pill.
- * The thumb sits inside the blue end cap, leaving its four-pixel blue ring
- * visible at the endpoints.
+ * The reference uses a 64dp neutral capsule around a 44dp blue progress pill.
+ * The capsule and exposed ticks follow the active theme. The thumb sits inside
+ * the blue end cap, leaving its four-pixel blue ring visible at the endpoints.
  */
 export function EffortSliderTrack({
   trackHeight,
   stopCount,
   position,
   measuredWidth,
-  constantBlack,
-  constantWhite,
 }: EffortSliderTrackProps) {
+  const [trackColor, trackForegroundColor, constantBlack, constantWhite] = useThemeColor([
+    'secondary',
+    'secondary-foreground',
+    'constant-black',
+    'constant-white',
+  ]);
   const scale = trackHeight / effortSliderTrackHeight;
   const progressHeight = effortSliderProgressHeight * scale;
   const thumbInset = effortSliderThumbInset * scale;
@@ -66,7 +69,7 @@ export function EffortSliderTrack({
       <View
         className="absolute inset-0"
         style={{
-          backgroundColor: effortSliderTrackColor,
+          backgroundColor: trackColor,
           borderRadius: trackRadius,
         }}
       >
@@ -75,7 +78,7 @@ export function EffortSliderTrack({
             key={fraction}
             pointerEvents="none"
             style={{
-              backgroundColor: constantWhite,
+              backgroundColor: trackForegroundColor,
               borderRadius: tickSize / 2,
               height: tickSize,
               left: centerX - tickSize / 2,
@@ -123,7 +126,7 @@ export function EffortSliderTrack({
         <View
           pointerEvents="none"
           style={{
-            borderColor: constantWhite,
+            borderColor: trackForegroundColor,
             borderRadius: trackRadius,
             borderWidth: 1,
             bottom: 0,

--- a/src/frontend/features/chat/input/effortSlider/utils/effortSliderVisual.ts
+++ b/src/frontend/features/chat/input/effortSlider/utils/effortSliderVisual.ts
@@ -1,9 +1,5 @@
-/**
- * Artwork exemption: these colors were sampled as one visual from the iOS
- * reference and must not theme-shift independently.
- */
+/** Sampled from the iOS reference; neutral track colors come from the theme. */
 export const effortSliderAccentColor = '#3995ff';
-export const effortSliderTrackColor = '#161616';
 export const effortSliderTrackHeight = 64;
 export const effortSliderProgressHeight = 44;
 export const effortSliderThumbSize = 36;

--- a/src/frontend/features/chat/input/effortSlider/utils/effortSliderVisual.ts
+++ b/src/frontend/features/chat/input/effortSlider/utils/effortSliderVisual.ts
@@ -1,5 +1,3 @@
-/** Sampled from the iOS reference; neutral track colors come from the theme. */
-export const effortSliderAccentColor = '#3995ff';
 export const effortSliderTrackHeight = 64;
 export const effortSliderProgressHeight = 44;
 export const effortSliderThumbSize = 36;


### PR DESCRIPTION
## Summary

- Use semantic `secondary` and `secondary-foreground` colors for the effort slider track, exposed ticks, and outline.
- Use the shared `brand` token for the progress pill and gauge pointer, removing the component-local `#3995ff`.
- Preserve the thumb, geometry, animations, and interactions while documenting the theme contract.

## Validation

- `pnpm test:app --runInBand src/frontend/features/chat/input/effortSlider/utils/__tests__/effortSliderMath.test.ts`
- `pnpm typecheck:app`, `pnpm lint`, and `pnpm format:check`
- Verified light and dark themes on iPhone 17 Pro with the keyboard open and blur intensity 30.