### PR TITLE
fix(chat-input): stabilize attachment sending

### DIFF
--- a/src/frontend/components/composer/README.md
+++ b/src/frontend/components/composer/README.md
@@ -65,8 +65,9 @@ Sending. Trim, clear before awaiting, restore the draft *and* the attachments if
 it rejects, toast, log, and the un-animated keyboard dismissal — that is a
 protocol, not a part, and two screens assembling it separately would be two
 implementations of it. It lives in `ComposerSurface`, which is what renders the
-surface, so there is no way to compose a composer that skips it. Pasting is
-baked into `ComposerField` for the same reason.
+surface, so there is no way to compose a composer that skips it. A synchronous
+in-flight lock also prevents a repeated gesture from snapshotting and restoring
+the same draft twice. Pasting is baked into `ComposerField` for the same reason.
 
 The full checklist for it is the behaviour contract in
 `src/frontend/features/chat/input/README.md` — that is the screen you actually
@@ -95,10 +96,16 @@ walk to verify it.
 
 ## Behavior notes
 
-- The ＋ menu takes the keyboard down but leaves the field first responder, so
-  iOS restores the keyboard the instant the menu closes. Pickers and settings
-  surfaces blur via `useComposerFieldDismiss`; the chat effort slider instead
+- Opening the ＋ menu leaves the keyboard and field focus unchanged so its
+  portalled panel stays anchored to the trigger. Camera, photo, and file rows
+  close the menu, await `useComposerFieldDismiss()`, and only then open their
+  system picker. Success and cancellation both return with the keyboard closed;
+  caller-owned tool rows do not dismiss or blur. The chat effort slider also
   keeps focus and covers the live keyboard.
+- Transient attachments render their own progress tile while they are imported
+  into managed storage. Any importing attachment disables send; text editing,
+  removal, and tools remain available. Import timing logs contain only kind,
+  size, result, and duration.
 - The i18n keys are still under `chat.*`. Two of them (`chat.media.camera`,
   `chat.media.photos`) are shared with the settings screens, so a `composer.*`
   namespace would fork strings rather than move them.

--- a/src/frontend/components/composer/components/ComposerAttachments.tsx
+++ b/src/frontend/components/composer/components/ComposerAttachments.tsx
@@ -14,11 +14,14 @@ export function ComposerAttachments() {
   const { attachments } = useComposerState();
   const { removeAttachment } = useComposerActions();
 
+  // A collapsed row keeps its last frame mounted while it animates out. File
+  // previews can keep that native frame visible after the composer state has
+  // already cleared, so the empty attachment row must leave the tree entirely.
+  if (attachments.length === 0) return null;
+
   return (
     <Composer.Collapsible style={attachmentRowStyle}>
-      {attachments.length > 0 ? (
-        <ComposerAttachmentStrip attachments={attachments} onAttachmentRemove={removeAttachment} />
-      ) : null}
+      <ComposerAttachmentStrip attachments={attachments} onAttachmentRemove={removeAttachment} />
     </Composer.Collapsible>
   );
 }

--- a/src/frontend/components/composer/components/ComposerMenu.tsx
+++ b/src/frontend/components/composer/components/ComposerMenu.tsx
@@ -9,6 +9,7 @@ import { View } from 'react-native';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 
 import { useComposerActions } from '../context/ComposerProvider';
