### PR TITLE
fix(chat): stop the scroll-to-bottom button flickering during streaming

### DIFF
--- a/src/frontend/components/messagePresentation/components/MessageList.tsx
+++ b/src/frontend/components/messagePresentation/components/MessageList.tsx
@@ -11,7 +11,12 @@ import {
   useState,
 } from 'react';
 import { type LayoutChangeEvent, View } from 'react-native';
-import { runOnJS, useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
+import {
+  runOnJS,
+  useAnimatedReaction,
+  useDerivedValue,
+  useSharedValue,
+} from 'react-native-reanimated';
 
 import { usePreference } from '@/frontend/data/hooks';
 import { resolveTypographyScale } from '@/frontend/utils/typographyScale';
@@ -144,6 +149,8 @@ export function MessageList({
   // arm 发生在假模型被构造时（晚于本组件挂载），worklet 读不到 JS 侧的模块变量，
   // 因此每次渲染把 arm 状态同步进 shared value，未 arm 时连 runOnJS 都不发生。
   const probeArmed = useSharedValue(false);
+  // 尾随相位是 React state，worklet 读不到，镜像一份供按钮显隐推导使用。
+  const isTailControlled = useSharedValue(false);
   const [fontSizeStep] = usePreference('ui.font_size_step');
   const [contentBaseHeight, setContentBaseHeight] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
@@ -218,8 +225,20 @@ export function MessageList({
     probeArmed.set(isLayoutBenchProbeArmed());
   });
 
+  // 「滚动到底部」只在**用户自己**离开底部时才有意义。而 isAtEnd 用的是 ~0px 的判定边界，
+  // 只要 app 正把列表往底部推（钉顶动画、流式尾随），内容每长一截都会先把视口挤离底部、
+  // 下一帧滚动再吸回来，isAtEnd 就跟着以帧为周期翻转（实测一轮流式 33 次）。
+  //
+  // 关键是**不能**拿「是否在尾随」去否决它：相位是 React state，镜像进 shared value 必然是
+  // JS→UI 的跨线程写，落地比 UI 线程自己翻的 isAtEnd 晚一帧，那一帧里两个条件都为假，按钮
+  // 照闪不误（实测把镜像挪进 layout effect 也没用，晚的是线程不是 React 时序）。
+  // 换成「列表是否正被程序化接管」后，延迟的方向就全是安全的：进入接管态发生在用户刚发出
+  // 消息、列表本就贴底的那一刻，anchoring→following 根本不改变它；退出接管态只会让按钮晚
+  // 一帧出现。paused 是唯一不会自动滚的相位，也正是按钮该出现的相位。
+  const isScrollButtonHidden = useDerivedValue(() => isAtBottom.get() || isTailControlled.get());
+
   useAnimatedReaction(
-    () => isAtBottom.get(),
+    () => isScrollButtonHidden.get(),
     (current, previous) => {
       if (previous !== null && current !== previous) {
         runOnJS(emitButtonVisibility)(!current);
@@ -238,10 +257,13 @@ export function MessageList({
 
   useLayoutEffect(() => {
     tailFollowPhaseRef.current = tailFollowPhase;
+    // anchoring 与 following 都由 app 主动把列表推向底部（钉顶滚动 / 尾随滚动），
+    // 只有 paused 全程不自动滚。没有锚点时不存在任何自动滚动，交回 isAtEnd 单独判定。
+    isTailControlled.set(hasAnchor && tailFollowPhase !== 'paused');
     // 相位决定同一条位移轨迹该被判成合格还是缺陷（钉顶期应静止、尾随期应跟随），
     // 所以它必须作为独立信号进日志，否则 harness 无从判定。
     emitLayoutBenchProbe('phase', { anchorId: anchorMessageId, phase: tailFollowPhase });
-  }, [anchorMessageId, tailFollowPhase]);
+  }, [anchorMessageId, hasAnchor, isTailControlled, tailFollowPhase]);
 
   // Read from size and layout callbacks, which the platform dispatches well
   // after commit, so mirroring the staged anchor here is soon enough.
@@ -719,7 +741,7 @@ export function MessageList({
           <ScrollToBottomButton
             gap={SCROLL_BUTTON_GAP_ABOVE_ACCESSORY}
             inputHeight={bottomAccessoryHeight}
-            isAtBottom={isAtBottom}
+            isHidden={isScrollButtonHidden}
             onPress={handleScrollToEnd}
           />
         ) : null}

--- a/src/frontend/components/messagePresentation/components/ScrollToBottomButton/ScrollToBottomButton.tsx
+++ b/src/frontend/components/messagePresentation/components/ScrollToBottomButton/ScrollToBottomButton.tsx
@@ -12,16 +12,16 @@ const visibilityMotion = { duration: duration.fast, easing: easing.settle } as c
 export function ScrollToBottomButton({
   gap,
   inputHeight,
-  isAtBottom,
+  isHidden,
   onPress,
 }: ScrollToBottomButtonProps) {
   const wrapStyle = useAnimatedStyle(() => ({ bottom: inputHeight.get() + gap }));
   const containerStyle = useAnimatedStyle(() => ({
-    opacity: withTiming(isAtBottom.get() ? 0 : 1, visibilityMotion),
-    transform: [{ scale: withTiming(isAtBottom.get() ? 0.8 : 1, visibilityMotion) }],
+    opacity: withTiming(isHidden.get() ? 0 : 1, visibilityMotion),
+    transform: [{ scale: withTiming(isHidden.get() ? 0.8 : 1, visibilityMotion) }],
   }));
   const containerProps = useAnimatedProps(() => ({
-    pointerEvents: (isAtBottom.get() ? 'none' : 'auto') as 'auto' | 'none',
+    pointerEvents: (isHidden.get() ? 'none' : 'auto') as 'auto' | 'none',
   }));
 
   return (

--- a/src/frontend/components/messagePresentation/components/ScrollToBottomButton/types.ts
+++ b/src/frontend/components/messagePresentation/components/ScrollToBottomButton/types.ts
@@ -5,7 +5,8 @@ export type ScrollToBottomButtonProps = {
   gap: number;
   // 输入框实测高度共享值：逐帧驱动按钮定位。
   inputHeight: SharedValue<number>;
-  // 列表「是否精确在最底部」共享值：true 时按钮淡出并禁用点击。
-  isAtBottom: SharedValue<boolean>;
+  // 按钮是否应当隐藏：true 时淡出并禁用点击。
+  // 刻意不叫 isAtBottom——「是否在最底部」不足以决定显隐，见 MessageList 的推导注释。
+  isHidden: SharedValue<boolean>;
   onPress: () => void;
 };

--- a/src/frontend/components/messagePresentation/components/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messagePresentation/components/__tests__/MessageList.test.tsx
@@ -63,18 +63,24 @@ const mockLegendListRef = {
   getState: () => mockListMetrics,
   scrollToEnd: mockListScrollToEndMethod,
 } as unknown as LegendListRef;
-const mockIsAtBottom = {
-  get: jest.fn(() => true),
-  set: jest.fn(),
-  value: true,
-} as unknown as SharedValue<boolean>;
+function mockCreateSharedValue<T>(initial: T): SharedValue<T> {
+  const shared = {
+    get: () => shared.value,
+    set: (next: T) => {
+      shared.value = next;
+    },
+    value: initial,
+  };
+
+  return shared as unknown as SharedValue<T>;
+}
 const mockAssistantMessageRow = jest.fn((_props: { message: MessagePresentationItem }) => null);
 const mockUserMessageRow = jest.fn((_props: { message: MessagePresentationItem }) => null);
 let mockSlideInMessageId: string | undefined;
 let mockScrollButtonProps:
   | {
       inputHeight: SharedValue<number>;
-      isAtBottom: SharedValue<boolean>;
+      isHidden: SharedValue<boolean>;
       onPress: () => void;
     }
   | undefined;
@@ -132,13 +138,26 @@ jest.mock('@/shared/core/logger/LoggerService', () => ({
   },
 }));
 
-jest.mock('react-native-reanimated', () => ({
-  // 探针用 useAnimatedReaction 从 UI 线程回抛按钮显隐；这里只需存在即可，
-  // 本套件不断言探针输出。
-  runOnJS: (fn: unknown) => fn,
-  useAnimatedReaction: () => undefined,
-  useSharedValue: () => mockIsAtBottom,
-}));
+jest.mock('react-native-reanimated', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    // 探针用 useAnimatedReaction 从 UI 线程回抛按钮显隐；这里只需存在即可，
+    // 本套件不断言探针输出。
+    runOnJS: (fn: unknown) => fn,
+    useAnimatedReaction: () => undefined,
+    // 真实求值，好让「按钮显隐」的推导语义可断言。
+    useDerivedValue: (compute: () => unknown) => ({ get: compute }),
+    // 语义等价于「持有可变盒子的 useRef」：每个调用点一个独立实例（组件里有多个 shared
+    // value，共用一个对象会互相污染），且跨渲染保持同一身份——否则重渲后组件换用新盒子，
+    // 测试握着的旧引用就再也影响不了组件，断言会静默失真。
+    useSharedValue: <T,>(initial: T) => {
+      const ref = React.useRef<SharedValue<T> | null>(null);
+      ref.current ??= mockCreateSharedValue(initial);
+      return ref.current;
+    },
+  };
+});
 
 jest.mock('../../messageRow', () => ({
   AssistantMessageRow: (props: { message: MessagePresentationItem }) =>
@@ -159,7 +178,7 @@ jest.mock('../../messageRow', () => ({
 jest.mock('../ScrollToBottomButton', () => ({
   ScrollToBottomButton: (props: {
     inputHeight: SharedValue<number>;
-    isAtBottom: SharedValue<boolean>;
+    isHidden: SharedValue<boolean>;
     onPress: () => void;
   }) => {
     mockScrollButtonProps = props;
@@ -381,7 +400,11 @@ describe('MessageList anchored tail following', () => {
 
     expect(mockSlideInMessageId).toBe('user-1');
     expect(mockScrollButtonProps?.inputHeight).toBe(bottomAccessoryHeight);
-    expect(mockScrollButtonProps?.isAtBottom).toBe(mockLatestListProps?.sharedValues?.isAtEnd);
+
+    // 停在底部时隐藏。离开底部要不要显示还取决于相位，见下方的 paused 用例。
+    const isAtEnd = mockLatestListProps?.sharedValues?.isAtEnd;
+    isAtEnd?.set(true);
+    expect(mockScrollButtonProps?.isHidden.get()).toBe(true);
 
     act(() => mockScrollButtonProps?.onPress());
     expect(mockListScrollToEndMethod).toHaveBeenCalledWith({ animated: true });
@@ -515,6 +538,36 @@ describe('MessageList anchored tail following', () => {
     });
     expect(mockLatestListProps?.maintainVisibleContentPosition).toBeUndefined();
     expect(mockListScrollToEnd).toHaveBeenCalledTimes(2);
+  });
+
+  test('shows the scroll control only once the user pauses tail following', () => {
+    const messages = [
+      createMessage('user-1', 'user', [textPart('hello')]),
+      createMessage('assistant-1', 'assistant'),
+    ];
+    act(() => {
+      renderer = create(
+        <MessageList {...listProps(messages)} bottomAccessoryHeight={mockCreateSharedValue(88)} />,
+      );
+    });
+
+    // 钉顶期与尾随期都由 app 主动把列表推向底部：内容每长一截都会先把视口挤离底部、
+    // 下一帧滚动再吸回来，isAtEnd 因此逐帧翻转。这两个相位必须一律隐藏，否则按钮脉动。
+    const isAtEnd = mockLatestListProps?.sharedValues?.isAtEnd;
+    isAtEnd?.set(false);
+    expect(mockScrollButtonProps?.isHidden.get()).toBe(true);
+
+    act(() => mockLatestListProps?.anchoredEndSpace?.onSizeChanged?.(0));
+    act(() => flushAnimationFrames());
+    isAtEnd?.set(false);
+    expect(mockScrollButtonProps?.isHidden.get()).toBe(true);
+
+    // 用户拖动打断尾随后不再有自动滚动，此时离开底部才是真的「用户自己走开了」。
+    act(() => mockLatestListProps?.onScrollBeginDrag?.());
+    expect(mockScrollButtonProps?.isHidden.get()).toBe(false);
+
+    isAtEnd?.set(true);
+    expect(mockScrollButtonProps?.isHidden.get()).toBe(true);
   });
 
   test('cancels a queued follow before a touch can begin dragging', () => {

--- a/src/frontend/components/messagePresentation/components/__tests__/ScrollToBottomButton.test.tsx
+++ b/src/frontend/components/messagePresentation/components/__tests__/ScrollToBottomButton.test.tsx
@@ -68,7 +68,7 @@ describe('ScrollToBottomButton', () => {
         <ScrollToBottomButton
           gap={8}
           inputHeight={sharedValue(72)}
-          isAtBottom={sharedValue(false)}
+          isHidden={sharedValue(false)}
           onPress={onPress}
         />,
       );


### PR DESCRIPTION
The button was driven straight off LegendList's `isAtEnd`, whose decision
boundary is ~0px. While the app is pushing the list toward the bottom
(anchor pin-to-top, tail follow), every content growth first shoves the
viewport off the end and the next frame's scroll pulls it back — so
`isAtEnd` flips false/true once per frame and the button pulsed with it.
The layout-bench probe measured 33 toggles in a single stream, 25 of the
32 gaps under 200ms.

Vetoing it with a mirror of the tail-follow phase does not work: the
phase is React state, so the mirror is a JS→UI shared-value write and
lands one frame after the `isAtEnd` flip the UI thread performs itself.
In that frame both conditions read false and the button still flashes.
Moving the write into a layout effect changed nothing (measured), since
what is late is the thread hop, not the React timing.

Derive the veto from "is the list under programmatic control" instead —
an anchor exists and the phase is not `paused`. Every direction of the
one-frame lag is then harmless: control is entered the moment the user
sends, when the list is already at the bottom; `anchoring → following`
does not change the value at all; leaving control merely delays the
button by a frame. `paused` is the only phase that never auto-scrolls,
which is exactly when the affordance is meaningful.

Measured over the same scripted stream-and-drag scenario: 33 toggles →
1, and that one is the user's own swipe away from the bottom.

Also renames the prop to `isHidden`, since "at bottom" is no longer what
decides it, and fixes the reanimated test mock to return a stable shared
value per hook call — the previous mock handed out a fresh object on
every render, so a reference captured by a test silently stopped
affecting the component after the next re-render.

Co-Authored-By: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
