### PR TITLE
refactor(message-presentation): make assistant messages composable

### DIFF
--- a/src/frontend/components/messagePresentation/README.md
+++ b/src/frontend/components/messagePresentation/README.md
@@ -12,9 +12,21 @@ history, message rows and parts, live-turn anchoring, entry motion, and scroll-t
   bottom-accessory inputs, and a feature-owned assistant renderer. Chat uses the default assistant
   row; painting supplies its proportional loader and image result without changing message data.
   Single-turn workspaces can opt into animating their first entering anchor.
+- `AssistantMessage` is the default assistant row — pending placeholder, structured parts, and entry
+  motion. Its `children` render after the message body, so a feature composes its own accessory
+  (a toolbar, for example) into an otherwise standard message instead of teaching this module about
+  that feature's state. The slot is unconditional, including while the placeholder is up; an
+  accessory holds the message and decides for itself when to appear.
 
-Message rows, part renderers, animation providers, and platform controls are private implementation
-details. Callers import only from `@/frontend/components/messagePresentation`.
+A feature-owned assistant row wraps `AssistantMessage` and reaches `MessageList` through
+`renderAssistantMessage`, which must be a stable reference. LegendList refreshes mounted rows
+through `itemKey`, `data`, and `extraData` — a new `renderItem` identity is not a channel for
+pushing state into them. Dynamic state therefore has to arrive either as changed message items
+(painting's route) or through the feature's own context or external store read inside the accessory
+(the route for message actions).
+
+Other message rows, part renderers, animation providers, and platform controls are private
+implementation details. Callers import only from `@/frontend/components/messagePresentation`.
 
 ## Ownership
 

--- a/src/frontend/components/messagePresentation/components/MessageList.tsx
+++ b/src/frontend/components/messagePresentation/components/MessageList.tsx
@@ -9,7 +9,7 @@ import { usePreference } from '@/frontend/data/hooks';
 import { resolveTypographyScale } from '@/frontend/utils/typographyScale';
 import { emitLayoutBenchProbe } from '@/shared/devBench/layoutBenchProbe';
 
-import { AssistantMessageRow, MessageSlideInProvider, UserMessageRow } from '../messageRow';
+import { AssistantMessage, MessageSlideInProvider, UserMessageRow } from '../messageRow';
 import { useMessageSlideInFlight } from '../messageRow/slideIn/hooks/useMessageSlideInFlight';
 import type { MessageListProps, MessagePresentationItem } from '../types';
 import { useAnchorPin } from './hooks/useAnchorPin';
@@ -132,7 +132,7 @@ export function MessageList({
       ) : renderAssistantMessage ? (
         renderAssistantMessage(item)
       ) : (
-        <AssistantMessageRow message={item} />
+        <AssistantMessage message={item} />
       ),
     [renderAssistantMessage],
   );

--- a/src/frontend/components/messagePresentation/components/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messagePresentation/components/__tests__/MessageList.test.tsx
@@ -68,7 +68,7 @@ function mockCreateSharedValue<T>(initial: T): SharedValue<T> {
 
   return shared as unknown as SharedValue<T>;
 }
-const mockAssistantMessageRow = jest.fn((_props: { message: MessagePresentationItem }) => null);
+const mockAssistantMessage = jest.fn((_props: { message: MessagePresentationItem }) => null);
 const mockUserMessageRow = jest.fn((_props: { message: MessagePresentationItem }) => null);
 let mockSlideInFlight: MessageSlideInFlight | undefined;
 let mockScrollButtonProps:
@@ -173,8 +173,7 @@ jest.mock('react-native-reanimated', () => {
 });
 
 jest.mock('../../messageRow', () => ({
-  AssistantMessageRow: (props: { message: MessagePresentationItem }) =>
-    mockAssistantMessageRow(props),
+  AssistantMessage: (props: { message: MessagePresentationItem }) => mockAssistantMessage(props),
   MessageSlideInProvider: ({
     children,
     flight,
@@ -294,7 +293,7 @@ describe('MessageList anchoring and manual scrolling', () => {
 
     expect(mockUserMessageRow).toHaveBeenCalledWith({ message: user });
     expect(renderAssistantMessage).toHaveBeenCalledWith(assistant);
-    expect(mockAssistantMessageRow).not.toHaveBeenCalled();
+    expect(mockAssistantMessage).not.toHaveBeenCalled();
   });
 
   test('does not show the scroll control for an empty message list', () => {
@@ -348,7 +347,7 @@ describe('MessageList anchoring and manual scrolling', () => {
     });
 
     expect(mockUserMessageRow).toHaveBeenCalledWith({ message: userMessage });
-    expect(mockAssistantMessageRow).toHaveBeenCalledWith({ message: emptyAssistantMessage });
+    expect(mockAssistantMessage).toHaveBeenCalledWith({ message: emptyAssistantMessage });
     expect(mockLatestListProps?.getItemType?.(userMessage)).toBe('user');
     // 空助手行是加载点占位，不能继承成稿长回复的尺寸均值，否则新建时会先占住上一条回复的
     // 高度再塌回去。第一个 chunk 落地后才归入 assistant，那时行还很小。

--- a/src/frontend/components/messagePresentation/index.ts
+++ b/src/frontend/components/messagePresentation/index.ts
@@ -1,2 +1,3 @@
 export { MessageList } from './components/MessageList';
+export { AssistantMessage } from './messageRow/components/AssistantMessage';
 export type { MessageListProps, MessagePresentationItem } from './types';

--- a/src/frontend/components/messagePresentation/messageRow/README.md
+++ b/src/frontend/components/messagePresentation/messageRow/README.md
@@ -4,12 +4,15 @@ This module renders role-level chat message rows.
 
 ## Internal Interface
 
-- `AssistantMessage`, `UserMessageRow`, and `MessageSlideInProvider` are exported from the local
-  `index.ts` only for `MessageList`.
+- `AssistantMessage` is re-exported from the module root: features compose their own accessories
+  into it through `children`. `UserMessageRow` and `MessageSlideInProvider` are exported from the
+  local `index.ts` only for `MessageList`.
 
 ## Organization
 
-- `components/` contains the role-specific row layouts.
+- `components/` contains the role-specific row layouts. Both rows memoize on their message
+  reference. Inside the assistant row, the body — placeholder or parts — carries its own boundary,
+  so a composed accessory re-rendering never reaches part dispatch and markdown.
 - User rows compose a right-aligned attachment strip above the optional text bubble. Both remain
   inside one long-press menu and one entry animation.
 - `utils/partitionUserMessageParts.ts` projects managed file parts into that strip without changing

--- a/src/frontend/components/messagePresentation/messageRow/README.md
+++ b/src/frontend/components/messagePresentation/messageRow/README.md
@@ -4,7 +4,7 @@ This module renders role-level chat message rows.
 
 ## Internal Interface
 
-- `AssistantMessageRow`, `UserMessageRow`, and `MessageSlideInProvider` are exported from the local
+- `AssistantMessage`, `UserMessageRow`, and `MessageSlideInProvider` are exported from the local
   `index.ts` only for `MessageList`.
 
 ## Organization

--- a/src/frontend/components/messagePresentation/messageRow/components/AssistantMessage.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/AssistantMessage.tsx
@@ -1,4 +1,5 @@
 import { DotMatrixSquare20 } from '@cherrystudio/ui/components';
+import { memo, type ReactNode } from 'react';
 import Animated from 'react-native-reanimated';
 
 import { MessageStatusRow, StatusRowTextFloor } from '../../components/MessageStatusRow';
@@ -7,26 +8,46 @@ import type { MessagePresentationItem } from '../../types';
 import { useAssistantSlideInStyle } from '../slideIn/hooks/useAssistantSlideInStyle';
 
 type AssistantMessageProps = {
+  /**
+   * 正文之后的组合槽位，留给功能方自己的配件（工具栏之类）。这里无条件渲染，包括
+   * 正文还没到的 pending 占位期——配件拿得到 message，什么时候现身由它自己决定。
+   */
+  children?: ReactNode;
   message: MessagePresentationItem;
 };
 
-export function AssistantMessage({ message }: AssistantMessageProps) {
+// 正文渲染很贵（parts 分派、markdown），所以单独立一层 memo：配件重渲染时 children 的
+// JSX 身份必然变、外层 memo 必然被打穿，正文得由这一层按 message 引用挡住。
+const AssistantMessageBody = memo(function AssistantMessageBody({
+  message,
+}: {
+  message: MessagePresentationItem;
+}) {
   const isPendingEmptyMessage = message.status === 'pending' && !message.data.parts?.length;
+
+  return isPendingEmptyMessage ? (
+    // 这一行不含文字，所以要自己撑到一行正文的高度——否则只有 20px 的圆点撑高，比接下来
+    // 顶替它的思考行/工具行/正文矮 4px，切换那一帧整条消息在锚点正下方跳一下（48→52）。
+    <MessageStatusRow>
+      <DotMatrixSquare20 active size={20} />
+      <StatusRowTextFloor />
+    </MessageStatusRow>
+  ) : (
+    <MessageParts message={message} />
+  );
+});
+
+export const AssistantMessage = memo(function AssistantMessage({
+  children,
+  message,
+}: AssistantMessageProps) {
   // 行高从第一帧起就要占住（预留空白与钉顶落点都靠它），所以显形只走 opacity。
   const slideInStyle = useAssistantSlideInStyle(message.id);
 
   return (
     <Animated.View className="w-full gap-2 px-4 py-3" style={slideInStyle}>
-      {isPendingEmptyMessage ? (
-        // 这一行不含文字，所以要自己撑到一行正文的高度——否则只有 20px 的圆点撑高，比接下来
-        // 顶替它的思考行/工具行/正文矮 4px，切换那一帧整条消息在锚点正下方跳一下（48→52）。
-        <MessageStatusRow>
-          <DotMatrixSquare20 active size={20} />
-          <StatusRowTextFloor />
-        </MessageStatusRow>
-      ) : (
-        <MessageParts message={message} />
-      )}
+      <AssistantMessageBody message={message} />
+      {children}
     </Animated.View>
   );
-}
+});

--- a/src/frontend/components/messagePresentation/messageRow/components/AssistantMessage.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/AssistantMessage.tsx
@@ -6,11 +6,11 @@ import { MessageParts } from '../../messageContent';
 import type { MessagePresentationItem } from '../../types';
 import { useAssistantSlideInStyle } from '../slideIn/hooks/useAssistantSlideInStyle';
 
-type AssistantMessageRowProps = {
+type AssistantMessageProps = {
   message: MessagePresentationItem;
 };
 
-export function AssistantMessageRow({ message }: AssistantMessageRowProps) {
+export function AssistantMessage({ message }: AssistantMessageProps) {
   const isPendingEmptyMessage = message.status === 'pending' && !message.data.parts?.length;
   // 行高从第一帧起就要占住（预留空白与钉顶落点都靠它），所以显形只走 opacity。
   const slideInStyle = useAssistantSlideInStyle(message.id);

--- a/src/frontend/components/messagePresentation/messageRow/components/UserMessageRow.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/UserMessageRow.tsx
@@ -1,5 +1,5 @@
 import { Menu, type MenuItem } from '@cherrystudio/ui/components';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -14,7 +14,7 @@ type UserMessageRowProps = {
   message: MessagePresentationItem;
 };
 
-export function UserMessageRow({ message }: UserMessageRowProps) {
+export const UserMessageRow = memo(function UserMessageRow({ message }: UserMessageRowProps) {
   const { t } = useTranslation();
   const slideInStyle = useUserMessageSlideInStyle(message.id);
   const { attachments, bodyMessage } = useMemo(() => partitionUserMessageParts(message), [message]);
@@ -54,6 +54,6 @@ export function UserMessageRow({ message }: UserMessageRowProps) {
       </View>
     </Animated.View>
   );
-}
+});
 
 function noopMessageAction() {}

--- a/src/frontend/components/messagePresentation/messageRow/components/__tests__/AssistantMessage.test.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/__tests__/AssistantMessage.test.tsx
@@ -1,9 +1,13 @@
+import { createElement } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import type { MessagePresentationItem } from '../../../types';
 import { AssistantMessage } from '../AssistantMessage';
 
-const mockMessageParts = jest.fn((_props: { message: MessagePresentationItem }) => null);
+// 正文渲染成宿主元素而不是 null，组合槽位的测试才能在树里定位它、断言正文与配件的先后。
+const mockMessageParts = jest.fn((props: { message: MessagePresentationItem }) =>
+  createElement('MessageParts', props),
+);
 const mockDotMatrixSquare20 = jest.fn((_props: { active: boolean; size: number }) => null);
 
 jest.mock('../../../messageContent', () => ({
@@ -66,4 +70,39 @@ describe('AssistantMessage', () => {
     expect(mockMessageParts).toHaveBeenCalledWith({ message });
     expect(mockDotMatrixSquare20).not.toHaveBeenCalled();
   });
+
+  test('renders composed children after the message body', () => {
+    const message = createAssistantMessage('success', [{ text: 'Answer', type: 'text' }]);
+
+    act(() => {
+      renderer = create(
+        <AssistantMessage message={message}>
+          <AccessoryProbe />
+        </AssistantMessage>,
+      );
+    });
+
+    const rendered = renderer?.root.findAll(
+      (node) => node.type === 'MessageParts' || node.type === AccessoryProbe,
+    );
+
+    expect(rendered?.map((node) => node.type)).toEqual(['MessageParts', AccessoryProbe]);
+  });
+
+  test('keeps the composition slot during the pending placeholder', () => {
+    act(() => {
+      renderer = create(
+        <AssistantMessage message={createAssistantMessage('pending')}>
+          <AccessoryProbe />
+        </AssistantMessage>,
+      );
+    });
+
+    expect(mockDotMatrixSquare20).toHaveBeenCalledWith({ active: true, size: 20 });
+    expect(renderer?.root.findAllByType(AccessoryProbe)).toHaveLength(1);
+  });
 });
+
+function AccessoryProbe() {
+  return null;
+}

--- a/src/frontend/components/messagePresentation/messageRow/components/__tests__/AssistantMessage.test.tsx
+++ b/src/frontend/components/messagePresentation/messageRow/components/__tests__/AssistantMessage.test.tsx
@@ -1,7 +1,7 @@
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import type { MessagePresentationItem } from '../../../types';
-import { AssistantMessageRow } from '../AssistantMessageRow';
+import { AssistantMessage } from '../AssistantMessage';
 
 const mockMessageParts = jest.fn((_props: { message: MessagePresentationItem }) => null);
 const mockDotMatrixSquare20 = jest.fn((_props: { active: boolean; size: number }) => null);
@@ -36,7 +36,7 @@ function createAssistantMessage(
   };
 }
 
-describe('AssistantMessageRow', () => {
+describe('AssistantMessage', () => {
   let renderer: ReactTestRenderer | undefined;
 
   beforeEach(() => {
@@ -49,7 +49,7 @@ describe('AssistantMessageRow', () => {
 
   test('shows the pending placeholder for an empty pending assistant message', () => {
     act(() => {
-      renderer = create(<AssistantMessageRow message={createAssistantMessage('pending')} />);
+      renderer = create(<AssistantMessage message={createAssistantMessage('pending')} />);
     });
 
     expect(mockDotMatrixSquare20).toHaveBeenCalledWith({ active: true, size: 20 });
@@ -60,7 +60,7 @@ describe('AssistantMessageRow', () => {
     const message = createAssistantMessage('pending', [{ text: 'Thinking', type: 'text' }]);
 
     act(() => {
-      renderer = create(<AssistantMessageRow message={message} />);
+      renderer = create(<AssistantMessage message={message} />);
     });
 
     expect(mockMessageParts).toHaveBeenCalledWith({ message });

--- a/src/frontend/components/messagePresentation/messageRow/index.ts
+++ b/src/frontend/components/messagePresentation/messageRow/index.ts
@@ -1,3 +1,3 @@
-export { AssistantMessageRow } from './components/AssistantMessageRow';
+export { AssistantMessage } from './components/AssistantMessage';
 export { UserMessageRow } from './components/UserMessageRow';
 export { MessageSlideInProvider } from './slideIn/MessageSlideInProvider';


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: `MessageList` renders the default assistant row itself, and the only way for a feature to put anything of its own into an assistant message is `renderAssistantMessage`, which replaces the whole row. A feature that just wants to add an accessory — a toolbar, say — has to either reimplement the row or push its state through the list. No row in the module has a memo boundary, so any list-level re-render re-runs part dispatch and markdown for every mounted row.

After this PR: `AssistantMessage` is exported from the module root and takes `children`, rendered after the message body. A feature composes its own accessory into an otherwise standard assistant message, and `MessageList` stays unaware of that feature's state. Rows memoize on their message reference, and the assistant body carries its own boundary inside the row, so a composed accessory re-rendering never reaches part dispatch and markdown.

```tsx
// what a feature can now write, without MessageList learning anything about it
function ChatAssistantMessage({ message }: Props) {
  return (
    <AssistantMessage message={message}>
      <AssistantMessageToolbar message={message} />
    </AssistantMessage>
  );
}
```

No behavior changes: with no `children`, `AssistantMessage` renders exactly what `AssistantMessageRow` rendered.

Fixes #

### Screenshots or videos

N/A — the default render path is unchanged, so there is nothing visually different to show.

### Why we need it and why it was done in this way

This is the foundation #556 asked for. That PR's review found the toolbar's state (`copiedMessageId`, `isRegenerateDisabled`, `onCopy`, `onRegenerate`) threaded from `ChatWorkspace` through `MessageList` and `extraData` down into the row — four layers, plus a mutually-exclusive union type and a compile-only contract file to keep the two rendering modes apart, and the callbacks were left out of `extraData` so a mounted row could keep calling a stale handler. The list should not have to know any of that. Landing composition first means #556 can rebase onto an interface where the toolbar and its state are entirely chat's, reached through a stable `renderAssistantMessage`; #557's read-aloud then joins that same feature-owned context rather than adding another list prop.

The following tradeoffs were made:

- **The slot is unconditional, including during the pending placeholder.** Swallowing `children` while a reply streams would close off legitimate accessories — a stop button being the obvious one. The accessory holds the message and decides for itself when to appear.
- **Three memo boundaries rather than one.** The outer row bails on the default path; the body is the load-bearing one, because a composed accessory's `children` gets a new JSX identity on every parent render and necessarily punches through the outer memo. This is safe here: streaming produces a new message object per chunk (`applyStreamingMessage`), entry motion runs on shared values on the UI thread, and the font-size preference is read by the markdown leaf itself — none of them need a row re-render to land.
- **No `AssistantMessageActions` context in this module.** Copy and regenerate have exactly one adapter today; a shared abstraction over one caller would be a shallow one. That context belongs in the chat feature.

The following alternatives were considered: keeping the `extraData` plumbing and merely adding the callbacks to it (fixes the stale-handler bug, leaves the list owning toolbar state); making `AssistantMessage` a compound component with named sub-slots (more API than one accessory position justifies).

Links to places where the discussion took place: review of #556 — https://github.com/CherryHQ/cherry-studio-app/pull/556#issuecomment-5311219280

### Breaking changes

None. `AssistantMessageRow` was private to the module — no caller outside `messagePresentation` referenced it — and `MessageListProps` is untouched, so `renderAssistantMessage` keeps working as-is for painting.

### Special notes for your reviewer

The first commit is a pure rename and can be read in one pass; the second carries the actual change.

The memo boundaries are deliberately not covered by tests. Asserting a render count means asserting on a mocked collaborator's call count, which `AGENTS.md` rules out, and such a test breaks when an internal component is swapped even though the performance behavior is intact. The two new tests cover the observable contract instead — that `children` render after the body, and that the slot survives the pending placeholder — and both were confirmed to fail when that behavior is inverted. Memo effectiveness belongs to the profiler and device acceptance.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
