### PR TITLE
docs(agent-architecture): define local-only agent protocol and runtime contracts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ They are the source of truth for how the repository works today.
 
 | Document | Description |
 | --- | --- |
+| [Agent Architecture](./references/agent/README.md) | Mobile-owned Agent Protocol, per-session record authority, and independent Agent Runtime integration for v2 (design, not yet implemented) |
 | [AI Provider Integration](./references/ai/provider-integration.md) | Provider/model resolution, AI SDK adapters, options, and transport behavior |
 | [Chat Streaming And Rendering](./references/chat/streaming-and-rendering.md) | Chat Runtime streaming, message windows, persistence, and rendering boundaries |
 | [Data Layer](./references/data/README.md) | Data API, preferences, caches, SQLite ownership, and service composition |
@@ -55,6 +56,13 @@ They are the source of truth for how the repository works today.
 
 - Put task-oriented procedures under `docs/guides`.
 - Put current technical facts, rules, and constraints under `docs/references`.
+- A reference may describe a design that is not yet built, but only when it carries a
+  `Status:` line naming its state (`design`, `as-built`, `Phase N landed`) and it does not
+  overwrite the current-state description of anything it will replace. Current-state references
+  change in the same PR as the code, never ahead of it — a reference that describes an intended
+  future as if it were present is the one failure mode this rule exists to prevent. Promote a
+  design document to current-state prose as each phase lands, and record superseded decisions as
+  explicit deviations rather than silent edits.
 - Keep module-specific `README.md` files beside the code they describe and link to these documents
   for repository-wide rules.
 - Do not add ADR or TODO directories. Git history preserves superseded decisions; unfinished work

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ They are the source of truth for how the repository works today.
 
 | Document | Description |
 | --- | --- |
-| [Agent Architecture](./references/agent/README.md) | Mobile-owned Agent Protocol, per-session record authority, and independent Agent Runtime integration for v2 (design, not yet implemented) |
+| [Agent Architecture](./references/agent/README.md) | Local-only Agent Protocol, Runtime Router, and independent Pi/AI SDK contract for v1 (design, not yet implemented) |
 | [AI Provider Integration](./references/ai/provider-integration.md) | Provider/model resolution, AI SDK adapters, options, and transport behavior |
 | [Chat Streaming And Rendering](./references/chat/streaming-and-rendering.md) | Chat Runtime streaming, message windows, persistence, and rendering boundaries |
 | [Data Layer](./references/data/README.md) | Data API, preferences, caches, SQLite ownership, and service composition |

--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -14,8 +14,9 @@ protocol** and **which execution behavior belongs to the reusable runtime**.
 > Every Cherry conversation is an agent session. A plain assistant chat is bound to an in-app
 > Runtime; a coding session may be bound to a LAN or cloud Runtime. They share one application
 > protocol and renderer, but not one persistence policy: a local session keeps its complete record
-> locally, while a remote session keeps only a compact local projection and reads execution detail
-> from its authoritative Runtime endpoint on demand.
+> locally, while a remote session keeps a selective compact projection of Mobile-initiated
+> executions and reads execution detail from its authoritative Runtime endpoint on demand. That
+> projection may remain permanently stale relative to activity on the remote PC.
 
 Five rules follow, and everything else in these documents is a consequence of them:
 
@@ -36,8 +37,8 @@ Five rules follow, and everything else in these documents is a consequence of th
 5. **Authority is explicit per session.** A `local-canonical` session treats Mobile persistence as
    its complete record. A `remote-canonical` session treats the LAN or cloud execution store as the
    authority and never mirrors raw reasoning, MCP payloads, command logs, traces, or other detailed
-   execution content into Mobile persistence. The local projection contains only what list,
-   transcript, search, and offline shells need.
+   execution content into Mobile persistence. Its local projection records only Mobile-initiated
+   executions; remote-native activity is neither constrained nor automatically imported.
 
 Runtime implementation and deployment location are separate dimensions. For example, a coding
 Runtime may be hosted over LAN or in the cloud, while an AI SDK Runtime may run locally or behind a

--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -53,6 +53,12 @@ LAN/cloud execution targets, their Runtime adapters, and remote-authoritative Se
 direction. They enter through the same Router, but their transport, security, storage, and recovery
 rules require a separate design. Version 1 defines none of those details.
 
+## Open Questions
+
+- **Agent tool** is the sole routing criterion, but it does not yet have a precise definition:
+  which tool kinds qualify (built-in, MCP, or both) and how they relate to the Runtime contract's
+  `RuntimeTool` are TODO, pending confirmation before implementation.
+
 ## Documents
 
 | Document | Scope |

--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -1,71 +1,74 @@
 # Agent Architecture
 
-Status: **design**. This subtree specifies the Cherry Mobile Agent Protocol and its boundary with an
-independent Agent Runtime for Cherry Mobile v2. It describes the target architecture, not current
-implementation behavior; each document is promoted to current-state reference as its phase lands.
+Status: **design**. Version 1 is local-only.
 
-Mobile v2 is a clean build. There is no persisted format to preserve, no shipped agent runtime to
-retrofit, and no client contract to keep compatible. The design takes that freedom and spends it on
-the two decisions that are expensive to change later: **which semantics belong to the application
-protocol** and **which execution behavior belongs to the reusable runtime**.
+Cherry Mobile owns Agents and Sessions. An independent Agent Runtime executes one prepared turn.
+The first Runtime implementations may use Pi or the AI SDK; both implement the same contract and
+remain invisible to the application protocol.
 
-## Thesis
+## Boundaries
 
-> Every Cherry conversation is an agent session. A plain assistant chat is bound to an in-app
-> Runtime; a coding session may be bound to a LAN or cloud Runtime. They share one application
-> protocol and renderer, but not one persistence policy: a local session keeps its complete record
-> locally, while a remote session keeps a selective compact projection of Mobile-initiated
-> executions and reads execution detail from its authoritative Runtime endpoint on demand. That
-> projection may remain permanently stale relative to activity on the remote PC.
+```text
+Agent Client
+    ↕ Agent Protocol
+Mobile Agent Host
+    ↓ Agent Runtime Router
+    ↕ Agent Runtime contract
+Pi Runtime | AI SDK Runtime
+```
 
-Five rules follow, and everything else in these documents is a consequence of them:
+- The **Agent Protocol** is the application contract between the frontend Agent Client and the
+  backend Mobile Agent Host. It defines Sessions, execution targets, turns, messages, commands,
+  snapshots, and events.
+- The **Mobile Agent Host** owns Agent lookup, Session persistence, message history, runtime
+  routing, tool policy, streaming overlay, and lifecycle recovery.
+- The **Agent Runtime Router** is the only place that selects an implementation. It receives the
+  execution target and resolved Agent configuration, then resolves a registered Runtime.
+- An **Agent Runtime** receives prepared execution input and emits normalized execution events. It
+  does not know Cherry Agent rows, Session rows, SQLite, React, Expo, or application protocol types.
+- **Pi** and **AI SDK** are Host-private Runtime implementations. The Agent Client sees only the
+  Agent Protocol and protocol-level capabilities; Runtime identity never crosses that boundary.
 
-1. **Cherry Mobile owns the application protocol.** Commands, events, snapshots, session views, and
-   message parts describe Cherry Mobile product behavior. They live under
-   `src/shared/agent/protocol`, not in a workspace package and not in `packages/universal`.
-2. **The application protocol spans frontend and backend.** Every command, event, and snapshot is
-   JSON and survives an application transport. It remains separate from any protocol used by a LAN
-   or cloud Runtime.
-3. **Every Agent Runtime implements one independent contract.** Local, LAN, and cloud deployments
-   accept the same execution requests and produce the same normalized execution events. The
-   contract does not know Cherry sessions, message branches, revisions, snapshots, persistence,
-   React, or Expo.
-4. **The application adapter is the boundary.** `src/backend/services/agent` translates protocol
-   commands into runtime operations and runtime events into persisted Cherry state plus protocol
-   events. Runtime-specific requests, events, authentication, and transports remain inside thin
-   adapters.
-5. **Authority is explicit per session.** A `local-canonical` session treats Mobile persistence as
-   its complete record. A `remote-canonical` session treats the LAN or cloud execution store as the
-   authority and never mirrors raw reasoning, MCP payloads, command logs, traces, or other detailed
-   execution content into Mobile persistence. Its local projection records only Mobile-initiated
-   executions; remote-native activity is neither constrained nor automatically imported.
+The Agent Client must not import the Agent Runtime contract. Only the Mobile Agent Host depends on
+both contracts and maps between them.
 
-Runtime implementation and deployment location are separate dimensions. For example, a coding
-Runtime may be hosted over LAN or in the cloud, while an AI SDK Runtime may run locally or behind a
-service. Shared application code reads declared capabilities and the session's record mode; it
-never infers behavior from a Runtime implementation id. Mobile v2 assigns `local-canonical` to
-local endpoints and `remote-canonical` to LAN and cloud endpoints, but records that decision on the
-session instead of scattering endpoint checks through the application.
+Runtime independence is a dependency rule, not a packaging decision. The contract may begin in the
+app and move to a package when a real independent consumer exists.
+
+## Version 1
+
+- All execution is local to the Mobile process.
+- The application selects the `local` execution target, never a Runtime id.
+- The Router selects Pi when the resolved Agent configuration contains Agent tools; otherwise it
+  selects the AI SDK Runtime.
+- A Session has at most one active turn.
+- Mobile persistence is the complete conversation record.
+- The Host supplies complete normalized context for every turn; a Runtime may keep private
+  in-memory state, but it is not authoritative.
+- Route remounts and foreground transitions recover from a Host snapshot.
+- A process death cannot resume a local turn. Startup reconciliation marks unfinished work as
+  interrupted.
+
+LAN/cloud execution targets, their Runtime adapters, and remote-authoritative Sessions are a future
+direction. They enter through the same Router, but their transport, security, storage, and recovery
+rules require a separate design. Version 1 defines none of those details.
 
 ## Documents
 
 | Document | Scope |
 | --- | --- |
-| [Agent Protocol](./agent-protocol.md) | The Mobile-owned application contract: entities, message and part model, commands, events, snapshots, capabilities, errors, versioning, invariants |
-| [Agent Runtime](./agent-runtime.md) | The independent execution contract, Local/LAN/Cloud adapters, and the Mobile-owned host, storage, recovery, and frontend integration around it |
+| [Agent Protocol](./agent-protocol.md) | Mobile application entities, operations, events, snapshots, errors, and invariants |
+| [Agent Runtime](./agent-runtime.md) | Independent local execution contract, Host boundary, lifecycle, and implementation conformance |
 
-Read the protocol first. The runtime document assumes its vocabulary.
+## Current Implementation
+
+This design does not yet replace the current Topic, Chat Runtime, or desktop-aligned `agent_*`
+surfaces. Current-state references remain authoritative until implementation lands.
 
 ## Related
 
 - [Architecture Overview](../architecture-overview.md) — dependency direction and layer boundaries