+import { useComposerFieldDismiss } from '../hooks/useComposerFieldDismiss';
 import {
   COMPOSER_PHOTO_SELECTION_LIMIT,
   createCameraAttachmentDraft,
@@ -26,20 +27,25 @@ const logger = loggerService.withContext('ComposerMenu');
  * `children` are `Composer.Menu.Item`s — chat puts its tools there; painting
  * has nothing to add, so its menu is media only.
  *
- * Opening it leaves the keyboard **up**. It used to take the keyboard down so
+ * Opening it leaves the keyboard **up**. Choosing camera, photos, or files
+ * closes the menu, dismisses and blurs the field, then opens the system picker;
+ * caller-owned tool rows only close the menu and keep the input context live.
+ *
+ * The menu used to take the keyboard down when it opened so
  * the panel could grow into that space, but the panel is portalled and anchored
  * to where the trigger was measured *before* the dismissal — so the composer
  * dropped ~290pt while the panel stayed put, and the menu ended up floating in
  * the middle of the screen with nothing under it. The panel grows upward out of
  * the ＋ button and clears the keyboard on its own, so it never needed that
- * space. Leaving the keyboard alone also means there is nothing to restore when
- * the menu closes.
+ * space.
  */
 export function ComposerMenu({ children }: PropsWithChildren) {
   const { t } = useTranslation();
   const { addAttachments } = useComposerActions();
+  const dismissField = useComposerFieldDismiss();
 
   const openCamera = useCallback(async () => {
+    await dismissField();
     const permission = await ImagePicker.requestCameraPermissionsAsync();
 
     if (!permission.granted) {
@@ -53,8 +59,9 @@ export function ComposerMenu({ children }: PropsWithChildren) {
     }
 
     addAttachments(result.assets.map((asset) => createCameraAttachmentDraft({ uri: asset.uri })));
-  }, [addAttachments]);
+  }, [addAttachments, dismissField]);
   const openPhotoLibrary = useCallback(async () => {
+    await dismissField();
     // `false` means "don't ask for write access". Limited access needs no
     // special handling here: the picker runs out of process and returns what
     // was chosen in it, whether or not the app can see the rest of the library.
@@ -93,8 +100,9 @@ export function ComposerMenu({ children }: PropsWithChildren) {
         };
       }),
     );
