### PR TITLE
fix(chat): normalize iOS images and pending loader

### DIFF
--- a/src/backend/ai/messages/__tests__/attachmentRouting.test.ts
+++ b/src/backend/ai/messages/__tests__/attachmentRouting.test.ts
@@ -122,16 +122,35 @@ describe('resolveUIMessageFileUrls', () => {
     ]);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
   });
+
+  test('drops unsupported image formats before building an AI request', async () => {
+    testState.contents.set('file:///managed/photo.heic', {
+      base64: 'heic-data',
+      type: 'image/heic',
+    });
+
+    const [message] = await resolveUIMessageFileUrls(
+      [createMessage([filePart('file:///legacy/photo.heic', 'entry-1', 'image/heic')])],
+      async () => 'file:///managed/photo.heic',
+    );
+
+    expect(message.parts).toEqual([]);
+    expect(testState.reads).toEqual([]);
+  });
 });
 
 function createMessage(parts: UIMessage['parts']): UIMessage {
   return { id: 'message-1', parts, role: 'user' };
 }
 
-function filePart(url: string, fileEntryId: string): UIMessage['parts'][number] {
+function filePart(
+  url: string,
+  fileEntryId: string,
+  mediaType = 'application/pdf',
+): UIMessage['parts'][number] {
   return {
-    filename: 'brief.pdf',
-    mediaType: 'application/pdf',
+    filename: url.split('/').pop() ?? 'attachment',
+    mediaType,
     providerMetadata: { cherry: { fileEntryId } },
     type: 'file',
     url,

--- a/src/backend/ai/messages/fileProcessor.ts
+++ b/src/backend/ai/messages/fileProcessor.ts
@@ -11,6 +11,11 @@ import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 import { File } from 'expo-file-system';
 
 import { loggerService } from '@/shared/core/logger/LoggerService';
+import {
+  imageMediaTypeFromExtension,
+  isAiSupportedImageMediaType,
+  isImageFileExtension,
+} from '@/shared/utils/imageFileTypes';
 
 const FALLBACK_MEDIA_TYPE = 'application/octet-stream';
 const logger = loggerService.withContext('fileProcessor');
@@ -63,9 +68,33 @@ async function readLocalFilePart(
 ): Promise<FileUIPart | null> {
   try {
     const file = new File(uri);
-    const base64 = await file.base64();
     const mediaType = file.type || part.mediaType || FALLBACK_MEDIA_TYPE;
-    return { ...part, mediaType, url: `data:${mediaType};base64,${base64}` };
+    const extension = part.filename?.trim().split('.').pop()?.toLowerCase();
+    const isImage =
+      mediaType.startsWith('image/') ||
+      part.mediaType.startsWith('image/') ||
+      isImageFileExtension(extension);
+    const imageMediaType = mediaType.startsWith('image/')
+      ? mediaType
+      : part.mediaType.startsWith('image/')
+        ? part.mediaType
+        : imageMediaTypeFromExtension(extension);
+
+    if (isImage && !isAiSupportedImageMediaType(imageMediaType)) {
+      logger.warn('Unsupported image attachment was excluded from AI request', {
+        fileEntryId,
+        mediaType: imageMediaType,
+      });
+      return null;
+    }
+
+    const resolvedMediaType = isImage ? imageMediaType : mediaType;
+    const base64 = await file.base64();
+    return {
+      ...part,
+      mediaType: resolvedMediaType,
+      url: `data:${resolvedMediaType};base64,${base64}`,
+    };
   } catch (error) {
     logger.warn('Failed to read attachment for AI request', toError(error), {
       fileEntryId,

--- a/src/frontend/components/composer/components/ComposerMenu.tsx
+++ b/src/frontend/components/composer/components/ComposerMenu.tsx
@@ -68,6 +68,8 @@ export function ComposerMenu({ children }: PropsWithChildren) {
       allowsMultipleSelection: true,
       mediaTypes: ['images'],
       orderedSelection: true,
+      preferredAssetRepresentationMode:
+        ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
       quality: 1,
       selectionLimit: COMPOSER_PHOTO_SELECTION_LIMIT,
     });

--- a/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
+++ b/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
@@ -137,6 +137,18 @@ describe('useManagedComposerAttachments', () => {
       { name: 'ready.pdf', status: 'ready' },
     ]);
   });
+
+  it('rejects unsupported images before importing them', async () => {
+    await renderHook([imageSource('initial.heic', 'image/heic')]);
+
+    await act(async () => snapshot?.addAttachments([imageSource('file.avif', 'image/avif')]));
+
+    expect(snapshot?.attachments).toEqual([]);
+    expect(mockCreateInternalEntry).not.toHaveBeenCalled();
+    expect(mockAlertShow).toHaveBeenCalledWith({
+      title: 'chat.attachments.unsupportedImageFormat',
+    });
+  });
 });
 
 function Probe({
@@ -163,6 +175,16 @@ function source(name: string): ComposerAttachmentSource {
     id: `source:${name}`,
     kind: 'file',
     mediaType: 'application/pdf',
+    name,
+    uri: `file:///source/${name}`,
+  };
+}
+
+function imageSource(name: string, mediaType: string): ComposerAttachmentSource {
+  return {
+    id: `image:${name}`,
+    kind: 'image',
+    mediaType,
     name,
     uri: `file:///source/${name}`,
   };

--- a/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
+++ b/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
@@ -12,6 +12,7 @@ import {
   type ComposerAttachmentReady,
   type ComposerAttachmentSource,
   type ComposerInitialAttachment,
+  isComposerAttachmentSupported,
   isComposerAttachmentReady,
   removeComposerAttachment,
 } from '../utils/composerAttachments';
@@ -27,13 +28,17 @@ export function useManagedComposerAttachments(
   const { t } = useTranslation();
   const { alert } = useAlert();
   const file = useBackendModule('file');
-  const initialAttachmentsRef = useRef(initialAttachments);
+  const [initialAttachmentState] = useState(() => {
+    const accepted = initialAttachments.filter(isComposerAttachmentSupported);
+    return { accepted, rejectedCount: initialAttachments.length - accepted.length };
+  });
+  const didReportRejectedInitialAttachmentsRef = useRef(false);
   const didImportInitialAttachmentsRef = useRef(false);
   const isMountedRef = useRef(true);
   const importTokensRef = useRef(new Map<string, symbol>());
   const cancelledImportTokensRef = useRef(new Set<symbol>());
   const [attachments, setAttachmentState] = useState<ComposerAttachmentDraft[]>(() =>
-    initialAttachments.map((attachment) =>
+    initialAttachmentState.accepted.map((attachment) =>
       isComposerAttachmentReady(attachment)
         ? attachment
         : { ...attachment, status: 'importing' as const },
@@ -133,8 +138,12 @@ export function useManagedComposerAttachments(
 
   const addAttachments = useCallback(
     (nextAttachments: ComposerAttachmentDraft[]) => {
+      const supportedAttachments = nextAttachments.filter(isComposerAttachmentSupported);
+      if (supportedAttachments.length < nextAttachments.length) {
+        alert.show({ title: t('chat.attachments.unsupportedImageFormat') });
+      }
       const seenIds = new Set(attachmentsRef.current.map((attachment) => attachment.id));
-      const accepted = nextAttachments.filter((attachment) => {
+      const accepted = supportedAttachments.filter((attachment) => {
         if (seenIds.has(attachment.id)) return false;
         seenIds.add(attachment.id);
         return true;
@@ -153,7 +162,7 @@ export function useManagedComposerAttachments(
       commitAttachments(appendComposerAttachments(attachmentsRef.current, staged));
       if (sources.length > 0) void importAttachments(sources);
     },
-    [commitAttachments, importAttachments],
+    [alert, commitAttachments, importAttachments, t],
   );
 
   const removeAttachment = useCallback(
@@ -187,9 +196,16 @@ export function useManagedComposerAttachments(
 
   useEffect(() => {
     isMountedRef.current = true;
+    if (
+      initialAttachmentState.rejectedCount > 0 &&
+      !didReportRejectedInitialAttachmentsRef.current
+    ) {
+      didReportRejectedInitialAttachmentsRef.current = true;
+      alert.show({ title: t('chat.attachments.unsupportedImageFormat') });
+    }
     if (!didImportInitialAttachmentsRef.current) {
       didImportInitialAttachmentsRef.current = true;
-      const sources = initialAttachmentsRef.current.filter(
+      const sources = initialAttachmentState.accepted.filter(
         (attachment): attachment is ComposerAttachmentSource =>
           !isComposerAttachmentReady(attachment),
       );
@@ -199,7 +215,7 @@ export function useManagedComposerAttachments(
     return () => {
       isMountedRef.current = false;
     };
-  }, [importAttachments]);
+  }, [alert, importAttachments, initialAttachmentState, t]);
 
   return useMemo(
     () => ({

--- a/src/frontend/components/composer/utils/__tests__/composerAttachments.test.ts
+++ b/src/frontend/components/composer/utils/__tests__/composerAttachments.test.ts
@@ -11,6 +11,7 @@ import {
   createPhotoAttachmentDraft,
   hasComposerSendableContent,
   hasImportingComposerAttachments,
+  isComposerAttachmentSupported,
   isComposerAttachmentReady,
   isComposerImageFileName,
   isComposerImageMediaType,
@@ -107,7 +108,25 @@ describe('composer attachments', () => {
         name: 'photo.webp',
         uri: 'file://photo.webp',
       }),
-    ).toMatchObject({ kind: 'image', mediaType: 'image/*' });
+    ).toMatchObject({ kind: 'image', mediaType: 'image/webp' });
+  });
+
+  test('allows only model-supported image attachment formats', () => {
+    expect(
+      isComposerAttachmentSupported(
+        createPhotoAttachmentDraft({ fileName: 'photo.jpg', id: 'jpg', uri: 'file://photo.jpg' }),
+      ),
+    ).toBe(true);
+    expect(
+      isComposerAttachmentSupported(
+        createDocumentAttachmentDraft({
+          lastModified: 0,
+          mimeType: 'image/heic',
+          name: 'photo.heic',
+          uri: 'file://photo.heic',
+        }),
+      ),
+    ).toBe(false);
   });
 
   test('classifies non-image documents as file attachments', () => {

--- a/src/frontend/components/composer/utils/composerAttachments.ts
+++ b/src/frontend/components/composer/utils/composerAttachments.ts
@@ -3,7 +3,11 @@ import type { CherryMessagePart } from '@cherrystudio/universal/data/types/messa
 import { withCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 import type { DocumentPickerAsset } from 'expo-document-picker';
 
-import { imageMediaTypeFromExtension, isImageFileExtension } from '@/shared/utils/imageFileTypes';
+import {
+  imageMediaTypeFromExtension,
+  isAiSupportedImageMediaType,
+  isImageFileExtension,
+} from '@/shared/utils/imageFileTypes';
 
 export type ComposerAttachmentKind = 'file' | 'image';
 
@@ -44,7 +48,6 @@ type PhotoAttachmentInput = {
   uri: string;
 };
 
-const fallbackImageMediaType = 'image/*';
 const fallbackFileMediaType = 'application/octet-stream';
 const fallbackImageName = 'Image';
 const fallbackFileName = 'File';
@@ -127,15 +130,24 @@ export function createDocumentAttachmentDraft(
 ): ComposerAttachmentSource {
   const mediaType = asset.mimeType ?? fallbackFileMediaType;
   const isImage = isComposerImageMediaType(mediaType) || isComposerImageFileName(asset.name);
+  const extension = asset.name.trim().split('.').pop()?.toLowerCase();
+  const resolvedMediaType =
+    isImage && mediaType === fallbackFileMediaType
+      ? imageMediaTypeFromExtension(extension)
+      : mediaType;
 
   return {
     id: getFileAttachmentId(asset.uri),
     kind: isImage ? 'image' : 'file',
-    mediaType: isImage && mediaType === fallbackFileMediaType ? fallbackImageMediaType : mediaType,
+    mediaType: resolvedMediaType,
     name: asset.name || fallbackFileName,
     size: asset.size,
     uri: asset.uri,
   };
+}
+
+export function isComposerAttachmentSupported(attachment: ComposerAttachmentDraft): boolean {
+  return attachment.kind !== 'image' || isAiSupportedImageMediaType(attachment.mediaType);
 }
 
 export function getPhotoAttachmentId(photoId: string) {

--- a/src/frontend/components/messagePresentation/messageRow/components/AssistantMessageRow.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/AssistantMessageRow.tsx
@@ -1,4 +1,4 @@
-import { PrismSweep } from '@cherrystudio/ui/components';
+import { DotMatrixSquare20 } from '@cherrystudio/ui/components';
 import Animated from 'react-native-reanimated';
 
 import { MessageStatusRow, StatusRowTextFloor } from '../../components/MessageStatusRow';
@@ -21,7 +21,7 @@ export function AssistantMessageRow({ message }: AssistantMessageRowProps) {
         // 这一行不含文字，所以要自己撑到一行正文的高度——否则只有 20px 的圆点撑高，比接下来
         // 顶替它的思考行/工具行/正文矮 4px，切换那一帧整条消息在锚点正下方跳一下（48→52）。
         <MessageStatusRow>
-          <PrismSweep active />
+          <DotMatrixSquare20 active size={20} />
           <StatusRowTextFloor />
         </MessageStatusRow>
       ) : (

--- a/src/frontend/components/messagePresentation/messageRow/components/__tests__/AssistantMessageRow.test.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/__tests__/AssistantMessageRow.test.tsx
@@ -4,14 +4,14 @@ import type { MessagePresentationItem } from '../../../types';
 import { AssistantMessageRow } from '../AssistantMessageRow';
 
 const mockMessageParts = jest.fn((_props: { message: MessagePresentationItem }) => null);
-const mockPrismSweep = jest.fn((_props: { active: boolean }) => null);
+const mockDotMatrixSquare20 = jest.fn((_props: { active: boolean; size: number }) => null);
 
 jest.mock('../../../messageContent', () => ({
   MessageParts: (props: { message: MessagePresentationItem }) => mockMessageParts(props),
 }));
 
 jest.mock('@cherrystudio/ui/components', () => ({
-  PrismSweep: (props: { active: boolean }) => mockPrismSweep(props),
+  DotMatrixSquare20: (props: { active: boolean; size: number }) => mockDotMatrixSquare20(props),
 }));
 
 // 真模块在 jest 下会去装 worklets 的原生 unpacker 并崩掉，本套件只关心渲染出什么。
@@ -52,7 +52,7 @@ describe('AssistantMessageRow', () => {
       renderer = create(<AssistantMessageRow message={createAssistantMessage('pending')} />);
     });
 
-    expect(mockPrismSweep).toHaveBeenCalledWith({ active: true });
+    expect(mockDotMatrixSquare20).toHaveBeenCalledWith({ active: true, size: 20 });
     expect(mockMessageParts).not.toHaveBeenCalled();
   });
 
@@ -64,6 +64,6 @@ describe('AssistantMessageRow', () => {
     });
 
     expect(mockMessageParts).toHaveBeenCalledWith({ message });
-    expect(mockPrismSweep).not.toHaveBeenCalled();
+    expect(mockDotMatrixSquare20).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/features/paintings/DrawingList.tsx
+++ b/src/frontend/features/paintings/DrawingList.tsx
@@ -123,6 +123,8 @@ export function DrawingList() {
         allowsMultipleSelection: true,
         mediaTypes: ['images'],
         orderedSelection: true,
+        preferredAssetRepresentationMode:
+          ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
         quality: 1,
         selectionLimit: COMPOSER_PHOTO_SELECTION_LIMIT,
       });

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -112,6 +112,7 @@
   "chat.attachments.image": "Image attachment",
   "chat.attachments.importFailed_one": "Could not add {{count}} attachment.",
   "chat.attachments.importFailed_other": "Could not add {{count}} attachments.",
+  "chat.attachments.unsupportedImageFormat": "Only JPEG, PNG, GIF, and WebP images are supported.",
   "chat.default.description": "Hello, I'm Default Assistant. You can start chatting with me right away",
   "chat.default.name": "Default Assistant",
   "chat.default.topic.name": "Default Topic",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -111,6 +111,7 @@
   "chat.assistant.edit": "编辑助手",
   "chat.attachments.image": "图片附件",
   "chat.attachments.importFailed": "有 {{count}} 个附件导入失败。",
+  "chat.attachments.unsupportedImageFormat": "仅支持 JPEG、PNG、GIF 和 WebP 格式的图片。",
   "chat.default.description": "你好，我是默认助手。你可以立刻开始跟我聊天",
   "chat.default.name": "默认助手",
   "chat.default.topic.name": "默认话题",

--- a/src/shared/utils/__tests__/imageFileTypes.test.ts
+++ b/src/shared/utils/__tests__/imageFileTypes.test.ts
@@ -1,6 +1,8 @@
 import {
+  AI_SUPPORTED_IMAGE_MEDIA_TYPES,
   generatedImageExtension,
   imageMediaTypeFromExtension,
+  isAiSupportedImageMediaType,
   isImageFileExtension,
 } from '../imageFileTypes';
 
@@ -25,5 +27,17 @@ describe('image file types', () => {
     expect(generatedImageExtension('unknown')).toBe('png');
     expect(isImageFileExtension('pdf')).toBe(false);
     expect(imageMediaTypeFromExtension(null)).toBe('image/*');
+  });
+
+  it('recognizes only model-supported image media types', () => {
+    expect(AI_SUPPORTED_IMAGE_MEDIA_TYPES).toEqual([
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ]);
+    expect(isAiSupportedImageMediaType('IMAGE/JPEG')).toBe(true);
+    expect(isAiSupportedImageMediaType('image/heic')).toBe(false);
+    expect(isAiSupportedImageMediaType('image/*')).toBe(false);
   });
 });

--- a/src/shared/utils/imageFileTypes.ts
+++ b/src/shared/utils/imageFileTypes.ts
@@ -8,6 +8,13 @@ const imageFileTypes = [
   { extensions: ['webp'], mediaType: 'image/webp', outputExtension: 'webp' },
 ] as const;
 
+export const AI_SUPPORTED_IMAGE_MEDIA_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+] as const;
+
 type ImageFileType = (typeof imageFileTypes)[number];
 
 const imageFileTypeByExtension = new Map<string, ImageFileType>(
@@ -18,6 +25,7 @@ const imageFileTypeByExtension = new Map<string, ImageFileType>(
 const imageFileTypeByMediaType = new Map<string, ImageFileType>(
   imageFileTypes.map((fileType) => [fileType.mediaType, fileType] as const),
 );
+const aiSupportedImageMediaTypes = new Set<string>(AI_SUPPORTED_IMAGE_MEDIA_TYPES);
 
 export function isImageFileExtension(extension: string | null | undefined): boolean {
   return extension ? imageFileTypeByExtension.has(extension.toLowerCase()) : false;
@@ -27,6 +35,10 @@ export function imageMediaTypeFromExtension(extension: string | null | undefined
   return extension
     ? (imageFileTypeByExtension.get(extension.toLowerCase())?.mediaType ?? 'image/*')
     : 'image/*';
+}
+
+export function isAiSupportedImageMediaType(mediaType: string | null | undefined): boolean {
+  return mediaType ? aiSupportedImageMediaTypes.has(mediaType.toLowerCase()) : false;
 }
 
 export function generatedImageExtension(mediaType: string): string {


### PR DESCRIPTION
## Summary
- transcode iOS photo-picker assets to compatible formats and allow only JPEG, PNG, GIF, and WebP images
- reject unsupported image attachments at import and AI request boundaries, including file uploads
- replace the empty pending assistant indicator with the 20pt dot matrix loader
- add regression coverage for attachment validation, MIME routing, and pending rendering

## Validation
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- 5 focused Jest suites (37 tests)