-- [Runtime Ownership](../runtime-ownership.md) — owner roles, bootstrap, backgrounding constraints
-- [Code Organization](../code-organization.md) — module placement and public surfaces
-- [Domain Language](../domain-language.md) — terminology; the v2 vocabulary in these documents
-  supersedes the Topic, Chat Runtime, Chat Module, and Streaming Message Overlay entries once
-  its implementation phases land; `AgentSessionView` remains distinct from the caller-owned
-  lifecycle role described in [Agent Runtime §12](./agent-runtime.md#12-placement-and-integration)
-- [`@cherrystudio/ai-runtime`](../../../packages/ai-runtime/README.md) — existing portable AI SDK,
-  provider, message, and tool behavior used beneath the Agent Runtime adapter
-- Desktop [issue #18802](https://github.com/CherryHQ/cherry-studio/issues/18802) — a related desktop
-  proposal; it informs behavior but does not own the Mobile application protocol
+- [Runtime Ownership](../runtime-ownership.md) — app-owned runtime lifetime and background limits
+- [Chat Streaming And Rendering](../chat/streaming-and-rendering.md) — current Chat Runtime behavior
+- [`@cherrystudio/ai-runtime`](../../../packages/ai-runtime/README.md) — existing AI SDK execution
+  primitives available to the AI SDK Runtime implementation

--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -1,0 +1,70 @@
+# Agent Architecture
+
+Status: **design**. This subtree specifies the Cherry Mobile Agent Protocol and its boundary with an
+independent Agent Runtime for Cherry Mobile v2. It describes the target architecture, not current
+implementation behavior; each document is promoted to current-state reference as its phase lands.
+
+Mobile v2 is a clean build. There is no persisted format to preserve, no shipped agent runtime to
+retrofit, and no client contract to keep compatible. The design takes that freedom and spends it on
+the two decisions that are expensive to change later: **which semantics belong to the application
+protocol** and **which execution behavior belongs to the reusable runtime**.
+
+## Thesis
+
+> Every Cherry conversation is an agent session. A plain assistant chat is bound to an in-app
+> Runtime; a coding session may be bound to a LAN or cloud Runtime. They share one application
+> protocol and renderer, but not one persistence policy: a local session keeps its complete record
+> locally, while a remote session keeps only a compact local projection and reads execution detail
+> from its authoritative Runtime endpoint on demand.
+
+Five rules follow, and everything else in these documents is a consequence of them:
+
+1. **Cherry Mobile owns the application protocol.** Commands, events, snapshots, session views, and
+   message parts describe Cherry Mobile product behavior. They live under
+   `src/shared/agent/protocol`, not in a workspace package and not in `packages/universal`.
+2. **The application protocol spans frontend and backend.** Every command, event, and snapshot is
+   JSON and survives an application transport. It remains separate from any protocol used by a LAN
+   or cloud Runtime.
+3. **Every Agent Runtime implements one independent contract.** Local, LAN, and cloud deployments
+   accept the same execution requests and produce the same normalized execution events. The
+   contract does not know Cherry sessions, message branches, revisions, snapshots, persistence,
+   React, or Expo.
+4. **The application adapter is the boundary.** `src/backend/services/agent` translates protocol
+   commands into runtime operations and runtime events into persisted Cherry state plus protocol
+   events. Runtime-specific requests, events, authentication, and transports remain inside thin
+   adapters.
+5. **Authority is explicit per session.** A `local-canonical` session treats Mobile persistence as
+   its complete record. A `remote-canonical` session treats the LAN or cloud execution store as the
+   authority and never mirrors raw reasoning, MCP payloads, command logs, traces, or other detailed
+   execution content into Mobile persistence. The local projection contains only what list,
+   transcript, search, and offline shells need.
+
+Runtime implementation and deployment location are separate dimensions. For example, a coding
+Runtime may be hosted over LAN or in the cloud, while an AI SDK Runtime may run locally or behind a
+service. Shared application code reads declared capabilities and the session's record mode; it
+never infers behavior from a Runtime implementation id. Mobile v2 assigns `local-canonical` to
+local endpoints and `remote-canonical` to LAN and cloud endpoints, but records that decision on the
+session instead of scattering endpoint checks through the application.
+
+## Documents
+
+| Document | Scope |
+| --- | --- |
+| [Agent Protocol](./agent-protocol.md) | The Mobile-owned application contract: entities, message and part model, commands, events, snapshots, capabilities, errors, versioning, invariants |
+| [Agent Runtime](./agent-runtime.md) | The independent execution contract, Local/LAN/Cloud adapters, and the Mobile-owned host, storage, recovery, and frontend integration around it |
+
+Read the protocol first. The runtime document assumes its vocabulary.
+
+## Related
+
+- [Architecture Overview](../architecture-overview.md) — dependency direction and layer boundaries
+- [Runtime Ownership](../runtime-ownership.md) — owner roles, bootstrap, backgrounding constraints
+- [Code Organization](../code-organization.md) — module placement and public surfaces
+- [Domain Language](../domain-language.md) — terminology; the v2 vocabulary in these documents
+  supersedes the Topic, Chat Runtime, Chat Module, and Streaming Message Overlay entries once
+  its implementation phases land; `AgentSessionView` remains distinct from the caller-owned
+  lifecycle role described in [Agent Runtime §12](./agent-runtime.md#12-placement-and-integration)
+- [`@cherrystudio/ai-runtime`](../../../packages/ai-runtime/README.md) — existing portable AI SDK,
+  provider, message, and tool behavior used beneath the Agent Runtime adapter
+- Desktop [issue #18802](https://github.com/CherryHQ/cherry-studio/issues/18802) — a related desktop
+  proposal; it informs behavior but does not own the Mobile application protocol

--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -26,8 +26,8 @@ Pi Runtime | AI SDK Runtime
   execution target and resolved Agent configuration, then resolves a registered Runtime.
 - An **Agent Runtime** receives prepared execution input and emits normalized execution events. It
   does not know Cherry Agent rows, Session rows, SQLite, React, Expo, or application protocol types.
-- **Pi** and **AI SDK** are Host-private Runtime implementations. The Agent Client sees only the
-  Agent Protocol and protocol-level capabilities; Runtime identity never crosses that boundary.
+- **Pi** and **AI SDK** are Host-private local Runtime implementations. The Agent Client sees only
+  the Agent Protocol and protocol-level capabilities; Runtime identity never crosses that boundary.
 
 The Agent Client must not import the Agent Runtime contract. Only the Mobile Agent Host depends on
 both contracts and maps between them.

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -38,9 +38,10 @@ Runtime identity may be displayed for selection and diagnostics; it must not dri
 sequence gap produces an explicit protocol error. Nothing is silently ignored or approximated as
 success.
 
-**R6 — Persist a projection, not a remote mirror.** Session record mode decides which facts Mobile
-may persist. A remote session may carry stable summaries and opaque locators, but raw execution
-detail is neither pushed through the event stream nor written to Mobile storage.
+**R6 — Persist a selective projection, not a remote mirror.** Session record mode decides which
+facts Mobile may persist. A remote session carries compact records only for Mobile-initiated
+executions. Remote-native turns are not imported, and raw execution detail is neither pushed
+through the event stream nor written to Mobile storage.
 
 ### 1.1 Ownership and non-goals
 
@@ -124,7 +125,7 @@ type AgentSessionView = {
   }
   recordMode: 'local-canonical' | 'remote-canonical'
   workspaceId: string | null
-  activeMessageId: string | null   // branch tip
+  activeMessageId: string | null   // tip of Mobile's local projection, not the remote head
   status: 'idle' | 'running' | 'awaiting-approval' | 'cancelling'
   createdAt: string                // ISO 8601
   updatedAt: string
@@ -142,13 +143,16 @@ The two modes have different source-of-truth rules:
 | Fact | `local-canonical` | `remote-canonical` |
 | --- | --- | --- |
 | Cherry-only metadata such as local id, pin/order, manual title, and binding | Mobile record | Mobile record |
-| User input, final assistant output, and execution status | Mobile record | Remote record; compactly projected for offline display |
+| User input, final assistant output, and execution status | Mobile record | Remote record; selectively projected only for Mobile-initiated executions |
 | Raw reasoning, tool/MCP input and output, command logs, traces | Mobile record when the product retains it | Remote execution store only |
 | Detail shown after expansion | Read locally | Fetched through the backend adapter; held in memory only |
 
 There is no conflict between two complete stores because a remote session has only one complete
 execution record. Mobile remains authoritative for Cherry-only metadata and local UI state; the
-remote service owns execution-derived transcript and detail facts.
+remote service owns execution-derived transcript and detail facts. The Mobile projection may remain
+incomplete and permanently stale after the user continues the same session on the remote PC.
+For `remote-canonical`, `status`, `activeMessageId`, and `updatedAt` describe the last state Mobile
+observed through its own executions, not the remote Session's current state.
 
 Unifying assistant chat and agent session into one aggregate is the main deviation from the desktop
 proposal, which keeps them physically separate. That separation is argued on migration grounds —
@@ -410,6 +414,11 @@ remote authority. Moving to a different authority is a separate export, import, 
 and is out of scope in protocol v1. Treating a compact projection as a complete transcript would
 silently lose execution context, so the host rejects that transition.
 
+For `remote-canonical`, `parentMessageId`, `activeMessageId`, `expectedRevision`, and the local
+message tree describe Mobile's projection only. They are not concurrency guards for the remote
+Session head. A subsequent Mobile command continues against the Runtime's current native context,
+which may include PC-originated turns that Mobile has never observed.
+
 ### 4.1 Envelope
 
 ```ts
@@ -516,9 +525,10 @@ guaranteed by the envelope's gapless `sequence`; a client that detects a gap rel
 rather than attempting delta reconciliation. Mid-stream state is carried in the snapshot
 (§6), so a client joining a running turn never needs the deltas it missed.
 
-For `remote-canonical`, deltas contain compact projection fields only. Raw execution detail is not
-temporarily smuggled through `message.delta`; it remains behind the detail query even while the turn
-is live.
+For `remote-canonical`, deltas exist only for a Mobile-initiated execution and contain compact
+projection fields only. The host does not subscribe to the remote Session's global event stream.
+Raw execution detail is not temporarily smuggled through
+`message.delta`; it remains behind the detail query even while the turn is live.
 
 This is the concrete replacement for whole-message overlays. Today's runtime republishes the entire
 accumulated assistant message on every chunk, which is quadratic in serialized size and repeated
@@ -560,7 +570,8 @@ type AgentSessionSnapshot = {
 ```
 
 Every message in a snapshot obeys `session.recordMode`. A local snapshot may contain inline detail;
-a remote snapshot contains the compact projection only. `AgentPartDetailView` is deliberately not
+a remote snapshot contains only Mobile's selective compact projection. It is not a snapshot of the
+remote Session and need not include PC-originated turns. `AgentPartDetailView` is deliberately not
 part of this type.
 
 Recovery is one loop, identical over every transport:
@@ -571,9 +582,10 @@ Recovery is one loop, identical over every transport:
    to 1.
 
 No frontend client inspects Runtime-native state to recover the application projection. For a
-remote session, the Mobile Agent Host serves the cached compact snapshot first, then asks the
-adapter to advance it from the remote cursor or projection snapshot. Each committed advance arrives
-through normal application events. Detail is independent of recovery and remains on demand.
+remote session, the Mobile Agent Host serves the cached compact snapshot as-is. It may resume a
+Mobile-known unfinished execution by `executionId` and its per-execution cursor, but it never asks
+for messages added elsewhere to the remote Session. Each recovered event for that known execution
+arrives through normal application events. Detail is independent of recovery and remains on demand.
 
 `activeTurn.streamingMessages` is what makes step 1 sufficient mid-turn: the host serves the
 accumulated application projection, so a client joining at any moment gets the complete locally
@@ -718,9 +730,13 @@ suite of its own. See [Agent Runtime](./agent-runtime.md#13-conformance) for the
 13. Every envelope survives a JSON round trip and re-validates against its schema.
 14. A turn settles as `interrupted` when its bound Runtime cannot continue or recover after the
     application loses its execution window; a recoverable detached execution remains resumable.
-15. Autonomous, scheduled, and channel-triggered turns enter through the same command path as
-    client-issued ones.
+15. Cherry-owned autonomous, scheduled, and channel-triggered turns enter through the same command
+    path as client-issued ones; remote-native PC activity is outside this rule.
 16. Raw detail for a `remote-canonical` session is returned only by an explicit detail query and is
     never persisted, indexed, logged, snapshotted, or replayed by Mobile.
 17. A session never changes record authority through ordinary `session.rebind`; an explicit
     transfer or fork must prove it has a complete source record.
+18. A remote PC may continue or mutate its native Session without Mobile coordination. Mobile does
+    not import those turns, and its selective projection is allowed to remain stale indefinitely.
+19. Remote recovery is scoped to Mobile-known `executionId` values and per-execution cursors; it
+    never enumerates or synchronizes the remote Session transcript.

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -1,0 +1,726 @@
+# Cherry Agent Protocol
+
+Status: **design**. Version `1`.
+
+This reference defines the Cherry Mobile-owned, transport-neutral application contract between the
+Agent Client and the Mobile Agent Host. It spans frontend state, host orchestration, persistence
+projection, transport, and rendering. It is deliberately **not** the API of the independent Agent
+Runtime. Read [Agent Architecture](./README.md) for the thesis and
+[Agent Runtime](./agent-runtime.md) for the execution boundary behind the host.
+
+## 1. Scope and design rules
+
+The protocol defines what a conversation *is* in Cherry Mobile. Everything else — which runtime
+executes a turn, which SDK or remote process the runtime uses, and which component renders a part —
+is an implementation choice behind or above the application boundary.
+
+Six rules govern every definition in this document.
+
+**R1 — JSON only.** Every command, event, and snapshot survives `JSON.parse(JSON.stringify(x))` and
+re-validates against its zod schema. No `AbortSignal`, no `ReadableStream`, no `Error` instance, no
+callback, no class. This is asserted in `__DEV__` on the in-process transport, so a violation fails
+in development rather than the first time someone pairs a PC.
+
+**R2 — Application-transport-safe.** Definitions do not rely on frontend and backend sharing object
+identity. They remain valid if that application boundary later crosses a process or network. A LAN
+or cloud Agent Runtime has its own independent contract behind the backend adapter; it does not
+receive these envelopes directly.
+
+**R3 — Addressable, incremental deltas.** Streaming content is addressed by stable part id and
+applied as an append or patch. Re-sending an entire message per chunk is O(n²) serialization and
+projection work and prevents the application boundary from moving cleanly across a process or
+network later.
+
+**R4 — Capabilities, never runtime identity.** Shared code branches on declared capabilities.
+Runtime identity may be displayed for selection and diagnostics; it must not drive behavior.
+
+**R5 — Fail closed.** An unsupported command, an unknown approval, a stale generation, or a
+sequence gap produces an explicit protocol error. Nothing is silently ignored or approximated as
+success.
+
+**R6 — Persist a projection, not a remote mirror.** Session record mode decides which facts Mobile
+may persist. A remote session may carry stable summaries and opaque locators, but raw execution
+detail is neither pushed through the event stream nor written to Mobile storage.
+
+### 1.1 Ownership and non-goals
+
+The source owner is `src/shared/agent/protocol`. This is a Mobile-native shared domain because both
+the frontend Agent Client and backend Agent Host consume it. It does not belong in
+`src/shared/contracts`: that directory defines the existing in-process workflow seam and explicitly
+excludes serialized envelopes and transport concerns. It also does not belong in
+`packages/universal`, whose owner is desktop-mirrored portable data.
+
+The protocol does not define `AgentRuntime`, runtime ports, runtime-native events, AI SDK projection,
+or process-local execution handles. The Agent Host maps between this document and the independent
+runtime contract. External Runtime implementations and their transports never consume the Mobile
+application protocol directly.
+
+## 2. Entities
+
+### 2.1 Agent definition
+
+Business identity. Runtime-independent, portable between runtime bindings.
+
+```ts
+type AgentDefinition = {
+  id: string
+  name: string
+  description: string
+  instructions: string
+  model: ModelRef                 // { providerId, modelId }
+  planModel?: ModelRef
+  smallModel?: ModelRef
+  tools: ToolPolicy[]             // { toolId, mode: 'auto' | 'ask' | 'deny' }
+  skills: SkillRef[]
+  knowledgeBases: KnowledgeBaseRef[]
+  mcpServers: McpServerRef[]
+}
+```
+
+A "plain assistant" is an `AgentDefinition` with no skills, no workspace, and the in-app binding.
+There is no second configuration entity.
+
+### 2.2 Runtime binding
+
+How a definition executes.
+
+```ts
+type AgentRuntimeBinding = {
+  agentId: string
+  runtimeId: string               // implementation: 'ai-sdk' | 'codex' | 'claude' | …
+  endpoint:
+    | { kind: 'local'; endpointId: null }
+    | { kind: 'lan' | 'cloud'; endpointId: string }
+  generation: number              // increments on every rebind, never reused
+  capabilities: AgentCapabilities
+}
+```
+
+Runtime-specific configuration, credentials, and transport details are backend-private adapter
+state. The application protocol exposes identity, location, generation, and capabilities only.
+
+`generation` is the safety boundary. A continuation token, a warm connection, a pending approval,
+or an in-flight turn is valid only for the exact `(sessionId, runtimeId, endpoint, generation)`
+tuple that produced it. Rebinding closes the previous connection and discards its private state.
+A `local-canonical` session may rebuild context from its complete Mobile record. A
+`remote-canonical` session cannot rebuild from its compact projection; moving it to another
+authority requires an explicit Runtime export/import capability or creates a new fork. Compact
+history is never silently promoted into a complete execution record.
+
+### 2.3 Session
+
+The single conversation aggregate. There is no separate Topic entity.
+
+```ts
+type AgentSessionView = {
+  id: string
+  agentId: string
+  title: string
+  titleIsManual: boolean
+  binding: {
+    runtimeId: string
+    endpoint: { kind: 'local' | 'lan' | 'cloud'; endpointId: string | null }
+    generation: number
+  }
+  recordMode: 'local-canonical' | 'remote-canonical'
+  workspaceId: string | null
+  activeMessageId: string | null   // branch tip
+  status: 'idle' | 'running' | 'awaiting-approval' | 'cancelling'
+  createdAt: string                // ISO 8601
+  updatedAt: string
+}
+```
+
+`recordMode` identifies authority, not transport. It is fixed when the session is created and is
+persisted explicitly. In Mobile v2 a local endpoint creates `local-canonical`; LAN and cloud
+endpoints create `remote-canonical`. Application code branches on `recordMode` when it chooses a
+storage or detail-loading path, rather than assuming that every Runtime with a particular id has
+the same deployment.
+
+The two modes have different source-of-truth rules:
+
+| Fact | `local-canonical` | `remote-canonical` |
+| --- | --- | --- |
+| Cherry-only metadata such as local id, pin/order, manual title, and binding | Mobile record | Mobile record |
+| User input, final assistant output, and execution status | Mobile record | Remote record; compactly projected for offline display |
+| Raw reasoning, tool/MCP input and output, command logs, traces | Mobile record when the product retains it | Remote execution store only |
+| Detail shown after expansion | Read locally | Fetched through the backend adapter; held in memory only |
+
+There is no conflict between two complete stores because a remote session has only one complete
+execution record. Mobile remains authoritative for Cherry-only metadata and local UI state; the
+remote service owns execution-derived transcript and detail facts.
+
+Unifying assistant chat and agent session into one aggregate is the main deviation from the desktop
+proposal, which keeps them physically separate. That separation is argued on migration grounds —
+two shipped stores with incompatible invariants. In a clean build the objection largely dissolves: a
+linear history is a tree that never branches, and the cost of carrying tree columns on a linear
+session is two nullable fields plus one constraint. The benefit is that the desktop workaround —
+a synthetic `agent-session:` topic namespace and a derived Topic view — cannot exist here, because
+there is nothing to synthesize.
+
+Branching is therefore a **capability** (§7), not a schema difference.
+
+### 2.4 Turn
+
+One admitted unit of execution.
+
+```ts
+type AgentTurnView = {
+  id: string
+  sessionId: string
+  generation: number
+  status: 'reserved' | 'running' | 'awaiting-approval' | 'completed'
+        | 'cancelled' | 'failed' | 'interrupted'
+  executions: AgentExecutionView[]   // one per target model; length 1 unless multiExecution
+  startedAt: string
+  endedAt: string | null
+  error: AgentErrorView | null
+}
+
+type AgentExecutionView = {
+  id: string
+  messageId: string
+  model: ModelRef
+  status: 'pending' | 'streaming' | 'completed' | 'cancelled' | 'failed' | 'interrupted'
+}
+```
+
+`interrupted` is a first-class terminal state, not a variant of `failed`. It means the host lost its
+execution window — on mobile, the OS suspended JS mid-turn. It renders as resume-or-regenerate, not
+as an error.
+
+### 2.5 Message
+
+```ts
+type AgentMessageView = {
+  id: string                        // UUIDv7, time-ordered
+  sessionId: string
+  turnId: string | null             // null for the session root
+  parentId: string | null
+  role: 'user' | 'assistant' | 'system' | 'root'
+  status: 'streaming' | 'complete' | 'cancelled' | 'failed' | 'interrupted'
+  parts: AgentMessagePart[]
+  model: ModelRef | null
+  siblingGroupId: string | null     // set for regenerate / multi-execution siblings
+  usage: AgentUsageView | null
+  timing: AgentTimingView | null
+  createdAt: string
+  updatedAt: string
+}
+```
+
+Messages form an adjacency-list tree. `role: 'root'` is a single virtual root per session with
+`parentId === null`; every other message has a non-null parent. A session with `branching: false`
+never produces siblings, and its active path is a plain id-ordered scan.
+
+### 2.6 Supporting entities
+
+`AgentToolInvocationView`, `AgentApprovalView`, `AgentTaskView`, `AgentUsageView`,
+`AgentArtifactView`, and runtime-private continuation metadata namespaced by `runtimeId` and
+`generation`. Their shapes appear where they are used below.
+
+## 3. Message parts
+
+The part union is Cherry-owned, zod-validated, and shaped for Cherry's needs rather than mirroring
+any SDK.
+
+```ts
+type AgentMessagePart =
+  | AgentTextPart
+  | AgentReasoningPart
+  | AgentFilePart
+  | AgentToolPart
+  | AgentSourcePart
+  | AgentDataPart
+  | AgentErrorPart
+```
+
+Every part carries a stable `id`, unique within its message:
+
+```ts
+type AgentTextPart = {
+  id: string
+  type: 'text'
+  text: string
+  state: 'streaming' | 'done'
+}
+
+type AgentReasoningPart = {
+  id: string
+  type: 'reasoning'
+  state: 'streaming' | 'done'
+  summary?: string
+  durationMs?: number
+  detail:
+    | { kind: 'inline'; text: string; signature?: string }
+    | { kind: 'on-demand'; available: boolean }
+    | { kind: 'none' }
+}
+
+type AgentFilePart = {
+  id: string
+  type: 'file'
+  mediaType: string
+  name?: string
+  uri: string                       // cherry-file://<fileId> or https://
+  sizeBytes?: number
+}
+
+type AgentToolPart = {
+  id: string
+  type: 'tool'
+  toolCallId: string
+  toolName: string                  // explicit field, never encoded in `type`
+  source: 'builtin' | 'mcp' | 'provider'
+  serverId?: string                 // for source: 'mcp'
+  state: 'input-streaming' | 'input-available' | 'awaiting-approval'
+       | 'executing' | 'output-available' | 'output-error' | 'denied'
+  approvalId?: string
+  summary?: string                   // safe compact label for transcript/search
+  error?: AgentErrorView             // user-facing summary, never a raw remote error
+  detail:
+    | { kind: 'inline'; input?: unknown; output?: unknown }
+    | { kind: 'on-demand'; available: boolean }
+    | { kind: 'none' }
+}
+
+type AgentSourcePart = {
+  id: string
+  type: 'source'
+  sourceType: 'url' | 'document'
+  url?: string
+  title?: string
+  snippet?: string
+}
+
+type AgentDataPart = {
+  id: string
+  type: 'data'
+  kind: string                      // 'code' | 'translation' | 'compact' | 'video' | vendor-namespaced
+  payload: unknown                  // validated by a kind-specific schema
+}
+
+type AgentErrorPart = {
+  id: string
+  type: 'error'
+  error: AgentErrorView
+}
+```
+
+`detail` is a persistence boundary, not merely a rendering hint. A `local-canonical` session may
+persist an `inline` tool detail. A `remote-canonical` session persists only `on-demand` or `none`;
+its tool input, output, MCP payload, trace, shell log, and provider-native event never appear in a
+snapshot, application event, SQLite row, search index, log field, or disk cache on Mobile.
+
+The same rule applies beyond tools. A remote compact projection may retain user-visible prompts,
+final assistant text, attachment metadata, artifact references, status, usage summary, timestamps,
+and safe error summaries. It does not retain raw reasoning, full source bodies, terminal output,
+debug traces, continuation state, remote file contents, or Runtime-native snapshots.
+
+When a user expands a remote part, the frontend requests a detail view by Cherry ids:
+
+```ts
+type AgentPartDetailView = {
+  sessionId: string
+  messageId: string
+  partId: string
+  input?: unknown
+  output?: unknown
+  reasoning?: string
+  log?: string
+  error?: AgentErrorView
+}
+```
+
+The backend resolves those ids through its private adapter mapping. The response is ephemeral UI
+state: it is not merged into `AgentMessageView`, persisted, indexed, included in a snapshot, or
+replayed as an event. Collapsing the part, leaving the screen, or backgrounding the app may discard
+it.
+
+Three deliberate departures from the AI SDK shape, each of which would be a painful migration later
+and is free now:
+
+**Explicit `toolName`.** The SDK encodes the tool name in the discriminant (`tool-${name}`). That
+defeats a closed discriminated union, defeats runtime validation, and forces typed tool-renderer
+routing to parse strings. A `toolName` field costs nothing and makes tool rendering a table lookup.
+
+**Stable part ids.** The SDK addresses parts positionally in its UI stream. Positional addressing is
+fine in a lossless in-process pipe and fragile over a network where a client may join mid-stream or
+apply events out of a replay buffer. Ids make deltas addressable (§5.3) and idempotent-by-position
+bugs impossible.
+
+**`data` parts are a namespace, not a union arm each.** `AgentDataPart.kind` keeps the top-level
+union closed and stable while letting product features add content types without a protocol version
+bump. Each `kind` registers its own payload schema.
+
+### 3.1 Input parts
+
+Commands carry a narrower union — a client may not fabricate assistant content:
+
+```ts
+type AgentInputPart =
+  | { type: 'text'; text: string }
+  | { type: 'file'; mediaType: string; name?: string; uri: string }
+```
+
+## 4. Commands
+
+```ts
+type AgentCommand =
+  // session
+  | { type: 'session.create'; agentId: string; workspaceId?: string; title?: string }
+  | { type: 'session.rename'; title: string }
+  | { type: 'session.delete' }
+  | { type: 'session.rebind'; runtimeId: string
+      endpoint: { kind: 'local' | 'lan' | 'cloud'; endpointId: string | null } }
+  // conversation
+  | { type: 'message.submit'; parts: AgentInputPart[]; parentMessageId?: string
+      models?: ModelRef[]; options?: AgentTurnOptions }
+  | { type: 'message.edit'; messageId: string; parts: AgentInputPart[]; options?: AgentTurnOptions }
+  | { type: 'message.delete'; messageId: string; cascade: boolean }
+  | { type: 'branch.select'; throughMessageId: string }
+  // turn
+  | { type: 'turn.regenerate'; messageId: string; models?: ModelRef[]; options?: AgentTurnOptions }
+  | { type: 'turn.steer'; turnId: string; parts: AgentInputPart[] }
+  | { type: 'turn.queue'; parts: AgentInputPart[]; options?: AgentTurnOptions }
+  | { type: 'turn.cancel'; turnId: string; executionId?: string }
+  // tools and tasks
+  | { type: 'approval.respond'; approvalId: string; decision: ApprovalDecision }
+  | { type: 'task.stop'; taskId: string }
+
+type AgentTurnOptions = {
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  mode?: 'auto' | 'fast' | 'plan'
+}
+
+type ApprovalDecision =
+  | { approved: true; updatedInput?: Record<string, unknown> }
+  | { approved: false; reason?: string }
+```
+
+Commands express user intent. None of them names a runtime or SDK operation, and none of them carries
+a process-local handle — notably, **cancellation is a command, not an `AbortSignal`**. The Mobile
+Agent Host translates the command to the runtime's cancellation API; the execution adapter owns any
+`AbortController` internally.
+
+`session.rebind` changes a Runtime binding only when the target preserves the session's
+`recordMode` and authoritative record. A local record may reconstruct a compatible local Runtime;
+a remote record may reconnect through another endpoint only when it still identifies the same
+remote authority. Moving to a different authority is a separate export, import, or fork workflow
+and is out of scope in protocol v1. Treating a compact projection as a complete transcript would
+silently lose execution context, so the host rejects that transition.
+
+### 4.1 Envelope
+
+```ts
+type AgentCommandEnvelope = {
+  protocolVersion: number
+  commandId: string            // client-generated, idempotency key
+  sessionId: string            // absent only for session.create
+  expectedGeneration?: number
+  expectedRevision?: number
+  issuedAt: string
+  command: AgentCommand
+}
+
+type AgentCommandAck =
+  | { ok: true; commandId: string; revision: number; sequence: number; result?: unknown }
+  | { ok: false; commandId: string; error: AgentErrorView }
+```
+
+`commandId` idempotency is mandatory, not advisory. A flaky network plus a user tapping send twice
+on a stalled spinner is the ordinary failure mode; a replayed `message.submit` must return the
+original ack, not create a second turn. Hosts persist command receipts
+([Agent Runtime §8](./agent-runtime.md#8-storage-boundary)) so idempotency survives a restart.
+
+`expectedGeneration` guards against a command issued against a binding the user has since changed.
+`expectedRevision` is used only where lost-update semantics matter — `message.edit`, `branch.select`,
+`session.rename`.
+
+### 4.2 On-demand detail query
+
+Execution detail is a read, not a durable command and not an event subscription:
+
+```text
+GET /agent-sessions/:sessionId/messages/:messageId/parts/:partId/detail
+  -> AgentPartDetailView
+```
+
+The route is part of the Mobile application boundary even when its current implementation is an
+in-process Data API call. For `local-canonical`, the host reads the local record. For
+`remote-canonical`, the adapter performs an authenticated HTTP request to the bound LAN or cloud
+endpoint. The frontend never receives a remote URL, credential, or Runtime-native locator.
+
+Remote responses use `Cache-Control: no-store`; the Mobile query layer does not persist them or
+hydrate them into an offline cache. If the endpoint is offline, expired, or has deleted the detail,
+the compact part remains renderable and the query returns an explicit unavailable error.
+
+## 5. Events
+
+```ts
+type AgentEvent =
+  | { type: 'session.updated'; session: AgentSessionView }
+  | { type: 'session.deleted'; sessionId: string }
+  | { type: 'turn.started'; turn: AgentTurnView }
+  | { type: 'turn.updated'; turn: AgentTurnView }
+  | { type: 'turn.completed'; turnId: string }
+  | { type: 'turn.failed'; turnId: string; error: AgentErrorView }
+  | { type: 'message.created'; message: AgentMessageView }
+  | { type: 'message.delta'; messageId: string; delta: AgentPartDelta }
+  | { type: 'message.finalized'; message: AgentMessageView }
+  | { type: 'message.deleted'; messageId: string }
+  | { type: 'approval.requested'; approval: AgentApprovalView }
+  | { type: 'approval.resolved'; approval: AgentApprovalView }
+  | { type: 'task.updated'; task: AgentTaskView }
+  | { type: 'usage.updated'; messageId: string; usage: AgentUsageView }
+```
+
+### 5.1 Envelope
+
+```ts
+type AgentEventEnvelope = {
+  protocolVersion: number
+  epoch: string        // host instance identity
+  sessionId: string
+  generation: number   // runtime binding generation
+  sequence: number     // monotonic per session, per epoch, gapless
+  revision: number     // persisted-state revision after this event
+  event: AgentEvent
+}
+```
+
+### 5.2 `epoch` and `generation` are different
+
+Both are required and conflating them produces a subtle class of bug.
+
+`generation` changes when the **user rebinds** the session to another Runtime implementation or
+endpoint. It scopes continuations, approvals, and connections.
+
+`epoch` changes when the **host process restarts**. On mobile that is every cold start and every
+background kill. A restarted host resumes its sequence counter at 1; a client holding sequence 400
+would read the next events as a stale replay and discard them. With `epoch`, the mismatch is
+detected on the first envelope and the client takes a fresh snapshot.
+
+### 5.3 Deltas
+
+```ts
+type AgentPartDelta =
+  | { op: 'add'; index: number; part: AgentMessagePart }
+  | { op: 'append'; partId: string; text: string }        // text and inline reasoning only
+  | { op: 'patch'; partId: string; patch: Record<string, unknown> }   // shallow merge
+  | { op: 'remove'; partId: string }
+```
+
+Deltas are ephemeral — never persisted, never replayed from storage. Ordering and completeness are
+guaranteed by the envelope's gapless `sequence`; a client that detects a gap reloads the snapshot
+rather than attempting delta reconciliation. Mid-stream state is carried in the snapshot
+(§6), so a client joining a running turn never needs the deltas it missed.
+
+For `remote-canonical`, deltas contain compact projection fields only. Raw execution detail is not
+temporarily smuggled through `message.delta`; it remains behind the detail query even while the turn
+is live.
+
+This is the concrete replacement for whole-message overlays. Today's runtime republishes the entire
+accumulated assistant message on every chunk, which is quadratic in serialized size and repeated
+projection work.
+
+### 5.4 Ordering guarantee
+
+> A durable application-projection fact is persisted before its event is published.
+
+`message.delta` is fire-and-forget. `message.finalized`, `turn.completed`, and `turn.failed` are
+emitted only after the corresponding local record or compact projection is committed. A client that
+observes `turn.completed` and immediately queries the transcript must find the terminal projection
+already there. This ordering does not transfer authority for remote execution detail to Mobile.
+
+Optimistic pre-persistence display is a client concern, expressed through
+`turn.started` and `message.created` before content exists — not through publishing a terminal fact
+early.
+
+## 6. Snapshot and recovery
+
+```ts
+type AgentSessionSnapshot = {
+  protocolVersion: number
+  epoch: string
+  session: AgentSessionView
+  capabilities: AgentCapabilities
+  activeTurn: (AgentTurnView & {
+    streamingMessages: AgentMessageView[]   // accumulated-so-far, one per execution
+  }) | null
+  messages: AgentMessageView[]              // active branch window
+  branchPoints: BranchPointView[]           // sibling counts for navigable nodes
+  approvals: AgentApprovalView[]            // unresolved only
+  tasks: AgentTaskView[]                    // active only
+  queued: QueuedInputView[]
+  generation: number
+  revision: number
+  lastSequence: number
+}
+```
+
+Every message in a snapshot obeys `session.recordMode`. A local snapshot may contain inline detail;
+a remote snapshot contains the compact projection only. `AgentPartDetailView` is deliberately not
+part of this type.
+
+Recovery is one loop, identical over every transport:
+
+1. Load the snapshot.
+2. Subscribe from `lastSequence + 1`.
+3. On an `epoch` mismatch, or a sequence gap the host cannot replay, discard local state and go
+   to 1.
+
+No frontend client inspects Runtime-native state to recover the application projection. For a
+remote session, the Mobile Agent Host serves the cached compact snapshot first, then asks the
+adapter to advance it from the remote cursor or projection snapshot. Each committed advance arrives
+through normal application events. Detail is independent of recovery and remains on demand.
+
+`activeTurn.streamingMessages` is what makes step 1 sufficient mid-turn: the host serves the
+accumulated application projection, so a client joining at any moment gets the complete locally
+renderable picture without replaying deltas. For a remote session this is still the compact picture,
+not a copy of the remote execution log.
+
+On mobile this loop is not an error path. It runs on every foreground transition.
+
+## 7. Capabilities
+
+One declaration per binding, enforced by the host and read by the UI.
+
+```ts
+type AgentCapabilities = {
+  // conversation shape
+  branching: boolean              // sibling messages, edit-and-resend, regenerate
+  multiExecution: boolean         // one turn fanning out to several models
+  followUpQueue: boolean
+  // execution control
+  steering: boolean
+  cancellation: boolean
+  detachedExecution: DetachedExecution   // can execution recover after the app connection goes away?
+  // tools
+  editableApprovalInput: boolean
+  taskStop: boolean
+  backgroundTasks: boolean
+  autonomousTurns: boolean
+  // context
+  compaction: boolean
+  contextUsage: boolean
+  slashCommands: boolean
+  // input
+  attachments: { audio: boolean; image: boolean; pdf: boolean; video: boolean }
+  modes: { auto: boolean; fast: boolean; plan: boolean }
+}
+```
+
+`detachedExecution` is not a boolean, because on mobile the honest answer is "for a while":
+
+```ts
+type DetachedExecution =
+  | { kind: 'none' }
+  | { kind: 'bounded'; budgetMs: number; mechanism: string; userVisible: boolean }
+  | { kind: 'unbounded' }
+```
+
+The Mobile Agent Host derives this value from the Runtime's recovery support, endpoint properties,
+platform budget, and product policy. A LAN or cloud label alone never implies `unbounded`: the
+Runtime must retain execution state and support resume or snapshot recovery.
+[Runtime Ownership](../runtime-ownership.md#principles) already records that backgrounding is not a
+reliable execution window, and
+[Agent Runtime §9.2](./agent-runtime.md#92-execution-lifetime)
+applies that constraint to local and remote execution.
+
+A boolean would force the UI to lie in one direction or the other. The budget lets the composer say
+"about 30 seconds after you leave the app" versus "keeps running, stop it from the notification"
+versus "keeps running on your Mac" — which is the whole difference between a long-running agent a
+user can trust and one that silently dies in their pocket.
+
+Two enforcement rules:
+
+- Shared components branch on capabilities, never on `runtimeId` (R4).
+- **Client-side gating is UX. The host re-validates every command against the binding's
+  capabilities**, because a remote client is untrusted input. An unsupported command returns
+  `CAPABILITY_UNSUPPORTED`.
+
+## 8. Errors
+
+```ts
+type AgentErrorView = {
+  code: AgentErrorCode
+  message: string             // already localized or localizable by key
+  retryable: boolean
+  details?: Record<string, unknown>
+}
+```
+
+| Code | Meaning |
+| --- | --- |
+| `PROTOCOL_VERSION_UNSUPPORTED` | Host and client cannot negotiate a version |
+| `COMMAND_INVALID` | Failed schema validation |
+| `SESSION_NOT_FOUND` / `TURN_NOT_FOUND` | Unknown id |
+| `SESSION_BUSY` | A turn is already active and the binding rejects concurrency |
+| `GENERATION_MISMATCH` | `expectedGeneration` does not match the current binding |
+| `REVISION_CONFLICT` | `expectedRevision` is stale |
+| `CAPABILITY_UNSUPPORTED` | The binding does not declare the required capability |
+| `APPROVAL_NOT_FOUND` / `APPROVAL_ALREADY_SETTLED` | Approval correlation failed |
+| `RUNTIME_UNAVAILABLE` | Endpoint unreachable, unpaired, or not running |
+| `RUNTIME_FAILED` | The runtime reported a terminal failure |
+| `DETAIL_UNAVAILABLE` | On-demand detail is offline, expired, deleted, or not retained by the Runtime |
+| `AUTHORITY_TRANSFER_UNSUPPORTED` | A rebind would change record mode or execution authority without an explicit transfer workflow |
+| `CANCELLED` / `INTERRUPTED` | Terminal, non-error outcomes surfaced as turn results |
+| `UNAUTHORIZED` | Pairing token invalid or revoked |
+| `RATE_LIMITED` | Provider or host throttling; `details.retryAfterMs` |
+
+An `Error` instance never crosses the boundary. Stack traces stay in host logs.
+For a `remote-canonical` session, `details` is limited to explicitly allowlisted display metadata;
+it never carries a native error, request body, tool payload, remote response, or stack trace.
+
+## 9. Versioning
+
+A single integer `protocolVersion`. Additive, optional fields do not bump it; removing a field,
+narrowing a type, or changing a semantic does.
+
+Negotiation happens once per connection: the host advertises `supportedVersions: number[]`, the
+client picks the highest it also supports, and a failed negotiation is
+`PROTOCOL_VERSION_UNSUPPORTED`.
+
+The compatibility rule is asymmetric, and deliberately so:
+
+- **Clients ignore unknown events and unknown part types.** A newer host must be able to add an
+  event or a `data` part `kind` without breaking older clients. An unknown part renders as a
+  neutral placeholder.
+- **Hosts reject unknown commands.** Guessing at an intent the host does not implement is exactly
+  the silent-downgrade failure R5 exists to prevent.
+
+Unknown-part tolerance is why the part union is closed at the top level with an open `data`
+namespace (§3): product features extend without a version bump, structural changes do not sneak in
+without one.
+
+## 10. Invariants
+
+These are executable application-protocol conformance tests, run against every Mobile Agent Host
+implementation and transport adapter. The independent runtime has a smaller execution-conformance
+suite of its own. See [Agent Runtime](./agent-runtime.md#13-conformance) for the separation.
+
+1. Every admitted turn reaches exactly one terminal outcome.
+2. No content event is accepted for a turn after its terminal state.
+3. Commands are idempotent by `commandId`, across host restarts.
+4. Per session and epoch, `sequence` is gapless and strictly increasing.
+5. A durable application-projection fact is persisted before its event is published.
+6. `turn.cancel` and connection close are idempotent.
+7. Approval decisions correlate to session, generation, turn, and tool call, and fail closed.
+8. Runtime-private continuation state is never reused across a change of runtime, endpoint, or
+   generation.
+9. `session.rebind` closes the previous connection before activating the next generation.
+10. An unsupported capability is rejected explicitly, never silently downgraded.
+11. A client recovers the locally renderable projection from snapshot plus subsequent events alone.
+12. A `local-canonical` session's complete record is authoritative in Mobile persistence; a
+    `remote-canonical` session's execution record is authoritative at its bound Runtime endpoint,
+    and its Mobile record is explicitly a compact projection.
+13. Every envelope survives a JSON round trip and re-validates against its schema.
+14. A turn settles as `interrupted` when its bound Runtime cannot continue or recover after the
+    application loses its execution window; a recoverable detached execution remains resumable.
+15. Autonomous, scheduled, and channel-triggered turns enter through the same command path as
+    client-issued ones.
+16. Raw detail for a `remote-canonical` session is returned only by an explicit detail query and is
+    never persisted, indexed, logged, snapshotted, or replayed by Mobile.
+17. A session never changes record authority through ordinary `session.rebind`; an explicit
+    transfer or fork must prove it has a complete source record.

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -91,6 +91,7 @@ type AgentMessageView = {
   role: 'user' | 'assistant' | 'system'
   status: 'pending' | 'streaming' | 'success' | 'error' | 'cancelled' | 'interrupted'
   parts: AgentMessagePart[]
+  usage: AgentUsageView | null
   createdAt: string
   updatedAt: string
 }
@@ -131,10 +132,21 @@ type AgentMessagePart =
       type: 'error'
       error: AgentErrorView
     }
+
+type AgentUsageView = {
+  inputTokens?: number
+  outputTokens?: number
+  totalTokens?: number
+}
 ```
 
 Part ids are stable within a message. The protocol owns these normalized parts; neither Pi nor the
 AI SDK shape leaks through the boundary.
+
+`usage` is populated only on assistant messages. The Host accumulates Runtime usage reports during
+the turn and commits the final value together with the terminal message state, so
+`message.finalized` and later transcript reads both carry it. While the message is streaming,
+`usage` is `null`; there is no dedicated usage event.
 
 ### Input and approval
 
@@ -164,7 +176,11 @@ type AgentCapabilities = {
 `assistant` remains the standard message role; the configurable product entity is always `Agent`.
 
 Cancellation is required by the Runtime contract and is therefore not a capability flag.
-The Host projects these values from the selected Runtime descriptor.
+The Host evaluates capabilities on demand from the Session's current Agent configuration: it asks
+the Router which Runtime that configuration selects and projects that descriptor's capability
+flags. No turn needs to have run, so a fresh Session's snapshot already carries correct values.
+Configuration changes do not push a capabilities event; a new observation is the only refresh
+point, and an already-admitted turn still finishes on its original route.
 The Agent Client may branch on these protocol capabilities, never on Runtime identity.
 
 ## Operations

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -1,742 +1,288 @@
 # Cherry Agent Protocol
 
-Status: **design**. Version `1`.
+Status: **design**. Version 1 is local-only.
 
-This reference defines the Cherry Mobile-owned, transport-neutral application contract between the
-Agent Client and the Mobile Agent Host. It spans frontend state, host orchestration, persistence
-projection, transport, and rendering. It is deliberately **not** the API of the independent Agent
-Runtime. Read [Agent Architecture](./README.md) for the thesis and
-[Agent Runtime](./agent-runtime.md) for the execution boundary behind the host.
+This document defines the application contract between the Agent Client and the Mobile Agent Host.
+It does not define the independent [Agent Runtime](./agent-runtime.md) behind the Host.
 
-## 1. Scope and design rules
+## Scope
 
-The protocol defines what a conversation *is* in Cherry Mobile. Everything else — which runtime
-executes a turn, which SDK or remote process the runtime uses, and which component renders a part —
-is an implementation choice behind or above the application boundary.
+The protocol owns the product meaning of an Agent Session: creating the Session, submitting a
+message, observing a turn, cancelling it, responding to tool approval, and recovering UI state from
+a snapshot.
 
-Six rules govern every definition in this document.
+Version 1 uses an in-process interface. Operation inputs, results, snapshots, and events are
+JSON-safe values validated at the boundary. Subscription callbacks and unsubscribe handles are
+process-local transport mechanics, not protocol data.
 
-**R1 — JSON only.** Every command, event, and snapshot survives `JSON.parse(JSON.stringify(x))` and
-re-validates against its zod schema. No `AbortSignal`, no `ReadableStream`, no `Error` instance, no
-callback, no class. This is asserted in `__DEV__` on the in-process transport, so a violation fails
-in development rather than the first time someone pairs a PC.
+The protocol does not expose provider SDK objects, Runtime-native events, SQLite rows,
+`AbortSignal`, streams, callbacks inside values, or implementation-specific Pi/AI SDK state.
 
-**R2 — Application-transport-safe.** Definitions do not rely on frontend and backend sharing object
-identity. They remain valid if that application boundary later crosses a process or network. A LAN
-or cloud Agent Runtime has its own independent contract behind the backend adapter; it does not
-receive these envelopes directly.
-
-**R3 — Addressable, incremental deltas.** Streaming content is addressed by stable part id and
-applied as an append or patch. Re-sending an entire message per chunk is O(n²) serialization and
-projection work and prevents the application boundary from moving cleanly across a process or
-network later.
-
-**R4 — Capabilities, never runtime identity.** Shared code branches on declared capabilities.
-Runtime identity may be displayed for selection and diagnostics; it must not drive behavior.
-
-**R5 — Fail closed.** An unsupported command, an unknown approval, a stale generation, or a
-sequence gap produces an explicit protocol error. Nothing is silently ignored or approximated as
-success.
-
-**R6 — Persist a selective projection, not a remote mirror.** Session record mode decides which
-facts Mobile may persist. A remote session carries compact records only for Mobile-initiated
-executions. Remote-native turns are not imported, and raw execution detail is neither pushed
-through the event stream nor written to Mobile storage.
-
-### 1.1 Ownership and non-goals
-
-The source owner is `src/shared/agent/protocol`. This is a Mobile-native shared domain because both
-the frontend Agent Client and backend Agent Host consume it. It does not belong in
-`src/shared/contracts`: that directory defines the existing in-process workflow seam and explicitly
-excludes serialized envelopes and transport concerns. It also does not belong in
-`packages/universal`, whose owner is desktop-mirrored portable data.
-
-The protocol does not define `AgentRuntime`, runtime ports, runtime-native events, AI SDK projection,
-or process-local execution handles. The Agent Host maps between this document and the independent
-runtime contract. External Runtime implementations and their transports never consume the Mobile
-application protocol directly.
-
-## 2. Entities
-
-### 2.1 Agent definition
-
-Business identity. Runtime-independent, portable between runtime bindings.
+## Values
 
 ```ts
-type AgentDefinition = {
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+type AgentView = {
   id: string
   name: string
-  description: string
-  instructions: string
-  model: ModelRef                 // { providerId, modelId }
-  planModel?: ModelRef
-  smallModel?: ModelRef
-  tools: ToolPolicy[]             // { toolId, mode: 'auto' | 'ask' | 'deny' }
-  skills: SkillRef[]
-  knowledgeBases: KnowledgeBaseRef[]
-  mcpServers: McpServerRef[]
 }
-```
 
-A "plain assistant" is an `AgentDefinition` with no skills, no workspace, and the in-app binding.
-There is no second configuration entity.
+type AgentExecutionTarget = { kind: 'local' }
 
-### 2.2 Runtime binding
-
-How a definition executes.
-
-```ts
-type AgentRuntimeBinding = {
-  agentId: string
-  runtimeId: string               // implementation: 'ai-sdk' | 'codex' | 'claude' | …
-  endpoint:
-    | { kind: 'local'; endpointId: null }
-    | { kind: 'lan' | 'cloud'; endpointId: string }
-  generation: number              // increments on every rebind, never reused
-  capabilities: AgentCapabilities
-}
-```
-
-Runtime-specific configuration, credentials, and transport details are backend-private adapter
-state. The application protocol exposes identity, location, generation, and capabilities only.
-
-`generation` is the safety boundary. A continuation token, a warm connection, a pending approval,
-or an in-flight turn is valid only for the exact `(sessionId, runtimeId, endpoint, generation)`
-tuple that produced it. Rebinding closes the previous connection and discards its private state.
-A `local-canonical` session may rebuild context from its complete Mobile record. A
-`remote-canonical` session cannot rebuild from its compact projection; moving it to another
-authority requires an explicit Runtime export/import capability or creates a new fork. Compact
-history is never silently promoted into a complete execution record.
-
-### 2.3 Session
-
-The single conversation aggregate. There is no separate Topic entity.
-
-```ts
 type AgentSessionView = {
   id: string
   agentId: string
+  executionTarget: AgentExecutionTarget
   title: string
   titleIsManual: boolean
-  binding: {
-    runtimeId: string
-    endpoint: { kind: 'local' | 'lan' | 'cloud'; endpointId: string | null }
-    generation: number
-  }
-  recordMode: 'local-canonical' | 'remote-canonical'
-  workspaceId: string | null
-  activeMessageId: string | null   // tip of Mobile's local projection, not the remote head
-  status: 'idle' | 'running' | 'awaiting-approval' | 'cancelling'
-  createdAt: string                // ISO 8601
-  updatedAt: string
-}
-```
-
-`recordMode` identifies authority, not transport. It is fixed when the session is created and is
-persisted explicitly. In Mobile v2 a local endpoint creates `local-canonical`; LAN and cloud
-endpoints create `remote-canonical`. Application code branches on `recordMode` when it chooses a
-storage or detail-loading path, rather than assuming that every Runtime with a particular id has
-the same deployment.
-
-The two modes have different source-of-truth rules:
-
-| Fact | `local-canonical` | `remote-canonical` |
-| --- | --- | --- |
-| Cherry-only metadata such as local id, pin/order, manual title, and binding | Mobile record | Mobile record |
-| User input, final assistant output, and execution status | Mobile record | Remote record; selectively projected only for Mobile-initiated executions |
-| Raw reasoning, tool/MCP input and output, command logs, traces | Mobile record when the product retains it | Remote execution store only |
-| Detail shown after expansion | Read locally | Fetched through the backend adapter; held in memory only |
-
-There is no conflict between two complete stores because a remote session has only one complete
-execution record. Mobile remains authoritative for Cherry-only metadata and local UI state; the
-remote service owns execution-derived transcript and detail facts. The Mobile projection may remain
-incomplete and permanently stale after the user continues the same session on the remote PC.
-For `remote-canonical`, `status`, `activeMessageId`, and `updatedAt` describe the last state Mobile
-observed through its own executions, not the remote Session's current state.
-
-Unifying assistant chat and agent session into one aggregate is the main deviation from the desktop
-proposal, which keeps them physically separate. That separation is argued on migration grounds —
-two shipped stores with incompatible invariants. In a clean build the objection largely dissolves: a
-linear history is a tree that never branches, and the cost of carrying tree columns on a linear
-session is two nullable fields plus one constraint. The benefit is that the desktop workaround —
-a synthetic `agent-session:` topic namespace and a derived Topic view — cannot exist here, because
-there is nothing to synthesize.
-
-Branching is therefore a **capability** (§7), not a schema difference.
-
-### 2.4 Turn
-
-One admitted unit of execution.
-
-```ts
-type AgentTurnView = {
-  id: string
-  sessionId: string
-  generation: number
-  status: 'reserved' | 'running' | 'awaiting-approval' | 'completed'
-        | 'cancelled' | 'failed' | 'interrupted'
-  executions: AgentExecutionView[]   // one per target model; length 1 unless multiExecution
-  startedAt: string
-  endedAt: string | null
-  error: AgentErrorView | null
-}
-
-type AgentExecutionView = {
-  id: string
-  messageId: string
-  model: ModelRef
-  status: 'pending' | 'streaming' | 'completed' | 'cancelled' | 'failed' | 'interrupted'
-}
-```
-
-`interrupted` is a first-class terminal state, not a variant of `failed`. It means the host lost its
-execution window — on mobile, the OS suspended JS mid-turn. It renders as resume-or-regenerate, not
-as an error.
-
-### 2.5 Message
-
-```ts
-type AgentMessageView = {
-  id: string                        // UUIDv7, time-ordered
-  sessionId: string
-  turnId: string | null             // null for the session root
-  parentId: string | null
-  role: 'user' | 'assistant' | 'system' | 'root'
-  status: 'streaming' | 'complete' | 'cancelled' | 'failed' | 'interrupted'
-  parts: AgentMessagePart[]
-  model: ModelRef | null
-  siblingGroupId: string | null     // set for regenerate / multi-execution siblings
-  usage: AgentUsageView | null
-  timing: AgentTimingView | null
   createdAt: string
   updatedAt: string
 }
 ```
 
-Messages form an adjacency-list tree. `role: 'root'` is a single virtual root per session with
-`parentId === null`; every other message has a non-null parent. A session with `branching: false`
-never produces siblings, and its active path is a plain id-ordered scan.
+`executionTarget` expresses application intent, not implementation choice. Version 1 accepts only
+`local`; LAN and cloud may add target variants after their authority and transport contracts are
+designed. Runtime ids and Pi/AI SDK implementation details never appear in protocol values.
 
-### 2.6 Supporting entities
+`agentId` identifies the application-owned Agent configuration. Before each turn, the Host resolves
+that configuration, including its Agent tools, and passes the result to the Runtime Router. The
+client does not duplicate configuration or select a Runtime.
 
-`AgentToolInvocationView`, `AgentApprovalView`, `AgentTaskView`, `AgentUsageView`,
-`AgentArtifactView`, and runtime-private continuation metadata namespaced by `runtimeId` and
-`generation`. Their shapes appear where they are used below.
+### Turn
 
-## 3. Message parts
-
-The part union is Cherry-owned, zod-validated, and shaped for Cherry's needs rather than mirroring
-any SDK.
+One submitted user input creates one turn and one assistant response.
 
 ```ts
-type AgentMessagePart =
-  | AgentTextPart
-  | AgentReasoningPart
-  | AgentFilePart
-  | AgentToolPart
-  | AgentSourcePart
-  | AgentDataPart
-  | AgentErrorPart
-```
-
-Every part carries a stable `id`, unique within its message:
-
-```ts
-type AgentTextPart = {
+type AgentTurnView = {
   id: string
-  type: 'text'
-  text: string
-  state: 'streaming' | 'done'
-}
-
-type AgentReasoningPart = {
-  id: string
-  type: 'reasoning'
-  state: 'streaming' | 'done'
-  summary?: string
-  durationMs?: number
-  detail:
-    | { kind: 'inline'; text: string; signature?: string }
-    | { kind: 'on-demand'; available: boolean }
-    | { kind: 'none' }
-}
-
-type AgentFilePart = {
-  id: string
-  type: 'file'
-  mediaType: string
-  name?: string
-  uri: string                       // cherry-file://<fileId> or https://
-  sizeBytes?: number
-}
-
-type AgentToolPart = {
-  id: string
-  type: 'tool'
-  toolCallId: string
-  toolName: string                  // explicit field, never encoded in `type`
-  source: 'builtin' | 'mcp' | 'provider'
-  serverId?: string                 // for source: 'mcp'
-  state: 'input-streaming' | 'input-available' | 'awaiting-approval'
-       | 'executing' | 'output-available' | 'output-error' | 'denied'
-  approvalId?: string
-  summary?: string                   // safe compact label for transcript/search
-  error?: AgentErrorView             // user-facing summary, never a raw remote error
-  detail:
-    | { kind: 'inline'; input?: unknown; output?: unknown }
-    | { kind: 'on-demand'; available: boolean }
-    | { kind: 'none' }
-}
-
-type AgentSourcePart = {
-  id: string
-  type: 'source'
-  sourceType: 'url' | 'document'
-  url?: string
-  title?: string
-  snippet?: string
-}
-
-type AgentDataPart = {
-  id: string
-  type: 'data'
-  kind: string                      // 'code' | 'translation' | 'compact' | 'video' | vendor-namespaced
-  payload: unknown                  // validated by a kind-specific schema
-}
-
-type AgentErrorPart = {
-  id: string
-  type: 'error'
-  error: AgentErrorView
-}
-```
-
-`detail` is a persistence boundary, not merely a rendering hint. A `local-canonical` session may
-persist an `inline` tool detail. A `remote-canonical` session persists only `on-demand` or `none`;
-its tool input, output, MCP payload, trace, shell log, and provider-native event never appear in a
-snapshot, application event, SQLite row, search index, log field, or disk cache on Mobile.
-
-The same rule applies beyond tools. A remote compact projection may retain user-visible prompts,
-final assistant text, attachment metadata, artifact references, status, usage summary, timestamps,
-and safe error summaries. It does not retain raw reasoning, full source bodies, terminal output,
-debug traces, continuation state, remote file contents, or Runtime-native snapshots.
-
-When a user expands a remote part, the frontend requests a detail view by Cherry ids:
-
-```ts
-type AgentPartDetailView = {
   sessionId: string
-  messageId: string
-  partId: string
-  input?: unknown
-  output?: unknown
-  reasoning?: string
-  log?: string
-  error?: AgentErrorView
+  status:
+    | 'running'
+    | 'awaiting-approval'
+    | 'cancelling'
+    | 'completed'
+    | 'failed'
+    | 'cancelled'
+    | 'interrupted'
+  assistantMessageId: string
+  error: AgentErrorView | null
+  startedAt: string
+  endedAt: string | null
 }
 ```
 
-The backend resolves those ids through its private adapter mapping. The response is ephemeral UI
-state: it is not merged into `AgentMessageView`, persisted, indexed, included in a snapshot, or
-replayed as an event. Collapsing the part, leaving the screen, or backgrounding the app may discard
-it.
+Version 1 has one execution per turn and at most one active turn per Session. It has no execution
+entity, follow-up queue, steering, autonomous turn, or background task.
 
-Three deliberate departures from the AI SDK shape, each of which would be a painful migration later
-and is free now:
+### Message
 
-**Explicit `toolName`.** The SDK encodes the tool name in the discriminant (`tool-${name}`). That
-defeats a closed discriminated union, defeats runtime validation, and forces typed tool-renderer
-routing to parse strings. A `toolName` field costs nothing and makes tool rendering a table lookup.
+```ts
+type AgentMessageView = {
+  id: string
+  sessionId: string
+  turnId: string | null
+  role: 'user' | 'assistant' | 'system'
+  status: 'pending' | 'streaming' | 'success' | 'error' | 'cancelled' | 'interrupted'
+  parts: AgentMessagePart[]
+  createdAt: string
+  updatedAt: string
+}
 
-**Stable part ids.** The SDK addresses parts positionally in its UI stream. Positional addressing is
-fine in a lossless in-process pipe and fragile over a network where a client may join mid-stream or
-apply events out of a replay buffer. Ids make deltas addressable (§5.3) and idempotent-by-position
-bugs impossible.
+type AgentMessagePart =
+  | {
+      id: string
+      type: 'text' | 'reasoning'
+      text: string
+      state: 'streaming' | 'done'
+    }
+  | {
+      id: string
+      type: 'file'
+      mediaType: string
+      name?: string
+      uri: string
+    }
+  | {
+      id: string
+      type: 'tool'
+      toolCallId: string
+      toolName: string
+      state:
+        | 'input-available'
+        | 'awaiting-approval'
+        | 'running'
+        | 'output-available'
+        | 'denied'
+        | 'error'
+      input?: JsonValue
+      output?: JsonValue
+      approvalId?: string
+      error?: AgentErrorView
+    }
+  | {
+      id: string
+      type: 'error'
+      error: AgentErrorView
+    }
+```
 
-**`data` parts are a namespace, not a union arm each.** `AgentDataPart.kind` keeps the top-level
-union closed and stable while letting product features add content types without a protocol version
-bump. Each `kind` registers its own payload schema.
+Part ids are stable within a message. The protocol owns these normalized parts; neither Pi nor the
+AI SDK shape leaks through the boundary.
 
-### 3.1 Input parts
-
-Commands carry a narrower union — a client may not fabricate assistant content:
+### Input and approval
 
 ```ts
 type AgentInputPart =
   | { type: 'text'; text: string }
   | { type: 'file'; mediaType: string; name?: string; uri: string }
-```
 
-## 4. Commands
-
-```ts
-type AgentCommand =
-  // session
-  | { type: 'session.create'; agentId: string; workspaceId?: string; title?: string }
-  | { type: 'session.rename'; title: string }
-  | { type: 'session.delete' }
-  | { type: 'session.rebind'; runtimeId: string
-      endpoint: { kind: 'local' | 'lan' | 'cloud'; endpointId: string | null } }
-  // conversation
-  | { type: 'message.submit'; parts: AgentInputPart[]; parentMessageId?: string
-      models?: ModelRef[]; options?: AgentTurnOptions }
-  | { type: 'message.edit'; messageId: string; parts: AgentInputPart[]; options?: AgentTurnOptions }
-  | { type: 'message.delete'; messageId: string; cascade: boolean }
-  | { type: 'branch.select'; throughMessageId: string }
-  // turn
-  | { type: 'turn.regenerate'; messageId: string; models?: ModelRef[]; options?: AgentTurnOptions }
-  | { type: 'turn.steer'; turnId: string; parts: AgentInputPart[] }
-  | { type: 'turn.queue'; parts: AgentInputPart[]; options?: AgentTurnOptions }
-  | { type: 'turn.cancel'; turnId: string; executionId?: string }
-  // tools and tasks
-  | { type: 'approval.respond'; approvalId: string; decision: ApprovalDecision }
-  | { type: 'task.stop'; taskId: string }
-
-type AgentTurnOptions = {
-  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
-  mode?: 'auto' | 'fast' | 'plan'
+type AgentApprovalView = {
+  id: string
+  sessionId: string
+  turnId: string
+  toolCallId: string
+  toolName: string
+  input: JsonValue
+  status: 'pending' | 'approved' | 'denied'
 }
 
-type ApprovalDecision =
-  | { approved: true; updatedInput?: Record<string, unknown> }
-  | { approved: false; reason?: string }
+type AgentCapabilities = {
+  reasoning: boolean
+  tools: boolean
+  approvals: boolean
+  attachments: boolean
+}
 ```
 
-Commands express user intent. None of them names a runtime or SDK operation, and none of them carries
-a process-local handle — notably, **cancellation is a command, not an `AbortSignal`**. The Mobile
-Agent Host translates the command to the runtime's cancellation API; the execution adapter owns any
-`AbortController` internally.
+`assistant` remains the standard message role; the configurable product entity is always `Agent`.
 
-`session.rebind` changes a Runtime binding only when the target preserves the session's
-`recordMode` and authoritative record. A local record may reconstruct a compatible local Runtime;
-a remote record may reconnect through another endpoint only when it still identifies the same
-remote authority. Moving to a different authority is a separate export, import, or fork workflow
-and is out of scope in protocol v1. Treating a compact projection as a complete transcript would
-silently lose execution context, so the host rejects that transition.
+Cancellation is required by the Runtime contract and is therefore not a capability flag.
+The Host projects these values from the selected Runtime descriptor.
+The Agent Client may branch on these protocol capabilities, never on Runtime identity.
 
-For `remote-canonical`, `parentMessageId`, `activeMessageId`, `expectedRevision`, and the local
-message tree describe Mobile's projection only. They are not concurrency guards for the remote
-Session head. A subsequent Mobile command continues against the Runtime's current native context,
-which may include PC-originated turns that Mobile has never observed.
-
-### 4.1 Envelope
+## Operations
 
 ```ts
-type AgentCommandEnvelope = {
-  protocolVersion: number
-  commandId: string            // client-generated, idempotency key
-  sessionId: string            // absent only for session.create
-  expectedGeneration?: number
-  expectedRevision?: number
-  issuedAt: string
-  command: AgentCommand
+interface AgentProtocol {
+  createSession(input: {
+    agentId: string
+    executionTarget: AgentExecutionTarget
+    title?: string
+  }): Promise<AgentSessionView>
+  renameSession(input: { sessionId: string; title: string }): Promise<AgentSessionView>
+  deleteSession(input: { sessionId: string }): Promise<void>
+
+  submitMessage(input: {
+    sessionId: string
+    parts: AgentInputPart[]
+  }): Promise<{ turnId: string; userMessageId: string; assistantMessageId: string }>
+
+  cancelTurn(input: { sessionId: string; turnId: string }): Promise<void>
+
+  respondApproval(input: {
+    sessionId: string
+    turnId: string
+    approvalId: string
+    decision: 'approve' | 'deny'
+  }): Promise<void>
+
+  observeSession(
+    sessionId: string,
+    listener: (event: AgentEvent) => void,
+  ): Promise<AgentSessionObservation>
 }
 
-type AgentCommandAck =
-  | { ok: true; commandId: string; revision: number; sequence: number; result?: unknown }
-  | { ok: false; commandId: string; error: AgentErrorView }
+type AgentSessionObservation = {
+  snapshot: AgentSessionSnapshot
+  unsubscribe(): void
+}
 ```
 
-`commandId` idempotency is mandatory, not advisory. A flaky network plus a user tapping send twice
-on a stalled spinner is the ordinary failure mode; a replayed `message.submit` must return the
-original ack, not create a second turn. Hosts persist command receipts
-([Agent Runtime §8](./agent-runtime.md#8-storage-boundary)) so idempotency survives a restart.
+`observeSession` registers the listener and captures the snapshot as one Host operation, so an
+event cannot fall into a snapshot/subscription gap. Calling it again replaces stale frontend state;
+the protocol does not need event sequence, host epoch, replay buffers, or revision counters in
+version 1.
 
-`expectedGeneration` guards against a command issued against a binding the user has since changed.
-`expectedRevision` is used only where lost-update semantics matter — `message.edit`, `branch.select`,
-`session.rename`.
-
-### 4.2 On-demand detail query
-
-Execution detail is a read, not a durable command and not an event subscription:
-
-```text
-GET /agent-sessions/:sessionId/messages/:messageId/parts/:partId/detail
-  -> AgentPartDetailView
-```
-
-The route is part of the Mobile application boundary even when its current implementation is an
-in-process Data API call. For `local-canonical`, the host reads the local record. For
-`remote-canonical`, the adapter performs an authenticated HTTP request to the bound LAN or cloud
-endpoint. The frontend never receives a remote URL, credential, or Runtime-native locator.
-
-Remote responses use `Cache-Control: no-store`; the Mobile query layer does not persist them or
-hydrate them into an offline cache. If the endpoint is offline, expired, or has deleted the detail,
-the compact part remains renderable and the query returns an explicit unavailable error.
-
-## 5. Events
+## Events
 
 ```ts
 type AgentEvent =
-  | { type: 'session.updated'; session: AgentSessionView }
-  | { type: 'session.deleted'; sessionId: string }
-  | { type: 'turn.started'; turn: AgentTurnView }
   | { type: 'turn.updated'; turn: AgentTurnView }
-  | { type: 'turn.completed'; turnId: string }
-  | { type: 'turn.failed'; turnId: string; error: AgentErrorView }
   | { type: 'message.created'; message: AgentMessageView }
-  | { type: 'message.delta'; messageId: string; delta: AgentPartDelta }
+  | { type: 'message.delta'; messageId: string; delta: AgentMessageDelta }
   | { type: 'message.finalized'; message: AgentMessageView }
-  | { type: 'message.deleted'; messageId: string }
   | { type: 'approval.requested'; approval: AgentApprovalView }
   | { type: 'approval.resolved'; approval: AgentApprovalView }
-  | { type: 'task.updated'; task: AgentTaskView }
-  | { type: 'usage.updated'; messageId: string; usage: AgentUsageView }
+
+type AgentMessageDelta =
+  | { op: 'part.add'; index: number; part: AgentMessagePart }
+  | { op: 'text.append'; partId: string; text: string }
+  | { op: 'part.replace'; part: AgentMessagePart }
 ```
 
-### 5.1 Envelope
+`text.append` applies only to text and reasoning parts. State changes replace the addressed part;
+there is no untyped patch object.
 
-```ts
-type AgentEventEnvelope = {
-  protocolVersion: number
-  epoch: string        // host instance identity
-  sessionId: string
-  generation: number   // runtime binding generation
-  sequence: number     // monotonic per session, per epoch, gapless
-  revision: number     // persisted-state revision after this event
-  event: AgentEvent
-}
-```
+Durable facts commit before their events publish. Streaming deltas are ephemeral; a fresh observer
+gets the accumulated streaming message from the snapshot.
 
-### 5.2 `epoch` and `generation` are different
-
-Both are required and conflating them produces a subtle class of bug.
-
-`generation` changes when the **user rebinds** the session to another Runtime implementation or
-endpoint. It scopes continuations, approvals, and connections.
-
-`epoch` changes when the **host process restarts**. On mobile that is every cold start and every
-background kill. A restarted host resumes its sequence counter at 1; a client holding sequence 400
-would read the next events as a stale replay and discard them. With `epoch`, the mismatch is
-detected on the first envelope and the client takes a fresh snapshot.
-
-### 5.3 Deltas
-
-```ts
-type AgentPartDelta =
-  | { op: 'add'; index: number; part: AgentMessagePart }
-  | { op: 'append'; partId: string; text: string }        // text and inline reasoning only
-  | { op: 'patch'; partId: string; patch: Record<string, unknown> }   // shallow merge
-  | { op: 'remove'; partId: string }
-```
-
-Deltas are ephemeral — never persisted, never replayed from storage. Ordering and completeness are
-guaranteed by the envelope's gapless `sequence`; a client that detects a gap reloads the snapshot
-rather than attempting delta reconciliation. Mid-stream state is carried in the snapshot
-(§6), so a client joining a running turn never needs the deltas it missed.
-
-For `remote-canonical`, deltas exist only for a Mobile-initiated execution and contain compact
-projection fields only. The host does not subscribe to the remote Session's global event stream.
-Raw execution detail is not temporarily smuggled through
-`message.delta`; it remains behind the detail query even while the turn is live.
-
-This is the concrete replacement for whole-message overlays. Today's runtime republishes the entire
-accumulated assistant message on every chunk, which is quadratic in serialized size and repeated
-projection work.
-
-### 5.4 Ordering guarantee
-
-> A durable application-projection fact is persisted before its event is published.
-
-`message.delta` is fire-and-forget. `message.finalized`, `turn.completed`, and `turn.failed` are
-emitted only after the corresponding local record or compact projection is committed. A client that
-observes `turn.completed` and immediately queries the transcript must find the terminal projection
-already there. This ordering does not transfer authority for remote execution detail to Mobile.
-
-Optimistic pre-persistence display is a client concern, expressed through
-`turn.started` and `message.created` before content exists — not through publishing a terminal fact
-early.
-
-## 6. Snapshot and recovery
+## Snapshot and recovery
 
 ```ts
 type AgentSessionSnapshot = {
-  protocolVersion: number
-  epoch: string
+  agent: AgentView
   session: AgentSessionView
   capabilities: AgentCapabilities
-  activeTurn: (AgentTurnView & {
-    streamingMessages: AgentMessageView[]   // accumulated-so-far, one per execution
-  }) | null
-  messages: AgentMessageView[]              // active branch window
-  branchPoints: BranchPointView[]           // sibling counts for navigable nodes
-  approvals: AgentApprovalView[]            // unresolved only
-  tasks: AgentTaskView[]                    // active only
-  queued: QueuedInputView[]
-  generation: number
-  revision: number
-  lastSequence: number
+  activeTurn: AgentTurnView | null
+  streamingMessage: AgentMessageView | null
+  pendingApprovals: AgentApprovalView[]
 }
 ```
 
-Every message in a snapshot obeys `session.recordMode`. A local snapshot may contain inline detail;
-a remote snapshot contains only Mobile's selective compact projection. It is not a snapshot of the
-remote Session and need not include PC-originated turns. `AgentPartDetailView` is deliberately not
-part of this type.
+Persisted transcript pagination remains a normal data read and is not duplicated in the runtime
+snapshot. The snapshot contains only live state that must be composed over persisted messages.
 
-Recovery is one loop, identical over every transport:
+On route remount or foreground transition, the client creates a new observation and replaces its
+live projection with the returned snapshot. On process restart, the Host reconciles unfinished
+local turns to `interrupted`; version 1 does not resume execution.
 
-1. Load the snapshot.
-2. Subscribe from `lastSequence + 1`.
-3. On an `epoch` mismatch, or a sequence gap the host cannot replay, discard local state and go
-   to 1.
-
-No frontend client inspects Runtime-native state to recover the application projection. For a
-remote session, the Mobile Agent Host serves the cached compact snapshot as-is. It may resume a
-Mobile-known unfinished execution by `executionId` and its per-execution cursor, but it never asks
-for messages added elsewhere to the remote Session. Each recovered event for that known execution
-arrives through normal application events. Detail is independent of recovery and remains on demand.
-
-`activeTurn.streamingMessages` is what makes step 1 sufficient mid-turn: the host serves the
-accumulated application projection, so a client joining at any moment gets the complete locally
-renderable picture without replaying deltas. For a remote session this is still the compact picture,
-not a copy of the remote execution log.
-
-On mobile this loop is not an error path. It runs on every foreground transition.
-
-## 7. Capabilities
-
-One declaration per binding, enforced by the host and read by the UI.
-
-```ts
-type AgentCapabilities = {
-  // conversation shape
-  branching: boolean              // sibling messages, edit-and-resend, regenerate
-  multiExecution: boolean         // one turn fanning out to several models
-  followUpQueue: boolean
-  // execution control
-  steering: boolean
-  cancellation: boolean
-  detachedExecution: DetachedExecution   // can execution recover after the app connection goes away?
-  // tools
-  editableApprovalInput: boolean
-  taskStop: boolean
-  backgroundTasks: boolean
-  autonomousTurns: boolean
-  // context
-  compaction: boolean
-  contextUsage: boolean
-  slashCommands: boolean
-  // input
-  attachments: { audio: boolean; image: boolean; pdf: boolean; video: boolean }
-  modes: { auto: boolean; fast: boolean; plan: boolean }
-}
-```
-
-`detachedExecution` is not a boolean, because on mobile the honest answer is "for a while":
-
-```ts
-type DetachedExecution =
-  | { kind: 'none' }
-  | { kind: 'bounded'; budgetMs: number; mechanism: string; userVisible: boolean }
-  | { kind: 'unbounded' }
-```
-
-The Mobile Agent Host derives this value from the Runtime's recovery support, endpoint properties,
-platform budget, and product policy. A LAN or cloud label alone never implies `unbounded`: the
-Runtime must retain execution state and support resume or snapshot recovery.
-[Runtime Ownership](../runtime-ownership.md#principles) already records that backgrounding is not a
-reliable execution window, and
-[Agent Runtime §9.2](./agent-runtime.md#92-execution-lifetime)
-applies that constraint to local and remote execution.
-
-A boolean would force the UI to lie in one direction or the other. The budget lets the composer say
-"about 30 seconds after you leave the app" versus "keeps running, stop it from the notification"
-versus "keeps running on your Mac" — which is the whole difference between a long-running agent a
-user can trust and one that silently dies in their pocket.
-
-Two enforcement rules:
-
-- Shared components branch on capabilities, never on `runtimeId` (R4).
-- **Client-side gating is UX. The host re-validates every command against the binding's
-  capabilities**, because a remote client is untrusted input. An unsupported command returns
-  `CAPABILITY_UNSUPPORTED`.
-
-## 8. Errors
+## Errors
 
 ```ts
 type AgentErrorView = {
-  code: AgentErrorCode
-  message: string             // already localized or localizable by key
+  code:
+    | 'AGENT_NOT_FOUND'
+    | 'SESSION_NOT_FOUND'
+    | 'SESSION_BUSY'
+    | 'CAPABILITY_UNSUPPORTED'
+    | 'APPROVAL_NOT_FOUND'
+    | 'EXECUTION_UNAVAILABLE'
+    | 'EXECUTION_FAILED'
+    | 'CANCELLED'
+    | 'INTERRUPTED'
+  message: string
   retryable: boolean
-  details?: Record<string, unknown>
 }
 ```
 
-| Code | Meaning |
-| --- | --- |
-| `PROTOCOL_VERSION_UNSUPPORTED` | Host and client cannot negotiate a version |
-| `COMMAND_INVALID` | Failed schema validation |
-| `SESSION_NOT_FOUND` / `TURN_NOT_FOUND` | Unknown id |
-| `SESSION_BUSY` | A turn is already active and the binding rejects concurrency |
-| `GENERATION_MISMATCH` | `expectedGeneration` does not match the current binding |
-| `REVISION_CONFLICT` | `expectedRevision` is stale |
-| `CAPABILITY_UNSUPPORTED` | The binding does not declare the required capability |
-| `APPROVAL_NOT_FOUND` / `APPROVAL_ALREADY_SETTLED` | Approval correlation failed |
-| `RUNTIME_UNAVAILABLE` | Endpoint unreachable, unpaired, or not running |
-| `RUNTIME_FAILED` | The runtime reported a terminal failure |
-| `DETAIL_UNAVAILABLE` | On-demand detail is offline, expired, deleted, or not retained by the Runtime |
-| `AUTHORITY_TRANSFER_UNSUPPORTED` | A rebind would change record mode or execution authority without an explicit transfer workflow |
-| `CANCELLED` / `INTERRUPTED` | Terminal, non-error outcomes surfaced as turn results |
-| `UNAUTHORIZED` | Pairing token invalid or revoked |
-| `RATE_LIMITED` | Provider or host throttling; `details.retryAfterMs` |
+Native errors and stack traces stay behind the Host boundary.
 
-An `Error` instance never crosses the boundary. Stack traces stay in host logs.
-For a `remote-canonical` session, `details` is limited to explicitly allowlisted display metadata;
-it never carries a native error, request body, tool payload, remote response, or stack trace.
+## Invariants
 
-## 9. Versioning
-
-A single integer `protocolVersion`. Additive, optional fields do not bump it; removing a field,
-narrowing a type, or changing a semantic does.
-
-Negotiation happens once per connection: the host advertises `supportedVersions: number[]`, the
-client picks the highest it also supports, and a failed negotiation is
-`PROTOCOL_VERSION_UNSUPPORTED`.
-
-The compatibility rule is asymmetric, and deliberately so:
-
-- **Clients ignore unknown events and unknown part types.** A newer host must be able to add an
-  event or a `data` part `kind` without breaking older clients. An unknown part renders as a
-  neutral placeholder.
-- **Hosts reject unknown commands.** Guessing at an intent the host does not implement is exactly
-  the silent-downgrade failure R5 exists to prevent.
-
-Unknown-part tolerance is why the part union is closed at the top level with an open `data`
-namespace (§3): product features extend without a version bump, structural changes do not sneak in
-without one.
-
-## 10. Invariants
-
-These are executable application-protocol conformance tests, run against every Mobile Agent Host
-implementation and transport adapter. The independent runtime has a smaller execution-conformance
-suite of its own. See [Agent Runtime](./agent-runtime.md#13-conformance) for the separation.
-
-1. Every admitted turn reaches exactly one terminal outcome.
-2. No content event is accepted for a turn after its terminal state.
-3. Commands are idempotent by `commandId`, across host restarts.
-4. Per session and epoch, `sequence` is gapless and strictly increasing.
-5. A durable application-projection fact is persisted before its event is published.
-6. `turn.cancel` and connection close are idempotent.
-7. Approval decisions correlate to session, generation, turn, and tool call, and fail closed.
-8. Runtime-private continuation state is never reused across a change of runtime, endpoint, or
-   generation.
-9. `session.rebind` closes the previous connection before activating the next generation.
-10. An unsupported capability is rejected explicitly, never silently downgraded.
-11. A client recovers the locally renderable projection from snapshot plus subsequent events alone.
-12. A `local-canonical` session's complete record is authoritative in Mobile persistence; a
-    `remote-canonical` session's execution record is authoritative at its bound Runtime endpoint,
-    and its Mobile record is explicitly a compact projection.
-13. Every envelope survives a JSON round trip and re-validates against its schema.
-14. A turn settles as `interrupted` when its bound Runtime cannot continue or recover after the
-    application loses its execution window; a recoverable detached execution remains resumable.
-15. Cherry-owned autonomous, scheduled, and channel-triggered turns enter through the same command
-    path as client-issued ones; remote-native PC activity is outside this rule.
-16. Raw detail for a `remote-canonical` session is returned only by an explicit detail query and is
-    never persisted, indexed, logged, snapshotted, or replayed by Mobile.
-17. A session never changes record authority through ordinary `session.rebind`; an explicit
-    transfer or fork must prove it has a complete source record.
-18. A remote PC may continue or mutate its native Session without Mobile coordination. Mobile does
-    not import those turns, and its selective projection is allowed to remain stale indefinitely.
-19. Remote recovery is scoped to Mobile-known `executionId` values and per-execution cursors; it
-    never enumerates or synchronizes the remote Session transcript.
+1. A Session has at most one active turn.
+2. An admitted submission reserves the user message and assistant placeholder before execution.
+3. Every admitted turn reaches exactly one terminal state.
+4. No content event is accepted after the turn becomes terminal.
+5. Terminal message and turn state commit before terminal events publish.
+6. Cancellation is idempotent and settles as `cancelled` or `interrupted`, not `failed`.
+7. Approval responses correlate to the active Session, turn, and approval and fail closed.
+8. A new observation is sufficient to reconstruct all live UI state.
+9. Every protocol value survives a JSON round trip and re-validates against its schema.
+10. The client supplies an execution target and Agent identity, never a Runtime identity.

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -41,7 +41,9 @@ interface AgentRuntimeRouter {
 ```
 
 The Host derives `agentToolIds` from the current Agent configuration; the client does not send this
-derived field or a Runtime id. Version 1 routing is deliberately small:
+derived field or a Runtime id. What qualifies as an Agent tool is not yet defined; see the
+[open question](./README.md#open-questions) in the overview. Version 1 routing is deliberately
+small:
 
 | Execution target | Resolved Agent configuration | Runtime |
 | --- | --- | --- |
@@ -50,7 +52,9 @@ derived field or a Runtime id. Version 1 routing is deliberately small:
 
 The Router is the only component that branches on `pi` or `ai-sdk`. It resolves the selected
 implementation through the Runtime registry and fails closed when no registered Runtime satisfies
-the route. The selected route is fixed for an active turn; configuration changes are evaluated on
+the route. Route selection is a pure function of the execution target and resolved configuration,
+so the Host may also evaluate it without starting execution; protocol capabilities are projected
+this way. The selected route is fixed for an active turn; configuration changes are evaluated on
 the next turn. If that changes the selected Runtime, the Host closes the old Runtime session before
 opening the new one.
 
@@ -259,6 +263,10 @@ type RuntimeError = {
 
 Every execution emits exactly one terminal event: `completed`, `failed`, or `cancelled`. No event
 may follow it. Runtime-native errors are normalized and must not expose credentials or stack traces.
+
+`usage` values are cumulative for the execution; the last report before the terminal event is
+authoritative. A Runtime that cannot report usage emits no `usage` event, and the assistant
+message's protocol `usage` stays `null`.
 
 ## Host execution flow
 

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -59,8 +59,11 @@ the next turn. If that changes the selected Runtime, the Host closes the old Run
 opening the new one.
 
 LAN and cloud may add execution-target variants and corresponding adapters later. They use this
-same routing point, but version 1 does not define their markers, connections, authority, or fallback
-behavior.
+same routing point, but a remote adapter is selected by target alone: Pi and the AI SDK are local
+engine choices, and whatever engine executes behind a remote endpoint is that endpoint's concern.
+The application layer is unaware either way — the Router assigns the implementation, and the
+protocol carries only normalized results. Version 1 does not define remote markers, connections,
+authority, or fallback behavior.
 
 ## Descriptor and lifecycle
 

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -1,413 +1,318 @@
 # Cherry Agent Runtime
 
-Status: **design**.
+Status: **design**. Version 1 is local-only.
 
-This reference defines the independent execution boundary behind the Cherry Mobile Agent Host. It
-also defines how the host integrates local, LAN, and cloud Runtime endpoints without making their
-private protocols part of the [Cherry Agent Protocol](./agent-protocol.md).
+The Agent Runtime is the independent execution boundary behind the Mobile Agent Host. Pi and the AI
+SDK are separate implementations of this contract.
 
-The central rule is that one application protocol does not require one physical database. Session
-record mode determines where complete facts live and what Mobile is allowed to retain.
-
-## 1. Layers and dependency direction
+## Dependency rule
 
 ```text
-Cherry Mobile Frontend
-        ↕
-Cherry Mobile Agent Protocol
-        ↕
 Mobile Agent Host
-        ↕
-Agent Runtime Adapter
-        ├── local endpoint
-        ├── LAN endpoint
-        └── cloud endpoint
+    ↓ Agent Runtime Router
+    ↕ Agent Runtime contract
+Pi Runtime | AI SDK Runtime
 ```
 
-- The frontend knows only Cherry sessions, turns, messages, parts, commands, snapshots, and
-  capabilities.
-- The Mobile Agent Host owns application orchestration, protocol sequencing, local persistence,
-  selective compact remote projections, and frontend recovery.
-- An adapter translates between the host's execution port and one Runtime's native API.
-- A Runtime executes turns. It does not import Cherry protocol envelopes, React, Expo, SQLite,
-  Drizzle, or frontend state.
+The Runtime knows prepared prompts, models, history, tools, input, and normalized execution events.
+It does not know Cherry Agent or Session entities, application commands or snapshots, SQLite,
+Data API, React, Expo, navigation, or UI state.
 
-Runtime implementation and deployment are separate dimensions. `codex` or `claude` identifies an
-implementation; `local`, `lan`, or `cloud` identifies an endpoint. Application behavior depends on
-declared capabilities and session record mode, never an implementation-id switch.
+The Host is the only adapter between the [Agent Protocol](./agent-protocol.md) and the Runtime. It
+loads application data, invokes the Router, constructs the request, maps events, and persists the
+result. The Router is Host-owned orchestration, not part of the Agent Runtime contract.
 
-## 2. Session record modes
+Runtime independence is enforced by imports and conformance, not by checking the directory name.
+Promotion to a workspace package happens only when a real independent consumer exists.
 
-There are two data paths, both exposed through the same application protocol and renderer.
+## Runtime routing
 
-### 2.1 `local-canonical`
-
-The Mobile Agent Host owns the complete normalized session record.
-
-- Commands execute through a local adapter.
-- User messages, final assistant content, reasoning retained by product policy, tool/MCP detail,
-  turn state, and usage are persisted locally.
-- Local SQLite is authoritative for the normalized Cherry transcript.
-- Runtime-native transient objects remain private to the Runtime and do not become application
-  records merely because execution is local.
-
-### 2.2 `remote-canonical`
-
-The LAN or cloud endpoint owns the complete execution record. Mobile stores a selective compact
-projection of Mobile-initiated executions.
-
-- The projection is sufficient for the Mobile session list, Mobile-initiated activity transcript,
-  status, search of projected text, offline shells, and recovery of Mobile-known executions.
-- It may contain user-visible prompts, final assistant text, safe tool summaries, attachment and
-  artifact references, status, usage summary, timestamps, per-execution recovery cursors, and
-  opaque remote locators.
-- It must not contain raw reasoning, MCP/tool input or output, shell or command logs, traces,
-  provider-native events, Runtime snapshots, continuation state, or remote file bodies.
-- Expanding a tool, reasoning, trace, or log view performs an authenticated request to the remote
-  endpoint. The result remains ephemeral and is not merged into the persisted message.
-- Turns created directly on the remote PC are not automatically discovered or imported. The local
-  projection may remain incomplete and stale indefinitely.
-
-The compact Mobile row is an observation, not a competing source of truth or an eventually
-consistent mirror. Recovery may advance a Mobile-known execution from its own cursor; it never
-advances the whole Session from a remote transcript cursor.
-Mobile still owns Cherry-only facts such as the local session id, pin/order state, local display
-preferences, and a manually overridden title. Remote authority applies to execution-derived
-transcript, state, and detail; it does not turn the independent Runtime into Cherry's product
-database.
-
-### 2.3 Default mapping in v1
-
-| Endpoint | Session record mode | Complete execution authority | Mobile detail path |
-| --- | --- | --- | --- |
-| Local | `local-canonical` | Mobile | Inline/local read |
-| LAN | `remote-canonical` | Paired PC | Authenticated HTTP on demand |
-| Cloud | `remote-canonical` | Cloud service | Authenticated HTTP on demand |
-
-Record mode is persisted on the session even though v1 has this fixed mapping. This keeps the
-policy at one decision point and prevents storage code from accumulating endpoint-kind checks.
-
-## 3. Runtime adapter port
-
-The port is Mobile-owned but does not expose application protocol envelopes to external Runtimes.
-Concrete adapters may live in the app; a reusable built-in Runtime may later justify its own
-workspace package.
+The Agent Runtime Router is the single implementation-selection point:
 
 ```ts
-type RuntimeEndpoint =
-  | { kind: 'local'; endpointId: null }
-  | { kind: 'lan' | 'cloud'; endpointId: string }
-
-type RuntimeBindingPrivate = {
-  runtimeId: string
-  endpoint: RuntimeEndpoint
-  generation: number
-  credentialRef?: string
-  remoteSessionRef?: string
+type RuntimeRouteInput = {
+  target: { kind: 'local' }
+  agentToolIds: string[]
 }
 
-interface AgentRuntimeAdapter {
-  describe(binding: RuntimeBindingPrivate): Promise<RuntimeDescriptor>
-  open(binding: RuntimeBindingPrivate): Promise<AgentRuntimeConnection>
+interface AgentRuntimeRouter {
+  resolve(input: RuntimeRouteInput): AgentRuntime
+}
+```
+
+The Host derives `agentToolIds` from the current Agent configuration; the client does not send this
+derived field or a Runtime id. Version 1 routing is deliberately small:
+
+| Execution target | Resolved Agent configuration | Runtime |
+| --- | --- | --- |
+| `local` | At least one Agent tool | Pi Runtime |
+| `local` | No Agent tools | AI SDK Runtime |
+
+The Router is the only component that branches on `pi` or `ai-sdk`. It resolves the selected
+implementation through the Runtime registry and fails closed when no registered Runtime satisfies
+the route. The selected route is fixed for an active turn; configuration changes are evaluated on
+the next turn. If that changes the selected Runtime, the Host closes the old Runtime session before
+opening the new one.
+
+LAN and cloud may add execution-target variants and corresponding adapters later. They use this
+same routing point, but version 1 does not define their markers, connections, authority, or fallback
+behavior.
+
+## Descriptor and lifecycle
+
+```ts
+type RuntimeDescriptor = {
+  id: string
+  name: string
+  capabilities: RuntimeCapabilities
 }
 
-interface AgentRuntimeConnection {
+type RuntimeCapabilities = {
+  reasoning: boolean
+  tools: boolean
+  approvals: boolean
+  attachments: boolean
+}
+
+interface AgentRuntime {
+  readonly descriptor: RuntimeDescriptor
+  open(): Promise<AgentRuntimeSession>
+}
+
+interface AgentRuntimeSession {
   execute(request: RuntimeExecutionRequest): AsyncIterable<RuntimeEvent>
-  resume?(executionId: string, afterCursor?: string): AsyncIterable<RuntimeEvent>
-  projectionSnapshot?(executionId: string): Promise<RuntimeProjectionSnapshot>
-  loadDetail?(locator: RuntimeDetailLocator): Promise<RuntimeDetail>
-  cancel(executionId: string): Promise<void>
-  steer?(executionId: string, input: RuntimeInputPart[]): Promise<void>
-  respondApproval?(
-    executionId: string,
-    approvalId: string,
-    decision: RuntimeApprovalDecision,
-  ): Promise<void>
+  cancel(turnId: string): Promise<void>
+  respondApproval(input: {
+    turnId: string
+    approvalId: string
+    decision: 'approve' | 'deny'
+  }): Promise<void>
   close(): Promise<void>
 }
 ```
 
-`RuntimeExecutionRequest` contains prepared instructions, model selection, context, input, tools,
-and a host-generated execution id. It does not contain an `AgentCommandEnvelope`, application
-revision, event sequence, React callback, or SQLite row.
+The Host owns one `AgentRuntimeSession` for each active application Session. The Runtime session may
+hold provider clients and execution-local state, but every `execute` request contains the complete
+normalized context required for that turn.
 
-`RuntimeEvent` is normalized execution output. Content-bearing events may provide one of:
+`cancel` and `close` are required and idempotent. Version 1 permits only one active `execute` call
+per Runtime session.
+
+## Execution input
 
 ```ts
-type RuntimeEventDetail =
-  | { kind: 'inline'; detail: RuntimeDetail }
-  | { kind: 'remote'; locator: RuntimeDetailLocator; available: boolean }
-  | { kind: 'none' }
+type RuntimeJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | RuntimeJsonValue[]
+  | { [key: string]: RuntimeJsonValue }
+
+type RuntimeExecutionRequest = {
+  turnId: string
+  instructions: string
+  model: RuntimeModel
+  history: RuntimeMessage[]
+  input: RuntimeInputPart[]
+  tools: RuntimeTool[]
+  options: RuntimeOptions
+}
+
+type RuntimeModel = {
+  providerId: string
+  modelId: string
+}
+
+type RuntimeOptions = {
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  maxOutputTokens?: number
+  temperature?: number
+}
+
+type RuntimeInputPart =
+  | { type: 'text'; text: string }
+  | { type: 'file'; mediaType: string; name?: string; uri: string }
 ```
 
-A local adapter may emit `inline`; a LAN or cloud adapter emits a safe summary plus `remote` or
-`none`. `RuntimeDetailLocator` is backend-private. It may be persisted as an opaque mapping but is
-never sent to the frontend or used as a remote URL directly.
+Runtime implementations receive model/provider dependencies from application composition. They do
+not query Cherry provider or model tables.
 
-The contract does not force every external Runtime through a built-in Runtime implementation.
-Codex, Claude, a Cherry cloud service, or a paired-PC service may each implement this adapter
-directly. A future `packages/agent-runtime` would be one local implementation, not a mandatory
-intermediate protocol.
+### History
 
-## 4. Adapter responsibilities
+```ts
+type RuntimeMessage = {
+  role: 'user' | 'assistant' | 'system'
+  parts: RuntimeMessagePart[]
+}
 
-An adapter owns exactly the Runtime-specific boundary:
+type RuntimeMessagePart =
+  | { type: 'text' | 'reasoning'; text: string }
+  | { type: 'file'; mediaType: string; name?: string; uri: string }
+  | {
+      type: 'tool-call'
+      toolCallId: string
+      toolName: string
+      input: RuntimeJsonValue
+    }
+  | {
+      type: 'tool-result'
+      toolCallId: string
+      output: RuntimeJsonValue
+      isError: boolean
+    }
+```
 
-- request and event translation;
-- authentication, pairing, connection setup, and remote transport;
-- mapping host execution ids to Runtime-native session, execution, event, and approval ids;
-- capability discovery;
-- compact, safe summaries for remote projection events;
-- per-execution resume cursor or projection-snapshot translation when supported;
-- on-demand detail loading;
-- cancellation, steering, and approval translation;
-- redaction of native errors before they reach application views.
+The Host converts persisted Cherry messages into this normalized history. Runtime-native messages
+never become the application source of truth.
 
-An adapter does not:
+### Tools
 
-- write Cherry session or message tables;
-- assign application `revision`, `sequence`, or `generation`;
-- emit `AgentEventEnvelope` directly;
-- expose credentials, native locators, or remote URLs to the frontend;
-- persist fetched remote detail in a Mobile cache;
-- make navigation or rendering decisions.
+```ts
+type RuntimeTool = {
+  name: string
+  description: string
+  inputSchema: RuntimeJsonValue
+  approval: 'auto' | 'ask' | 'deny'
+  execute(
+    input: RuntimeJsonValue,
+    context: { signal: AbortSignal; toolCallId: string },
+  ): Promise<RuntimeJsonValue>
+}
+```
 
-## 5. Mobile Agent Host responsibilities
+`inputSchema` is portable JSON Schema, not a provider-native schema object.
 
-`src/backend/services/agent` owns the application workflow around every adapter:
+The Host supplies tool implementations after applying Agent policy. A Runtime validates tool input,
+enforces the approval mode, and invokes `execute` only after approval when the mode is `ask`.
 
-- admit and deduplicate commands by `commandId`;
-- enforce session generation, revision, record mode, and capabilities;
-- build a Runtime execution request from the allowed context;
-- map normalized Runtime events into Cherry turns, messages, and parts;
-- apply the session's persistence policy before any write;
-- persist a local record or selective compact remote projection;
-- assign application `revision` and event `sequence`;
-- publish protocol events only after durable projection facts commit;
-- provide snapshots and recover frontend subscriptions;
-- resolve a Cherry part id to a backend-private detail locator;
-- coordinate cancellation, shutdown, background loss, and recovery of Mobile-known executions.
+Tool callbacks and `AbortSignal` are allowed here because the Runtime contract is process-local.
+They never cross the JSON-safe application protocol.
 
-SQL-only data services remain responsible for rows and transactions. The Agent Host owns the
-cross-resource workflow because a remote request, connection, or secure credential cannot be made
-atomic with SQLite.
+## Execution output
 
-## 6. Local execution flow
+```ts
+type RuntimeEvent =
+  | { type: 'part.add'; index: number; part: RuntimeOutputPart }
+  | { type: 'text.delta'; partId: string; text: string }
+  | { type: 'part.replace'; part: RuntimeOutputPart }
+  | { type: 'approval.requested'; approval: RuntimeApproval }
+  | { type: 'approval.resolved'; approval: RuntimeApproval }
+  | { type: 'usage'; usage: RuntimeUsage }
+  | { type: 'completed' }
+  | { type: 'failed'; error: RuntimeError }
+  | { type: 'cancelled' }
 
-1. The host admits `message.submit`, persists the user message and turn reservation, and publishes
-   the corresponding application events.
-2. The local adapter executes the prepared request.
-3. The host accumulates normalized events. Inline detail allowed by product policy is part of the
-   local normalized record.
-4. Streaming deltas remain ephemeral; terminal message and turn state commit before terminal events
-   are published.
-5. If the app loses its execution window and the Runtime cannot continue, the host persists the
-   partial result and settles the turn as `interrupted`.
+type RuntimeOutputPart =
+  | {
+      id: string
+      type: 'text' | 'reasoning'
+      text: string
+      state: 'streaming' | 'done'
+    }
+  | {
+      id: string
+      type: 'file'
+      mediaType: string
+      name?: string
+      uri: string
+    }
+  | {
+      id: string
+      type: 'tool'
+      toolCallId: string
+      toolName: string
+      state:
+        | 'input-available'
+        | 'awaiting-approval'
+        | 'running'
+        | 'output-available'
+        | 'denied'
+        | 'error'
+      input?: RuntimeJsonValue
+      output?: RuntimeJsonValue
+      approvalId?: string
+      error?: RuntimeError
+    }
 
-The Runtime may keep transient provider state while the turn is active. That state is not a second
-application source of truth and is discarded or fenced when the turn or binding generation ends.
+type RuntimeApproval = {
+  id: string
+  turnId: string
+  toolCallId: string
+  toolName: string
+  input: RuntimeJsonValue
+  status: 'pending' | 'approved' | 'denied'
+}
 
-## 7. Remote execution flow
+type RuntimeUsage = {
+  inputTokens?: number
+  outputTokens?: number
+  totalTokens?: number
+}
 
-### 7.1 Submit and observe
+type RuntimeError = {
+  code: string
+  message: string
+  retryable: boolean
+}
+```
 
-1. The host persists an outbox receipt and an optimistic user-visible projection.
-2. The adapter submits the request to the LAN or cloud endpoint with an idempotency key.
-3. The remote service accepts the command and returns its private session/execution ids and a
-   per-execution cursor. Until this acknowledgement, the optimistic message is local pending state,
-   not a remote transcript fact; rejection leaves an explicit retry-or-discard state.
-4. The adapter consumes compact events for that execution, usually over SSE, and emits normalized
-   summaries. It does not subscribe to or enumerate the remote Session's other turns. Raw execution
-   detail is not included.
-5. The host commits each durable projection change and then publishes the corresponding Cherry
-   application event.
-6. The remote service retains the complete execution record and can continue while Mobile is
-   suspended or disconnected when detached execution is supported.
+Every execution emits exactly one terminal event: `completed`, `failed`, or `cancelled`. No event
+may follow it. Runtime-native errors are normalized and must not expose credentials or stack traces.
 
-HTTP plus SSE is the default remote shape: HTTP for commands, per-execution recovery snapshots, and
-detail reads; SSE for events belonging to a Mobile-initiated execution. A Runtime may use
-WebSocket internally, but that choice stays inside its adapter and does not turn the connection
-into a subscription to all remote Session activity.
+## Host execution flow
 
-### 7.2 Expand execution detail
+1. The Host validates that the Session is idle.
+2. It persists the user message and assistant placeholder.
+3. It loads the Session's execution target and resolves the current Agent configuration.
+4. The Router selects a Runtime from the target and configured Agent tools.
+5. The Host normalizes instructions, model, history, tools, input, and options.
+6. The selected Runtime executes the prepared request.
+7. The Host maps Runtime parts, approvals, usage, and terminal events into Agent Protocol state.
+8. Terminal message and turn state commit before the Host publishes terminal protocol events.
+
+The Runtime never writes application storage. The Host never interprets Pi- or AI-SDK-native events
+outside the corresponding implementation.
+
+## Runtime registry
+
+Application composition registers implementations by descriptor id. The Router resolves its
+decision through this registry. Agent and Session configuration do not store a selected
+`runtimeId`; neither Runtime ids nor the registry are exposed through the Agent Protocol.
 
 ```text
-Frontend
-  └─ GET /agent-sessions/:sessionId/messages/:messageId/parts/:partId/detail
-       └─ Mobile Agent Host
-            └─ private locator lookup
-                 └─ Runtime adapter
-                      └─ authenticated HTTP GET to LAN/cloud endpoint
+pi      -> Pi AgentRuntime
+ai-sdk  -> AI SDK AgentRuntime
 ```
 
-The response is an `AgentPartDetailView`. It uses `Cache-Control: no-store`, remains in volatile UI
-memory, and is discarded on normal query collection, screen exit, or app background. It is not
-written to SQLite, MMKV, logs, search indexes, protocol snapshots, or event replay buffers.
+Adding an implementation means registering another conforming Runtime and, when needed, adding one
+Router policy. Shared Host workflow, protocol, persistence, and frontend code do not add a
+Runtime-name branch.
 
-If the endpoint is unavailable or no longer retains the detail, the UI still renders the locally
-stored summary and reports `DETAIL_UNAVAILABLE` for the expanded view.
+## Execution lifetime
 
-### 7.3 Approval
+Route unmount does not own or cancel execution; the app-owned Host and Runtime session do. A
+foreground transition creates a fresh protocol observation from the Host snapshot.
 
-An approval event may persist the tool name, safe summary, deadline, and decision state. If the user
-needs raw input to decide, opening the approval fetches it through the same detail path. The
-approval response carries the user's decision and explicitly edited fields only; the fetched source
-payload is not copied into Mobile persistence.
+Local execution depends on the Mobile JavaScript process. If the process is suspended or killed and
+the turn cannot reach a terminal event, startup reconciliation marks the persisted placeholder and
+turn as interrupted. Version 1 has no resume API or background-execution guarantee.
 
-## 8. Storage boundary
+## Conformance
 
-The target schema may use separate tables or discriminated columns, but it must preserve this
-semantic boundary:
+Every Runtime implementation passes the same suite:
 
-| Mobile may persist for remote sessions | Mobile must not persist for remote sessions |
-| --- | --- |
-| Session id, agent id, title, binding summary, record mode | Remote credentials or URLs in protocol rows |
-| Remote session/execution locator and per-execution cursor in backend-private rows | Raw reasoning or provider event streams |
-| User-visible prompt and final answer projection | MCP/tool input and output |
-| Tool name, state, safe summary, and `hasDetail` | Shell/terminal/command logs |
-| Attachment/artifact metadata and remote references | Remote file bodies or Runtime snapshots |
-| Turn status, safe error summary, usage summary, timestamps | Traces, stack traces, continuation payloads |
-| Command receipts, generation, revision, local sequence | Persistent caches of on-demand detail |
+1. Descriptor id and capabilities are stable.
+2. A valid request reaches exactly one terminal event.
+3. No output follows a terminal event.
+4. Text deltas and part replacements address existing stable part ids.
+5. Unsupported input or tools fail before partial execution.
+6. `cancel` is idempotent and causes the active turn to settle as cancelled.
+7. Approval is requested only for an `ask` tool and correlates to the active turn and tool call.
+8. Denied tools are never executed.
+9. `close` is idempotent and releases provider, iterator, and tool resources.
+10. Native errors are normalized without secrets or stack traces.
+11. The implementation imports no application protocol, persistence, React, or Expo module.
 
-Local full-text search indexes only text from Mobile-initiated executions. It does not search or
-download PC-originated turns. Searching remote execution detail, if offered, is a separate remote
-capability and query.
-
-Application logs follow the same policy as storage. Logging a raw HTTP response, MCP argument, or
-tool output would violate the boundary even if no database row were written.
-
-## 9. Snapshot, recovery, and backgrounding
-
-### 9.1 Application snapshot
-
-The frontend always recovers through `AgentSessionSnapshot` plus subsequent application events.
-For `remote-canonical`, that snapshot contains only Mobile's selective compact projection.
-
-On foreground or sequence mismatch, the host:
-
-1. loads and serves the local projection immediately;
-2. finds Mobile-known unfinished executions recorded in that projection;
-3. resumes each one by `executionId` and its per-execution cursor, or requests that execution's
-   projection snapshot if replay is unavailable;
-4. commits recovered events for those executions through the normal local event sequence.
-
-The host does not list the remote transcript, read a Session-wide cursor, or import PC-originated
-turns during this loop. Execution detail is fetched only after an explicit user action.
-
-### 9.2 Execution lifetime
-
-- A local Runtime depends on the Mobile execution window. If iOS or Android suspends the required
-  process and no supported continuation mechanism exists, the turn becomes `interrupted`.
-- A LAN or cloud Runtime may declare detached execution only if it retains execution state and can
-  resume a Mobile-known execution after disconnection.
-- Endpoint kind alone does not prove recovery. A paired PC that shuts down is unavailable; a cloud
-  service that does not retain events is not detached.
-
-When a remote endpoint is offline, Mobile may show its compact offline projection. It cannot show
-uncached detail, and it does not fabricate terminal state for an execution whose remote outcome is
-unknown.
-
-### 9.3 Remote-native activity
-
-The remote PC remains free to continue the same native Session through its own UI, automation, or
-other clients. Mobile neither locks that Session nor imports those turns. Consequently:
-
-- the Mobile projection may remain permanently behind the remote transcript;
-- local `status`, `activeMessageId`, `updatedAt`, message parents, and `revision` describe only
-  Mobile's projection;
-- the next Mobile command executes against the Runtime's current native context, which may contain
-  PC-originated turns that are absent locally.
-
-## 10. Rebind, transfer, and fork
-
-`session.rebind` changes the Runtime implementation or endpoint only when record authority remains
-compatible.
-
-- A complete `local-canonical` record can reconstruct context for another compatible local Runtime.
-- A `remote-canonical` session may reconnect to the same remote authority using its native ids and
-  any cursors for Mobile-known executions.
-- A compact remote projection is not sufficient to create an equivalent local session or move to a
-  different remote authority.
-
-Changing authority therefore requires a separate explicit operation:
-
-- **transfer** obtains a complete, supported export from the old authority and imports it into the
-  new authority; or
-- **fork** creates a new session from the user-visible projected messages and clearly reports that
-  Runtime-native context and detail were not copied.
-
-Protocol v1 does not define transfer. An ordinary rebind that would change record mode fails with
-`AUTHORITY_TRANSFER_UNSUPPORTED`.
-
-## 11. Security and retention
-
-- LAN pairing uses a short-lived bootstrap token and stores the resulting credential in platform
-  secure storage, referenced from backend-private binding state.
-- Production LAN and cloud detail requests require authenticated TLS. LAN pairing should pin the
-  selected host identity rather than trust any device on the network.
-- Detail locators are opaque, scoped to session, generation, execution, and part, and validated by
-  the backend before use.
-- Remote detail endpoints enforce the same authorization as the parent execution and return
-  `no-store` responses.
-- Runtime retention or deletion may make detail unavailable without invalidating the compact
-  transcript. The UI represents that state explicitly.
-- Session deletion must define whether it removes only the Mobile projection or also requests
-  deletion from the remote authority; the product must not imply remote deletion after only a local
-  row is removed.
-
-## 12. Placement and integration
-
-```text
-src/shared/agent/protocol/           # Mobile application protocol and schemas
-src/backend/services/agent/          # Agent Host, adapter registry, workflows
-src/backend/services/agent/adapters/ # Local, LAN, and cloud adapters
-src/backend/data/                    # SQL-only records and projection persistence
-src/frontend/features/agent/         # Client reducer, queries, and rendering
-packages/ai-runtime/                 # Existing provider/AI SDK execution primitives
-packages/agent-runtime/              # Optional future reusable local Runtime
-```
-
-`packages/agent-runtime` is admitted only after an independent consumer exists. It may depend on
-portable AI execution primitives, but it must not depend on Mobile protocol, storage, React, Expo,
-or application adapters.
-
-`AgentSessionView` is the persisted product conversation aggregate. It is not the caller-owned,
-disposable `Session` lifecycle role defined by [Runtime Ownership](../runtime-ownership.md#role-names).
-
-This design does not replace the current Topic, Chat Runtime, or agent-session tables until an
-implementation phase lands. Current-state references remain authoritative for shipped behavior.
-In particular, the current
-[`agent_session_message.data`](../../../src/backend/data/db/schemas/agentSessionMessage.ts) row
-stores complete `MessageData`; the existing
-[`deferToolOutputs`](../../../src/backend/data/api/handlers/agentSessionMessages.ts) query only
-projects large tool results at the renderer boundary. It reduces transport payload but does not
-implement `remote-canonical` storage or prevent the full output from being stored locally.
-
-## 13. Conformance
-
-Runtime adapter conformance proves:
-
-- declared capabilities match actual behavior;
-- execute reaches one terminal outcome or a recoverable detached state;
-- cancellation and close are idempotent;
-- approval and steering correlate to the active execution;
-- per-execution resume cursors do not duplicate or skip compact events for Mobile-known executions;
-- recovery never enumerates or imports PC-originated turns from the remote Session;
-- remote-native activity remains unrestricted by the Mobile binding;
-- remote projection events exclude raw detail;
-- detail lookup returns the correct event and fails closed for stale generation or authorization;
-- native errors are redacted before conversion.
-
-Mobile Agent Host conformance is defined by
-[Agent Protocol §10](./agent-protocol.md#10-invariants). Storage tests additionally prove that a
-`remote-canonical` session never writes forbidden detail to SQLite, MMKV, search indexes, logs, or
-snapshot fixtures.
-
-## 14. Delivery order
-
-1. Land the Mobile protocol schemas and record-mode invariants.
-2. Add local-canonical Host orchestration behind the existing application composition boundary.
-3. Add the selective compact remote projection store and forbidden-detail tests.
-4. Add one LAN adapter using HTTP, SSE, per-execution resume, and on-demand detail.
-5. Reuse the same port for a cloud adapter.
-6. Add explicit transfer or fork UX only after a Runtime supplies a complete export contract.
+The first conformance targets are the AI SDK Runtime and the Pi Runtime. A fake Runtime exercises
+Host behavior without either implementation.

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -1,0 +1,391 @@
+# Cherry Agent Runtime
+
+Status: **design**.
+
+This reference defines the independent execution boundary behind the Cherry Mobile Agent Host. It
+also defines how the host integrates local, LAN, and cloud Runtime endpoints without making their
+private protocols part of the [Cherry Agent Protocol](./agent-protocol.md).
+
+The central rule is that one application protocol does not require one physical database. Session
+record mode determines where complete facts live and what Mobile is allowed to retain.
+
+## 1. Layers and dependency direction
+
+```text
+Cherry Mobile Frontend
+        ↕
+Cherry Mobile Agent Protocol
+        ↕
+Mobile Agent Host
+        ↕
+Agent Runtime Adapter
+        ├── local endpoint
+        ├── LAN endpoint
+        └── cloud endpoint
+```
+
+- The frontend knows only Cherry sessions, turns, messages, parts, commands, snapshots, and
+  capabilities.
+- The Mobile Agent Host owns application orchestration, protocol sequencing, local persistence,
+  compact remote projections, and frontend recovery.
+- An adapter translates between the host's execution port and one Runtime's native API.
+- A Runtime executes turns. It does not import Cherry protocol envelopes, React, Expo, SQLite,
+  Drizzle, or frontend state.
+
+Runtime implementation and deployment are separate dimensions. `codex` or `claude` identifies an
+implementation; `local`, `lan`, or `cloud` identifies an endpoint. Application behavior depends on
+declared capabilities and session record mode, never an implementation-id switch.
+
+## 2. Session record modes
+
+There are two data paths, both exposed through the same application protocol and renderer.
+
+### 2.1 `local-canonical`
+
+The Mobile Agent Host owns the complete normalized session record.
+
+- Commands execute through a local adapter.
+- User messages, final assistant content, reasoning retained by product policy, tool/MCP detail,
+  turn state, and usage are persisted locally.
+- Local SQLite is authoritative for the normalized Cherry transcript.
+- Runtime-native transient objects remain private to the Runtime and do not become application
+  records merely because execution is local.
+
+### 2.2 `remote-canonical`
+
+The LAN or cloud endpoint owns the complete execution record. Mobile stores a compact projection.
+
+- The projection is sufficient for session lists, the ordinary transcript, status, search of
+  projected text, offline shells, and resuming projection synchronization.
+- It may contain user-visible prompts, final assistant text, safe tool summaries, attachment and
+  artifact references, status, usage summary, timestamps, a synchronization cursor, and opaque
+  remote locators.
+- It must not contain raw reasoning, MCP/tool input or output, shell or command logs, traces,
+  provider-native events, Runtime snapshots, continuation state, or remote file bodies.
+- Expanding a tool, reasoning, trace, or log view performs an authenticated request to the remote
+  endpoint. The result remains ephemeral and is not merged into the persisted message.
+
+The compact Mobile row is a projection, not a competing source of truth. A stale projection can be
+advanced from the remote cursor; it must never overwrite the remote execution record.
+Mobile still owns Cherry-only facts such as the local session id, pin/order state, local display
+preferences, and a manually overridden title. Remote authority applies to execution-derived
+transcript, state, and detail; it does not turn the independent Runtime into Cherry's product
+database.
+
+### 2.3 Default mapping in v1
+
+| Endpoint | Session record mode | Complete execution authority | Mobile detail path |
+| --- | --- | --- | --- |
+| Local | `local-canonical` | Mobile | Inline/local read |
+| LAN | `remote-canonical` | Paired PC | Authenticated HTTP on demand |
+| Cloud | `remote-canonical` | Cloud service | Authenticated HTTP on demand |
+
+Record mode is persisted on the session even though v1 has this fixed mapping. This keeps the
+policy at one decision point and prevents storage code from accumulating endpoint-kind checks.
+
+## 3. Runtime adapter port
+
+The port is Mobile-owned but does not expose application protocol envelopes to external Runtimes.
+Concrete adapters may live in the app; a reusable built-in Runtime may later justify its own
+workspace package.
+
+```ts
+type RuntimeEndpoint =
+  | { kind: 'local'; endpointId: null }
+  | { kind: 'lan' | 'cloud'; endpointId: string }
+
+type RuntimeBindingPrivate = {
+  runtimeId: string
+  endpoint: RuntimeEndpoint
+  generation: number
+  credentialRef?: string
+  remoteSessionRef?: string
+}
+
+interface AgentRuntimeAdapter {
+  describe(binding: RuntimeBindingPrivate): Promise<RuntimeDescriptor>
+  open(binding: RuntimeBindingPrivate): Promise<AgentRuntimeConnection>
+}
+
+interface AgentRuntimeConnection {
+  execute(request: RuntimeExecutionRequest): AsyncIterable<RuntimeEvent>
+  resume?(executionId: string, afterCursor?: string): AsyncIterable<RuntimeEvent>
+  projectionSnapshot?(executionId: string): Promise<RuntimeProjectionSnapshot>
+  loadDetail?(locator: RuntimeDetailLocator): Promise<RuntimeDetail>
+  cancel(executionId: string): Promise<void>
+  steer?(executionId: string, input: RuntimeInputPart[]): Promise<void>
+  respondApproval?(
+    executionId: string,
+    approvalId: string,
+    decision: RuntimeApprovalDecision,
+  ): Promise<void>
+  close(): Promise<void>
+}
+```
+
+`RuntimeExecutionRequest` contains prepared instructions, model selection, context, input, tools,
+and a host-generated execution id. It does not contain an `AgentCommandEnvelope`, application
+revision, event sequence, React callback, or SQLite row.
+
+`RuntimeEvent` is normalized execution output. Content-bearing events may provide one of:
+
+```ts
+type RuntimeEventDetail =
+  | { kind: 'inline'; detail: RuntimeDetail }
+  | { kind: 'remote'; locator: RuntimeDetailLocator; available: boolean }
+  | { kind: 'none' }
+```
+
+A local adapter may emit `inline`; a LAN or cloud adapter emits a safe summary plus `remote` or
+`none`. `RuntimeDetailLocator` is backend-private. It may be persisted as an opaque mapping but is
+never sent to the frontend or used as a remote URL directly.
+
+The contract does not force every external Runtime through a built-in Runtime implementation.
+Codex, Claude, a Cherry cloud service, or a paired-PC service may each implement this adapter
+directly. A future `packages/agent-runtime` would be one local implementation, not a mandatory
+intermediate protocol.
+
+## 4. Adapter responsibilities
+
+An adapter owns exactly the Runtime-specific boundary:
+
+- request and event translation;
+- authentication, pairing, connection setup, and remote transport;
+- mapping host execution ids to Runtime-native session, execution, event, and approval ids;
+- capability discovery;
+- compact, safe summaries for remote projection events;
+- resume cursor or projection-snapshot translation when supported;
+- on-demand detail loading;
+- cancellation, steering, and approval translation;
+- redaction of native errors before they reach application views.
+
+An adapter does not:
+
+- write Cherry session or message tables;
+- assign application `revision`, `sequence`, or `generation`;
+- emit `AgentEventEnvelope` directly;
+- expose credentials, native locators, or remote URLs to the frontend;
+- persist fetched remote detail in a Mobile cache;
+- make navigation or rendering decisions.
+
+## 5. Mobile Agent Host responsibilities
+
+`src/backend/services/agent` owns the application workflow around every adapter:
+
+- admit and deduplicate commands by `commandId`;
+- enforce session generation, revision, record mode, and capabilities;
+- build a Runtime execution request from the allowed context;
+- map normalized Runtime events into Cherry turns, messages, and parts;
+- apply the session's persistence policy before any write;
+- persist a local record or compact remote projection;
+- assign application `revision` and event `sequence`;
+- publish protocol events only after durable projection facts commit;
+- provide snapshots and recover frontend subscriptions;
+- resolve a Cherry part id to a backend-private detail locator;
+- coordinate cancellation, shutdown, background loss, and remote resynchronization.
+
+SQL-only data services remain responsible for rows and transactions. The Agent Host owns the
+cross-resource workflow because a remote request, connection, or secure credential cannot be made
+atomic with SQLite.
+
+## 6. Local execution flow
+
+1. The host admits `message.submit`, persists the user message and turn reservation, and publishes
+   the corresponding application events.
+2. The local adapter executes the prepared request.
+3. The host accumulates normalized events. Inline detail allowed by product policy is part of the
+   local normalized record.
+4. Streaming deltas remain ephemeral; terminal message and turn state commit before terminal events
+   are published.
+5. If the app loses its execution window and the Runtime cannot continue, the host persists the
+   partial result and settles the turn as `interrupted`.
+
+The Runtime may keep transient provider state while the turn is active. That state is not a second
+application source of truth and is discarded or fenced when the turn or binding generation ends.
+
+## 7. Remote execution flow
+
+### 7.1 Submit and synchronize
+
+1. The host persists an outbox receipt and an optimistic user-visible projection.
+2. The adapter submits the request to the LAN or cloud endpoint with an idempotency key.
+3. The remote service accepts the command and returns its private session/execution ids and a
+   projection cursor. Until this acknowledgement, the optimistic message is local pending state,
+   not a remote transcript fact; rejection leaves an explicit retry-or-discard state.
+4. The adapter consumes compact events, usually over SSE, and emits normalized summaries. Raw
+   execution detail is not included.
+5. The host commits each durable projection change and then publishes the corresponding Cherry
+   application event.
+6. The remote service retains the complete execution record and can continue while Mobile is
+   suspended or disconnected when detached execution is supported.
+
+HTTP plus SSE is the default remote shape: HTTP for commands, snapshots, and detail reads; SSE for
+compact forward events. A Runtime may use WebSocket internally, but that choice stays inside its
+adapter and does not change the Mobile application protocol.
+
+### 7.2 Expand execution detail
+
+```text
+Frontend
+  └─ GET /agent-sessions/:sessionId/messages/:messageId/parts/:partId/detail
+       └─ Mobile Agent Host
+            └─ private locator lookup
+                 └─ Runtime adapter
+                      └─ authenticated HTTP GET to LAN/cloud endpoint
+```
+
+The response is an `AgentPartDetailView`. It uses `Cache-Control: no-store`, remains in volatile UI
+memory, and is discarded on normal query collection, screen exit, or app background. It is not
+written to SQLite, MMKV, logs, search indexes, protocol snapshots, or event replay buffers.
+
+If the endpoint is unavailable or no longer retains the detail, the UI still renders the locally
+stored summary and reports `DETAIL_UNAVAILABLE` for the expanded view.
+
+### 7.3 Approval
+
+An approval event may persist the tool name, safe summary, deadline, and decision state. If the user
+needs raw input to decide, opening the approval fetches it through the same detail path. The
+approval response carries the user's decision and explicitly edited fields only; the fetched source
+payload is not copied into Mobile persistence.
+
+## 8. Storage boundary
+
+The target schema may use separate tables or discriminated columns, but it must preserve this
+semantic boundary:
+
+| Mobile may persist for remote sessions | Mobile must not persist for remote sessions |
+| --- | --- |
+| Session id, agent id, title, binding summary, record mode | Remote credentials or URLs in protocol rows |
+| Remote session/execution locator and sync cursor in backend-private rows | Raw reasoning or provider event streams |
+| User-visible prompt and final answer projection | MCP/tool input and output |
+| Tool name, state, safe summary, and `hasDetail` | Shell/terminal/command logs |
+| Attachment/artifact metadata and remote references | Remote file bodies or Runtime snapshots |
+| Turn status, safe error summary, usage summary, timestamps | Traces, stack traces, continuation payloads |
+| Command receipts, generation, revision, local sequence | Persistent caches of on-demand detail |
+
+Local full-text search indexes only projected text. Searching remote execution detail, if offered,
+is a remote capability and query; Mobile does not download detail to improve its local index.
+
+Application logs follow the same policy as storage. Logging a raw HTTP response, MCP argument, or
+tool output would violate the boundary even if no database row were written.
+
+## 9. Snapshot, recovery, and backgrounding
+
+### 9.1 Application snapshot
+
+The frontend always recovers through `AgentSessionSnapshot` plus subsequent application events.
+For `remote-canonical`, that snapshot contains only the compact projection.
+
+On foreground or sequence mismatch, the host:
+
+1. loads the local projection and remote sync cursor and serves that snapshot immediately;
+2. asks the adapter in the background for compact events after that cursor, or a compact projection
+   snapshot if replay is unavailable;
+3. commits each advanced projection and publishes it through the normal local event sequence.
+
+Execution detail is not part of this loop. It is fetched only after an explicit user action.
+
+### 9.2 Execution lifetime
+
+- A local Runtime depends on the Mobile execution window. If iOS or Android suspends the required
+  process and no supported continuation mechanism exists, the turn becomes `interrupted`.
+- A LAN or cloud Runtime may declare detached execution only if it retains execution state and can
+  resume compact projection delivery after disconnection.
+- Endpoint kind alone does not prove recovery. A paired PC that shuts down is unavailable; a cloud
+  service that does not retain events is not detached.
+
+When a remote endpoint is offline, Mobile may show its compact offline projection. It cannot show
+uncached detail, and it does not fabricate terminal state for an execution whose remote outcome is
+unknown.
+
+## 10. Rebind, transfer, and fork
+
+`session.rebind` changes the Runtime implementation or endpoint only when record authority remains
+compatible.
+
+- A complete `local-canonical` record can reconstruct context for another compatible local Runtime.
+- A `remote-canonical` session may reconnect to the same remote authority using its native ids and
+  cursor.
+- A compact remote projection is not sufficient to create an equivalent local session or move to a
+  different remote authority.
+
+Changing authority therefore requires a separate explicit operation:
+
+- **transfer** obtains a complete, supported export from the old authority and imports it into the
+  new authority; or
+- **fork** creates a new session from the user-visible projected messages and clearly reports that
+  Runtime-native context and detail were not copied.
+
+Protocol v1 does not define transfer. An ordinary rebind that would change record mode fails with
+`AUTHORITY_TRANSFER_UNSUPPORTED`.
+
+## 11. Security and retention
+
+- LAN pairing uses a short-lived bootstrap token and stores the resulting credential in platform
+  secure storage, referenced from backend-private binding state.
+- Production LAN and cloud detail requests require authenticated TLS. LAN pairing should pin the
+  selected host identity rather than trust any device on the network.
+- Detail locators are opaque, scoped to session, generation, execution, and part, and validated by
+  the backend before use.
+- Remote detail endpoints enforce the same authorization as the parent execution and return
+  `no-store` responses.
+- Runtime retention or deletion may make detail unavailable without invalidating the compact
+  transcript. The UI represents that state explicitly.
+- Session deletion must define whether it removes only the Mobile projection or also requests
+  deletion from the remote authority; the product must not imply remote deletion after only a local
+  row is removed.
+
+## 12. Placement and integration
+
+```text
+src/shared/agent/protocol/           # Mobile application protocol and schemas
+src/backend/services/agent/          # Agent Host, adapter registry, workflows
+src/backend/services/agent/adapters/ # Local, LAN, and cloud adapters
+src/backend/data/                    # SQL-only records and projection persistence
+src/frontend/features/agent/         # Client reducer, queries, and rendering
+packages/ai-runtime/                 # Existing provider/AI SDK execution primitives
+packages/agent-runtime/              # Optional future reusable local Runtime
+```
+
+`packages/agent-runtime` is admitted only after an independent consumer exists. It may depend on
+portable AI execution primitives, but it must not depend on Mobile protocol, storage, React, Expo,
+or application adapters.
+
+`AgentSessionView` is the persisted product conversation aggregate. It is not the caller-owned,
+disposable `Session` lifecycle role defined by [Runtime Ownership](../runtime-ownership.md#role-names).
+
+This design does not replace the current Topic, Chat Runtime, or agent-session tables until an
+implementation phase lands. Current-state references remain authoritative for shipped behavior.
+In particular, the current
+[`agent_session_message.data`](../../../src/backend/data/db/schemas/agentSessionMessage.ts) row
+stores complete `MessageData`; the existing
+[`deferToolOutputs`](../../../src/backend/data/api/handlers/agentSessionMessages.ts) query only
+projects large tool results at the renderer boundary. It reduces transport payload but does not
+implement `remote-canonical` storage or prevent the full output from being stored locally.
+
+## 13. Conformance
+
+Runtime adapter conformance proves:
+
+- declared capabilities match actual behavior;
+- execute reaches one terminal outcome or a recoverable detached state;
+- cancellation and close are idempotent;
+- approval and steering correlate to the active execution;
+- resume cursors do not duplicate or skip compact events;
+- remote projection events exclude raw detail;
+- detail lookup returns the correct event and fails closed for stale generation or authorization;
+- native errors are redacted before conversion.
+
+Mobile Agent Host conformance is defined by
+[Agent Protocol §10](./agent-protocol.md#10-invariants). Storage tests additionally prove that a
+`remote-canonical` session never writes forbidden detail to SQLite, MMKV, search indexes, logs, or
+snapshot fixtures.
+
+## 14. Delivery order
+
+1. Land the Mobile protocol schemas and record-mode invariants.
+2. Add local-canonical Host orchestration behind the existing application composition boundary.
+3. Add the compact remote projection store and forbidden-detail tests.
+4. Add one LAN adapter using HTTP, SSE, resume cursor, and on-demand detail.
+5. Reuse the same port for a cloud adapter.
+6. Add explicit transfer or fork UX only after a Runtime supplies a complete export contract.

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -27,7 +27,7 @@ Agent Runtime Adapter
 - The frontend knows only Cherry sessions, turns, messages, parts, commands, snapshots, and
   capabilities.
 - The Mobile Agent Host owns application orchestration, protocol sequencing, local persistence,
-  compact remote projections, and frontend recovery.
+  selective compact remote projections, and frontend recovery.
 - An adapter translates between the host's execution port and one Runtime's native API.
 - A Runtime executes turns. It does not import Cherry protocol envelopes, React, Expo, SQLite,
   Drizzle, or frontend state.
@@ -53,20 +53,24 @@ The Mobile Agent Host owns the complete normalized session record.
 
 ### 2.2 `remote-canonical`
 
-The LAN or cloud endpoint owns the complete execution record. Mobile stores a compact projection.
+The LAN or cloud endpoint owns the complete execution record. Mobile stores a selective compact
+projection of Mobile-initiated executions.
 
-- The projection is sufficient for session lists, the ordinary transcript, status, search of
-  projected text, offline shells, and resuming projection synchronization.
+- The projection is sufficient for the Mobile session list, Mobile-initiated activity transcript,
+  status, search of projected text, offline shells, and recovery of Mobile-known executions.
 - It may contain user-visible prompts, final assistant text, safe tool summaries, attachment and
-  artifact references, status, usage summary, timestamps, a synchronization cursor, and opaque
-  remote locators.
+  artifact references, status, usage summary, timestamps, per-execution recovery cursors, and
+  opaque remote locators.
 - It must not contain raw reasoning, MCP/tool input or output, shell or command logs, traces,
   provider-native events, Runtime snapshots, continuation state, or remote file bodies.
 - Expanding a tool, reasoning, trace, or log view performs an authenticated request to the remote
   endpoint. The result remains ephemeral and is not merged into the persisted message.
+- Turns created directly on the remote PC are not automatically discovered or imported. The local
+  projection may remain incomplete and stale indefinitely.
 
-The compact Mobile row is a projection, not a competing source of truth. A stale projection can be
-advanced from the remote cursor; it must never overwrite the remote execution record.
+The compact Mobile row is an observation, not a competing source of truth or an eventually
+consistent mirror. Recovery may advance a Mobile-known execution from its own cursor; it never
+advances the whole Session from a remote transcript cursor.
 Mobile still owns Cherry-only facts such as the local session id, pin/order state, local display
 preferences, and a manually overridden title. Remote authority applies to execution-derived
 transcript, state, and detail; it does not turn the independent Runtime into Cherry's product
@@ -154,7 +158,7 @@ An adapter owns exactly the Runtime-specific boundary:
 - mapping host execution ids to Runtime-native session, execution, event, and approval ids;
 - capability discovery;
 - compact, safe summaries for remote projection events;
-- resume cursor or projection-snapshot translation when supported;
+- per-execution resume cursor or projection-snapshot translation when supported;
 - on-demand detail loading;
 - cancellation, steering, and approval translation;
 - redaction of native errors before they reach application views.
@@ -177,12 +181,12 @@ An adapter does not:
 - build a Runtime execution request from the allowed context;
 - map normalized Runtime events into Cherry turns, messages, and parts;
 - apply the session's persistence policy before any write;
-- persist a local record or compact remote projection;
+- persist a local record or selective compact remote projection;
 - assign application `revision` and event `sequence`;
 - publish protocol events only after durable projection facts commit;
 - provide snapshots and recover frontend subscriptions;
 - resolve a Cherry part id to a backend-private detail locator;
-- coordinate cancellation, shutdown, background loss, and remote resynchronization.
+- coordinate cancellation, shutdown, background loss, and recovery of Mobile-known executions.
 
 SQL-only data services remain responsible for rows and transactions. The Agent Host owns the
 cross-resource workflow because a remote request, connection, or secure credential cannot be made
@@ -205,23 +209,25 @@ application source of truth and is discarded or fenced when the turn or binding 
 
 ## 7. Remote execution flow
 
-### 7.1 Submit and synchronize
+### 7.1 Submit and observe
 
 1. The host persists an outbox receipt and an optimistic user-visible projection.
 2. The adapter submits the request to the LAN or cloud endpoint with an idempotency key.
 3. The remote service accepts the command and returns its private session/execution ids and a
-   projection cursor. Until this acknowledgement, the optimistic message is local pending state,
+   per-execution cursor. Until this acknowledgement, the optimistic message is local pending state,
    not a remote transcript fact; rejection leaves an explicit retry-or-discard state.
-4. The adapter consumes compact events, usually over SSE, and emits normalized summaries. Raw
-   execution detail is not included.
+4. The adapter consumes compact events for that execution, usually over SSE, and emits normalized
+   summaries. It does not subscribe to or enumerate the remote Session's other turns. Raw execution
+   detail is not included.
 5. The host commits each durable projection change and then publishes the corresponding Cherry
    application event.
 6. The remote service retains the complete execution record and can continue while Mobile is
    suspended or disconnected when detached execution is supported.
 
-HTTP plus SSE is the default remote shape: HTTP for commands, snapshots, and detail reads; SSE for
-compact forward events. A Runtime may use WebSocket internally, but that choice stays inside its
-adapter and does not change the Mobile application protocol.
+HTTP plus SSE is the default remote shape: HTTP for commands, per-execution recovery snapshots, and
+detail reads; SSE for events belonging to a Mobile-initiated execution. A Runtime may use
+WebSocket internally, but that choice stays inside its adapter and does not turn the connection
+into a subscription to all remote Session activity.
 
 ### 7.2 Expand execution detail
 
@@ -256,15 +262,16 @@ semantic boundary:
 | Mobile may persist for remote sessions | Mobile must not persist for remote sessions |
 | --- | --- |
 | Session id, agent id, title, binding summary, record mode | Remote credentials or URLs in protocol rows |
-| Remote session/execution locator and sync cursor in backend-private rows | Raw reasoning or provider event streams |
+| Remote session/execution locator and per-execution cursor in backend-private rows | Raw reasoning or provider event streams |
 | User-visible prompt and final answer projection | MCP/tool input and output |
 | Tool name, state, safe summary, and `hasDetail` | Shell/terminal/command logs |
 | Attachment/artifact metadata and remote references | Remote file bodies or Runtime snapshots |
 | Turn status, safe error summary, usage summary, timestamps | Traces, stack traces, continuation payloads |
 | Command receipts, generation, revision, local sequence | Persistent caches of on-demand detail |
 
-Local full-text search indexes only projected text. Searching remote execution detail, if offered,
-is a remote capability and query; Mobile does not download detail to improve its local index.
+Local full-text search indexes only text from Mobile-initiated executions. It does not search or
+download PC-originated turns. Searching remote execution detail, if offered, is a separate remote
+capability and query.
 
 Application logs follow the same policy as storage. Logging a raw HTTP response, MCP argument, or
 tool output would violate the boundary even if no database row were written.
@@ -274,29 +281,42 @@ tool output would violate the boundary even if no database row were written.
 ### 9.1 Application snapshot
 
 The frontend always recovers through `AgentSessionSnapshot` plus subsequent application events.
-For `remote-canonical`, that snapshot contains only the compact projection.
+For `remote-canonical`, that snapshot contains only Mobile's selective compact projection.
 
 On foreground or sequence mismatch, the host:
 
-1. loads the local projection and remote sync cursor and serves that snapshot immediately;
-2. asks the adapter in the background for compact events after that cursor, or a compact projection
-   snapshot if replay is unavailable;
-3. commits each advanced projection and publishes it through the normal local event sequence.
+1. loads and serves the local projection immediately;
+2. finds Mobile-known unfinished executions recorded in that projection;
+3. resumes each one by `executionId` and its per-execution cursor, or requests that execution's
+   projection snapshot if replay is unavailable;
+4. commits recovered events for those executions through the normal local event sequence.
 
-Execution detail is not part of this loop. It is fetched only after an explicit user action.
+The host does not list the remote transcript, read a Session-wide cursor, or import PC-originated
+turns during this loop. Execution detail is fetched only after an explicit user action.
 
 ### 9.2 Execution lifetime
 
 - A local Runtime depends on the Mobile execution window. If iOS or Android suspends the required
   process and no supported continuation mechanism exists, the turn becomes `interrupted`.
 - A LAN or cloud Runtime may declare detached execution only if it retains execution state and can
-  resume compact projection delivery after disconnection.
+  resume a Mobile-known execution after disconnection.
 - Endpoint kind alone does not prove recovery. A paired PC that shuts down is unavailable; a cloud
   service that does not retain events is not detached.
 
 When a remote endpoint is offline, Mobile may show its compact offline projection. It cannot show
 uncached detail, and it does not fabricate terminal state for an execution whose remote outcome is
 unknown.
+
+### 9.3 Remote-native activity
+
+The remote PC remains free to continue the same native Session through its own UI, automation, or
+other clients. Mobile neither locks that Session nor imports those turns. Consequently:
+
+- the Mobile projection may remain permanently behind the remote transcript;
+- local `status`, `activeMessageId`, `updatedAt`, message parents, and `revision` describe only
+  Mobile's projection;
+- the next Mobile command executes against the Runtime's current native context, which may contain
+  PC-originated turns that are absent locally.
 
 ## 10. Rebind, transfer, and fork
 
@@ -305,7 +325,7 @@ compatible.
 
 - A complete `local-canonical` record can reconstruct context for another compatible local Runtime.
 - A `remote-canonical` session may reconnect to the same remote authority using its native ids and
-  cursor.
+  any cursors for Mobile-known executions.
 - A compact remote projection is not sufficient to create an equivalent local session or move to a
   different remote authority.
 
@@ -371,7 +391,9 @@ Runtime adapter conformance proves:
 - execute reaches one terminal outcome or a recoverable detached state;
 - cancellation and close are idempotent;
 - approval and steering correlate to the active execution;
-- resume cursors do not duplicate or skip compact events;
+- per-execution resume cursors do not duplicate or skip compact events for Mobile-known executions;
+- recovery never enumerates or imports PC-originated turns from the remote Session;
+- remote-native activity remains unrestricted by the Mobile binding;
 - remote projection events exclude raw detail;
 - detail lookup returns the correct event and fails closed for stale generation or authorization;
 - native errors are redacted before conversion.
@@ -385,7 +407,7 @@ snapshot fixtures.
 
 1. Land the Mobile protocol schemas and record-mode invariants.
 2. Add local-canonical Host orchestration behind the existing application composition boundary.
-3. Add the compact remote projection store and forbidden-detail tests.
-4. Add one LAN adapter using HTTP, SSE, resume cursor, and on-demand detail.
+3. Add the selective compact remote projection store and forbidden-detail tests.
+4. Add one LAN adapter using HTTP, SSE, per-execution resume, and on-demand detail.
 5. Reuse the same port for a cloud adapter.
 6. Add explicit transfer or fork UX only after a Runtime supplies a complete export contract.

--- a/docs/references/data/README.md
+++ b/docs/references/data/README.md
@@ -138,15 +138,20 @@ writes the terminal, paused, or error state to the placeholder.
 
 `createBackendServices()` constructs concrete backend classes such as `CacheService`,
 `PreferenceService`, `ProviderService`, `MessageService`, `McpRuntimeService`, `WebSearchService`,
-`ToolResolver`, and `AiService`. The graph is private to bootstrap. `createBackend()` creates one
-`ChatRuntime`, builds the factory-shaped workflow modules, and returns the workflow-only `Backend`
-plus the MCP mutation coordinator needed by Data API handlers.
+`ToolResolver`, and `AiService`. The graph is private to bootstrap. `createBackend()` builds the
+factory-shaped workflow modules and returns the workflow-only `Backend` plus the MCP mutation
+coordinator needed by Data API handlers.
 `createAppBootstrapRuntime()` wires those handlers into `DataApiService` and exposes
 `PreferenceService` only through the `PreferenceClient` interface. The concrete graph and caches are
 never exposed to frontend code.
 
-There is no desktop application singleton, IPC handler layer, lifecycle registry, or frontend DI
-container for these concrete classes.
+Lifecycle-owned services are declared once in `src/backend/core/application/serviceRegistry.ts` and
+instantiated per `ApplicationHost` generation; `ChatRuntime` is one of them, and `createBackend()`
+exposes the instance rather than constructing it. See [Lifecycle](../lifecycle/README.md).
+
+There is no IPC handler layer or frontend DI container for these concrete classes. Mobile does have
+an application singleton and a lifecycle service registry — they are backend-private, and frontend
+code reaches this graph only through `Backend`, `ApiClient`, and `PreferenceClient`.
 
 ## Seeding And Compatibility
 

--- a/docs/references/job-manager-design.md
+++ b/docs/references/job-manager-design.md
@@ -600,6 +600,20 @@ readers know they are decisions, not oversights:
    shape is reserved for when it exists.
 8. **`server-required` is not an execution class value.** It is a product-mapping decision
    ("don't build this locally"); a local row with that class would be a bug, not a state.
+9. **Silent audio is used as a mechanism, against the assessment's ruling — with the review risk
+   accepted, not refuted.** The assessment states that silent audio "does not satisfy Apple's
+   production background audio contract" and "must not become the Job Manager's execution
+   foundation". Those are two separate objections, and the appendix revised the ruling on
+   continuation evidence without separating them. *Foundation*: honored — job correctness never
+   depends on keep-alive. The ledger, the fence, and cold-start recovery are what make a job
+   correct; keep-alive only extends a window.
+   *Contract*: the objection stands and is accepted as a known liability. `UIBackgroundModes:
+   ["audio"]` without audible content is reviewable under App Review guideline 2.5.4, and Apple
+   documents an interruption path for a session that "goes silent for too long" — which is why
+   `KeepAliveCoordinator.handlePlayerStatusUpdate` has to restart playback. The mitigation is the
+   exit already named in the appendix (iOS 26 Continued Processing, Android FGS); see
+   [Agent Runtime §9.2](./agent/agent-runtime.md#92-execution-lifetime), which keeps Mobile's bounded
+   execution window separate from detached LAN or cloud execution.
 
 ## Open Questions
 

--- a/docs/references/job-manager-design.md
+++ b/docs/references/job-manager-design.md
@@ -612,8 +612,8 @@ readers know they are decisions, not oversights:
    documents an interruption path for a session that "goes silent for too long" — which is why
    `KeepAliveCoordinator.handlePlayerStatusUpdate` has to restart playback. The mitigation is the
    exit already named in the appendix (iOS 26 Continued Processing, Android FGS); see
-   [Agent Runtime §9.2](./agent/agent-runtime.md#92-execution-lifetime), which keeps Mobile's bounded
-   execution window separate from detached LAN or cloud execution.
+   [Agent Runtime execution lifetime](./agent/agent-runtime.md#execution-lifetime), which treats
+   Mobile's local execution window as bounded and non-resumable in v1.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- add the Cherry Mobile Agent architecture references under `docs/references/agent/`: an overview, the Agent Protocol, and the Agent Runtime contract
- define the **Agent Protocol** as the application contract between the frontend Agent Client and the backend Mobile Agent Host: Sessions, execution targets, turns, messages, operations, snapshots, events, errors, and invariants
- define the **Agent Runtime** as an independent execution contract behind the Host: it receives prepared execution input and emits normalized events, with no knowledge of Agent/Session rows, SQLite, React, Expo, or protocol types
- define the **Agent Runtime Router** as the only implementation-selection point: Pi when the resolved Agent configuration contains Agent tools, otherwise the AI SDK Runtime; Runtime identity never crosses the protocol boundary
- scope version 1 to local-only execution: Mobile persistence is the complete conversation record, one active turn per Session, snapshot-based recovery on remount/foreground, and startup reconciliation marks turns interrupted after process death
- add a `docs/README.md` rule that references may describe not-yet-implemented designs when marked with a `Status:` line, without overriding current-state docs
- correct the Data Layer lifecycle description: `ChatRuntime` is declared in `serviceRegistry.ts` and instantiated per `ApplicationHost` generation; `createBackend()` only passes it through
- record job-manager Deviation #9: the silent-audio keep-alive is an accepted App Store review risk, not a rebuttal of the portability assessment

## Why

Executing a turn and owning the conversation are different responsibilities. The Host owns Agents, Sessions, history, tool policy, and recovery; a Runtime executes one prepared turn. Keeping the Runtime contract free of application types lets Pi and the AI SDK sit behind the same Router, invisible to the Agent Client, and leaves room for the contract to move into a package once a real independent consumer exists.

Version 1 deliberately defines local execution only. LAN/cloud execution targets and remote-authoritative Sessions are named as a future direction that enters through the same Router, but their transport, security, storage, and recovery rules are explicitly out of scope and require a separate design.

These references are marked `Status: design` and do not replace the current Topic, Chat Runtime, or desktop-aligned `agent_*` documentation.

## Validation

- `pnpm docs:check-links`
- `git diff --check origin/v0.2...HEAD`
- no tests run (documentation-only change; repository verification remains user-owned)