-  }, [addAttachments]);
+  }, [addAttachments, dismissField]);
   const openDocumentPicker = useCallback(async () => {
+    await dismissField();
     const result = await DocumentPicker.getDocumentAsync({
       copyToCacheDirectory: true,
       multiple: true,
@@ -106,7 +114,7 @@ export function ComposerMenu({ children }: PropsWithChildren) {
     }
 
     addAttachments(result.assets.map(createDocumentAttachmentDraft));
-  }, [addAttachments]);
+  }, [addAttachments, dismissField]);
   // A picker that fails to open leaves no trace otherwise: the menu has already
   // closed, so the gesture just looks ignored.
   const present = useCallback((label: string, open: () => Promise<void>) => {

--- a/src/frontend/components/composer/components/ComposerSurface.tsx
+++ b/src/frontend/components/composer/components/ComposerSurface.tsx
@@ -1,6 +1,6 @@
 import { Composer } from '@cherrystudio/ui/components';
 import { useToast } from 'heroui-native/toast';
-import { type PropsWithChildren, useCallback } from 'react';
+import { type PropsWithChildren, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KeyboardController } from 'react-native-keyboard-controller';
 
@@ -52,8 +52,21 @@ export function ComposerSurface({
   const { toast } = useToast();
   const { attachments, draft } = useComposerState();
   const { clearAttachments, setAttachments, setDraft } = useComposerActions();
+  const activeSendAttemptIdRef = useRef<number | null>(null);
+  const nextSendAttemptIdRef = useRef(0);
 
   const handleSend = useCallback(async () => {
+    if (activeSendAttemptIdRef.current !== null) {
+      logger.debug('Ignored duplicate message send', {
+        attemptId: activeSendAttemptIdRef.current,
+      });
+      return;
+    }
+
+    const attemptId = ++nextSendAttemptIdRef.current;
+    activeSendAttemptIdRef.current = attemptId;
+    logger.debug('Message send started', { attemptId });
+
     const draftSnapshot = draft;
     const attachmentSnapshot = [...attachments];
 
@@ -70,13 +83,18 @@ export function ComposerSurface({
     } catch (error) {
       // The toast is deliberately vague, so without this the failure leaves no
       // trace at all and there is nothing to go on when a send breaks on device.
-      logger.error('Message send failed', error instanceof Error ? error : { error });
+      logger.error('Message send failed', error instanceof Error ? error : { error }, {
+        attemptId,
+      });
       setDraft(draftSnapshot);
       setAttachments(attachmentSnapshot);
       toast.show({
         label: getSendErrorLabel?.(error) ?? t('chat.input.sendFailed'),
         variant: 'danger',
       });
+    } finally {
+      activeSendAttemptIdRef.current = null;
+      logger.debug('Message send finished', { attemptId });
     }
   }, [
     attachments,

--- a/src/frontend/components/composer/components/__tests__/ComposerMenu.test.tsx
+++ b/src/frontend/components/composer/components/__tests__/ComposerMenu.test.tsx
@@ -1,0 +1,245 @@
+import { Composer } from '@cherrystudio/ui/components';
+import { type ReactNode, useEffect } from 'react';
+import type { TextInput } from 'react-native';
+import { KeyboardController } from 'react-native-keyboard-controller';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import {
+  ComposerProvider,
+  useComposerMeta,
+  useComposerState,
+} from '../../context/ComposerProvider';
+import { ComposerMenu } from '../ComposerMenu';
+
+type MockMenuItemProps = {
+  label: string;
+  onPress: () => void;
+};
+
+const mockBlur = jest.fn();
+const mockFocus = jest.fn();
+const mockLaunchCamera = jest.fn();
+const mockLaunchImageLibrary = jest.fn();
+const mockPickDocument = jest.fn();
+const mockRequestCameraPermission = jest.fn();
+const mockRequestMediaLibraryPermission = jest.fn();
+const mockKeyboardDismiss = KeyboardController.dismiss as jest.MockedFunction<
+  typeof KeyboardController.dismiss
+>;
+let mockComposerState: ReturnType<typeof useComposerState> | undefined;
+
+jest.mock('@cherrystudio/app-icons', () => ({
+  CameraIcon: () => null,
+  FileIcon: () => null,
+  ImagesIcon: () => null,
+}));
+
+jest.mock('@cherrystudio/ui/components', () => {
+  const React = jest.requireActual('react');
+  const { Pressable, View } = jest.requireActual('react-native');
+
+  function MockMenu({ children }: { children?: ReactNode }) {
+    return React.createElement(View, null, children);
+  }
+
+  function MockMenuItem(props: MockMenuItemProps) {
+    return React.createElement(Pressable, {
+      accessibilityLabel: props.label,
+      onPress: props.onPress,
+    });
+  }
+
+  return { Composer: { Menu: Object.assign(MockMenu, { Item: MockMenuItem }) } };
+});
+
+jest.mock('expo-image-picker', () => ({
+  UIImagePickerPreferredAssetRepresentationMode: { Compatible: 'compatible' },
+  launchCameraAsync: (...args: unknown[]) => mockLaunchCamera(...args),
+  launchImageLibraryAsync: (...args: unknown[]) => mockLaunchImageLibrary(...args),
+  requestCameraPermissionsAsync: (...args: unknown[]) => mockRequestCameraPermission(...args),
+  requestMediaLibraryPermissionsAsync: (...args: unknown[]) =>
+    mockRequestMediaLibraryPermission(...args),
+}));
+
+jest.mock('expo-document-picker', () => ({
+  getDocumentAsync: (...args: unknown[]) => mockPickDocument(...args),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/shared/core/logger/LoggerService', () => ({
+  loggerService: {
+    withContext: () => ({ warn: jest.fn() }),
+  },
+}));
+
+describe('ComposerMenu', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockComposerState = undefined;
+    mockKeyboardDismiss.mockResolvedValue(undefined);
+    mockRequestCameraPermission.mockResolvedValue({ granted: true });
+    mockRequestMediaLibraryPermission.mockResolvedValue({ granted: true });
+    mockLaunchCamera.mockResolvedValue({ canceled: true });
+    mockLaunchImageLibrary.mockResolvedValue({ canceled: true });
+    mockPickDocument.mockResolvedValue({ canceled: true });
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('waits for field dismissal before opening the photo picker', async () => {
+    const dismissal = deferred<void>();
+    mockKeyboardDismiss.mockReturnValue(dismissal.promise);
+    render();
+
+    act(() => press('chat.media.photos'));
+
+    expect(mockKeyboardDismiss).toHaveBeenCalledTimes(1);
+    expect(mockBlur).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaLibraryPermission).not.toHaveBeenCalled();
+    expect(mockLaunchImageLibrary).not.toHaveBeenCalled();
+
+    await act(async () => {
+      dismissal.resolve();
+      await dismissal.promise;
+      await flushPromises();
+    });
+
+    expect(mockRequestMediaLibraryPermission).toHaveBeenCalledWith(false);
+    expect(mockLaunchImageLibrary).toHaveBeenCalledTimes(1);
+    expect(mockComposerState?.attachments).toEqual([]);
+    expect(mockFocus).not.toHaveBeenCalled();
+  });
+
+  it('waits for field dismissal before opening the camera and document pickers', async () => {
+    const cameraDismissal = deferred<void>();
+    const documentDismissal = deferred<void>();
+    mockKeyboardDismiss
+      .mockReturnValueOnce(cameraDismissal.promise)
+      .mockReturnValueOnce(documentDismissal.promise);
+    render();
+
+    act(() => press('chat.media.camera'));
+    expect(mockRequestCameraPermission).not.toHaveBeenCalled();
+    expect(mockLaunchCamera).not.toHaveBeenCalled();
+
+    await act(async () => {
+      cameraDismissal.resolve();
+      await cameraDismissal.promise;
+      await flushPromises();
+    });
+    expect(mockRequestCameraPermission).toHaveBeenCalledTimes(1);
+    expect(mockLaunchCamera).toHaveBeenCalledTimes(1);
+
+    act(() => press('chat.media.file'));
+    expect(mockPickDocument).not.toHaveBeenCalled();
+
+    await act(async () => {
+      documentDismissal.resolve();
+      await documentDismissal.promise;
+      await flushPromises();
+    });
+    expect(mockPickDocument).toHaveBeenCalledTimes(1);
+    expect(mockBlur).toHaveBeenCalledTimes(2);
+    expect(mockFocus).not.toHaveBeenCalled();
+  });
+
+  it('keeps the field blurred after a document is selected', async () => {
+    mockPickDocument.mockResolvedValue({
+      assets: [
+        {
+          mimeType: 'application/pdf',
+          name: 'notes.pdf',
+          size: 512,
+          uri: 'file:///source/notes.pdf',
+        },
+      ],
+      canceled: false,
+    });
+    render();
+
+    act(() => press('chat.media.file'));
+    await act(flushPromises);
+
+    expect(mockComposerState?.attachments).toEqual([
+      expect.objectContaining({
+        kind: 'file',
+        name: 'notes.pdf',
+        size: 512,
+        uri: 'file:///source/notes.pdf',
+      }),
+    ]);
+    expect(mockBlur).toHaveBeenCalledTimes(1);
+    expect(mockFocus).not.toHaveBeenCalled();
+  });
+
+  it('does not dismiss the field when a caller-owned tool is selected', () => {
+    const onToolPress = jest.fn();
+    render(<Composer.Menu.Item label="Web search" onPress={onToolPress} />);
+
+    act(() => press('Web search'));
+
+    expect(onToolPress).toHaveBeenCalledTimes(1);
+    expect(mockKeyboardDismiss).not.toHaveBeenCalled();
+    expect(mockBlur).not.toHaveBeenCalled();
+    expect(mockLaunchCamera).not.toHaveBeenCalled();
+    expect(mockLaunchImageLibrary).not.toHaveBeenCalled();
+    expect(mockPickDocument).not.toHaveBeenCalled();
+  });
+
+  function render(children?: ReactNode) {
+    act(() => {
+      renderer = create(
+        <ComposerProvider>
+          <FieldProbe />
+          <ComposerMenu>{children}</ComposerMenu>
+        </ComposerProvider>,
+      );
+    });
+  }
+
+  function press(label: string) {
+    const item = renderer?.root
+      .findAllByProps({ accessibilityLabel: label })
+      .find((node) => typeof node.props.onPress === 'function');
+
+    if (!item) throw new Error(`Missing menu item: ${label}`);
+    item.props.onPress();
+  }
+});
+
+function FieldProbe() {
+  const { inputRef } = useComposerMeta();
+  const composerState = useComposerState();
+
+  useEffect(() => {
+    mockComposerState = composerState;
+    inputRef.current = { blur: mockBlur, focus: mockFocus } as unknown as TextInput;
+    return () => {
+      inputRef.current = null;
+    };
+  }, [composerState, inputRef]);
+
+  return null;
+}
+
+function deferred<TValue>() {
+  let resolve!: (value: TValue) => void;
+  const promise = new Promise<TValue>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/src/frontend/components/composer/components/__tests__/ComposerSurface.test.tsx
+++ b/src/frontend/components/composer/components/__tests__/ComposerSurface.test.tsx
@@ -1,0 +1,254 @@
+import { type ReactNode, useEffect } from 'react';
+import { ActivityIndicator, Text } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import {
+  ComposerProvider,
+  useComposerActions,
+  useComposerState,
+} from '../../context/ComposerProvider';
+import type {
+  ComposerAttachmentDraft,
+  ComposerAttachmentReady,
+} from '../../utils/composerAttachments';
+import { ComposerAttachments } from '../ComposerAttachments';
+import { ComposerSurface } from '../ComposerSurface';
+
+type MockComposerProps = {
+  canSend?: boolean;
+  children?: ReactNode;
+  onSend: () => Promise<void> | void;
+  value: string;
+};
+
+const mockToastShow = jest.fn();
+const mockLoggerDebug = jest.fn();
+const mockLoggerError = jest.fn();
+let mockComposerProps: MockComposerProps | undefined;
+let mockComposerActions: ReturnType<typeof useComposerActions> | undefined;
+let mockComposerState: ReturnType<typeof useComposerState> | undefined;
+
+jest.mock('@cherrystudio/ui/components', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  function MockComposer(props: MockComposerProps) {
+    mockComposerProps = props;
+    return React.createElement(View, { testID: 'mock-composer' }, props.children);
+  }
+
+  function MockCollapsible({ children, ...props }: { children?: ReactNode }) {
+    return React.createElement(View, { ...props, testID: 'mock-collapsible' }, children);
+  }
+
+  return { Composer: Object.assign(MockComposer, { Collapsible: MockCollapsible }) };
+});
+
+jest.mock('@/frontend/components/FilePreview', () => ({ FilePreview: () => null }));
+
+jest.mock('heroui-native/toast', () => ({
+  useToast: () => ({ toast: { show: mockToastShow } }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/shared/core/logger/LoggerService', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: (...args: unknown[]) => mockLoggerDebug(...args),
+      error: (...args: unknown[]) => mockLoggerError(...args),
+    }),
+  },
+}));
+
+describe('ComposerSurface', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockComposerProps = undefined;
+    mockComposerActions = undefined;
+    mockComposerState = undefined;
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('accepts only one send while the current send promise is unsettled', async () => {
+    const pending = deferred<void>();
+    const onSend = jest.fn(() => pending.promise);
+    render(<ComposerSurface onSend={onSend} onStop={jest.fn()} streaming={false} />, 'hello');
+
+    let firstSend: Promise<void> | undefined;
+    let secondSend: Promise<void> | undefined;
+    act(() => {
+      firstSend = Promise.resolve(mockComposerProps?.onSend());
+      secondSend = Promise.resolve(mockComposerProps?.onSend());
+    });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(mockLoggerDebug).toHaveBeenCalledWith('Message send started', { attemptId: 1 });
+    expect(mockLoggerDebug).toHaveBeenCalledWith('Ignored duplicate message send', {
+      attemptId: 1,
+    });
+
+    await act(async () => {
+      pending.resolve();
+      await Promise.all([firstSend, secondSend]);
+    });
+  });
+
+  it('allows another send after the current attempt settles', async () => {
+    const onSend = jest.fn(async () => undefined);
+    render(
+      <ComposerSurface onSend={onSend} onStop={jest.fn()} streaming={false}>
+        <StateProbe />
+      </ComposerSurface>,
+      'first',
+    );
+
+    await act(async () => mockComposerProps?.onSend());
+    act(() => mockComposerActions?.setDraft('second'));
+    await act(async () => mockComposerProps?.onSend());
+
+    expect(onSend).toHaveBeenNthCalledWith(1, { attachments: [], text: 'first' });
+    expect(onSend).toHaveBeenNthCalledWith(2, { attachments: [], text: 'second' });
+    expect(mockLoggerDebug).toHaveBeenCalledWith('Message send started', { attemptId: 2 });
+  });
+
+  it('restores the exact draft and attachments once when sending fails', async () => {
+    const attachment = readyAttachment();
+    const onSend = jest.fn(async () => {
+      throw new Error('request was not accepted');
+    });
+    render(
+      <ComposerSurface onSend={onSend} onStop={jest.fn()} streaming={false}>
+        <StateProbe />
+      </ComposerSurface>,
+      '  hello  ',
+      [attachment],
+    );
+
+    await act(async () => mockComposerProps?.onSend());
+
+    expect(onSend).toHaveBeenCalledWith({ attachments: [attachment], text: 'hello' });
+    expect(mockComposerState).toEqual({ attachments: [attachment], draft: '  hello  ' });
+    expect(mockToastShow).toHaveBeenCalledTimes(1);
+    expect(mockToastShow).toHaveBeenCalledWith({
+      label: 'chat.input.sendFailed',
+      variant: 'danger',
+    });
+  });
+
+  it('unmounts the attachment row after a successful send clears it', async () => {
+    const attachment = readyAttachment();
+    const onSend = jest.fn(async () => undefined);
+    render(
+      <ComposerSurface onSend={onSend} onStop={jest.fn()} streaming={false}>
+        <ComposerAttachments />
+        <StateProbe />
+      </ComposerSurface>,
+      '',
+      [attachment],
+    );
+
+    expect(renderer?.root.findAllByProps({ testID: 'mock-collapsible' }).length).toBeGreaterThan(0);
+
+    await act(async () => mockComposerProps?.onSend());
+
+    expect(onSend).toHaveBeenCalledWith({ attachments: [attachment], text: '' });
+    expect(mockComposerState?.attachments).toEqual([]);
+    expect(renderer?.root.findAllByProps({ testID: 'mock-collapsible' })).toHaveLength(0);
+  });
+
+  it('shows attachment progress and blocks sending until the attachment is ready', () => {
+    const importingAttachment: ComposerAttachmentDraft = {
+      id: 'file:uploading',
+      kind: 'file',
+      mediaType: 'application/pdf',
+      name: 'uploading.pdf',
+      status: 'importing',
+      uri: 'file:///source/uploading.pdf',
+    };
+    render(
+      <ComposerSurface onSend={jest.fn(async () => undefined)} onStop={jest.fn()} streaming={false}>
+        <ComposerAttachments />
+        <StateProbe />
+      </ComposerSurface>,
+      'send later',
+      [importingAttachment],
+    );
+
+    expect(renderer?.root.findAllByType(ActivityIndicator)).toHaveLength(1);
+    expect(
+      renderer?.root.findAllByType(Text).some((node) => node.props.children === 'uploading.pdf'),
+    ).toBe(true);
+    expect(mockComposerProps?.canSend).toBe(false);
+
+    act(() => {
+      mockComposerActions?.setAttachments([
+        readyAttachment({
+          id: importingAttachment.id,
+          name: importingAttachment.name,
+        }),
+      ]);
+    });
+
+    expect(renderer?.root.findAllByType(ActivityIndicator)).toHaveLength(0);
+    expect(mockComposerProps?.canSend).toBe(true);
+  });
+
+  function render(
+    children: ReactNode,
+    initialDraft = '',
+    initialAttachments: readonly ComposerAttachmentDraft[] = [],
+  ) {
+    act(() => {
+      renderer = create(
+        <ComposerProvider initialAttachments={initialAttachments} initialDraft={initialDraft}>
+          {children}
+        </ComposerProvider>,
+      );
+    });
+  }
+});
+
+function StateProbe() {
+  const composerActions = useComposerActions();
+  const composerState = useComposerState();
+
+  useEffect(() => {
+    mockComposerActions = composerActions;
+    mockComposerState = composerState;
+  }, [composerActions, composerState]);
+
+  return null;
+}
+
+function readyAttachment(
+  overrides: Partial<ComposerAttachmentReady> = {},
+): ComposerAttachmentReady {
+  return {
+    fileEntryId: '00000000-0000-7000-8000-000000000001',
+    id: 'file:ready',
+    kind: 'file',
+    mediaType: 'application/pdf',
+    name: 'ready.pdf',
+    status: 'ready',
+    uri: 'file:///managed/ready.pdf',
+    ...overrides,
+  };
+}
+
+function deferred<TValue>() {
+  let resolve!: (value: TValue) => void;
+  const promise = new Promise<TValue>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}

--- a/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
+++ b/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
@@ -13,6 +13,8 @@ import { useManagedComposerAttachments } from '../useManagedComposerAttachments'
 const mockCreateInternalEntry = jest.fn();
 const mockDeleteIfUnreferenced = jest.fn(async () => true);
 const mockAlertShow = jest.fn();
+const mockLoggerDebug = jest.fn();
+const mockLoggerWarn = jest.fn();
 const mockFileModule = {
   createInternalEntry: mockCreateInternalEntry,
   deleteIfUnreferenced: mockDeleteIfUnreferenced,
@@ -25,6 +27,15 @@ jest.mock('@/frontend/data', () => ({
 
 jest.mock('@/frontend/components/AlertProvider', () => ({
   useAlert: () => ({ alert: { show: mockAlertShow } }),
+}));
+
+jest.mock('@/shared/core/logger/LoggerService', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: (...args: unknown[]) => mockLoggerDebug(...args),
+      warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    }),
+  },
 }));
 
 jest.mock('react-i18next', () => ({
@@ -46,6 +57,7 @@ describe('useManagedComposerAttachments', () => {
   afterEach(async () => {
     await act(async () => renderer?.unmount());
     renderer = undefined;
+    jest.restoreAllMocks();
   });
 
   it('preserves source order and keeps successful imports when one item fails', async () => {
@@ -136,6 +148,27 @@ describe('useManagedComposerAttachments', () => {
       { name: 'source.pdf', status: 'ready' },
       { name: 'ready.pdf', status: 'ready' },
     ]);
+  });
+
+  it('logs import duration without file identity or location', async () => {
+    const pending = deferred<ReturnType<typeof resolvedFile>>();
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    mockCreateInternalEntry.mockReturnValue(pending.promise);
+    await renderHook();
+
+    await act(async () => snapshot?.addAttachments([source('private.pdf')]));
+    now.mockReturnValue(1_830);
+    await act(async () => {
+      pending.resolve(resolvedFile('00000000-0000-7000-8000-000000000015', 'private.pdf'));
+      await pending.promise;
+    });
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith('Attachment import finished', {
+      durationMs: 830,
+      kind: 'file',
+      result: 'ready',
+      size: 128,
+    });
   });
 
   it('rejects unsupported images before importing them', async () => {

--- a/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
+++ b/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
@@ -64,22 +64,37 @@ export function useManagedComposerAttachments(
 
   const importAttachment = useCallback(
     async (source: ComposerAttachmentSource, token: symbol): Promise<ImportResult> => {
+      const startedAt = Date.now();
+      let importedSize = source.size;
+      const finishImport = (result: ImportResult) => {
+        if (__DEV__) {
+          logger.debug('Attachment import finished', {
+            durationMs: Date.now() - startedAt,
+            kind: source.kind,
+            result,
+            size: importedSize ?? null,
+          });
+        }
+        return result;
+      };
+
       try {
         const resolved = await file.createInternalEntry({
           name: source.name,
           uri: source.uri,
         });
+        importedSize = resolved.entry.origin === 'internal' ? resolved.entry.size : source.size;
 
         if (cancelledImportTokensRef.current.delete(token)) {
           await deleteEntry(resolved.entry.id);
-          return 'ignored';
+          return finishImport('ignored');
         }
         if (!isMountedRef.current) {
-          return 'ignored';
+          return finishImport('ignored');
         }
         if (importTokensRef.current.get(source.id) !== token) {
           await deleteEntry(resolved.entry.id);
-          return 'ignored';
+          return finishImport('ignored');
         }
 
         importTokensRef.current.delete(source.id);
@@ -89,20 +104,20 @@ export function useManagedComposerAttachments(
               ? {
                   ...source,
                   fileEntryId: resolved.entry.id,
-                  size: resolved.entry.origin === 'internal' ? resolved.entry.size : source.size,
+                  size: importedSize,
                   status: 'ready' as const,
                   uri: resolved.uri,
                 }
               : attachment,
           ),
         );
-        return 'ready';
+        return finishImport('ready');
       } catch (error) {
         if (cancelledImportTokensRef.current.delete(token)) {
-          return 'ignored';
+          return finishImport('ignored');
         }
         if (importTokensRef.current.get(source.id) !== token || !isMountedRef.current) {
-          return 'ignored';
+          return finishImport('ignored');
         }
 
         importTokensRef.current.delete(source.id);
@@ -111,7 +126,7 @@ export function useManagedComposerAttachments(
           name: source.name,
           uri: source.uri,
         });
-        return 'failed';
+        return finishImport('failed');
       }
     },
     [commitAttachments, deleteEntry, file],

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -41,6 +41,8 @@ Two consequences to take seriously:
       not trimmed — only what is sent.
 - [ ] The draft and attachments clear **before** the send is awaited, so the field is empty
       immediately.
+- [ ] Only one send may be in flight. Repeated triggers before its Promise settles are ignored and
+      cannot snapshot, clear, restore, or call the sender a second time.
 - [ ] If the send rejects: the draft is restored **verbatim, untrimmed**, the attachments are
       restored, a `danger` toast shows `chat.input.sendFailed`, and the error is logged. The toast is
       deliberately vague, so without the log a failed send leaves no trace to debug from.
@@ -53,6 +55,8 @@ Two consequences to take seriously:
 - [ ] Sendability defaults to "there is text or an attachment". A caller that passes `canSend`
       replaces that outright — painting does, because a promptless image model can send
       `{ attachments: [], text: '' }`.
+- [ ] Any attachment still marked `importing` disables send. Its tile shows a spinner and filename;
+      editing text, removing attachments, and opening tools remain available.
 - [ ] While streaming the send control becomes stop (`chat.input.action.stopGenerating`). It does not
       exist when not streaming.
 
@@ -73,9 +77,10 @@ Two consequences to take seriously:
 - [ ] The image-settings button (painting only) does the same. It is assembled by painting rather
       than by the composer, so it calls `useComposerFieldDismiss()` explicitly — the one thing
       assembling made the caller's job.
-- [ ] Opening the ＋ menu dismisses the keyboard but does **not** blur the field. The panel grows
-      upward into the space the keyboard occupies, so the keyboard has to go; leaving the field as
-      first responder is what makes iOS restore it the instant the menu closes.
+- [ ] Opening the ＋ menu leaves the keyboard and field focus unchanged, preserving the trigger
+      position used by its portalled panel. Choosing camera, photos, or file closes the menu, awaits
+      keyboard dismissal and field blur, then opens the system picker. Choosing a tool does not
+      dismiss or blur.
 
 ### Model and reasoning controls
 
@@ -116,7 +121,8 @@ rows. It is a menu and nothing else: every row closes it and hands off to a syst
       in it, whether or not the app can see the rest of the library.
 - [ ] The photo picker takes at most `COMPOSER_PHOTO_SELECTION_LIMIT` (9) images, in the order
       they were selected.
-- [ ] Cancelling any picker adds nothing and leaves the menu closed.
+- [ ] Cancelling any picker adds nothing and leaves both the menu and keyboard closed. Selecting or
+      cancelling never restores field focus; the user can tap the field to type again.
 - [ ] A picker that fails to launch is logged. The menu has already closed by then, so without the
       log the gesture just looks ignored.
 - [ ] Choosing a tool toggles it and closes the menu.
@@ -147,13 +153,11 @@ rows. It is a menu and nothing else: every row closes it and hands off to a syst
 
 ## Not covered by tests
 
-Walk these on device before shipping. They are the ones with no net at all:
+Walk these on device before shipping. They are the ones with no automated net:
 
-1. Send failure recovery — send with the network off and confirm the draft, the attachments, and the
-   toast.
-2. Pasting an image into the field.
-3. Switching assistants and watching the web-search tag follow the new assistant's setting.
-4. Switching models on an assistant whose effort the new model does not support.
+1. Pasting an image into the field.
+2. Switching assistants and watching the web-search tag follow the new assistant's setting.
+3. Switching models on an assistant whose effort the new model does not support.
 
 ## Deliberately dropped
 


### PR DESCRIPTION
Prevents duplicate composer sends and unmounts cleared attachment previews so sent images cannot reappear in the input.
Dismisses and blurs the field before camera, photo, and file pickers while keeping tool-menu focus behavior unchanged.
Adds privacy-safe import timing logs plus regression coverage for loading, recovery, picker focus, and duplicate sends.
Tested with the focused Composer suites, simulator acceptance, lint, format check, and full typecheck.