### PR TITLE
fix(chat): header 助手按钮在话题加载完之前不再消失

### DIFF
--- a/src/frontend/components/headers/MainHeader/MainHeaderAssistantButton.tsx
+++ b/src/frontend/components/headers/MainHeader/MainHeaderAssistantButton.tsx
@@ -12,7 +12,15 @@ export function useMainHeaderAssistant() {
     topicId?: string;
   }>();
   const topic = useTopic(topicId);
-  const currentAssistantId = topicId ? topic.data?.assistantId : assistantId;
+  // 话题一旦解析出来就以它为准，但在那之前**不放弃 URL 上还带着的 assistantId**。
+  // 硬切（`topicId ? topic.data?.assistantId : assistantId`）会让助手按钮在话题加载完之前
+  // 变成 null：新话题发出第一条消息时导航先于话题可读，按钮因此整个消失再回来，iOS 上
+  // toolbar 的 children 数量从 2 掉到 1，两个按钮一起走原生重建（实测淡出再淡入 600ms）。
+  //
+  // 回落值不会是别的助手：`open-topic` 走 `setParams({ topicId })`，assistantId 原样留在
+  // URL 上且就是这个话题的助手；而从话题列表进来那条路带的 params 只有 topicId，回落到
+  // undefined，与从前一致。
+  const currentAssistantId = (topicId ? topic.data?.assistantId : undefined) ?? assistantId;
   const { assistant } = useAssistantApiById(currentAssistantId);
 
   const openNewTopic = useCallback(() => {

--- a/src/frontend/components/headers/MainHeader/__tests__/MainHeaderAssistantButton.test.tsx
+++ b/src/frontend/components/headers/MainHeader/__tests__/MainHeaderAssistantButton.test.tsx
@@ -114,6 +114,22 @@ describe('MainHeaderAssistantButton', () => {
     });
   });
 
+  it('keeps the route assistant while the topic is still loading', async () => {
+    // 发出新话题第一条消息时导航先于话题可读：`topicId` 已经在 URL 上、`useTopic` 还没
+    // 返回。按钮此刻若消失，iOS 的 toolbar 会连着旁边那个按钮一起原生重建。
+    mockAssistantId = 'assistant-1';
+    mockTopicAssistantId = undefined;
+    mockTopicId = 'topic-1';
+
+    await act(async () => {
+      renderer = create(<Harness />);
+    });
+
+    expect(
+      renderer?.root.findByProps({ testID: 'current-assistant-button' }).props.accessibilityLabel,
+    ).toBe('Peanut');
+  });
+
   it('starts a new topic with the current topic assistant', async () => {
     await act(async () => {
       renderer = create(<NewTopicHarness />);


### PR DESCRIPTION
## 这条 PR 做什么

让 header 的助手按钮在新话题导航期间不再消失。

## 根因

`MainHeaderAssistantButton.tsx` 里这一行是硬切：

```ts
const currentAssistantId = topicId ? topic.data?.assistantId : assistantId;
```

`topicId` 一出现就立刻放弃 URL 上**还能用**的 `assistantId`，去等一个还在 fetch 的值。
新话题发出第一条消息时导航先于话题可读，于是 `assistant` 在那几百毫秒里是 `null`。

iOS 上后果被放大：`Stack.Toolbar` 的 children 数量从 2 掉到 1，**两个按钮一起走原生重建**
——不是只少一个，是整组淡出再淡入。

## 实测

逐帧读 header 区（y 55–105）的暗像素，导航窗口内：

| | 改前（`reorder-final`） | 改后（`hdrfix`） |
| --- | --- | --- |
| 轨迹 | 437 → 261 → **110**（几乎全空）→ 398 → 520 | **461 → 464** |
| 持续 | ~600ms | 无变化，601 帧全程稳定 |

抽帧目视确认：六帧跨越整个导航窗口，两个按钮始终清晰、位置不动、无淡入淡出。

## 为什么回落是安全的

回落值不会是**别的**助手：

- `open-topic` 走 `router.setParams({ topicId })`，是合并语义 → `assistantId` 原样留在 URL
  上，而它就是这个话题的助手（话题正是用它建的）。
- 从话题列表进来那条路（`TopicList.tsx` 的 `{ pathname: '/topics', params: { topicId } }`）
  带的 params 只有 `topicId`，回落到 `undefined`，与从前完全一致。

新增测试 `keeps the route assistant while the topic is still loading` 钉住这个行为。

## 备注

`ChatInput` 里有同一个模式的数据源硬切（`selectedAssistantId`），这次没有一并改——它的
症状是模型胶囊闪一下，不涉及原生 toolbar 重建，值得单独判断。
