### PR TITLE
docs(agent-guides): adopt progressive disclosure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,19 @@
-# Repository Guidelines
+# Cherry Studio Mobile
 
-Follow the project naming rules in
-[docs/references/naming-conventions.md](docs/references/naming-conventions.md).
+Cherry Mobile is Cherry Studio's Expo and React Native client.
 
-# Operational Rules
-- **Write conventional commits**: Commit small, focused changes using Conventional Commit messages (e.g., `feat(data-api):`, `fix(lifecycle):`, `refactor(quick-assistant):`, `docs(testing):`, `chore(deps):`, `test(window-manager):`). Scope must be a specific kebab-case module, never generic like `main` — when `git log` conflicts with this rule, this rule wins.
-- **Test behaviour, at the lowest layer that has it**: A test earns its place by failing when a defect exists and only then. Never assert that a wrapper forwards its props, that a mock was called, or that a render produced something. Cover logic in pure functions and hooks instead of re-asserting it through a screen render — screen-level render suites are not written here at all, because device coverage runs through agent-device. Always cover data contracts (DB schema, migrations, anything serialized), upstream patch guards, and regressions for bugs that were actually fixed. When removing a test, the justification must be that it has no protective value; slowness is a reason to change how it runs, not whether it exists.
+Use `pnpm@11.8.0`. This repository has no root application build script: build workspace packages
+with `pnpm packages:build`, and run the complete repository type check with `pnpm typecheck`.
+
+- When naming or renaming files, directories, identifiers, or documentation, read
+  [Naming Conventions](docs/references/naming-conventions.md).
+- When adding, moving, or exposing modules, read
+  [Code Organization](docs/references/code-organization.md).
+- When adding, changing, removing, or running tests, read
+  [Testing And CI](docs/guides/testing-and-ci.md).
+- Before creating commits, splitting work, or opening a pull request, read
+  [Git Workflow](docs/guides/git-workflow.md).
+- When building or changing product UI, read
+  [UI Development](docs/guides/ui-development.md).
+- When running iOS device acceptance in a Conductor workspace, read
+  [Parallel Device Testing](docs/guides/parallel-device-testing.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 Rules for visual decisions: where colour comes from, how hierarchy is built, when a surface or border is allowed, and where literal values are still permitted.
 
-Interaction component ownership is in [UI Components](docs/references/ui-components.md). Router structure and safe areas are in [Navigation And Insets](docs/references/navigation-and-insets.md). Naming is in [Naming Conventions](docs/references/naming-conventions.md).
+Interaction component ownership is in [UI Components](docs/references/ui-components.md). Router structure and safe areas are in [Navigation And Insets](docs/references/navigation-and-insets.md). Naming is in [Naming Conventions](docs/references/naming-conventions.md). Local and remote validation ownership is in [Testing And CI](docs/guides/testing-and-ci.md).
 
 ## Priority Order
 
@@ -190,10 +190,14 @@ Any visual change:
 
 ```bash
 pnpm typecheck:app
-pnpm test:app -- <pattern>  # affected suites only; run the full suite once before opening a PR
+pnpm test:app -- <pattern>  # affected suites only
 pnpm lint
 pnpm format:check
 ```
+
+Before opening a draft PR, follow the complete local gate in
+[Testing And CI](docs/guides/testing-and-ci.md). If the draft changes later, rerun that gate on the
+final head before marking it ready. The full test suite then runs in remote CI.
 
 **Plus: look at it in both light and dark on a device or simulator.** Structural verification is not the same as having seen it — contrast, hierarchy, and how a colour reads against real content only show up on screen.
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,47 @@
-# Welcome to your Expo app 👋
+# Cherry Studio Mobile
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+Cherry Mobile is the Expo and React Native client for Cherry Studio. It keeps Cherry's chat and
+provider model compatible with Desktop while using mobile-native data, navigation, rendering, and
+resource ownership.
 
-## Get started
+## Requirements
 
-1. Install dependencies
+- Node.js 24, matching pull request CI
+- `pnpm@11.8.0`
+- Xcode for iOS development or Android Studio for Android development
 
-   ```bash
-   npm install
-   ```
-
-2. Start the app
-
-   ```bash
-   npx expo start
-   ```
-
-In the output, you'll find options to open the app in a
-
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
-
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
-
-## Get a fresh project
-
-When you're ready, run:
+## Install
 
 ```bash
-npm run reset-project
+pnpm install
 ```
 
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
+## Run
 
-### Other setup steps
+The app uses an Expo development client because it includes custom native modules. Build and install
+the client for the target platform:
 
-- To set up ESLint for linting, run `npx expo lint`, or follow our guide on ["Using ESLint and Prettier"](https://docs.expo.dev/guides/using-eslint/)
-- If you'd like to set up unit testing, follow our guide on ["Unit Testing with Jest"](https://docs.expo.dev/develop/unit-testing/)
-- Learn more about the TypeScript setup in this template in our guide on ["Using TypeScript"](https://docs.expo.dev/guides/typescript/)
+```bash
+pnpm ios
+pnpm android
+```
 
-## Learn more
+After the development client is installed, start Metro with:
 
-To learn more about developing your project with Expo, look at the following resources:
+```bash
+pnpm dev
+```
 
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
+Rebuild the development client after native dependency or native configuration changes. Use
+`pnpm dev:clear` when the Metro cache must be reset.
 
-## Join the community
+## Validate
 
-Join our community of developers creating universal apps.
+Use the focused development loop and pre-PR gates in
+[Testing And CI](docs/guides/testing-and-ci.md). Pull request CI runs the complete repository test
+suite after a draft is marked ready for review.
 
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+## Documentation
+
+Start with the [project documentation index](docs/README.md) for architecture, conventions, and
+task-oriented guides.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,10 @@ Guides are task-oriented procedures for changing or extending the application.
 | Document | Description |
 | --- | --- |
 | [Extending Cherry Mobile](./guides/extending.md) | Add resource endpoints, workflows, persistence, backend behavior, and UI |
+| [Git Workflow](./guides/git-workflow.md) | Commits, stacked PRs, review readiness, and case-only renames |
+| [Parallel Device Testing](./guides/parallel-device-testing.md) | Conductor port and iOS simulator isolation and cleanup |
+| [Testing And CI](./guides/testing-and-ci.md) | Focused checks, test value, local PR gates, and remote CI |
+| [UI Development](./guides/ui-development.md) | CherryUI ownership and reusable React component composition |
 
 ## References
 
@@ -20,6 +24,7 @@ They are the source of truth for how the repository works today.
 | Document | Description |
 | --- | --- |
 | [Architecture Overview](./references/architecture-overview.md) | Runtime model, source ownership, dependency boundaries, and frontend/backend interfaces |
+| [Code Organization](./references/code-organization.md) | Module placement, domain promotion, layer ownership, and public surfaces |
 | [Domain Language](./references/domain-language.md) | Shared product and architecture terminology |
 | [Naming Conventions](./references/naming-conventions.md) | File, directory, identifier, and documentation naming rules |
 | [Runtime Ownership](./references/runtime-ownership.md) | Bootstrap, app runtimes, caller-owned sessions, cleanup, and post-ready work |

--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -1,9 +1,10 @@
 # Extending Cherry Mobile
 
 This is a placement guide for extending the in-process frontend/backend architecture. Prefer an
-existing deep module over a new registry or pass-through wrapper. Read the
-[Architecture Overview](../references/architecture-overview.md) and [Data Layer](../references/data/README.md)
-before introducing a new cross-layer interface.
+existing deep module over a new registry or pass-through wrapper. Read
+[Code Organization](../references/code-organization.md), the
+[Architecture Overview](../references/architecture-overview.md), and
+[Data Layer](../references/data/README.md) before introducing a new cross-layer interface.
 
 ## Add A Resource Endpoint
 
@@ -60,7 +61,7 @@ including model capability checks.
 Keep a direct Cherry Desktop service counterpart's `Service` name and public methods. Name
 mobile-only owners by role: `Module`, `Runtime`, `Session`, `Client`, `Adapter`, or `Manager`; never
 add an `Impl` suffix or a forwarding `Service` wrapper. See
-[Naming Conventions](../references/naming-conventions.md#52-architectural-role-names).
+[Runtime Ownership](../references/runtime-ownership.md#role-names).
 
 App-level tools are resolved by `ToolResolver` and attached in
 `src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts`. Provider plugins are

--- a/docs/guides/git-workflow.md
+++ b/docs/guides/git-workflow.md
@@ -1,0 +1,48 @@
+# Git Workflow
+
+This guide defines commit, stacked-review, pull request, and case-only rename procedures.
+
+## Commits
+
+Write small, focused Conventional Commits:
+
+```text
+<type>(<specific-kebab-case-scope>): <description>
+```
+
+Use a module scope such as `data-api`, `chat-input`, `testing`, or `window-manager`. Generic scopes
+such as `main` are not valid. Older unscoped commits are not precedents.
+
+## Stacked Pull Requests
+
+Use the project `gh-stack` skill before implementation when one coherent story contains multiple
+dependent concerns that can be reviewed in sequence. Plan the layers first, put foundations at the
+bottom, and keep Conventional Commit messages in every layer.
+
+Use one stack for one coherent story. Put unrelated features, bug fixes, or refactors in separate
+Conductor workspaces and separate stacks. A linear stack is not a container for parallel independent
+work.
+
+When a feature needs a new reusable CherryUI component, place the component package change in its
+own bottom PR and the feature integration in the PR above it. See
+[UI Development](./ui-development.md).
+
+## Pull Request Lifecycle
+
+1. Run the local gates in [Testing And CI](./testing-and-ci.md).
+2. Create a normal PR as a draft, or submit an entire stack with `gh stack submit --auto`.
+3. After successful PR or stack creation, release the workspace simulator and its allocated port
+   range using [Parallel Device Testing](./parallel-device-testing.md).
+4. Rerun local gates after later draft changes, then mark the final head ready for review.
+5. Treat the remote CI result as the complete-suite gate.
+
+For a stack, release resources once after all layers have been submitted, not after each layer.
+
+## Case-Only Renames
+
+Git on macOS may ignore a rename that changes only letter case. Use an intermediate name:
+
+```bash
+git mv Foo.tsx _tmp_foo.tsx
+git mv _tmp_foo.tsx foo.tsx
+```

--- a/docs/guides/parallel-device-testing.md
+++ b/docs/guides/parallel-device-testing.md
@@ -1,0 +1,58 @@
+# Parallel Device Testing
+
+This guide defines iOS simulator and Metro isolation for concurrent Conductor worktrees. Android
+emulator provisioning is outside this workflow.
+
+## Workspace Resources
+
+Conductor assigns each workspace ten ports: `$CONDUCTOR_PORT` through
+`$((CONDUCTOR_PORT + 9))`. Use the base port for Metro and only that reserved range for companion
+services. A Conductor device test must not use a fixed port such as `8081` or `8084`.
+
+Each worktree uses a dedicated simulator named:
+
+```text
+iPhone 17 Pro ($CONDUCTOR_WORKSPACE_NAME)
+```
+
+Provision it lazily for the workspace, record its UDID under that workspace's `.context`, and never
+reuse a simulator with a live ownership claim. If the dedicated simulator cannot be provisioned,
+stop and report the blocker rather than taking another workspace's device.
+
+Before opening the app, inspect devices and ownership:
+
+```bash
+agent-device devices --platform ios
+agent-device device status --platform ios
+```
+
+## Metro And App Session
+
+Start Metro on the allocated base port:
+
+```bash
+pnpm dev --port "$CONDUCTOR_PORT"
+```
+
+Use a workspace-unique session, explicit simulator, and explicit Metro hint:
+
+```bash
+agent-device open com.cherry-ai.cherry-studio-app --session "$CONDUCTOR_WORKSPACE_NAME" --platform ios --device "iPhone 17 Pro ($CONDUCTOR_WORKSPACE_NAME)" --metro-host 127.0.0.1 --metro-port "$CONDUCTOR_PORT" --relaunch
+```
+
+Keep commands for one session serial. Different sessions may run concurrently only when their
+devices and port ranges differ.
+
+## Cleanup
+
+After a PR or complete stack is created:
+
+1. Close the workspace session with `agent-device close --session "$CONDUCTOR_WORKSPACE_NAME"
+   --platform ios --shutdown`.
+2. Stop listeners only in `$CONDUCTOR_PORT..$((CONDUCTOR_PORT + 9))`.
+3. Delete only the simulator whose recorded UDID and expected workspace name both match.
+4. Remove the workspace simulator metadata after deletion succeeds or the recorded device is
+   already absent.
+
+The local Conductor archive script repeats this cleanup as a fallback. Cleanup must be idempotent and
+must refuse to delete an unrecorded or name-mismatched simulator.

--- a/docs/guides/testing-and-ci.md
+++ b/docs/guides/testing-and-ci.md
@@ -1,0 +1,70 @@
+# Testing And CI
+
+This guide defines the focused development loop, test-value rules, local pull request gates, and
+the remote CI boundary.
+
+## Test The Owned Behavior
+
+- Put a test at the lowest layer that owns the behavior. Prefer pure functions and hooks over
+  reasserting the same behavior through a screen.
+- A test must fail when its protected behavior regresses and remain stable across unrelated
+  implementation changes.
+- Do not write tests whose only claim is that a wrapper forwards props, a component renders without
+  throwing, or an implementation collaborator was called.
+- A mock interaction is valid when the interaction itself is the observable contract, such as a
+  transaction boundary, request shape, callback order, cancellation, subscription, or cleanup.
+- Do not add screen-level render suites. Exercise screen workflows on a device with `agent-device`;
+  test their pure logic and hooks directly.
+- Always cover database schemas and migrations, serialized contracts, upstream patch guards, and a
+  regression that reproduces a bug being fixed.
+- Remove a test only when it protects no behavior. If a valuable test is slow, change how it runs.
+
+## Focused Development Loop
+
+Format and lint only the files being changed:
+
+```bash
+pnpm exec oxfmt --no-error-on-unmatched-pattern <files...>
+pnpm exec oxlint <files...>
+pnpm exec expo lint <files...>
+```
+
+Run every fixed suite that protects the changed behavior, including relevant suites whose files were
+not edited:
+
+```bash
+pnpm test:app -- path/to/file.test.ts --runInBand
+pnpm --filter @cherrystudio/ai-runtime test src/path/to/file.test.ts
+```
+
+Use the owning package filter for `ai-core`, `ai-runtime`, `ai-sdk-provider`, and
+`provider-registry`. Jest owns app tests; package scripts select their package test runner.
+
+Run only the specialized contract checks triggered by the change. Examples include
+`pnpm docs:check-links`, `pnpm skills:check`, `pnpm design:check`, database migration checks, and
+desktop synchronization guards.
+
+## Before Creating A Draft PR
+
+Run these full local gates on the final local head:
+
+```bash
+pnpm lint
+pnpm format:check
+pnpm typecheck
+```
+
+Also rerun the behavior-related fixed suites and specialized checks selected above. Do not run the
+full local `pnpm test`; the complete suite belongs to remote PR CI.
+
+## Ready For Review
+
+Pull requests start as drafts. If the draft changed after its local gates, rerun the gates on the
+final head before marking it ready. The existing GitHub workflow runs the complete tests, typecheck,
+lint, format check, package build, and documentation link check only after the PR is ready.
+
+A PR is merge-ready only after its remote checks pass.
+
+`src/frontend/features/settings/__tests__/ModelSettingsScreen.test.tsx` predates the screen-suite
+rule. Treat it as follow-up migration debt: move any protected behavior to its owning hook or pure
+module before removing the render suite.

--- a/docs/guides/ui-development.md
+++ b/docs/guides/ui-development.md
@@ -1,0 +1,43 @@
+# UI Development
+
+This guide defines shared component ownership and the component-composition workflow. Current
+component behavior and platform boundaries live in [UI Components](../references/ui-components.md).
+
+## Start With CherryUI
+
+Search `@cherrystudio/ui/components` and read `packages/ui/README.md` before creating a product
+interaction primitive. Product code imports shared components from the component-only entry point:
+
+```tsx
+import { Button, Section, TextField } from '@cherrystudio/ui/components';
+```
+
+Keep a component feature-local when its state, language, or interaction belongs to one business
+workflow. Move it into CherryUI only when it is reusable across independent features and fits the
+package's platform-neutral interaction ownership.
+
+When CherryUI lacks a qualifying reusable component, create it in an independent bottom PR before
+the feature integration PR. Use a `gh-stack` layer when the integration depends on that component.
+
+## Compose Component APIs
+
+Use the project `vercel-composition-patterns` skill when creating or substantially changing a
+reusable React component API. In particular:
+
+- compose explicit variants instead of accumulating boolean mode props;
+- use compound components and children for structural composition;
+- keep state implementation inside providers behind a stable state/actions/meta interface;
+- lift shared state to the provider that owns all consumers; and
+- use React 19 ref and context APIs in new or substantially changed component APIs.
+
+Apply this rule prospectively. Do not migrate an untouched `forwardRef` component as incidental work.
+Render callbacks remain appropriate when a parent must supply item data, such as a virtualized
+list's `renderItem`.
+
+## Acceptance
+
+- Shared controls retain accessible labels, states, scalable text, and usable platform fallbacks.
+- Feature components keep business state and translations outside CherryUI.
+- Visual changes are inspected in light and dark themes on a device.
+- iOS device work in parallel worktrees follows
+  [Parallel Device Testing](./parallel-device-testing.md).

--- a/docs/guides/ui-development.md
+++ b/docs/guides/ui-development.md
@@ -20,8 +20,8 @@ When CherryUI lacks a qualifying reusable component, create it in an independent
 the feature integration PR. Use a `gh-stack` layer when the integration depends on that component.
 
 When an implementation differs between iOS and Android, follow
-[Platform Variants](../references/naming-conventions.md#platform-variants) and use matching
-`.ios.tsx` and `.android.tsx` component files.
+[Platform Variants](../references/naming-conventions.md#platform-variants): keep the full component
+family in its own directory and use matching `.ios.tsx` and `.android.tsx` files.
 
 ## Compose Component APIs
 

--- a/docs/guides/ui-development.md
+++ b/docs/guides/ui-development.md
@@ -19,6 +19,10 @@ package's platform-neutral interaction ownership.
 When CherryUI lacks a qualifying reusable component, create it in an independent bottom PR before
 the feature integration PR. Use a `gh-stack` layer when the integration depends on that component.
 
+When an implementation differs between iOS and Android, follow
+[Platform Variants](../references/naming-conventions.md#platform-variants) and use matching
+`.ios.tsx` and `.android.tsx` component files.
+
 ## Compose Component APIs
 
 Use the project `vercel-composition-patterns` skill when creating or substantially changing a

--- a/docs/references/code-organization.md
+++ b/docs/references/code-organization.md
@@ -1,0 +1,81 @@
+# Code Organization
+
+This reference defines module placement, domain promotion, layer ownership, and public surfaces.
+Use [Naming Conventions](./naming-conventions.md) after choosing the owner and location.
+
+## Choose The Narrowest Owner
+
+Keep code with the feature, layer, or package that owns its behavior. Promote it only when a new
+independent consumer creates a broader owner.
+
+| Code | Owner |
+| --- | --- |
+| Expo Router adapter | `src/app` |
+| Route-bound UI and orchestration | `src/frontend/features/<feature>` |
+| UI module shared by independent feature domains | `src/frontend/components` or `src/frontend/hooks` |
+| Frontend query, preference, and cache infrastructure | `src/frontend/data` |
+| Backend AI adaptation | `src/backend/ai` |
+| Backend persistence and Data API implementation | `src/backend/data` |
+| Backend workflow, platform, and external capability | `src/backend/services` |
+| Mobile-native pure contract or helper used by frontend and backend | `src/shared` |
+| Desktop-mirrored portable contract or helper | `packages/universal` |
+| Reusable platform-neutral product interaction component | `packages/ui` |
+| Global or generated declaration | `src/types` |
+
+The repository and `src` top-level directory sets are closed by default. The current `src` roots are
+`app`, `bootstrap`, `frontend`, `backend`, `shared`, and `types`. Add a new root only when no existing
+owner can contain the capability without changing its meaning, and document its non-overlapping
+scope in the PR.
+
+## Promote Domains When They Exist
+
+A single file is the default. Create a domain subtree only when the domain owns multiple concrete
+artifacts or one implementation can no longer remain coherent as a file.
+
+- Keep route-owned UI under its feature until a second independent screen or feature consumes it.
+  Multiple imports inside one screen tree still have one owner.
+- Put a large route-bound domain under `src/frontend/features/<name>` and keep its components,
+  hooks, context, and utilities together.
+- Put a large shared UI domain under `src/frontend/components/<name>`.
+- Put a large backend capability under `src/backend/services/<name>`.
+- Keep one persistence service in `src/backend/data/services`; keep a small helper in the nearest
+  owning `utils` directory.
+- App-shell, design-system, and platform-adapter modules may be app-wide with one direct consumer
+  when they expose a stable boundary and document that ownership.
+
+Feature-specific UI remains with its feature. A reusable interaction primitive belongs in CherryUI;
+follow [UI Development](../guides/ui-development.md) before extracting or adding one.
+
+## Respect Layer Ownership
+
+Repeated bucket names express different owners:
+
+| Path | Ownership |
+| --- | --- |
+| `src/frontend/data` | Frontend providers, endpoint query keys, data hooks, and UI cache state |
+| `packages/universal/src/data` | Desktop-mirrored entities, DTO schemas, preferences, and data errors |
+| `src/backend/data` | Backend cache, preferences, SQLite, migrations, and persistence services |
+| `src/frontend/utils` | Pure helpers used by independent frontend domains |
+| `src/backend/utils` | Pure helpers used by independent backend domains |
+| `src/shared/utils` | Mobile-native pure helpers used by frontend and backend |
+| `packages/universal/src/utils` | Desktop-mirrored portable helpers |
+| `src/frontend/types`, `src/backend/types` | Declarations owned by one layer |
+| `src/types` | Global environment and generated declarations only |
+
+A second consumer in another layer may justify promotion to `shared`; it does not justify a root
+`src/utils` bucket or layer-specific declarations in `src/types`. Keep concrete backend services out
+of frontend state. See [Architecture Overview](./architecture-overview.md) for dependency direction
+and [Runtime Ownership](./runtime-ownership.md) for long-lived resources.
+
+## Expose Deliberate Public Surfaces
+
+- Add `index.ts` or `index.tsx` only at a boundary consumed by routes, parent modules, sibling
+  domains, or package users.
+- A barrel contains named re-exports only and exposes the smallest interface callers need.
+- External callers import the module root. Module internals import their leaf files directly and do
+  not route dependencies back through their own barrel.
+- Private `components`, `hooks`, and `utils` buckets do not need barrels.
+- Route files remain thin adapters to feature module roots.
+
+When choosing between `Module`, `Runtime`, `Session`, `Client`, `Adapter`, or `Manager`, use
+[Runtime Ownership](./runtime-ownership.md#role-names).

--- a/docs/references/lifecycle/lifecycle-migration.md
+++ b/docs/references/lifecycle/lifecycle-migration.md
@@ -172,6 +172,7 @@ Scenarios 1–5 are Stage D; 6–7 are Stage B; 8–9 hold today and gain the gu
 
 ## Verification per stage
 
-Each commit: `pnpm typecheck`, the targeted `pnpm test:app -- <pattern>`, lint, format. Full
-`pnpm test:app` once before opening each PR. Stage A additionally required a simulator cold start —
-the framework being inert is the claim, and only running the app proves it.
+Each commit used targeted tests, lint, and formatting for its behavior. Before each PR, run the
+current local gate in [Testing And CI](../../guides/testing-and-ci.md); the full suite belongs to
+remote CI. Stage A additionally required a simulator cold start because only running the app proves
+that the framework is inert.

--- a/docs/references/naming-conventions.md
+++ b/docs/references/naming-conventions.md
@@ -1,591 +1,74 @@
 # Naming Conventions
 
-> Version: 2.3
-> Last Updated: 2026-08
-> **This document is the authoritative source for repository naming rules.**
-
-This document defines naming rules for files, directories, and identifiers across the Cherry Studio mobile app (Expo / React Native). It encodes both industry consensus (React/TypeScript, Node.js) and project-specific conventions. Toolchain-binding rules come from Expo Router (file-based routing) and React Native (Metro platform-extension resolution) — not shadcn or Next.js.
-
----
-
-## Table of Contents
-
-1. [Quick Reference](#1-quick-reference)
-2. [Core Principles](#2-core-principles)
-3. [File Naming](#3-file-naming)
-4. [Directory Naming](#4-directory-naming)
-5. [Identifier Naming](#5-identifier-naming)
-6. [Edge Cases](#6-edge-cases)
-7. [Decision Tree](#7-decision-tree)
-8. [Appendix: References](#appendix-references)
-
----
-
-## 1. Quick Reference
-
-The 90% case. See later sections for full rules and edge cases.
-
-| What you're naming | Convention | Example |
-|---|---|---|
-| Business React component file | `PascalCase.tsx` | `HeaderIconButton.tsx`, `ChatScreen.tsx` |
-| Platform-specific component file (RN) | `PascalCase.ios.tsx` / `PascalCase.android.tsx` | `MainHeader.ios.tsx`, `SearchScopeTabs.android.tsx` |
-| Expo Router route file (`src/app/`) | `kebab-case.tsx` + reserved tokens | `api-key-settings.tsx`, `_layout.tsx`, `index.tsx` |
-| Hook file | `useXxx.ts(x)` (camelCase, `use` prefix) | `useMessages.ts` |
-| Util / function file (function-as-default-export) | `camelCase.ts` | `messageQueryOptions.ts` |
-| Class-as-default-export file | `PascalCase.ts` (matches class name) | `AssistantService.ts`, `ChatRuntime.ts` |
-| Test file | `*.test.ts(x)` | `rowMappers.test.ts` |
-| Config file | `*.config.{ts,js}` | `metro.config.js`, `drizzle.config.ts` |
-| Type declaration | `*.d.ts` (lowercase / kebab) | `expo-env.d.ts` |
-| Repository meta doc | `UPPERCASE.md` | `README.md`, `AGENTS.md` |
-| Documentation guide or reference | `kebab-case.md` | `extending.md`, `architecture-overview.md` |
-| npm package directory (`packages/*`) | `kebab-case` | `ai-sdk-provider/` |
-| Business React component directory | `PascalCase` | `MainHeader/`, `ScrollToBottomButton/` |
-| Bucket directory (categorical container) | lowercase **plural** noun | `services/`, `hooks/`, `schemas/` |
-| Business / domain module directory | `camelCase` | `assistantPicker/`, `webSearch/` |
-| Large multi-file domain subtree | `src/frontend/features/<name>/` (route-bound) or `camelCase/` (under an owning bucket) | `frontend/features/chat/`, `integrations/webSearch/` |
-| `packages/ui/` directory | `kebab-case` | `bottom-sheet/`, `icons-webp/` |
-
-> Stateful classes are named by architectural role, not by statefulness alone; see §5.2. Files placed inside any `utils/` directory drop the `Utils` suffix — the directory already declares the role; see §3.2. React Native platform-divergent files carry a `.ios`/`.android` suffix on the base name — see §3.8.
-
----
-
-## 2. Core Principles
-
-Three rules trump any specific table below when in conflict:
-
-1. **Consistency beats style choice.** A directory that consistently uses a "suboptimal" convention is healthier than one mixing two "correct" conventions.
-2. **Cross-platform case safety.** Never rely on case to distinguish two files (e.g. `Foo.ts` and `foo.ts` in the same directory). macOS/Windows are case-insensitive by default; Linux is case-sensitive. Mixing breaks CI.
-3. **Toolchain constraints win.** npm package names, Expo Router file-route conventions, and React Native platform-extension resolution (`.ios`/`.android`) are hard requirements — they override stylistic preference.
-
----
-
-## 3. File Naming
-
-### 3.1 React Component Files (`.tsx`)
-
-| Location | Convention | Rationale |
-|---|---|---|
-| `src/frontend/components/**` | `PascalCase.tsx` | Filename mirrors the exported component name. |
-| `src/frontend/features/**` | `PascalCase.tsx` | Filename mirrors the exported component name. |
-| `src/app/**` (Expo Router routes) | `kebab-case.tsx` + reserved tokens | Filename maps to the route/navigation; see §6.6. |
-
-The component's **exported identifier** is always `PascalCase`, regardless of filename style:
-
-```tsx
-// src/frontend/features/chat/ChatScreen.tsx
-export function ChatScreen() { /* ... */ }
-
-// src/frontend/components/headers/components/HeaderIconButton.tsx
-export function HeaderIconButton() { /* ... */ }
-```
-
-Route files under `src/app/` keep kebab-case / reserved-token filenames (§6.6) but their default export is still a `PascalCase` screen component.
-
-### 3.2 TypeScript Source Files (`.ts`)
-
-Choose based on **what the file's default / primary export is**:
-
-| Primary export | Convention | Example |
-|---|---|---|
-| Hook function (`useXxx`) | `camelCase.ts(x)`, must start with `use` | `useMessages.ts` |
-| Plain function or function group | `camelCase.ts` | `messageQueryOptions.ts`, `rowMappers.ts` |
-| Class | `PascalCase.ts` (matches class name) | `AssistantService.ts`, `ChatRuntime.ts`, `CherryInClient.ts` |
-| Constants / enums only | `camelCase.ts` | `errorCodes.ts` |
-| Re-export barrel | `index.ts` | — |
-
-**Note:** Files under `packages/ui/` (and other publishable `packages/*`) use `kebab-case.ts` regardless of export type (e.g. `provider-aliases.ts`, `model-aliases.ts`), per §4.6 — that scope-specific rule overrides this section. The exported identifier (e.g. `providerAliases`) remains `camelCase`.
-
-**Inside any `utils/` directory** — the directory declares the role, so the filename does not repeat it:
-
-```
-utils/orderKey.ts      ✅
-utils/rowMappers.ts    ✅
-utils/messageQueryOptions.ts  ✅
-```
-
-A `*Utils` suffix is used only when the file lives outside any `utils/` directory.
-
-**Hooks (`useXxx.ts`)** — are co-located with their owning feature by default (e.g.
-`src/frontend/features/chat/input/hooks/`). A hook moves to `src/frontend/hooks/` only when
-independent feature or screen domains consume it; cross-domain hooks may group into a domain folder
-such as `src/frontend/hooks/chat/`. A hook that embeds JSX in its return value uses the `.tsx`
-extension (e.g. `useConfirmDialog.tsx`); a hook with no JSX uses `.ts`.
-
-**Utilities** — pure helpers stay in the owning module's `utils/` by default. A helper shared by
-independent modules moves to the narrowest owning layer: `src/frontend/utils`, `src/backend/utils`,
-or `src/shared/utils` when both layers consume it. There is no root `src/utils`. Multiple imports
-inside one screen tree do not establish cross-domain reuse.
-
-**Native module wrappers** — wrappers around custom native modules (under `modules/`, e.g. `modules/pdf-text-extractor/`) or Expo modules carry no generic `*Api`, `*Client`, or `*Bridge` suffix. Name a retained wrapper by the platform capability it adapts, such as `DevicePermissions`; use `Adapter` only when the translation role would otherwise be ambiguous. Pure-function wrappers belong in `utils/`.
-
-### 3.3 Test Files
-
-- **Suffix**: `*.test.ts` or `*.test.tsx`. Do **not** use `.spec.*`.
-- **Location**: prefer co-location in `__tests__/` subdirectory next to source. Inline (`foo.ts` + `foo.test.ts` in same dir) is also acceptable.
-- **Filename base**: match the file under test (`rowMappers.ts` → `rowMappers.test.ts`).
-
-### 3.4 Config Files
-
-- Pattern: `*.config.ts` (or `*.config.js` / `*.config.mjs` when TS is unsupported).
-- Examples: `metro.config.js`, `babel.config.js`, `drizzle.config.ts`, `jest.config.js`.
-- Tool-mandated root config names (`app.json`, `eas.json`, `tsconfig.json`) keep their required names; do not customize.
-
-### 3.5 Type Declaration Files
-
-- Pattern: `*.d.ts`, all-lowercase or `kebab-case`.
-- Examples: `expo-env.d.ts`, `global-types.d.ts`.
-
-### 3.6 Markdown / Documentation
-
-| Type | Convention | Example |
-|---|---|---|
-| Repository meta docs at root | `UPPERCASE.md` | `README.md`, `AGENTS.md` |
-| Directory index | `README.md` (always uppercase) | `docs/README.md`, `src/frontend/components/README.md` |
-| Task-oriented guide under `docs/guides` | `kebab-case.md` | `extending.md` |
-| Current-state reference under `docs/references` | `kebab-case.md` | `architecture-overview.md`, `naming-conventions.md` |
-| Package-local documentation | `kebab-case.md` except directory indexes | `architecture.md`, `provider-aliases.md` |
-
-`docs/README.md` is the repository documentation entry point. Guides explain how to perform a task;
-references describe current behavior, terminology, constraints, or measurements. Do not create ADR
-or TODO documentation trees. Git history preserves superseded decisions, and unfinished work belongs
-in the project issue tracker. Module-specific `README.md` files remain beside their code.
-
-### 3.7 JSON / YAML / TOML
-
-- `package.json`, `tsconfig.json`, `app.json`, `eas.json`, `pnpm-workspace.yaml`: tool-mandated names; do not customize.
-- Project-specific config JSON: `kebab-case.json`.
-
-### 3.8 Platform-Specific Files (`.ios` / `.android`)
-
-A component or module with platform-divergent implementations splits via Metro's platform-extension resolution:
-
-```
-MainHeader/
-├── MainHeader.tsx          # shared API / types / fallback (optional)
-├── MainHeader.ios.tsx      # iOS implementation
-└── MainHeader.android.tsx  # Android implementation
-```
-
-- The **base name** keeps its normal casing — `PascalCase` for components (§3.1), `camelCase` for `.ts` modules (§3.2). The `.ios` / `.android` segment is the platform selector, not part of the name.
-- Applies to both `.tsx` and `.ts` (`Foo.ios.ts`, `Foo.android.ts`).
-- These are **not** §6.3 case/duplicate violations — Metro resolves exactly one variant per platform at build time.
-- Examples: `MainHeader.{ios,android}.tsx`, `BackHeader.{ios,android}.tsx`, `ScrollToBottomButton.{ios,android}.tsx`, `SearchScopeTabs.{ios,android}.tsx`.
-
----
-
-## 4. Directory Naming
-
-Directory naming splits into category rules (§4.1–§4.3, §4.5–§4.7, §4.10) and cross-cutting rules: §4.4 (file vs subdirectory), §4.8 (top-level closed), §4.9 (singular vs plural).
-
-### 4.1 npm Package Directories — `kebab-case`
-
-`packages/*` directory names must be `kebab-case`. The directory name must equal the `name` field in `package.json` (minus the scope prefix).
-
-```
-packages/ai-sdk-provider/     ✅
-packages/app-icons/           ✅
-packages/provider-registry/   ✅
-packages/somePkg/             ❌ (camelCase not allowed)
-packages/SomePkg/             ❌ (PascalCase not allowed)
-```
-
-> The dir name equals the unscoped package name: `packages/ui/` publishes `@cherrystudio/ui`; `packages/ai-core/` publishes the matching `ai-core` name. See §6.5.
-
-### 4.2 Business React Component Directories — `PascalCase`
-
-When a directory **is** a component (i.e. contains `index.tsx` exporting the component, or groups files under one component name), use `PascalCase`.
-
-```
-src/frontend/components/headers/MainHeader/                       ✅
-src/frontend/components/headers/BackHeader/                       ✅
-src/frontend/components/messagePresentation/components/ScrollToBottomButton/  ✅
-```
-
-### 4.3 Bucket Directories — `lowercase plural noun`
-
-"Bucket" = a categorical container holding many unrelated items of the same kind.
-
-```
-services/   utils/   hooks/   components/   features/   types/   schemas/
-```
-
-Bucket names are **plural** (see §4.9 for singular-vs-plural rules across all directory kinds). Do **not** invent variants like `Services/` or `helpers-and-utils/`.
-
-### 4.4 File-Level vs Subdirectory Organization Inside a Bucket
-
-Inside any bucket or domain directory, a **single file is the default**. Promote to a subdirectory only when the topic requires multiple files.
-
-| Situation | Layout | Examples |
-|---|---|---|
-| One file can express the entire capability / topic | One `.ts` file | `data/services/TagService.ts`, `utils/orderKey.ts`, `hooks/chat/useMessages.ts` |
-| Implementation is too large for one file, **or** the topic owns several closely related artifacts (helpers, types, sub-files) that belong together | A subdirectory grouping the files | `services/webSearch/`, `components/modelPicker/`, `features/chat/input/` |
-
-Do not pre-create a subdirectory for anticipated growth — promote only when the second file actually arrives.
-
-### 4.5 Business / Domain Module Directories — `camelCase`
-
-When a directory represents a **named domain** (a coherent business module with its own internal structure), use `camelCase`.
-
-```
-src/frontend/components/confirmDialog/                      ✅
-src/frontend/components/modelPicker/                        ✅
-src/backend/services/webSearch/                             ✅
-src/backend/services/permissions/                           ✅
-```
-
-Placement — whether a domain module lives as a large subtree or as a subdirectory inside a bucket like `services/` — is governed by §4.10; this section governs only its name.
-
-### 4.6 `packages/ui` Directories — `kebab-case`
-
-Everything inside `packages/ui/` (both files and directories) uses `kebab-case` for package-local consistency. `packages/ui` (`@cherrystudio/ui`) owns shared mobile interaction components and the icon registry:
-
-```
-packages/ui/src/components/bottom-sheet/  ✅
-packages/ui/src/icons/        ✅
-packages/ui/src/icons-webp/    ✅
-packages/ui/src/icons-webp/provider-aliases.ts   ✅
-```
-
-The other publishable packages (`ai-sdk-provider/`, `provider-registry/`, `app-icons/`) follow the same package-local `kebab-case` for their files.
-
-### 4.7 Convention-Mandated Directories
-
-These have fixed names dictated by tools or community convention:
-
-| Directory | Purpose |
-|---|---|
-| `__tests__/` | Test files (Jest convention) |
-| `__mocks__/` | Mock files (Jest convention) |
-| `node_modules/` | Dependencies (npm/pnpm) |
-| `ios/`, `android/` | Native project dirs (Expo prebuild / bare) |
-| `dist/`, `build/`, `out/` | Build output |
-
-### 4.8 Top-Level Directories — Closed by Default
-
-The set of top-level directories under each of:
-
-- repository root `/`
-- `/src/`
-
-is **closed by default**. The current `/src/` roots are `app/`, `bootstrap/`, `frontend/`, `backend/`,
-`shared/`, and `types/`. Their ownership is also closed:
-
-- `frontend/`: `components/`, `data/`, `features/`, `hooks/`, `i18n/`, `styles/`, `types/`, and
-  `utils/`.
-- `backend/`: `ai/`, `data/`, `services/`, `types/`, and `utils/`.
-- `shared/`: `ai/`, `contracts/`, `core/`, `data/`, and `utils/`.
-
-Adding a root or overlapping one of these layer-owned buckets is a structural commitment governed by
-the [Architecture Overview](./architecture-overview.md).
-
-**A new top-level directory MAY be added only when the PR description establishes both:**
-
-1. **Necessity** — no existing top-level bucket can host the new files without semantic loss.
-2. **Completeness** — the new directory has a clear scope, follows §4.3 (plural bucket) or §4.5 (singular domain module) form, and does not overlap with any existing bucket.
-
-If either is in doubt, place the files inside an existing bucket. Subdirectories under existing buckets are unrestricted.
-
-For the architecture rationale behind these roots, see the
-[Architecture Overview](./architecture-overview.md) and its linked area references.
-
-### 4.9 Singular vs Plural
-
-Choose number based on what the directory **conceptually contains**, not on which sounds nicer.
-
-| Directory role | Number | Examples |
-|---|---|---|
-| **Collection bucket** — holds many items of the same kind | **plural** | `services/`, `utils/`, `hooks/`, `components/`, `features/`, `types/`, `schemas/`, `providers/`, `presets/` |
-| **Namespace / theme** — represents one subject area, not a collection | **singular** | `config/`, `data/`, `core/`, `api/`, `runtime/` |
-| **Business / domain module** — named action or concept | **singular** (default) | `webSearch/`, `assistantPicker/`, `devicePermissions/`, `bootstrap/` |
-| **Component directory** (dir = component) | follows the **component name** | `MainHeader/`, `McpScreen/` (singular component); `SettingsSection/` (component representing a group) |
-
-Decision rule: ask "does this directory hold **many of X**?" — yes → plural; no → singular. When two readings both make sense, pick the one that matches the directory's **default import name** (e.g. `import { ... } from './config'` reads naturally with `config/` singular).
-
-### 4.10 Large Multi-File Domains — Subtree vs Type Buckets
-
-A **large multi-file domain** co-locates *everything* it owns — its components or services, domain-local `utils/` and `hooks/`, context, and sub-components — in one subtree, instead of scattering them across the top-level buckets.
-
-**A domain earns its own subtree only when it is large, complex, and multi-file** — cohesion alone is not enough (this is §4.4 applied at the top level).
-
-| The domain is… | Home | Layout |
-|---|---|---|
-| A large route-bound UI domain | `src/frontend/features/<name>/` | self-contained tree (`input/`, `workspace/`, `components/`, `hooks/`, `utils/`) |
-| A large shared UI domain | `src/frontend/components/<domain>/` | self-contained tree |
-| A large backend capability domain | `src/backend/services/<domain>/` | module, runtime, client, adapter, provider, and utility subtree |
-| One cohesive persistence service | `src/backend/data/services/<Domain>Service.ts` | a single file; its lone helper stays in the nearest `utils/` |
-| A small standalone helper | the owning module's or layer's `utils/` | a single file |
-
-This is the §4.4 promotion rule applied at the top level: a domain graduates from "a file (plus maybe one util) in a bucket" to "its own subtree" only once the additional files actually arrive and span more than one concern. Do not pre-create a subtree for an anticipated module.
-
-**Canonical examples** — route-owned Chat orchestration and shared message presentation:
-
-```
-src/frontend/features/chat/
-├── ChatScreen.tsx        # the route-bound screen component (§3.1)
-├── input/                # ChatInput + its components/hooks/utils
-├── workspace/            # runtime projection, loading gates, approvals, composer placement
-└── runtime/              # React subscription layer for the app-owned ChatRuntime
-
-src/frontend/components/messagePresentation/
-├── components/           # virtualized MessageList and its private platform controls
-├── messageContent/       # structured message part renderers and hooks
-├── messageRow/           # user/assistant rows and entry animation
-└── utils/                # private presentation mappings
-```
-
-Layer-level buckets such as `frontend/components`, `frontend/hooks`, `backend/services`,
-`backend/data/services`, and each layer's `utils` stay reserved for small, independent,
-cross-domain pieces. A large, multi-file domain left scattered across those buckets instead of
-gathered into one subtree is the §6.7 scattered/impure anti-pattern.
-
-For UI modules, promotion is owner-based: keep the module under its screen until a second independent screen or feature domain consumes it. Import count inside one screen tree is not evidence of cross-domain ownership. App shell, design-system, and platform-adapter modules may be app-wide with one direct consumer, but must document that ownership and expose a stable public interface.
-
-For how screen subtrees fit the navigation, data, and runtime layering, see the
-[Architecture Overview](./architecture-overview.md).
-
-### 4.11 Layer-Owned Data, Utils, And Types
-
-Repeated bucket names across layers express different ownership; they are not candidates for a
-root-level merge:
-
-| Path | Ownership |
-|---|---|
-| `src/frontend/data` | `DataApiProvider`, `PreferenceProvider`, workflow `BackendProvider`, `QueryProvider`, endpoint query keys, data/preference/cache hooks, and frontend `CacheService` |
-| `packages/universal/src/data` | frontend/backend entities, DTO schemas, preferences, shared cache schemas, and data errors (`@cherrystudio/universal/data`, desktop-mirrored) |
-| `src/backend/data` | backend `CacheService`, `PreferenceService`, SQLite/Drizzle, seeders, fixtures, and persistence services |
-| `src/frontend/utils` | pure helpers and constants used only by frontend modules |
-| `src/backend/utils` | pure helpers and constants used only by backend modules |
-| `src/shared/utils` | mobile-native platform-independent pure helpers used by both frontend and backend |
-| `packages/universal/src/utils` | desktop-mirrored portable pure helpers (`@cherrystudio/universal/utils`) |
-| `src/frontend/types` / `src/backend/types` | declarations owned by one layer |
-| `src/types` | truly global environment declarations and generated declarations only |
-
-Choose the narrowest correct owner. A second consumer in another layer promotes a pure helper or
-declaration to `shared`; it does not justify restoring root `src/utils` or putting layer-specific
-declarations in root `src/types`.
-
----
-
-## 5. Identifier Naming
-
-Names inside source code — separate axis from filenames.
-
-| Identifier kind | Convention | Example |
-|---|---|---|
-| Component, Class, Interface, Type alias, Enum type | `PascalCase` | `class AssistantService`, `interface UserConfig`, `type Status` |
-| Variable, function, method, parameter | `camelCase` | `fetchUser`, `isReady` |
-| Hook | `camelCase` with mandatory `use` prefix | `useMessages` |
-| Constant, enum member | `UPPER_SNAKE_CASE` | `MAX_RETRY_COUNT`, `CHERRYIN_CONFIG` |
-| Private class member | no `_` prefix; use `private` modifier | `private cache` |
-| Generic type parameter | `PascalCase`, prefer descriptive | `<TItem>`, `<TError>` (avoid bare `T` for non-trivial cases) |
-
-### 5.1 Singular vs Plural in Identifiers
-
-| Identifier kind | Number | Example |
-|---|---|---|
-| Class, interface, type alias, enum type | **singular** | `User`, `OrderItem`, `LogLevel` (not `Users`, `OrderItems`) |
-| Variable / property holding a single value | **singular** | `const user = ...`, `currentOrder` |
-| Variable / property holding a collection (array, `Map`, `Set`) | **plural** | `const users = [...]`, `orderItems`, `connectedClients` |
-| Boolean | no plural; use `is` / `has` / `can` / `should` prefix | `isReady`, `hasPermission`, `canEdit`, `shouldRetry` |
-| Function returning one item | **singular** verb phrase | `getUser(id)`, `findOrder()` |
-| Function returning many items | **plural** noun in name | `getUsers()`, `listOrders()`, `fetchPendingJobs()` |
-| Function that mutates a collection | verb + plural object | `addUsers(...)`, `removeTags(...)` |
-| Event / handler name | follows the event subject | `onMessageReceived` (one), `onItemsLoaded` (many) |
-
-### 5.2 Architectural Role Names
-
-State is not a naming role. Name a mobile-owned capability by who can call it and who owns its
-lifetime. Do not use `Service` as the fallback for every stateful class.
-
-Desktop alignment is checked first: a class that directly corresponds to a Cherry Desktop service
-keeps the desktop `XxxService` name and public methods. This includes `DbService`, `CacheService`,
-`PreferenceService`, persistence services, `DataApiService`, `AiService`, `McpRuntimeService`,
-`OAuthRuntimeService`, and `WebSearchService`. Do not rename these to repositories or mobile role
-names merely for local consistency.
-
-Use these roles for mobile-only code:
-
-| Role | Use when the type… | Examples |
-|---|---|---|
-| `Module` | Is a frontend-visible workflow capability exposed through `Backend` | `ChatModule`, `ModelsModule`, `PaintingsModule` |
-| `Runtime` | Is one app- or bootstrap-owned executor with state that spans calls or routes | `ChatRuntime`, `AppBootstrapRuntime` |
-| `Session` | Is one caller-owned, isolated unit of work with explicit cancellation or disposal | `PaintingGenerationSession` |
-| `Client` | Speaks to one external account, protocol, or remote API | `CherryInClient`, `PkceOAuthClient` |
-| `Adapter` | Translates a platform or SDK boundary; a clear capability noun may stand alone | `DevicePermissions` (native permission adapter) |
-| `Manager` | Coordinates a pool or registry of many homogeneous instances as its defining job | `PluginManager`, `ConnectionManager` |
-
-`Backend`, `BackendProvider`, and `useBackendModule()` are intentional aggregate and React
-integration names. Leaf workflow contracts use `XxxModule`; do not add parallel `XxxBackend`,
-`XxxService`, and `XxxImpl` layers for the same operations.
-
-Factory-shaped modules use `createXxxModule()`. A caller-owned session exposes its lifecycle on the
-session itself. An app-owned runtime is created once by bootstrap and is not disposed by route or
-component unmount. `Manager` is not the fallback when none of the other roles fit; use a precise
-domain noun or a plain function instead.
-
-The `Impl` suffix is forbidden. It only says that a type implements another type and adds no
-ownership information. Name the concrete type by its role; when a private class shares a contract
-name, alias the imported contract type rather than appending `Impl`.
-
-Use this decision order:
-
-1. Direct Cherry Desktop service counterpart? Keep its aligned `XxxService` name and spelling.
-2. Frontend-visible workflow contract? `XxxModule`.
-3. App- or bootstrap-owned long-lived executor? `XxxRuntime`.
-4. Caller-owned isolated lifecycle? `XxxSession`.
-5. External protocol or account API? `XxxClient`.
-6. Platform or SDK translation boundary? `XxxAdapter`, or the unambiguous capability noun.
-7. Homogeneous instance pool or registry? `XxxManager`.
-8. Otherwise use a domain noun, hook, component, or plain function; never default to `Service`.
-
-Pure-function collections, queries, conversions, and formatters stay in `utils/`. React lifecycle
-belongs in hooks or providers, JSX belongs in components/features, and a one-call pass-through
-should normally be inlined.
-
-There is no main-process DI container in the mobile app. `src/bootstrap` is the only composition
-root, and readiness is coordinated by startup gates rather than lifecycle phases. See
-[Runtime Ownership](./runtime-ownership.md), the [Architecture Overview](./architecture-overview.md),
-and [`src/bootstrap/README.md`](../../src/bootstrap/README.md).
-
-### 5.3 Drizzle Schema Inferred Row Types
-
-Every Drizzle table in `src/backend/data/db/schemas/` exports its inferred select/insert
-types using the **`Row` suffix** form:
-
-| Inferred from | Type name | Example |
-|---|---|---|
-| `xxxTable.$inferSelect` | `XxxRow` | `TopicRow`, `MessageRow` |
-| `xxxTable.$inferInsert` | `InsertXxxRow` | `InsertTopicRow`, `InsertMessageRow` |
-
-```ts
-export const topicTable = sqliteTable('topic', { /* ... */ })
-
-export type TopicRow = typeof topicTable.$inferSelect
-export type InsertTopicRow = typeof topicTable.$inferInsert
-```
-
-`Row` names the raw database row and is deliberately distinct from the shared entity type to which
-the backend service maps it. The `Xxx` stem matches the table-derived `xxxTable` const (see §3.2),
-so `user_model` → `userModelTable` → `UserModelRow` / `InsertUserModelRow`.
-
-Do **not** use the alternatives that previously coexisted here: `XxxSelect` / `XxxInsert`, `Xxx` /
-`NewXxx`, or Drizzle's docs-style `SelectXxx` / `InsertXxx`. The `Row` suffix is chosen over Drizzle's
-docs form precisely because it keeps the DB-row type visibly separate from the shared entity type.
-Export the `Row` types from the schema file (and re-export them through `schemas/index.ts`) so backend
-services consume them instead of re-deriving `typeof xxxTable.$inferSelect` locally.
-
----
-
-## 6. Edge Cases
-
-### 6.1 Acronyms and Initialisms
-
-For new mobile-owned names, when an acronym (API, URL, ID, HTTP, MCP, AI, OAuth) appears inside
-`PascalCase` or `camelCase`:
-
-- **First letter uppercase, rest lowercase** — `HttpClient`, `UserId`, `ApiServer`, `McpService`, `Oauth`.
-- **Never all-caps** — `HTTPClient`, `UserID`, `APIServer`, `OAuth` (as in `CherryInOAuth`) are forbidden.
-- **At the start of `camelCase`** — entirely lowercase: `httpClient`, `userId`, `apiServer`.
-- **Same form applies to filenames** — `McpService.ts`, not `MCPService.ts`; `CherryInOauth.tsx`, not `CherryInOAuth.tsx`.
-
-Direct desktop-aligned names and public shared contracts keep their existing upstream spelling even
-when it differs from this local style, such as `OAuthRuntimeService`. Alignment takes precedence
-over cosmetic acronym normalization.
-
-### 6.2 Case-Only Renames
-
-`git` on macOS defaults to `core.ignorecase=true`, which silently swallows pure case-change renames. Always use the two-step pattern:
-
-```bash
-git mv Foo.tsx _tmp_foo.tsx
-git mv _tmp_foo.tsx foo.tsx
-```
-
-### 6.3 Two Files Differing Only in Case
-
-Forbidden. `Button.tsx` and `button.tsx` in the same directory will break on case-insensitive file systems. (Platform-extension pairs like `Foo.ios.tsx` / `Foo.android.tsx` differ by the platform selector, not by case, and are allowed — see §3.8.)
-
-### 6.4 Barrel / Index Files
-
-- Use `index.ts` or `index.tsx` (always lowercase).
-- A barrel must re-export only — no business logic.
-- Prefer **named exports** in barrels; avoid `export default` re-export chains.
-- Add a barrel only at a real module boundary used by routes, parent modules, sibling domains, or
-  external callers. Do not create barrels for private `components/`, `hooks/`, or `utils/` buckets.
-- External callers import the module root. Module internals import leaf files relatively and do not
-  route internal dependencies back through their own public barrel.
-- Keep the export surface narrow: export only the components, hooks, functions, and associated types
-  that callers need.
-
-### 6.5 Directory Name vs Package Name
-
-In `packages/*`, the directory name and `package.json#name` (after stripping scope) must match exactly. Renaming one requires renaming the other.
-
-### 6.6 Expo Router File-Based Routes
-
-Files under `src/app/` map to routes/navigation by filename (Expo Router). Route basenames are **kebab-case** (e.g. `api-key-settings.tsx`); the tokens below are folder/file conventions, not free names.
-
-| Token | Meaning |
-|---|---|
-| `_layout.tsx` | Layout route for the directory |
-| `index.tsx` | Index route for the directory |
-| `(group)/` | Route group — organizes without adding a URL segment (e.g. `(tabs)/`, `(messages)/`, `(search)/`) |
-| `[param].tsx` / `[param]/` | Dynamic segment (e.g. `[providerId]/`) |
-| `[...rest].tsx` | Catch-all segment |
-
-The route file's default export is a `PascalCase` screen component (§3.1); the file and folder names follow these tokens and kebab-case.
-
-### 6.7 Bucket Anti-Patterns
-
-A bucket directory drifts toward unhealth when **any** of these accumulate:
-
-1. **Singular name on a directory that holds many like items** — should be a §4.3 bucket but was misclassified as a §4.9 namespace.
-2. **Impure contents** — files inside the bucket that do not match the bucket's declared kind (e.g. a directory named after one React pattern that also holds wrapper components which do not use that pattern).
-3. **Thin bucket** — a top-level bucket holding 0–2 files for an extended period is usually an over-eager extraction; reconsider whether it should be a subdirectory inside an existing bucket (see §4.8).
-4. **Overlapping scope** — two top-level buckets whose names could each plausibly host the same file. One of them is redundant or the boundary is ill-defined.
-
-Any of these signals warrants a consolidation review.
-
----
-
-## 7. Decision Tree
-
-```
-Naming a new FILE
-├─ React component (.tsx)?
-│  ├─ Platform-divergent?                 → PascalCase.ios.tsx / .android.tsx  (MainHeader.ios.tsx, §3.8)
-│  ├─ Under src/app/ (Expo Router)?       → kebab-case.tsx + reserved tokens   (api-key-settings.tsx, _layout.tsx, §6.6)
-│  ├─ Under packages/ui/?             → kebab-case.tsx                      (§4.6)
-│  └─ Under frontend components/features? → PascalCase.tsx                      (HeaderIconButton.tsx, ChatScreen.tsx)
-├─ React hook?                    → useXxx.ts(x)    (useMessages.ts; .tsx only if it returns JSX)
-├─ Primary export is a class?     → PascalCase.ts   (ChatRuntime.ts; choose its role in §5.2)
-├─ Primary export is function(s)? → camelCase.ts    (messageQueryOptions.ts)
-├─ Type declaration?              → *.d.ts          (expo-env.d.ts)
-├─ Test?                          → *.test.ts(x)
-├─ Config?                        → *.config.{ts,js}
-└─ Documentation?
-   ├─ Repo meta or directory index? → UPPERCASE.md  (README.md, AGENTS.md)
-   └─ Guide, reference, or package doc? → kebab-case.md (architecture-overview.md)
-
-Naming a new DIRECTORY
-├─ npm package (packages/*)?      → kebab-case      (ai-sdk-provider)
-├─ Under packages/ui/?            → kebab-case      (bottom-sheet, icons-webp)
-├─ Is itself a React component?   → PascalCase      (MainHeader, ScrollToBottomButton)
-├─ Bucket / categorical container? → lowercase plural noun  (services, hooks, schemas)
-├─ Large route-bound UI domain?   → src/frontend/features/<name>/       (frontend/features/chat; §4.10)
-├─ Large non-route domain?        → camelCase under its owning layer    (integrations/webSearch; §4.10)
-├─ Business domain module?        → camelCase       (assistantPicker, devicePermissions)
-└─ Unsure singular vs plural?     → see §4.9
-```
-
----
-
-## Appendix: References
-
-This document distills consensus from:
-
-- [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript) — file name matches default export
-- [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html)
-- [Expo Router — file-based routing](https://docs.expo.dev/router/introduction/) — route file naming, route groups, dynamic segments
-- [React Native — Platform-specific code](https://reactnative.dev/docs/platform-specific-code) — `.ios` / `.android` file extensions
-- [typescript-eslint `naming-convention` rule](https://typescript-eslint.io/rules/naming-convention/)
+This reference defines names for files, directories, and identifiers. Read
+[Code Organization](./code-organization.md) for placement and public-surface rules, and
+[Runtime Ownership](./runtime-ownership.md#role-names) before naming a stateful owner.
+
+## Files
+
+| Location or role | Convention | Example |
+| --- | --- | --- |
+| Product React component under `src/frontend` | `PascalCase.tsx` | `ChatScreen.tsx` |
+| Expo Router route under `src/app` | `kebab-case.tsx` or a reserved route token | `api-key-settings.tsx`, `_layout.tsx` |
+| Hook | `useXxx.ts` or `useXxx.tsx` when it returns JSX | `useMessages.ts` |
+| Class outside `packages` | `PascalCase.ts` matching the class | `ChatRuntime.ts` |
+| Function, constants, or function group outside `packages` | `camelCase.ts` | `messageQueryOptions.ts` |
+| Test | matching base name plus `*.test.ts(x)` | `rowMappers.test.ts` |
+| Config | `*.config.ts`, or JS/MJS when TypeScript is unsupported | `drizzle.config.ts` |
+| Type declaration | lowercase or `kebab-case` plus `*.d.ts` | `expo-env.d.ts` |
+| Root meta document or directory index | `UPPERCASE.md` | `AGENTS.md`, `README.md` |
+| Guide, reference, or package-local document | `kebab-case.md` | `testing-and-ci.md` |
+
+Every file newly added or renamed under `packages/**` uses a `kebab-case` base name, regardless of
+its primary export. Tool-mandated names, `README.md`, and lowercase barrels such as `index.ts` keep
+their required spellings. Existing package filenames that differ are migration debt, not precedent;
+do not rename them incidentally.
+
+Tests use `.test.*`, not `.spec.*`, and normally live in a co-located `__tests__` directory. Files
+inside `utils` do not repeat a `Utils` suffix.
+
+React Native platform variants append `.ios` or `.android` to the normally cased base name, for
+example `MainHeader.ios.tsx` or `message-reader.android.ts` inside `packages`.
+
+## Directories
+
+| Directory role | Convention | Example |
+| --- | --- | --- |
+| Package under `packages/*` | `kebab-case`, matching the unscoped package name | `ai-sdk-provider` |
+| New or renamed directory anywhere under `packages/**` | `kebab-case` | `bottom-sheet` |
+| Component family outside `packages` | the `PascalCase` component name | `MainHeader` |
+| Collection bucket | lowercase plural noun | `services`, `hooks`, `schemas` |
+| Business or domain module outside `packages` | singular `camelCase` name | `modelPicker`, `webSearch` |
+| Namespace or subject | singular lowercase name | `config`, `data`, `runtime` |
+
+Use tool-reserved directory forms unchanged, including Expo Router groups and dynamic segments such
+as `(tabs)` and `[providerId]`.
+
+## Identifiers
+
+| Identifier | Convention | Example |
+| --- | --- | --- |
+| Component, class, interface, type alias, enum type | `PascalCase` | `AssistantService`, `UserConfig` |
+| Variable, function, method, parameter | `camelCase` | `fetchUser`, `currentOrder` |
+| Hook | `camelCase` with a `use` prefix | `useMessages` |
+| Constant and enum member | `UPPER_SNAKE_CASE` | `MAX_RETRY_COUNT` |
+| Boolean | `is`, `has`, `can`, or `should` prefix | `isReady`, `hasPermission` |
+| Private class member | no underscore prefix; use `private` | `private cache` |
+| Generic type parameter | descriptive `PascalCase` | `TItem`, `TError` |
+
+Collection values and collection-returning functions use plural nouns; single values and types use
+singular nouns.
+
+For new mobile-owned acronyms in `PascalCase` or `camelCase`, capitalize only the first letter:
+`HttpClient`, `UserId`, `McpServer`, `httpClient`. Desktop-aligned names and public shared contracts
+retain their existing upstream spelling, such as `OAuthRuntimeService`.
+
+Every Drizzle table in `src/backend/data/db/schemas` exports `XxxRow` and `InsertXxxRow` inferred
+types. The stem matches the table constant: `userModelTable` maps to `UserModelRow` and
+`InsertUserModelRow`.
+
+## Case Safety
+
+Two sibling paths must not differ only by letter case. Platform-extension pairs are distinct by
+platform selector and are allowed. Follow the case-only rename procedure in
+[Git Workflow](../guides/git-workflow.md#case-only-renames).

--- a/docs/references/naming-conventions.md
+++ b/docs/references/naming-conventions.md
@@ -27,8 +27,12 @@ do not rename them incidentally.
 Tests use `.test.*`, not `.spec.*`, and normally live in a co-located `__tests__` directory. Files
 inside `utils` do not repeat a `Utils` suffix.
 
-React Native platform variants append `.ios` or `.android` to the normally cased base name, for
-example `MainHeader.ios.tsx` or `message-reader.android.ts` inside `packages`.
+## Platform Variants
+
+When a React component needs different iOS and Android implementations, split it into matching
+`Name.ios.tsx` and `Name.android.tsx` files. Non-JSX modules use the corresponding `.ios.ts` and
+`.android.ts` suffixes. Keep shared types, APIs, and implementation in an unsuffixed file when both
+platform variants need them; Metro selects the platform file at build time.
 
 ## Directories
 

--- a/docs/references/naming-conventions.md
+++ b/docs/references/naming-conventions.md
@@ -31,8 +31,19 @@ inside `utils` do not repeat a `Utils` suffix.
 
 When a React component needs different iOS and Android implementations, split it into matching
 `Name.ios.tsx` and `Name.android.tsx` files. Non-JSX modules use the corresponding `.ios.ts` and
-`.android.ts` suffixes. Keep shared types, APIs, and implementation in an unsuffixed file when both
-platform variants need them; Metro selects the platform file at build time.
+`.android.ts` suffixes. Place the complete platform family in a dedicated directory named after its
+shared stem instead of placing platform siblings alongside unrelated files:
+
+```text
+Name/
+├── Name.tsx
+├── Name.ios.tsx
+└── Name.android.tsx
+```
+
+Under `packages/**`, apply the package naming rule to both directory and file stems, for example
+`icon-glyph/icon-glyph.ios.tsx`. Keep shared types, APIs, and implementation in the same family
+directory when both platform variants need them; Metro selects the platform file at build time.
 
 ## Directories
 

--- a/docs/references/runtime-ownership.md
+++ b/docs/references/runtime-ownership.md
@@ -4,6 +4,32 @@ This reference defines ownership for long-lived resources, startup work, caller-
 cleanup.
 Terms follow [Domain Language](./domain-language.md).
 
+## Role Names
+
+Name an owner by who calls it and who controls its lifetime. A class that directly corresponds to a
+Cherry Desktop service keeps the upstream `XxxService` name and public methods. This includes
+`DbService`, `CacheService`, `PreferenceService`, persistence services, `DataApiService`,
+`AiService`, `McpRuntimeService`, `OAuthRuntimeService`, and `WebSearchService`.
+
+Use these roles for mobile-owned code:
+
+| Role | Use when the type is | Example |
+| --- | --- | --- |
+| `Module` | A frontend-visible workflow capability exposed through `Backend` | `ChatModule` |
+| `Runtime` | One app- or bootstrap-owned executor whose state spans calls or routes | `ChatRuntime` |
+| `Session` | One caller-owned isolated unit with explicit cancellation or disposal | `PaintingGenerationSession` |
+| `Client` | A boundary to one external account, protocol, or remote API | `PkceOAuthClient` |
+| `Adapter` | A translation boundary for a platform or SDK; a precise capability noun may stand alone | `DevicePermissions` |
+| `Manager` | A coordinator whose defining job is owning a homogeneous pool or registry | `ConnectionManager` |
+
+`Backend`, `BackendProvider`, and `useBackendModule()` are intentional aggregate and React
+integration names. Leaf workflows use `XxxModule`; do not add parallel `XxxBackend`, `XxxService`,
+and `XxxImpl` layers for the same operations. Factory-shaped modules use `createXxxModule()`.
+
+An app-owned runtime is created once by bootstrap and is not disposed by route or component
+unmount. A caller-owned session exposes its own lifecycle. Use `Manager` only for a real pool or
+registry; otherwise prefer a precise domain noun or a plain function. Do not use the `Impl` suffix.
+
 ## Principles
 
 - Mobile adopts the desktop lifecycle framework, service registry, and a mobile-specific phase pair;

--- a/docs/references/ui-components.md
+++ b/docs/references/ui-components.md
@@ -1,72 +1,47 @@
 # UI Components
 
-This reference defines Cherry Studio Mobile interaction component boundaries, button/control
-ownership, top navigation actions, and platform enhancement strategy. Terms follow
-[Domain Language](./domain-language.md).
+This reference defines current shared component ownership and platform boundaries. Follow
+[UI Development](../guides/ui-development.md) when creating or changing product UI.
 
-## Principles
+## Ownership
 
-- Product UI does not use React Native `Button` as the general button foundation.
-- Product buttons should move toward Cherry-owned or feature-local `Pressable` wrappers that centralize pressed, disabled, loading, hit slop, accessibility, and visual states.
-- Platform features are enhancements, not the base interaction contract. iOS Liquid Glass can enhance appearance, while Android and older iOS must keep equally usable fallbacks.
-- Expo Router / React Navigation top-bar buttons use `headerRight` / `headerLeft` with Cherry-owned content.
-- Product horizontal gestures must not start from Android system edge zones, so they do not steal platform-native back gestures.
+`@cherrystudio/ui/components` is the public entry point for reusable, platform-neutral product
+interaction components. The package currently owns buttons, fields, menus, sheets, composer parts,
+surfaces, loading states, tabs, sliders, switches, sections, portals, and related primitives. Its
+[package README](../../packages/ui/README.md) is the component API reference.
 
-## Current Component Layers
-
-`HeaderIconButton`:
-
-- Shared Android header icon button used by header adapters.
-- Wraps `Pressable`, accessibility role/label, disabled behavior, hit slop, and active opacity.
-- iOS header adapters currently use Expo Router `Stack.Toolbar` instead of this wrapper.
-
-Feature-local Pressable wrappers:
-
-- Settings, chat input, and provider/model screens still contain local `Pressable` controls.
-- Local wrappers are acceptable when the state and styling are feature-specific.
-- Repeated interaction behavior should be extracted into a shared wrapper before it spreads across modules.
-
-HeroUI and Expo UI controls:
-
-- The app uses `heroui-native` controls for some settings and search-field surfaces.
-- The app uses `@expo/ui` community menus directly and platform controls for native-feeling
-  surfaces; bottom sheets use the package-owned `@cherrystudio/ui/components` wrapper over
-  `@swmansion/react-native-bottom-sheet`. Its `PageTransition` gives multi-level sheet content one
-  depth-aware push/pop motion while features retain their own navigation state.
-- These libraries are component choices, not replacements for Cherry-owned product interaction rules.
-
-Planned shared wrappers:
-
-- `AppPressable`, `AppButton`, `IconButton`, and glass variants are not current shared components.
-- Add them only when they remove repeated behavior from multiple product modules.
-- If a glass variant is added, it must remain a visual enhancement with Android and older-iOS fallbacks.
-
-## React Native Button Boundary
-
-RN `Button` is acceptable for temporary code, demos, system examples, or non-product test screens. Product screens default away from it because it:
-
-- Has limited styling and is hard to align with Cherry's visual system.
-- Does not carry custom pressed/loading/disabled behavior well.
-- Is not a good entry point for Liquid Glass enhancement.
-- Has less controllable cross-platform behavior.
-
-## Top Navigation Actions
-
-Android top navigation actions use shared header wrappers and self-rendered headers where needed:
+Runtime component imports use that entry point so Metro does not traverse icon registries:
 
 ```tsx
-<HeaderIconButton accessibilityLabel={t('navigation.newChat')} onPress={openNewTopic}>
-  <SquarePenIcon className="size-6 text-foreground" strokeWidth={2} />
-</HeaderIconButton>
+import { Button, Section, TextField } from '@cherrystudio/ui/components';
 ```
 
-iOS header adapters currently use Expo Router `Stack.Toolbar`. The base capability must remain available on Android through app-owned components.
+`@cherrystudio/app-icons` owns the cross-platform icon registry. Feature code owns business state,
+translations, query behavior, and workflow-specific composition. A local `Pressable` wrapper is
+appropriate only while its interaction remains specific to that feature. Shared navigation and
+platform adapters may remain under `src/frontend/components` when their contract depends on app
+navigation rather than a general product control.
+
+Direct `heroui-native` and `@expo/ui` usage remains limited to capabilities whose native or
+third-party behavior is itself part of the contract. A package-owned CherryUI wrapper is the public
+surface once the app standardizes behavior around such a dependency.
+
+## Platform Boundaries
+
+- Platform features enhance the common interaction contract. iOS Liquid Glass may enhance
+  appearance; Android and older iOS retain a complete fallback.
+- Expo Router and React Navigation top-bar actions use `headerRight`, `headerLeft`, or
+  `Stack.Toolbar` with Cherry-owned content.
+- Android horizontal product gestures start outside system back-gesture edge zones.
+- React Native `Button` is reserved for temporary examples and non-product test screens. Product UI
+  uses CherryUI or a feature-owned `Pressable` while the interaction remains local.
 
 ## Acceptance
 
-- Every product button has accessibility state, and any disabled/loading behavior that the feature exposes.
-- Header buttons keep consistent tap targets on iOS and Android.
-- Buttons remain recognizable, tappable, and accessible when platform-specific enhancement is unavailable.
-- Icon buttons do not require nearby explanatory text to be understood. Ambiguous icons need a tooltip or menu context.
-- New repeated button variants should extend Cherry wrappers instead of repeating `Pressable` state logic inside feature components.
-- Swipe actions, carousels, and similar horizontal components must avoid Android system edge back areas.
+- Controls expose accessible labels, state, disabled/loading behavior, and usable touch targets.
+- Text scales and wraps without fixed dimensions clipping its content.
+- Platform enhancement failure leaves the control recognizable and usable.
+- Ambiguous icon-only actions provide an accessible label and tooltip or menu context where the
+  platform supports it.
+- Repeated product interaction behavior moves to CherryUI through the workflow in
+  [UI Development](../guides/ui-development.md).

--- a/packages/ai-runtime/AGENTS.md
+++ b/packages/ai-runtime/AGENTS.md
@@ -1,6 +1,8 @@
 # AI Runtime Instructions
 
-When changing this package or syncing desktop AI behavior, read [README.md](README.md), update the
-provenance evidence, and run `pnpm check` plus `pnpm ai-runtime:check --desktop-root <path>` from this
-directory. A port is trusted only while both gates pass. Keep platform behavior behind backend
-adapters and expose package behavior only through the five declared subpaths.
+When changing mapped or ported source, or changing behavior synchronized from Desktop, read
+[README.md](README.md), update the provenance evidence, and run `pnpm check` plus
+`pnpm ai-runtime:check --desktop-root <path>` from this directory. A port is trusted only while both
+gates pass. Other package changes use the relevant checks in
+[Testing And CI](../../docs/guides/testing-and-ci.md). Keep platform behavior behind backend adapters
+and expose package behavior only through the five declared subpaths.

--- a/packages/provider-registry/package.json
+++ b/packages/provider-registry/package.json
@@ -6,7 +6,6 @@
   "main": "src/index.ts",
   "module": "src/index.ts",
   "types": "src/index.ts",
-  "packageManager": "pnpm@10.27.0",
   "scripts": {
     "build": "tsdown",
     "dev": "tsc -w",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -55,6 +55,12 @@
       "skillPath": "plugins/expo/skills/expo-tailwind-setup/SKILL.md",
       "computedHash": "d39e806942fe880347f161056729b588a3cb0f1796270eebf52633fe11cfdce1"
     },
+    "gh-stack": {
+      "source": "github/gh-stack",
+      "sourceType": "github",
+      "skillPath": "skills/gh-stack/SKILL.md",
+      "computedHash": "213d3fe0b3dc87b453912b5a5947fd189a884e4a82ce41fe8ce6c16fb93cd8b3"
+    },
     "improve-react": {
       "source": "aidenybai/react-doctor",
       "sourceType": "github",
@@ -102,6 +108,12 @@
       "sourceType": "github",
       "skillPath": "plugins/expo/skills/upgrading-expo/SKILL.md",
       "computedHash": "2c65483a035341da654b92b130fd5b45690b139b624613dc94c414bae1067f6c"
+    },
+    "vercel-composition-patterns": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/composition-patterns/SKILL.md",
+      "computedHash": "575757e3e25761c8c562d6e395d29f0b76c98b1273c0bd72d88e6ab1bc9c7d42"
     },
     "vercel-react-native-skills": {
       "source": "vercel-labs/agent-skills",

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -29,5 +29,6 @@ preferences use `PreferenceClient`, and multi-step workflows use `BackendProvide
 `useBackendModule()`; concrete backend objects never enter frontend state.
 
 See [Architecture Overview](../../docs/references/architecture-overview.md),
+[Code Organization](../../docs/references/code-organization.md),
 [Runtime Ownership](../../docs/references/runtime-ownership.md), and
 [Naming Conventions](../../docs/references/naming-conventions.md).

--- a/src/frontend/components/README.md
+++ b/src/frontend/components/README.md
@@ -1,8 +1,8 @@
 # Component Module Conventions
 
-This directory follows the repository-wide
-[naming conventions](../../../docs/references/naming-conventions.md). The notes below are the local
-conventions for `src/frontend/components`.
+This directory follows repository-wide [Code Organization](../../../docs/references/code-organization.md)
+and [Naming Conventions](../../../docs/references/naming-conventions.md). The notes below define only
+the local import boundary and concrete module shape for `src/frontend/components`.
 
 `src/frontend/components` is for independently owned modules shared across screens or feature
 domains. Route-owned UI should live under `src/frontend/features` until a second independent owner

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -199,11 +199,8 @@ Do not restore these; their absence is the design, not a regression.
 
 ## Manual acceptance with agent-device
 
-Use the workspace Expo dev server on port `8084`.
-
-```bash
-agent-device open com.cherry-ai.cherry-studio-app --session chat-input --platform ios --device "iPhone 17 Pro" --relaunch
-```
+Provision the workspace simulator, Metro port, and agent-device session through
+[Parallel Device Testing](../../../../../docs/guides/parallel-device-testing.md).
 
 Then walk the contract above. The four items under "Not covered by tests" are mandatory; the rest are
 worth a pass whenever this directory changes shape.


### PR DESCRIPTION
## Summary

- reduce the root `AGENTS.md` to project-wide essentials and conditional documentation pointers
- split testing/CI, Git and stacked PRs, CherryUI composition, device isolation, naming, code organization, and runtime ownership into focused guides and references
- replace the Expo template README, align the repository on root `pnpm@11.8.0`, and register `gh-stack` plus `vercel-composition-patterns`

## Validation

- `pnpm docs:check-links`
- `pnpm skills:check`
- `pnpm lint` (passes with existing warnings)
- `pnpm format:check`
- `pnpm typecheck`
- `git diff --check upstream/v0.2...HEAD`
- local Conductor lifecycle tests: 5 passing `node --test` cases plus a real prepare/status/cleanup cycle with no simulator, metadata, or allocated-port residue

The full local `pnpm test` was intentionally not run. The complete suite remains the remote CI gate after this draft is marked ready.

## Follow-ups

- move any behavior protected by `ModelSettingsScreen.test.tsx` to lower-level tests, then remove the screen render suite
- handle existing non-kebab-case package filenames as a dedicated migration rather than incidental churn

The Conductor simulator and port lifecycle automation is machine-local under `.conductor/settings.local.toml` and is not part of this repository diff.
