### PR TITLE
refactor(chat): 把 MessageList 的行为引擎抽成模块内 hook

### DIFF
--- a/src/frontend/components/messagePresentation/README.md
+++ b/src/frontend/components/messagePresentation/README.md
@@ -47,7 +47,11 @@ and anchoring.
 
 ## Organization
 
-- `components/MessageList.tsx` owns virtualization, anchoring, readiness, and list controls.
+- `components/MessageList.tsx` is the wiring layer: virtualization config, layout derivations, and
+  list controls. The behavior engines live beside it in `components/hooks/` — `useTailFollow`
+  (tail-follow state machine, sole owner of the interaction lock), `useAnchorPin` (anchor pinning,
+  first-anchor staging, readiness gate), and `useLayoutBenchInstrumentation` (dev-only layout
+  probes). Measurement-backed comments travel with the code they explain.
 - `messageRow/` owns user and assistant row layouts plus the private slide-in provider.
 - `messageContent/` dispatches structured message parts and owns citation/file hooks.
 - `utils/` contains the private built-in tool presentation mapping.

--- a/src/frontend/components/messagePresentation/components/MessageList.tsx
+++ b/src/frontend/components/messagePresentation/components/MessageList.tsx
@@ -1,51 +1,31 @@
 import { ScrollShadow } from '@cherrystudio/ui/components';
 import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list/keyboard';
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
-import {
-  type RefObject,
-  useCallback,
-  useEffect,
-  useEffectEvent,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { type LayoutChangeEvent, View } from 'react-native';
-import { KeyboardEvents } from 'react-native-keyboard-controller';
-import {
-  runOnJS,
-  useAnimatedReaction,
-  useDerivedValue,
-  useSharedValue,
-} from 'react-native-reanimated';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { View } from 'react-native';
+import { useDerivedValue, useSharedValue } from 'react-native-reanimated';
 
 import { usePreference } from '@/frontend/data/hooks';
 import { resolveTypographyScale } from '@/frontend/utils/typographyScale';
-import { loggerService } from '@/shared/core/logger/LoggerService';
-import { emitLayoutBenchProbe, isLayoutBenchProbeArmed } from '@/shared/devBench/layoutBenchProbe';
+import { emitLayoutBenchProbe } from '@/shared/devBench/layoutBenchProbe';
 
 import { AssistantMessageRow, MessageSlideInProvider, UserMessageRow } from '../messageRow';
 import type { MessageListProps, MessagePresentationItem } from '../types';
+import { useAnchorPin } from './hooks/useAnchorPin';
+import {
+  emitProgrammaticScroll,
+  scrollLog,
+  useLayoutBenchInstrumentation,
+} from './hooks/useLayoutBenchInstrumentation';
+import { useTailFollow } from './hooks/useTailFollow';
 import { followingMaintainVisibleContentPosition } from './messageListPlatform/messageListPlatform';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
-
-// 滚动/布局诊断埋点：记录会驱动列表位移的关键数值（scroll offset、内容高度、锚点就绪、
-// 翻页触发、钉顶滚动），用于把「界面跳动」量化成时间-位移轨迹。走 logger.debug → 仅 dev
-// 输出（生产环境被日志级别过滤），故长期保留无碍。用 `[SCROLL]` 前缀便于从 Metro 日志过滤。
-const scrollLog = loggerService.withContext('ChatScroll');
 
 // 被锚定的用户消息距内容区顶部（顶部安全区/导航栏之下）的视觉间距。
 const ANCHOR_TOP_GAP = 12;
 const ANCHOR_MAX_TEXT_LINES = 2;
 const SCROLL_BUTTON_GAP_ABOVE_ACCESSORY = 5;
 const USER_MESSAGE_VERTICAL_PADDING = 32;
-// 撤遮罩（onReady）前要求内容高度保持「静默」的窗口：这段时间内没有任何 contentSize 变化才判定
-// settle 完成。用于覆盖**冷 markdown 解析**——首次进入 topic 时 streamdown/代码/数学的 tokenize
-// 与 layout 全冷、耗时最长，行的真实高度可能在初始 rAF 之后才测出。若此时已 reportReady 撤遮罩，
-// 迟到的高度修正就泄漏成「第一次进入才有的跳动」。静默窗口内任何 contentSize 变化都会（经 effect
-// 依赖 contentBaseHeight 重跑）取消并重启计时，从而把迟到修正也挡在遮罩后，与设备快慢无关。
-const READY_SETTLE_MS = 150;
 
 // 流式/待生成的助手消息高度会持续变化（loading 圆点 → 思考块 → 正文流入）。若它被
 // maintainVisibleContentPosition 选作锚点，列表会为「保持它的位置不变」而反向平移整块内容，
@@ -61,26 +41,6 @@ const MAINTAIN_VISIBLE_CONTENT_POSITION = {
   data: true,
   shouldRestorePosition: shouldRestoreMessagePosition,
 };
-
-const TAIL_FOLLOW_END_THRESHOLD = 20;
-
-type TailFollowPhase = 'anchoring' | 'following' | 'paused';
-
-type TailFollowState = {
-  anchorMessageId: string | undefined;
-  phase: TailFollowPhase;
-};
-
-function createTailFollowState(anchorMessageId: string | undefined): TailFollowState {
-  return { anchorMessageId, phase: 'anchoring' };
-}
-
-function resolveTailFollowState(
-  state: TailFollowState,
-  anchorMessageId: string | undefined,
-): TailFollowState {
-  return state.anchorMessageId === anchorMessageId ? state : createTailFollowState(anchorMessageId);
-}
 
 function messageKeyExtractor(item: MessagePresentationItem) {
   return item.id;
@@ -98,8 +58,8 @@ function messageKeyExtractor(item: MessagePresentationItem) {
 // 分类后修正量 2964px → 5px。
 //
 // 注意它**不是**「发送后跳一下」的成因：分类修好之后，续轮发送前那一帧 -310px 的突跳原样
-// 还在，另有其因（收键盘按记录量回退，见下面 handleAnchorReady 的说明与 patches/）。两件事
-// 都在同一瞬间发生，别再合并归因。
+// 还在，另有其因（收键盘按记录量回退，见 useAnchorPin 里 handleAnchorReady 的说明与
+// patches/）。两件事都在同一瞬间发生，别再合并归因。
 //
 // 判据用「有没有 part」而不是 status：类型翻转因此发生在第一个 chunk 落地时，那一刻行还只有
 // 几十像素，翻转本身不产生可见修正；而 status 要到整条回复结束才变，翻转时行已有数千像素。
@@ -111,76 +71,6 @@ function getMessageRowType(item: MessagePresentationItem) {
   }
 
   return item.data.parts?.length ? 'assistant' : 'assistant-empty';
-}
-
-// 「滚动到底部」按钮的显隐完全由 UI 线程的 shared value 驱动（opacity/pointerEvents 都是
-// worklet 计算），JS 侧看不到状态变化，所以只能从 worklet 里回抛。
-function emitButtonVisibility(visible: boolean) {
-  emitLayoutBenchProbe('button', { visible });
-}
-
-function emitScrollOffset(y: number) {
-  emitLayoutBenchProbe('scroll', { y: Math.round(y) });
-}
-
-function emitFreeze(on: boolean) {
-  emitLayoutBenchProbe('freeze', { on });
-}
-
-// 键盘收放挪动内容却不改 contentSize、不改视口，因此不留下任何其它探针能看见的痕迹。发送时
-// `scrollMessageToEnd` 正好同时发起收键盘与钉顶滚动，缺了这条时间线就没法判断那一帧的位移
-// 是谁造成的。
-//
-// 一起记下当时的预留空白，是因为键盘造成净位移的充要条件就是它：抬起时按「当时的预留空白
-// 能吸收多少」决定抬多少，收起时回退的是抬起那一刻记下来的量——**两次之间预留空白变了，
-// 回退量就不再对**（实测续轮发送 0 → 512，净位移 310px）。没有这两个数，这类位移只能靠
-// 猜（上一轮就据此错误地怀疑过 MVCP）。
-//
-// 订阅不能按 `isLayoutBenchProbeArmed()` 开关：探针由假模型在**第一次发送**时 arm，而这个
-// effect 在列表挂载时就跑完了，按 armed 判断等于永远不订阅（实测整轮零 keyboard 事件）。
-// 改成 dev 下常驻订阅、由 emit 自己按 armed 过滤——键盘事件只在收放时各一条，不像 onScroll
-// 那样每帧都有，常驻的代价可以忽略。
-function useKeyboardProbe(endSpaceRef: RefObject<number>) {
-  useEffect(() => {
-    if (!__DEV__) {
-      return;
-    }
-
-    const subscriptions = (['keyboardWillShow', 'keyboardWillHide'] as const).map((event) =>
-      KeyboardEvents.addListener(event, ({ duration, height }) => {
-        emitLayoutBenchProbe('keyboard', {
-          dur: duration,
-          endSpace: Math.round(endSpaceRef.current),
-          event,
-          h: Math.round(height),
-        });
-      }),
-    );
-
-    return () => subscriptions.forEach((subscription) => subscription.remove());
-  }, [endSpaceRef]);
-}
-
-// 程序化滚动只记「谁调的」不够：同一个 scrollToEnd 落到哪里，取决于调用瞬间列表认为的
-// 内容长度与视口长度。发送消息时这两个量正在剧烈变化（新行未测量、预留空白在重算），
-// 落点因此可能远离用户当前位置——把三个量与调用点一起记下才谈得上归因。
-function emitProgrammaticScroll(
-  src: string,
-  listRef: RefObject<LegendListRef | null>,
-  extra?: Record<string, boolean | number | string | undefined>,
-) {
-  if (!isLayoutBenchProbeArmed()) {
-    return;
-  }
-
-  const listState = listRef.current?.getState();
-  emitLayoutBenchProbe('progScroll', {
-    ...extra,
-    content: listState ? Math.round(listState.contentLength) : undefined,
-    scroll: listState ? Math.round(listState.scroll) : undefined,
-    src,
-    viewport: listState ? Math.round(listState.scrollLength) : undefined,
-  });
 }
 
 function getAnchoredUserMessageIndex(messages: readonly MessagePresentationItem[]) {
@@ -212,28 +102,9 @@ export function MessageList({
   // `onScroll` 回调实测一次都不触发。`sharedValues.scrollOffset` 才是这套组件栈支持的
   // 读法，且它在 UI 线程逐帧更新，比 JS 回调更贴近真实位移。
   const scrollOffset = useSharedValue(0);
-  // arm 发生在假模型被构造时（晚于本组件挂载），worklet 读不到 JS 侧的模块变量，
-  // 因此每次渲染把 arm 状态同步进 shared value，未 arm 时连 runOnJS 都不发生。
-  const probeArmed = useSharedValue(false);
-  // 尾随相位是 React state，worklet 读不到，镜像一份供按钮显隐推导使用。
-  const isTailControlled = useSharedValue(false);
-  const [fontSizeStep] = usePreference('ui.font_size_step');
-  const [contentBaseHeight, setContentBaseHeight] = useState(0);
-  const [viewportHeight, setViewportHeight] = useState(0);
-  const didReportReadyRef = useRef(false);
-  const isMountedRef = useRef(true);
-  const pendingReadyFrameRef = useRef<number | null>(null);
-  const pendingReadySettleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const readyGenerationRef = useRef(0);
-  const pendingFirstAnchorReleaseFrameRef = useRef<number | null>(null);
-  const pendingTailFollowFrameRef = useRef<number | null>(null);
-  const pendingInteractionEndFrameRef = useRef<number | null>(null);
-  const isTouchingListRef = useRef(false);
-  const isDraggingListRef = useRef(false);
-  const isMomentumScrollingRef = useRef(false);
-  const isUserInteractingRef = useRef(false);
-  // 只服务于键盘探针：键盘事件里要报当时的预留空白（见 useKeyboardProbe）。
+  // 只服务于键盘探针：键盘事件里要报当时的预留空白（见 useLayoutBenchInstrumentation）。
   const endSpaceRef = useRef(0);
+  const [fontSizeStep] = usePreference('ui.font_size_step');
   const lastMessageId = messages[messages.length - 1]?.id;
   const anchorIndex = getAnchoredUserMessageIndex(messages);
   const listHeader = useMemo(() => <View style={{ height: contentTopInset }} />, [contentTopInset]);
@@ -259,22 +130,6 @@ export function MessageList({
   const hasAnchor = anchorIndex >= 0;
   const anchorMessage = hasAnchor ? messages[anchorIndex] : undefined;
   const anchorMessageId = anchorMessage?.id;
-  // A single-turn workspace has no previous content to scroll past. Keep its first live turn at
-  // the list end until the rows report a real size; then add the anchor space and animate to it.
-  const [releasedFirstAnchorId, setReleasedFirstAnchorId] = useState<string>();
-  const isFirstEnteringAnchor =
-    animateFirstEnteringMessage &&
-    anchorIndex === 0 &&
-    anchorMessageId !== undefined &&
-    anchorMessageId === enteringMessageId;
-  const isStagingFirstAnchor = isFirstEnteringAnchor && releasedFirstAnchorId !== anchorMessageId;
-  const stagedFirstAnchorIdRef = useRef<string | undefined>(undefined);
-  const [tailFollowState, setTailFollowState] = useState<TailFollowState>(() =>
-    createTailFollowState(anchorMessageId),
-  );
-  const tailFollowPhase = resolveTailFollowState(tailFollowState, anchorMessageId).phase;
-  const tailFollowPhaseRef = useRef(tailFollowPhase);
-  const isFollowing = tailFollowPhase === 'following';
   const anchorHasFile = anchorMessage?.data.parts?.some((part) => part.type === 'file') ?? false;
   const anchorMaxSize = anchorHasFile
     ? undefined
@@ -289,8 +144,41 @@ export function MessageList({
     [contentBottomInset],
   );
 
-  useEffect(() => {
-    probeArmed.set(isLayoutBenchProbeArmed());
+  const {
+    handleEndVisible,
+    handleMomentumScrollBegin,
+    handleMomentumScrollEnd,
+    handleScrollBeginDrag,
+    handleScrollEndDrag,
+    handleTouchEnd,
+    handleTouchStart,
+    isFollowing,
+    isTailControlled,
+    isUserInteractingRef,
+    notifyAnchorSpaceClosed,
+    scheduleTailFollow,
+  } = useTailFollow({ anchorMessageId, hasAnchor, listRef });
+
+  const {
+    handleAnchorReady,
+    handleAnchoredEndSpaceSizeChanged,
+    handleContentSizeChange,
+    handleLayout,
+    isStagingFirstAnchor,
+    releaseStagedFirstAnchor,
+  } = useAnchorPin({
+    anchorIndex,
+    anchorMessageId,
+    animateFirstEnteringMessage,
+    contentBottomInset,
+    endSpaceRef,
+    enteringMessageId,
+    isUserInteractingRef,
+    lastMessageId,
+    listRef,
+    notifyAnchorSpaceClosed,
+    onReady,
+    scrollMessageToEnd,
   });
 
   // 「滚动到底部」只在**用户自己**离开底部时才有意义。而 isAtEnd 用的是 ~0px 的判定边界，
@@ -305,286 +193,7 @@ export function MessageList({
   // 一帧出现。paused 是唯一不会自动滚的相位，也正是按钮该出现的相位。
   const isScrollButtonHidden = useDerivedValue(() => isAtBottom.get() || isTailControlled.get());
 
-  useAnimatedReaction(
-    () => isScrollButtonHidden.get(),
-    (current, previous) => {
-      if (previous !== null && current !== previous) {
-        runOnJS(emitButtonVisibility)(!current);
-      }
-    },
-  );
-
-  useAnimatedReaction(
-    () => scrollOffset.get(),
-    (current, previous) => {
-      if (probeArmed.get() && previous !== null && current !== previous) {
-        runOnJS(emitScrollOffset)(current);
-      }
-    },
-  );
-
-  useAnimatedReaction(
-    () => freeze.get(),
-    (current, previous) => {
-      if (probeArmed.get() && previous !== null && current !== previous) {
-        runOnJS(emitFreeze)(current);
-      }
-    },
-  );
-
-  useKeyboardProbe(endSpaceRef);
-
-  useLayoutEffect(() => {
-    tailFollowPhaseRef.current = tailFollowPhase;
-    // anchoring 与 following 都由 app 主动把列表推向底部（钉顶滚动 / 尾随滚动），
-    // 只有 paused 全程不自动滚。没有锚点时不存在任何自动滚动，交回 isAtEnd 单独判定。
-    isTailControlled.set(hasAnchor && tailFollowPhase !== 'paused');
-    // 相位决定同一条位移轨迹该被判成合格还是缺陷（钉顶期应静止、尾随期应跟随），
-    // 所以它必须作为独立信号进日志，否则 harness 无从判定。
-    emitLayoutBenchProbe('phase', { anchorId: anchorMessageId, phase: tailFollowPhase });
-  }, [anchorMessageId, hasAnchor, isTailControlled, tailFollowPhase]);
-
-  // Read from size and layout callbacks, which the platform dispatches well
-  // after commit, so mirroring the staged anchor here is soon enough.
-  useLayoutEffect(() => {
-    stagedFirstAnchorIdRef.current = isStagingFirstAnchor ? anchorMessageId : undefined;
-  }, [anchorMessageId, isStagingFirstAnchor]);
-
-  // LegendList 的 maintainScrollAtEnd 会在 rAF 中捕获旧配置，拖动已暂停后仍可能执行一次。
-  // 在应用层合并 follow 请求，并在直接派发给原生 ScrollView 前重新检查同步交互锁。
-  const cancelPendingTailFollow = useCallback(() => {
-    if (pendingTailFollowFrameRef.current !== null) {
-      cancelAnimationFrame(pendingTailFollowFrameRef.current);
-      pendingTailFollowFrameRef.current = null;
-    }
-  }, []);
-
-  const releaseStagedFirstAnchor = useCallback(() => {
-    const stagedAnchorId = stagedFirstAnchorIdRef.current;
-    if (!stagedAnchorId || pendingFirstAnchorReleaseFrameRef.current !== null) {
-      return;
-    }
-
-    pendingFirstAnchorReleaseFrameRef.current = requestAnimationFrame(() => {
-      pendingFirstAnchorReleaseFrameRef.current = null;
-      if (stagedFirstAnchorIdRef.current === stagedAnchorId) {
-        setReleasedFirstAnchorId(stagedAnchorId);
-      }
-    });
-  }, []);
-
-  const scheduleTailFollow = useCallback(() => {
-    if (
-      tailFollowPhaseRef.current !== 'following' ||
-      isUserInteractingRef.current ||
-      pendingTailFollowFrameRef.current !== null
-    ) {
-      return;
-    }
-
-    pendingTailFollowFrameRef.current = requestAnimationFrame(() => {
-      pendingTailFollowFrameRef.current = null;
-
-      if (tailFollowPhaseRef.current !== 'following' || isUserInteractingRef.current) {
-        return;
-      }
-
-      const nativeScrollRef = listRef.current?.getNativeScrollRef() as
-        | { scrollToEnd?: (options: { animated?: boolean }) => void }
-        | null
-        | undefined;
-      emitProgrammaticScroll('tailFollow', listRef);
-      nativeScrollRef?.scrollToEnd?.({ animated: false });
-    });
-  }, [listRef]);
-
-  const isListAtEnd = useCallback(() => {
-    const listState = listRef.current?.getState();
-    if (!listState || listState.scrollLength <= 0) {
-      return false;
-    }
-
-    const distanceFromEnd = listState.contentLength - listState.scrollLength - listState.scroll;
-    return Number.isFinite(distanceFromEnd) && distanceFromEnd <= TAIL_FOLLOW_END_THRESHOLD;
-  }, [listRef]);
-
-  const resumeTailFollowAtEnd = useCallback(() => {
-    if (!anchorMessageId || tailFollowPhaseRef.current !== 'paused' || !isListAtEnd()) {
-      return;
-    }
-
-    tailFollowPhaseRef.current = 'following';
-    setTailFollowState((previous) => {
-      const current = resolveTailFollowState(previous, anchorMessageId);
-      return current.phase === 'paused' ? { ...current, phase: 'following' } : current;
-    });
-    scheduleTailFollow();
-  }, [anchorMessageId, isListAtEnd, scheduleTailFollow]);
-
-  const cancelPendingInteractionEnd = useCallback(() => {
-    if (pendingInteractionEndFrameRef.current !== null) {
-      cancelAnimationFrame(pendingInteractionEndFrameRef.current);
-      pendingInteractionEndFrameRef.current = null;
-    }
-  }, []);
-
-  const finishUserInteraction = useCallback(() => {
-    if (isTouchingListRef.current || isDraggingListRef.current || isMomentumScrollingRef.current) {
-      return;
-    }
-
-    isUserInteractingRef.current = false;
-    if (tailFollowPhaseRef.current === 'paused') {
-      resumeTailFollowAtEnd();
-    } else {
-      scheduleTailFollow();
-    }
-  }, [resumeTailFollowAtEnd, scheduleTailFollow]);
-
-  const scheduleInteractionEnd = useCallback(() => {
-    cancelPendingInteractionEnd();
-    pendingInteractionEndFrameRef.current = requestAnimationFrame(() => {
-      pendingInteractionEndFrameRef.current = null;
-      finishUserInteraction();
-    });
-  }, [cancelPendingInteractionEnd, finishUserInteraction]);
-
-  const beginUserInteraction = useCallback(() => {
-    isUserInteractingRef.current = true;
-    cancelPendingInteractionEnd();
-    cancelPendingTailFollow();
-  }, [cancelPendingInteractionEnd, cancelPendingTailFollow]);
-
-  // 把刚发送的用户消息锚定到内容区顶部，并在其下方补足空白，让助手回复流式生长其间。
-  //
-  // onReady 是钉顶的正确触发点：LegendList 只在「锚点下方所有 item 尺寸都已**真实测量**」
-  // （含刚 mount 的助手 pending 占位、hasUnknownTailSize=false）后，才把预留空白算成真实值
-  // 并回调 onReady。此刻落点已是终值。
-  //
-  // 默认首轮瞬时定位，后续实时发送在权威尺寸就绪后动画钉顶；需要单轮工作区也播放
-  // 完整锚定动画时，由调用方显式开启 animateFirstEnteringMessage。历史恢复仍瞬时定位。
-  const scrolledAnchorKeyRef = useRef<string | undefined>(undefined);
-  const handleAnchorReady = useCallback(
-    (info: { anchorKey: string | undefined }) => {
-      // 只在锚点切换到「新一条用户消息」时钉顶一次；回复流式增长（同一 anchorKey）不重滚。
-      if (!info.anchorKey || scrolledAnchorKeyRef.current === info.anchorKey) {
-        return;
-      }
-
-      scrolledAnchorKeyRef.current = info.anchorKey;
-      scrollLog.debug('[SCROLL] anchorReady->scrollToEnd', {
-        anchorKey: info.anchorKey,
-        t: Date.now(),
-      });
-      const isEnteringMessage = info.anchorKey === enteringMessageId;
-      const shouldAnimate = isEnteringMessage && (animateFirstEnteringMessage || anchorIndex > 0);
-      requestAnimationFrame(() => {
-        emitProgrammaticScroll('anchorReady', listRef, { animated: shouldAnimate });
-        // 收键盘与钉顶滚动**必须**同时发起，别再试着把它挪到滚动之后：改成「先钉顶、
-        // 动画结束再收键盘」实测反转从 1 处 310px 变成 2 处 334px（位移搬到动画终点，
-        // 还要再被尾随滚动拉一次），更差。
-        //
-        // 这里曾经有一帧 -310px 的突跳，成因**不是**「收键盘抽掉底部 inset 触发原生夹回」
-        // ——inset 全程是 max(预留空白 512, 键盘 310) = 512，一动没动。真正写值的是
-        // react-native-keyboard-controller 的 keyboardWillHide worklet：它按**键盘抬起
-        // 那一刻记录下来的抬升量**原样回退，而这两次键盘事件之间预留空白从 0 涨到了 512、
-        // 可滚动末端跟着下移，回退的前提已经不成立。修法是 patches/ 里那个补丁：让
-        // whenAtEnd 在键盘变矮时「夹到当下的合法区间」而不是「按记录量回退」，两者只在
-        // 这一个情形下不同，其余逐值相同。补丁掉了这个跳动就会回来。
-        void scrollMessageToEnd({
-          animated: shouldAnimate,
-          closeKeyboard: isEnteringMessage,
-        });
-      });
-    },
-    [animateFirstEnteringMessage, anchorIndex, enteringMessageId, scrollMessageToEnd],
-  );
-
-  const handleAnchoredEndSpaceSizeChanged = useCallback(
-    (size: number) => {
-      endSpaceRef.current = size;
-      emitLayoutBenchProbe('endSpace', { size: Math.round(size) });
-
-      if (size > 0 || !anchorMessageId) {
-        return;
-      }
-
-      const nextPhase = isUserInteractingRef.current ? 'paused' : 'following';
-      tailFollowPhaseRef.current = nextPhase;
-      setTailFollowState((previous) => {
-        const current = resolveTailFollowState(previous, anchorMessageId);
-        if (current.phase !== 'anchoring') {
-          return current;
-        }
-
-        return { ...current, phase: nextPhase };
-      });
-    },
-    [anchorMessageId],
-  );
-
-  const handleEndVisible = useCallback(
-    (visible: boolean) => {
-      if (!visible || isUserInteractingRef.current) {
-        return;
-      }
-
-      resumeTailFollowAtEnd();
-    },
-    [resumeTailFollowAtEnd],
-  );
-
-  const handleScrollBeginDrag = useCallback(() => {
-    isDraggingListRef.current = true;
-    // 交互窗口的边界：harness 用它圈出「手势期间」，窗口内出现任何 progScroll 即为冲突。
-    emitLayoutBenchProbe('interaction', { kind: 'drag', state: 'begin' });
-    beginUserInteraction();
-
-    if (!anchorMessageId) {
-      return;
-    }
-
-    tailFollowPhaseRef.current =
-      tailFollowPhaseRef.current === 'following' ? 'paused' : tailFollowPhaseRef.current;
-    setTailFollowState((previous) => {
-      const current = resolveTailFollowState(previous, anchorMessageId);
-      if (current.phase !== 'following') {
-        return current;
-      }
-
-      return { ...current, phase: 'paused' };
-    });
-  }, [anchorMessageId, beginUserInteraction]);
-
-  const handleScrollEndDrag = useCallback(() => {
-    isDraggingListRef.current = false;
-    emitLayoutBenchProbe('interaction', { kind: 'drag', state: 'end' });
-    scheduleInteractionEnd();
-  }, [scheduleInteractionEnd]);
-
-  const handleMomentumScrollBegin = useCallback(() => {
-    isMomentumScrollingRef.current = true;
-    emitLayoutBenchProbe('interaction', { kind: 'momentum', state: 'begin' });
-    beginUserInteraction();
-  }, [beginUserInteraction]);
-
-  const handleMomentumScrollEnd = useCallback(() => {
-    isMomentumScrollingRef.current = false;
-    emitLayoutBenchProbe('interaction', { kind: 'momentum', state: 'end' });
-    scheduleInteractionEnd();
-  }, [scheduleInteractionEnd]);
-
-  const handleTouchStart = useCallback(() => {
-    isTouchingListRef.current = true;
-    emitLayoutBenchProbe('interaction', { kind: 'touch', state: 'begin' });
-    beginUserInteraction();
-  }, [beginUserInteraction]);
-
-  const handleTouchEnd = useCallback(() => {
-    isTouchingListRef.current = false;
-    emitLayoutBenchProbe('interaction', { kind: 'touch', state: 'end' });
-    scheduleInteractionEnd();
-  }, [scheduleInteractionEnd]);
+  useLayoutBenchInstrumentation({ endSpaceRef, freeze, isScrollButtonHidden, scrollOffset });
 
   const handleItemSizeChanged = useCallback(
     (info: { index: number; itemKey: string; previous: number; size: number }) => {
@@ -637,140 +246,11 @@ export function MessageList({
     void listRef.current?.scrollToEnd({ animated: true });
   }, []);
 
-  const cancelPendingReadyFrame = useCallback(() => {
-    if (pendingReadyFrameRef.current !== null) {
-      cancelAnimationFrame(pendingReadyFrameRef.current);
-      pendingReadyFrameRef.current = null;
-    }
-    if (pendingReadySettleRef.current !== null) {
-      clearTimeout(pendingReadySettleRef.current);
-      pendingReadySettleRef.current = null;
-    }
-  }, []);
-
-  const reportReady = useEffectEvent(() => {
-    if (didReportReadyRef.current || !isMountedRef.current) {
-      return;
-    }
-
-    didReportReadyRef.current = true;
-    onReady?.();
-  });
-
-  const handleContentSizeChange = useCallback(
-    (_width: number, height: number) => {
-      // ready=true 的 contentSize 变化 = 遮罩已撤/即将撤之后仍有高度修正 = 泄漏到可见区的跳动源。
-      // 冷首次进入 markdown 解析慢，末次修正可能迟到落在 ready 之后 → 复现「第一次进入才跳」。
-      scrollLog.debug('[SCROLL] contentSize', {
-        h: Math.round(height),
-        ready: didReportReadyRef.current,
-        t: Date.now(),
-      });
-      emitLayoutBenchProbe('content', {
-        h: Math.round(height),
-        ready: didReportReadyRef.current,
-      });
-      setContentBaseHeight(Math.max(0, height - contentBottomInset));
-      releaseStagedFirstAnchor();
-    },
-    [contentBottomInset, releaseStagedFirstAnchor],
-  );
-
-  const handleLayout = useCallback((event: LayoutChangeEvent) => {
-    emitLayoutBenchProbe('viewport', { h: Math.round(event.nativeEvent.layout.height) });
-    setViewportHeight(event.nativeEvent.layout.height);
-  }, []);
-
   useEffect(() => {
     if (isFollowing) {
       scheduleTailFollow();
     }
   }, [isFollowing, messages, scheduleTailFollow]);
-
-  useEffect(() => {
-    readyGenerationRef.current += 1;
-    const generation = readyGenerationRef.current;
-
-    cancelPendingReadyFrame();
-
-    if (
-      didReportReadyRef.current ||
-      contentBaseHeight <= 0 ||
-      !lastMessageId ||
-      viewportHeight <= 0
-    ) {
-      return;
-    }
-
-    const shouldScrollToEndBeforeReady = contentBottomInset > 0;
-
-    pendingReadyFrameRef.current = requestAnimationFrame(() => {
-      pendingReadyFrameRef.current = requestAnimationFrame(() => {
-        pendingReadyFrameRef.current = null;
-
-        if (
-          didReportReadyRef.current ||
-          !isMountedRef.current ||
-          readyGenerationRef.current !== generation
-        ) {
-          return;
-        }
-
-        // 揭示前再等一个静默窗口（READY_SETTLE_MS）：期间若有任何 contentSize 变化，effect（依赖
-        // contentBaseHeight）会重跑、经 cancelPendingReadyFrame 清掉此计时并重启，从而把冷 markdown
-        // 迟到的高度修正也挡在遮罩后再揭示，消除「reload 后第一次进入才跳」。
-        const reportReadyAfterSettle = () => {
-          pendingReadySettleRef.current = setTimeout(() => {
-            pendingReadySettleRef.current = null;
-
-            if (readyGenerationRef.current === generation) {
-              reportReady();
-            }
-          }, READY_SETTLE_MS);
-        };
-
-        // 本 effect 依赖 contentBaseHeight，而流式每来一个 chunk 内容高度就变一次 → 静默窗口
-        // 反复重启、gate 在整段流式里每帧重跑，这个 scrollToEnd 于是变成第二条不受尾随状态机
-        // 管的自动滚动。它必须和 scheduleTailFollow 守同一个不变式：用户手上有动作时一律不滚，
-        // 否则拖动过程中列表会被硬拽回底部（实测一次拖动被拽 +198px，harness 的
-        // gesture-conflict 判据就是这么抓到的）。
-        // 跳过滚动但照常进入 settle：遮罩存在的意义是挡住布局抖动，人都已经在拖了就别再挡着。
-        if (shouldScrollToEndBeforeReady && !isUserInteractingRef.current) {
-          scrollLog.debug('[SCROLL] gateScrollToEnd', {
-            contentBottomInset,
-            contentBaseHeight: Math.round(contentBaseHeight),
-            viewportHeight: Math.round(viewportHeight),
-            t: Date.now(),
-          });
-          emitProgrammaticScroll('readyGate', listRef);
-          void listRef.current?.scrollToEnd({ animated: false }).finally(reportReadyAfterSettle);
-          return;
-        }
-
-        reportReadyAfterSettle();
-      });
-    });
-  }, [
-    cancelPendingReadyFrame,
-    contentBottomInset,
-    contentBaseHeight,
-    lastMessageId,
-    listRef,
-    viewportHeight,
-  ]);
-
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false;
-      cancelPendingInteractionEnd();
-      if (pendingFirstAnchorReleaseFrameRef.current !== null) {
-        cancelAnimationFrame(pendingFirstAnchorReleaseFrameRef.current);
-        pendingFirstAnchorReleaseFrameRef.current = null;
-      }
-      cancelPendingReadyFrame();
-      cancelPendingTailFollow();
-    };
-  }, [cancelPendingInteractionEnd, cancelPendingReadyFrame, cancelPendingTailFollow]);
 
   return (
     <MessageSlideInProvider slideInMessageId={enteringMessageId}>

--- a/src/frontend/components/messagePresentation/components/hooks/useAnchorPin.ts
+++ b/src/frontend/components/messagePresentation/components/hooks/useAnchorPin.ts
@@ -1,0 +1,297 @@
+import { type LegendListRef } from '@legendapp/list/react-native';
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { type LayoutChangeEvent } from 'react-native';
+
+import { emitLayoutBenchProbe } from '@/shared/devBench/layoutBenchProbe';
+
+import { emitProgrammaticScroll, scrollLog } from './useLayoutBenchInstrumentation';
+
+// 撤遮罩（onReady）前要求内容高度保持「静默」的窗口：这段时间内没有任何 contentSize 变化才判定
+// settle 完成。用于覆盖**冷 markdown 解析**——首次进入 topic 时 streamdown/代码/数学的 tokenize
+// 与 layout 全冷、耗时最长，行的真实高度可能在初始 rAF 之后才测出。若此时已 reportReady 撤遮罩，
+// 迟到的高度修正就泄漏成「第一次进入才有的跳动」。静默窗口内任何 contentSize 变化都会（经 effect
+// 依赖 contentBaseHeight 重跑）取消并重启计时，从而把迟到修正也挡在遮罩后，与设备快慢无关。
+const READY_SETTLE_MS = 150;
+
+// 锚定生命周期：新用户消息就绪后钉顶（handleAnchorReady）、单轮工作区的首锚 staging、
+// 以及首帧揭示前的 ready-gate。它是尾随状态机之外唯一会主动滚动列表的地方，所以必须
+// 拿到 useTailFollow 的 isUserInteractingRef（只读）守同一个交互不变式，并在预留空白
+// 耗尽时经 notifyAnchorSpaceClosed 把相位交接给尾随。
+export function useAnchorPin({
+  anchorIndex,
+  anchorMessageId,
+  animateFirstEnteringMessage,
+  contentBottomInset,
+  endSpaceRef,
+  enteringMessageId,
+  isUserInteractingRef,
+  lastMessageId,
+  listRef,
+  notifyAnchorSpaceClosed,
+  onReady,
+  scrollMessageToEnd,
+}: {
+  anchorIndex: number;
+  anchorMessageId: string | undefined;
+  animateFirstEnteringMessage: boolean;
+  contentBottomInset: number;
+  endSpaceRef: RefObject<number>;
+  enteringMessageId: string | undefined;
+  isUserInteractingRef: RefObject<boolean>;
+  lastMessageId: string | undefined;
+  listRef: RefObject<LegendListRef | null>;
+  notifyAnchorSpaceClosed: () => void;
+  onReady: (() => void) | undefined;
+  scrollMessageToEnd: (options: { animated: boolean; closeKeyboard: boolean }) => Promise<void>;
+}): {
+  handleAnchorReady: (info: { anchorKey: string | undefined }) => void;
+  handleAnchoredEndSpaceSizeChanged: (size: number) => void;
+  handleContentSizeChange: (width: number, height: number) => void;
+  handleLayout: (event: LayoutChangeEvent) => void;
+  isStagingFirstAnchor: boolean;
+  releaseStagedFirstAnchor: () => void;
+} {
+  const [contentBaseHeight, setContentBaseHeight] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const didReportReadyRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const pendingReadyFrameRef = useRef<number | null>(null);
+  const pendingReadySettleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const readyGenerationRef = useRef(0);
+  const pendingFirstAnchorReleaseFrameRef = useRef<number | null>(null);
+
+  // A single-turn workspace has no previous content to scroll past. Keep its first live turn at
+  // the list end until the rows report a real size; then add the anchor space and animate to it.
+  const [releasedFirstAnchorId, setReleasedFirstAnchorId] = useState<string>();
+  const isFirstEnteringAnchor =
+    animateFirstEnteringMessage &&
+    anchorIndex === 0 &&
+    anchorMessageId !== undefined &&
+    anchorMessageId === enteringMessageId;
+  const isStagingFirstAnchor = isFirstEnteringAnchor && releasedFirstAnchorId !== anchorMessageId;
+  const stagedFirstAnchorIdRef = useRef<string | undefined>(undefined);
+
+  // Read from size and layout callbacks, which the platform dispatches well
+  // after commit, so mirroring the staged anchor here is soon enough.
+  useLayoutEffect(() => {
+    stagedFirstAnchorIdRef.current = isStagingFirstAnchor ? anchorMessageId : undefined;
+  }, [anchorMessageId, isStagingFirstAnchor]);
+
+  const releaseStagedFirstAnchor = useCallback(() => {
+    const stagedAnchorId = stagedFirstAnchorIdRef.current;
+    if (!stagedAnchorId || pendingFirstAnchorReleaseFrameRef.current !== null) {
+      return;
+    }
+
+    pendingFirstAnchorReleaseFrameRef.current = requestAnimationFrame(() => {
+      pendingFirstAnchorReleaseFrameRef.current = null;
+      if (stagedFirstAnchorIdRef.current === stagedAnchorId) {
+        setReleasedFirstAnchorId(stagedAnchorId);
+      }
+    });
+  }, []);
+
+  // 把刚发送的用户消息锚定到内容区顶部，并在其下方补足空白，让助手回复流式生长其间。
+  //
+  // onReady 是钉顶的正确触发点：LegendList 只在「锚点下方所有 item 尺寸都已**真实测量**」
+  // （含刚 mount 的助手 pending 占位、hasUnknownTailSize=false）后，才把预留空白算成真实值
+  // 并回调 onReady。此刻落点已是终值。
+  //
+  // 默认首轮瞬时定位，后续实时发送在权威尺寸就绪后动画钉顶；需要单轮工作区也播放
+  // 完整锚定动画时，由调用方显式开启 animateFirstEnteringMessage。历史恢复仍瞬时定位。
+  const scrolledAnchorKeyRef = useRef<string | undefined>(undefined);
+  const handleAnchorReady = useCallback(
+    (info: { anchorKey: string | undefined }) => {
+      // 只在锚点切换到「新一条用户消息」时钉顶一次；回复流式增长（同一 anchorKey）不重滚。
+      if (!info.anchorKey || scrolledAnchorKeyRef.current === info.anchorKey) {
+        return;
+      }
+
+      scrolledAnchorKeyRef.current = info.anchorKey;
+      scrollLog.debug('[SCROLL] anchorReady->scrollToEnd', {
+        anchorKey: info.anchorKey,
+        t: Date.now(),
+      });
+      const isEnteringMessage = info.anchorKey === enteringMessageId;
+      const shouldAnimate = isEnteringMessage && (animateFirstEnteringMessage || anchorIndex > 0);
+      requestAnimationFrame(() => {
+        emitProgrammaticScroll('anchorReady', listRef, { animated: shouldAnimate });
+        // 收键盘与钉顶滚动**必须**同时发起，别再试着把它挪到滚动之后：改成「先钉顶、
+        // 动画结束再收键盘」实测反转从 1 处 310px 变成 2 处 334px（位移搬到动画终点，
+        // 还要再被尾随滚动拉一次），更差。
+        //
+        // 这里曾经有一帧 -310px 的突跳，成因**不是**「收键盘抽掉底部 inset 触发原生夹回」
+        // ——inset 全程是 max(预留空白 512, 键盘 310) = 512，一动没动。真正写值的是
+        // react-native-keyboard-controller 的 keyboardWillHide worklet：它按**键盘抬起
+        // 那一刻记录下来的抬升量**原样回退，而这两次键盘事件之间预留空白从 0 涨到了 512、
+        // 可滚动末端跟着下移，回退的前提已经不成立。修法是 patches/ 里那个补丁：让
+        // whenAtEnd 在键盘变矮时「夹到当下的合法区间」而不是「按记录量回退」，两者只在
+        // 这一个情形下不同，其余逐值相同。补丁掉了这个跳动就会回来。
+        void scrollMessageToEnd({
+          animated: shouldAnimate,
+          closeKeyboard: isEnteringMessage,
+        });
+      });
+    },
+    [animateFirstEnteringMessage, anchorIndex, enteringMessageId, listRef, scrollMessageToEnd],
+  );
+
+  const handleAnchoredEndSpaceSizeChanged = useCallback(
+    (size: number) => {
+      endSpaceRef.current = size;
+      emitLayoutBenchProbe('endSpace', { size: Math.round(size) });
+
+      if (size > 0) {
+        return;
+      }
+
+      notifyAnchorSpaceClosed();
+    },
+    [endSpaceRef, notifyAnchorSpaceClosed],
+  );
+
+  const cancelPendingReadyFrame = useCallback(() => {
+    if (pendingReadyFrameRef.current !== null) {
+      cancelAnimationFrame(pendingReadyFrameRef.current);
+      pendingReadyFrameRef.current = null;
+    }
+    if (pendingReadySettleRef.current !== null) {
+      clearTimeout(pendingReadySettleRef.current);
+      pendingReadySettleRef.current = null;
+    }
+  }, []);
+
+  const reportReady = useEffectEvent(() => {
+    if (didReportReadyRef.current || !isMountedRef.current) {
+      return;
+    }
+
+    didReportReadyRef.current = true;
+    onReady?.();
+  });
+
+  const handleContentSizeChange = useCallback(
+    (_width: number, height: number) => {
+      // ready=true 的 contentSize 变化 = 遮罩已撤/即将撤之后仍有高度修正 = 泄漏到可见区的跳动源。
+      // 冷首次进入 markdown 解析慢，末次修正可能迟到落在 ready 之后 → 复现「第一次进入才跳」。
+      scrollLog.debug('[SCROLL] contentSize', {
+        h: Math.round(height),
+        ready: didReportReadyRef.current,
+        t: Date.now(),
+      });
+      emitLayoutBenchProbe('content', {
+        h: Math.round(height),
+        ready: didReportReadyRef.current,
+      });
+      setContentBaseHeight(Math.max(0, height - contentBottomInset));
+      releaseStagedFirstAnchor();
+    },
+    [contentBottomInset, releaseStagedFirstAnchor],
+  );
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    emitLayoutBenchProbe('viewport', { h: Math.round(event.nativeEvent.layout.height) });
+    setViewportHeight(event.nativeEvent.layout.height);
+  }, []);
+
+  useEffect(() => {
+    readyGenerationRef.current += 1;
+    const generation = readyGenerationRef.current;
+
+    cancelPendingReadyFrame();
+
+    if (
+      didReportReadyRef.current ||
+      contentBaseHeight <= 0 ||
+      !lastMessageId ||
+      viewportHeight <= 0
+    ) {
+      return;
+    }
+
+    const shouldScrollToEndBeforeReady = contentBottomInset > 0;
+
+    pendingReadyFrameRef.current = requestAnimationFrame(() => {
+      pendingReadyFrameRef.current = requestAnimationFrame(() => {
+        pendingReadyFrameRef.current = null;
+
+        if (
+          didReportReadyRef.current ||
+          !isMountedRef.current ||
+          readyGenerationRef.current !== generation
+        ) {
+          return;
+        }
+
+        // 揭示前再等一个静默窗口（READY_SETTLE_MS）：期间若有任何 contentSize 变化，effect（依赖
+        // contentBaseHeight）会重跑、经 cancelPendingReadyFrame 清掉此计时并重启，从而把冷 markdown
+        // 迟到的高度修正也挡在遮罩后再揭示，消除「reload 后第一次进入才跳」。
+        const reportReadyAfterSettle = () => {
+          pendingReadySettleRef.current = setTimeout(() => {
+            pendingReadySettleRef.current = null;
+
+            if (readyGenerationRef.current === generation) {
+              reportReady();
+            }
+          }, READY_SETTLE_MS);
+        };
+
+        // 本 effect 依赖 contentBaseHeight，而流式每来一个 chunk 内容高度就变一次 → 静默窗口
+        // 反复重启、gate 在整段流式里每帧重跑，这个 scrollToEnd 于是变成第二条不受尾随状态机
+        // 管的自动滚动。它必须和 scheduleTailFollow 守同一个不变式：用户手上有动作时一律不滚，
+        // 否则拖动过程中列表会被硬拽回底部（实测一次拖动被拽 +198px，harness 的
+        // gesture-conflict 判据就是这么抓到的）。
+        // 跳过滚动但照常进入 settle：遮罩存在的意义是挡住布局抖动，人都已经在拖了就别再挡着。
+        if (shouldScrollToEndBeforeReady && !isUserInteractingRef.current) {
+          scrollLog.debug('[SCROLL] gateScrollToEnd', {
+            contentBottomInset,
+            contentBaseHeight: Math.round(contentBaseHeight),
+            viewportHeight: Math.round(viewportHeight),
+            t: Date.now(),
+          });
+          emitProgrammaticScroll('readyGate', listRef);
+          void listRef.current?.scrollToEnd({ animated: false }).finally(reportReadyAfterSettle);
+          return;
+        }
+
+        reportReadyAfterSettle();
+      });
+    });
+  }, [
+    cancelPendingReadyFrame,
+    contentBottomInset,
+    contentBaseHeight,
+    isUserInteractingRef,
+    lastMessageId,
+    listRef,
+    viewportHeight,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      if (pendingFirstAnchorReleaseFrameRef.current !== null) {
+        cancelAnimationFrame(pendingFirstAnchorReleaseFrameRef.current);
+        pendingFirstAnchorReleaseFrameRef.current = null;
+      }
+      cancelPendingReadyFrame();
+    };
+  }, [cancelPendingReadyFrame]);
+
+  return {
+    handleAnchorReady,
+    handleAnchoredEndSpaceSizeChanged,
+    handleContentSizeChange,
+    handleLayout,
+    isStagingFirstAnchor,
+    releaseStagedFirstAnchor,
+  };
+}

--- a/src/frontend/components/messagePresentation/components/hooks/useLayoutBenchInstrumentation.ts
+++ b/src/frontend/components/messagePresentation/components/hooks/useLayoutBenchInstrumentation.ts
@@ -1,0 +1,140 @@
+import { type LegendListRef } from '@legendapp/list/react-native';
+import { type RefObject, useEffect } from 'react';
+import { KeyboardEvents } from 'react-native-keyboard-controller';
+import {
+  runOnJS,
+  type SharedValue,
+  useAnimatedReaction,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+import { loggerService } from '@/shared/core/logger/LoggerService';
+import { emitLayoutBenchProbe, isLayoutBenchProbeArmed } from '@/shared/devBench/layoutBenchProbe';
+
+// 滚动/布局诊断埋点：记录会驱动列表位移的关键数值（scroll offset、内容高度、锚点就绪、
+// 翻页触发、钉顶滚动），用于把「界面跳动」量化成时间-位移轨迹。走 logger.debug → 仅 dev
+// 输出（生产环境被日志级别过滤），故长期保留无碍。用 `[SCROLL]` 前缀便于从 Metro 日志过滤。
+export const scrollLog = loggerService.withContext('ChatScroll');
+
+// 「滚动到底部」按钮的显隐完全由 UI 线程的 shared value 驱动（opacity/pointerEvents 都是
+// worklet 计算），JS 侧看不到状态变化，所以只能从 worklet 里回抛。
+function emitButtonVisibility(visible: boolean) {
+  emitLayoutBenchProbe('button', { visible });
+}
+
+function emitScrollOffset(y: number) {
+  emitLayoutBenchProbe('scroll', { y: Math.round(y) });
+}
+
+function emitFreeze(on: boolean) {
+  emitLayoutBenchProbe('freeze', { on });
+}
+
+// 键盘收放挪动内容却不改 contentSize、不改视口，因此不留下任何其它探针能看见的痕迹。发送时
+// `scrollMessageToEnd` 正好同时发起收键盘与钉顶滚动，缺了这条时间线就没法判断那一帧的位移
+// 是谁造成的。
+//
+// 一起记下当时的预留空白，是因为键盘造成净位移的充要条件就是它：抬起时按「当时的预留空白
+// 能吸收多少」决定抬多少，收起时回退的是抬起那一刻记下来的量——**两次之间预留空白变了，
+// 回退量就不再对**（实测续轮发送 0 → 512，净位移 310px）。没有这两个数，这类位移只能靠
+// 猜（上一轮就据此错误地怀疑过 MVCP）。
+//
+// 订阅不能按 `isLayoutBenchProbeArmed()` 开关：探针由假模型在**第一次发送**时 arm，而这个
+// effect 在列表挂载时就跑完了，按 armed 判断等于永远不订阅（实测整轮零 keyboard 事件）。
+// 改成 dev 下常驻订阅、由 emit 自己按 armed 过滤——键盘事件只在收放时各一条，不像 onScroll
+// 那样每帧都有，常驻的代价可以忽略。
+function useKeyboardProbe(endSpaceRef: RefObject<number>) {
+  useEffect(() => {
+    if (!__DEV__) {
+      return;
+    }
+
+    const subscriptions = (['keyboardWillShow', 'keyboardWillHide'] as const).map((event) =>
+      KeyboardEvents.addListener(event, ({ duration, height }) => {
+        emitLayoutBenchProbe('keyboard', {
+          dur: duration,
+          endSpace: Math.round(endSpaceRef.current),
+          event,
+          h: Math.round(height),
+        });
+      }),
+    );
+
+    return () => subscriptions.forEach((subscription) => subscription.remove());
+  }, [endSpaceRef]);
+}
+
+// 程序化滚动只记「谁调的」不够：同一个 scrollToEnd 落到哪里，取决于调用瞬间列表认为的
+// 内容长度与视口长度。发送消息时这两个量正在剧烈变化（新行未测量、预留空白在重算），
+// 落点因此可能远离用户当前位置——把三个量与调用点一起记下才谈得上归因。
+export function emitProgrammaticScroll(
+  src: string,
+  listRef: RefObject<LegendListRef | null>,
+  extra?: Record<string, boolean | number | string | undefined>,
+) {
+  if (!isLayoutBenchProbeArmed()) {
+    return;
+  }
+
+  const listState = listRef.current?.getState();
+  emitLayoutBenchProbe('progScroll', {
+    ...extra,
+    content: listState ? Math.round(listState.contentLength) : undefined,
+    scroll: listState ? Math.round(listState.scroll) : undefined,
+    src,
+    viewport: listState ? Math.round(listState.scrollLength) : undefined,
+  });
+}
+
+// layout-bench 探针的常驻副作用：把只在 UI 线程可见的信号（滚动 offset、按钮显隐、freeze）
+// 回抛到 JS 侧的探针通道，并订阅键盘时间线。生产环境下 emit 未 arm 即早退、键盘订阅整个
+// 跳过，成本接近零。信息发生在业务回调体内的那几处（anchorReady/readyGate 的
+// emitProgrammaticScroll、onSizeChanged 里的 endSpace 上报）留在调用现场，搬不进来。
+export function useLayoutBenchInstrumentation({
+  endSpaceRef,
+  freeze,
+  isScrollButtonHidden,
+  scrollOffset,
+}: {
+  endSpaceRef: RefObject<number>;
+  freeze: SharedValue<boolean>;
+  isScrollButtonHidden: SharedValue<boolean>;
+  scrollOffset: SharedValue<number>;
+}) {
+  // arm 发生在假模型被构造时（晚于本组件挂载），worklet 读不到 JS 侧的模块变量，
+  // 因此每次渲染把 arm 状态同步进 shared value，未 arm 时连 runOnJS 都不发生。
+  const probeArmed = useSharedValue(false);
+
+  useEffect(() => {
+    probeArmed.set(isLayoutBenchProbeArmed());
+  });
+
+  useAnimatedReaction(
+    () => isScrollButtonHidden.get(),
+    (current, previous) => {
+      if (previous !== null && current !== previous) {
+        runOnJS(emitButtonVisibility)(!current);
+      }
+    },
+  );
+
+  useAnimatedReaction(
+    () => scrollOffset.get(),
+    (current, previous) => {
+      if (probeArmed.get() && previous !== null && current !== previous) {
+        runOnJS(emitScrollOffset)(current);
+      }
+    },
+  );
+
+  useAnimatedReaction(
+    () => freeze.get(),
+    (current, previous) => {
+      if (probeArmed.get() && previous !== null && current !== previous) {
+        runOnJS(emitFreeze)(current);
+      }
+    },
+  );
+
+  useKeyboardProbe(endSpaceRef);
+}

--- a/src/frontend/components/messagePresentation/components/hooks/useTailFollow.ts
+++ b/src/frontend/components/messagePresentation/components/hooks/useTailFollow.ts
@@ -1,0 +1,274 @@
+import { type LegendListRef } from '@legendapp/list/react-native';
+import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { type SharedValue, useSharedValue } from 'react-native-reanimated';
+
+import { emitLayoutBenchProbe } from '@/shared/devBench/layoutBenchProbe';
+
+import { emitProgrammaticScroll } from './useLayoutBenchInstrumentation';
+
+const TAIL_FOLLOW_END_THRESHOLD = 20;
+
+type TailFollowPhase = 'anchoring' | 'following' | 'paused';
+
+type TailFollowState = {
+  anchorMessageId: string | undefined;
+  phase: TailFollowPhase;
+};
+
+function createTailFollowState(anchorMessageId: string | undefined): TailFollowState {
+  return { anchorMessageId, phase: 'anchoring' };
+}
+
+function resolveTailFollowState(
+  state: TailFollowState,
+  anchorMessageId: string | undefined,
+): TailFollowState {
+  return state.anchorMessageId === anchorMessageId ? state : createTailFollowState(anchorMessageId);
+}
+
+// 尾随状态机：锚定（anchoring）→ 预留空白耗尽后尾随（following）→ 用户手势暂停（paused）
+// → 回到底部恢复。它持有全部交互状态（touch/drag/momentum/isUserInteracting）——
+// ready-gate 等其他自动滚动源必须与它守同一个不变式「用户手上有动作时一律不滚」，
+// 所以 isUserInteractingRef 由这里单一持有、对外只读。
+export function useTailFollow({
+  anchorMessageId,
+  hasAnchor,
+  listRef,
+}: {
+  anchorMessageId: string | undefined;
+  hasAnchor: boolean;
+  listRef: RefObject<LegendListRef | null>;
+}): {
+  handleEndVisible: (visible: boolean) => void;
+  handleMomentumScrollBegin: () => void;
+  handleMomentumScrollEnd: () => void;
+  handleScrollBeginDrag: () => void;
+  handleScrollEndDrag: () => void;
+  handleTouchEnd: () => void;
+  handleTouchStart: () => void;
+  isFollowing: boolean;
+  isTailControlled: SharedValue<boolean>;
+  isUserInteractingRef: RefObject<boolean>;
+  notifyAnchorSpaceClosed: () => void;
+  scheduleTailFollow: () => void;
+} {
+  // 尾随相位是 React state，worklet 读不到，镜像一份供按钮显隐推导使用。
+  const isTailControlled = useSharedValue(false);
+  const pendingTailFollowFrameRef = useRef<number | null>(null);
+  const pendingInteractionEndFrameRef = useRef<number | null>(null);
+  const isTouchingListRef = useRef(false);
+  const isDraggingListRef = useRef(false);
+  const isMomentumScrollingRef = useRef(false);
+  const isUserInteractingRef = useRef(false);
+  const [tailFollowState, setTailFollowState] = useState<TailFollowState>(() =>
+    createTailFollowState(anchorMessageId),
+  );
+  const tailFollowPhase = resolveTailFollowState(tailFollowState, anchorMessageId).phase;
+  const tailFollowPhaseRef = useRef(tailFollowPhase);
+  const isFollowing = tailFollowPhase === 'following';
+
+  useLayoutEffect(() => {
+    tailFollowPhaseRef.current = tailFollowPhase;
+    // anchoring 与 following 都由 app 主动把列表推向底部（钉顶滚动 / 尾随滚动），
+    // 只有 paused 全程不自动滚。没有锚点时不存在任何自动滚动，交回 isAtEnd 单独判定。
+    isTailControlled.set(hasAnchor && tailFollowPhase !== 'paused');
+    // 相位决定同一条位移轨迹该被判成合格还是缺陷（钉顶期应静止、尾随期应跟随），
+    // 所以它必须作为独立信号进日志，否则 harness 无从判定。
+    emitLayoutBenchProbe('phase', { anchorId: anchorMessageId, phase: tailFollowPhase });
+  }, [anchorMessageId, hasAnchor, isTailControlled, tailFollowPhase]);
+
+  // LegendList 的 maintainScrollAtEnd 会在 rAF 中捕获旧配置，拖动已暂停后仍可能执行一次。
+  // 在应用层合并 follow 请求，并在直接派发给原生 ScrollView 前重新检查同步交互锁。
+  const cancelPendingTailFollow = useCallback(() => {
+    if (pendingTailFollowFrameRef.current !== null) {
+      cancelAnimationFrame(pendingTailFollowFrameRef.current);
+      pendingTailFollowFrameRef.current = null;
+    }
+  }, []);
+
+  const scheduleTailFollow = useCallback(() => {
+    if (
+      tailFollowPhaseRef.current !== 'following' ||
+      isUserInteractingRef.current ||
+      pendingTailFollowFrameRef.current !== null
+    ) {
+      return;
+    }
+
+    pendingTailFollowFrameRef.current = requestAnimationFrame(() => {
+      pendingTailFollowFrameRef.current = null;
+
+      if (tailFollowPhaseRef.current !== 'following' || isUserInteractingRef.current) {
+        return;
+      }
+
+      const nativeScrollRef = listRef.current?.getNativeScrollRef() as
+        | { scrollToEnd?: (options: { animated?: boolean }) => void }
+        | null
+        | undefined;
+      emitProgrammaticScroll('tailFollow', listRef);
+      nativeScrollRef?.scrollToEnd?.({ animated: false });
+    });
+  }, [listRef]);
+
+  const isListAtEnd = useCallback(() => {
+    const listState = listRef.current?.getState();
+    if (!listState || listState.scrollLength <= 0) {
+      return false;
+    }
+
+    const distanceFromEnd = listState.contentLength - listState.scrollLength - listState.scroll;
+    return Number.isFinite(distanceFromEnd) && distanceFromEnd <= TAIL_FOLLOW_END_THRESHOLD;
+  }, [listRef]);
+
+  const resumeTailFollowAtEnd = useCallback(() => {
+    if (!anchorMessageId || tailFollowPhaseRef.current !== 'paused' || !isListAtEnd()) {
+      return;
+    }
+
+    tailFollowPhaseRef.current = 'following';
+    setTailFollowState((previous) => {
+      const current = resolveTailFollowState(previous, anchorMessageId);
+      return current.phase === 'paused' ? { ...current, phase: 'following' } : current;
+    });
+    scheduleTailFollow();
+  }, [anchorMessageId, isListAtEnd, scheduleTailFollow]);
+
+  const cancelPendingInteractionEnd = useCallback(() => {
+    if (pendingInteractionEndFrameRef.current !== null) {
+      cancelAnimationFrame(pendingInteractionEndFrameRef.current);
+      pendingInteractionEndFrameRef.current = null;
+    }
+  }, []);
+
+  const finishUserInteraction = useCallback(() => {
+    if (isTouchingListRef.current || isDraggingListRef.current || isMomentumScrollingRef.current) {
+      return;
+    }
+
+    isUserInteractingRef.current = false;
+    if (tailFollowPhaseRef.current === 'paused') {
+      resumeTailFollowAtEnd();
+    } else {
+      scheduleTailFollow();
+    }
+  }, [resumeTailFollowAtEnd, scheduleTailFollow]);
+
+  const scheduleInteractionEnd = useCallback(() => {
+    cancelPendingInteractionEnd();
+    pendingInteractionEndFrameRef.current = requestAnimationFrame(() => {
+      pendingInteractionEndFrameRef.current = null;
+      finishUserInteraction();
+    });
+  }, [cancelPendingInteractionEnd, finishUserInteraction]);
+
+  const beginUserInteraction = useCallback(() => {
+    isUserInteractingRef.current = true;
+    cancelPendingInteractionEnd();
+    cancelPendingTailFollow();
+  }, [cancelPendingInteractionEnd, cancelPendingTailFollow]);
+
+  // 钉顶预留空白耗尽（onSizeChanged 报 0）＝锚定阶段结束，进入尾随；用户手上有动作则
+  // 直接进 paused，不跟。
+  const notifyAnchorSpaceClosed = useCallback(() => {
+    if (!anchorMessageId) {
+      return;
+    }
+
+    const nextPhase = isUserInteractingRef.current ? 'paused' : 'following';
+    tailFollowPhaseRef.current = nextPhase;
+    setTailFollowState((previous) => {
+      const current = resolveTailFollowState(previous, anchorMessageId);
+      if (current.phase !== 'anchoring') {
+        return current;
+      }
+
+      return { ...current, phase: nextPhase };
+    });
+  }, [anchorMessageId]);
+
+  const handleEndVisible = useCallback(
+    (visible: boolean) => {
+      if (!visible || isUserInteractingRef.current) {
+        return;
+      }
+
+      resumeTailFollowAtEnd();
+    },
+    [resumeTailFollowAtEnd],
+  );
+
+  const handleScrollBeginDrag = useCallback(() => {
+    isDraggingListRef.current = true;
+    // 交互窗口的边界：harness 用它圈出「手势期间」，窗口内出现任何 progScroll 即为冲突。
+    emitLayoutBenchProbe('interaction', { kind: 'drag', state: 'begin' });
+    beginUserInteraction();
+
+    if (!anchorMessageId) {
+      return;
+    }
+
+    tailFollowPhaseRef.current =
+      tailFollowPhaseRef.current === 'following' ? 'paused' : tailFollowPhaseRef.current;
+    setTailFollowState((previous) => {
+      const current = resolveTailFollowState(previous, anchorMessageId);
+      if (current.phase !== 'following') {
+        return current;
+      }
+
+      return { ...current, phase: 'paused' };
+    });
+  }, [anchorMessageId, beginUserInteraction]);
+
+  const handleScrollEndDrag = useCallback(() => {
+    isDraggingListRef.current = false;
+    emitLayoutBenchProbe('interaction', { kind: 'drag', state: 'end' });
+    scheduleInteractionEnd();
+  }, [scheduleInteractionEnd]);
+
+  const handleMomentumScrollBegin = useCallback(() => {
+    isMomentumScrollingRef.current = true;
+    emitLayoutBenchProbe('interaction', { kind: 'momentum', state: 'begin' });
+    beginUserInteraction();
+  }, [beginUserInteraction]);
+
+  const handleMomentumScrollEnd = useCallback(() => {
+    isMomentumScrollingRef.current = false;
+    emitLayoutBenchProbe('interaction', { kind: 'momentum', state: 'end' });
+    scheduleInteractionEnd();
+  }, [scheduleInteractionEnd]);
+
+  const handleTouchStart = useCallback(() => {
+    isTouchingListRef.current = true;
+    emitLayoutBenchProbe('interaction', { kind: 'touch', state: 'begin' });
+    beginUserInteraction();
+  }, [beginUserInteraction]);
+
+  const handleTouchEnd = useCallback(() => {
+    isTouchingListRef.current = false;
+    emitLayoutBenchProbe('interaction', { kind: 'touch', state: 'end' });
+    scheduleInteractionEnd();
+  }, [scheduleInteractionEnd]);
+
+  useEffect(() => {
+    return () => {
+      cancelPendingInteractionEnd();
+      cancelPendingTailFollow();
+    };
+  }, [cancelPendingInteractionEnd, cancelPendingTailFollow]);
+
+  return {
+    handleEndVisible,
+    handleMomentumScrollBegin,
+    handleMomentumScrollEnd,
+    handleScrollBeginDrag,
+    handleScrollEndDrag,
+    handleTouchEnd,
+    handleTouchStart,
+    isFollowing,
+    isTailControlled,
+    isUserInteractingRef,
+    notifyAnchorSpaceClosed,
+    scheduleTailFollow,
+  };
+}


### PR DESCRIPTION
**行为保持重构**：MessageList 838 行里内联着三套彼此独立的引擎逻辑，业务接线被淹在里面。拆成三个模块私有 hook（`components/hooks/`，不出模块 index），MessageList 缩成 318 行接线层。

| hook | 职责 | 关键契约 |
| --- | --- | --- |
| `useTailFollow`（274 行） | 尾随状态机 anchoring→following→paused + 全部交互状态 | `isUserInteractingRef` 单一持有、对外只读——ready-gate 等其他自动滚动源必须与它守同一个「用户手上有动作时一律不滚」的不变式 |
| `useAnchorPin`（297 行） | 钉顶、单轮工作区首锚 staging、ready-gate 静默窗口 | 预留空白耗尽经 `notifyAnchorSpaceClosed` 把相位交接给尾随，两个 hook 不双写同一状态 |
| `useLayoutBenchInstrumentation`（140 行） | 探针常驻副作用（UI 线程回抛、键盘时间线、armed 同步） | 信息发生在业务回调体内的调用点（anchorReady/readyGate 的 progScroll、endSpace 上报）保留裸函数留在现场 |

跨域组合（`handleItemSizeChanged` 同时触发首锚释放与尾随）留在组件当接线。被实测纠正过的长注释逐字随代码迁移。

## 验证

- 传给 LegendList 的 props 逐值不变；单测断言零改动全绿（messagePresentation 10 套件 59 测试；全量 310 套件 2896 测试）。
- **bench 前后各三轮零违规**（#530 的 harness 就是本次重构的回归护栏，这是它第一次实战）：

  | 指标 | 重构前 | 重构后 |
  | --- | --- | --- |
  | follow-up-turn offset-reversal | 17 / 17 / 24 | 24 / 24 / 24（阈值 100） |
  | estimate-collapse（三场景） | 252 与 5 逐轮不变 | 252 与 5 逐轮不变 |
  | send/stream offset-reversal | 0-64 噪声带 | 0-64 噪声带，与文档确定性表逐档吻合 |

- 「改了没变化」做了阳性对照：临时给 phase 探针加 `v:2` 字段、确认出现在设备 trace 后撤除，排除 Fast Refresh/字节码缓存假阴性（此前有两次因此得出错误结论的记录）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
