### PR TITLE
docs(pull-request): add mobile PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,67 @@
+<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
+<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->
+
+> ### Branch strategy
+>
+> - Active development targets `v0.2`.
+
+### What this PR does
+
+Before this PR:
+
+After this PR:
+
+<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
+
+Fixes #
+
+### Screenshots or videos
+
+<!--
+Required for user-facing changes: upload screenshots or a video that demonstrates the result so reviewers can quickly verify the effect.
+For changes with no visible effect, write `N/A` and briefly explain why.
+-->
+
+### Why we need it and why it was done in this way
+
+The following tradeoffs were made:
+
+The following alternatives were considered:
+
+Links to places where the discussion took place: <!-- optional: GitHub issue, discussion, chat, etc. -->
+
+### Breaking changes
+
+<!-- optional -->
+
+If this PR introduces breaking changes, please describe the changes and the impact on users.
+
+### Special notes for your reviewer
+
+<!-- optional -->
+
+### Checklist
+
+This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
+Approvers are expected to review this list.
+
+- [ ] Branch: This PR targets `v0.2`
+- [ ] PR: The PR description is expressive enough and will help future contributors
+- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
+- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
+- [ ] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
+- [ ] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
+- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
+- [ ] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others
+
+### Release note
+
+<!-- Write your release note:
+1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, write "NONE".
+3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, or behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
### What this PR does

Before this PR:

The mobile repository did not provide a default pull request description template.

After this PR:

Adds a mobile PR template aligned with the desktop repository, targets `v0.2`, and asks contributors to attach screenshots or video for user-facing changes so reviewers can quickly verify the result.

### Screenshots or videos

N/A: this change only adds repository metadata and has no user-visible effect.

### Why we need it and why it was done in this way

The template standardizes reviewer context while making visual evidence explicit for mobile behavior changes.

The following tradeoffs were made: non-visible changes may use `N/A` with an explanation instead of attaching irrelevant media.

The following alternatives were considered: copying the desktop template unchanged, which would retain the wrong target branch and omit mobile-focused visual evidence.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: The change is straightforward and kept simple
- [x] Refactor: No unrelated changes were introduced
- [x] Upgrade: The impact on upgrade flows was considered and no action is required
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: I reviewed the complete diff before requesting review

### Release note

```release-note
NONE
```
