### PR TITLE
feat(profile): manage custom avatar uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "expo-glass-effect": "~57.0.1",
     "expo-haptics": "~57.0.1",
     "expo-image": "~57.0.1",
+    "expo-image-manipulator": "~57.0.11",
     "expo-image-picker": "~57.0.4",
     "expo-intent-launcher": "~57.0.1",
     "expo-linear-gradient": "~57.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       expo-image:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.6)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      expo-image-manipulator:
+        specifier: ~57.0.11
+        version: 57.0.11(expo@57.0.6)
       expo-image-picker:
         specifier: ~57.0.4
         version: 57.0.4(expo@57.0.6)
@@ -6129,6 +6132,11 @@ packages:
 
   expo-image-loader@57.0.1:
     resolution: {integrity: sha512-uhrZKLT/cTl2mXyR28kPpVkS5O+PK9N1QA/07IFM4f5T4g0lTW1JHT3NEWwEEsGFldPmVX4j7LwUVVZxE+woug==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-manipulator@57.0.11:
+    resolution: {integrity: sha512-SMl1X9Mu3qNwFPiiQx+JGsnrKD6F16owbMCTKb/bU8F4GNHy8Nx9SqKlwD7BhpwDYjg1bQt+WnvzKA7vGS1fgA==}
     peerDependencies:
       expo: '*'
 
@@ -14884,6 +14892,11 @@ snapshots:
   expo-image-loader@57.0.1(expo@57.0.6):
     dependencies:
       expo: 57.0.6(279bc2c55e70740faa01809fe39d5b6f)
+
+  expo-image-manipulator@57.0.11(expo@57.0.6):
+    dependencies:
+      expo: 57.0.6(279bc2c55e70740faa01809fe39d5b6f)
+      expo-image-loader: 57.0.1(expo@57.0.6)
 
   expo-image-picker@57.0.4(expo@57.0.6):
     dependencies:

--- a/src/backend/services/file/__tests__/userContentImageStorage.test.ts
+++ b/src/backend/services/file/__tests__/userContentImageStorage.test.ts
@@ -1,0 +1,122 @@
+import { FileEntryIdSchema } from '@cherrystudio/universal/data/types/file';
+
+import { createUserContentImageStorage } from '../userContentImageStorage';
+
+jest.mock('expo-file-system', () => {
+  const files = new Map<string, number>();
+
+  class MockFile {
+    readonly uri: string;
+
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+
+    get exists() {
+      return files.has(this.uri);
+    }
+
+    get size() {
+      return files.get(this.uri) ?? null;
+    }
+
+    delete() {
+      files.delete(this.uri);
+    }
+  }
+
+  return { File: MockFile, testState: { files } };
+});
+
+jest.mock('expo-image-manipulator', () => ({
+  ImageManipulator: { manipulate: jest.fn() },
+  SaveFormat: { WEBP: 'webp' },
+}));
+
+jest.mock('../fileStorage', () => ({
+  createInternalEntry: jest.fn(),
+  discardInternalEntries: jest.fn(),
+  getFileUri: jest.fn(),
+}));
+
+const storedId = FileEntryIdSchema.parse('00000000-0000-4000-8000-000000000001');
+const sourceUri = 'file:///picker/avatar.jpg';
+const normalizedUri = 'file:///cache/avatar.webp';
+const { testState: fileSystemState } = jest.requireMock<{
+  testState: { files: Map<string, number> };
+}>('expo-file-system');
+const { ImageManipulator } = jest.requireMock<{
+  ImageManipulator: { manipulate: jest.Mock };
+}>('expo-image-manipulator');
+const fileStorage = jest.requireMock<{
+  createInternalEntry: jest.Mock;
+  discardInternalEntries: jest.Mock;
+  getFileUri: jest.Mock;
+}>('../fileStorage');
+
+describe('userContentImageStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fileSystemState.files.clear();
+  });
+
+  it('center-crops, normalizes, and stores an avatar as a managed WebP', async () => {
+    fileSystemState.files.set(sourceUri, 4 * 1024 * 1024);
+    fileSystemState.files.set(normalizedUri, 320 * 1024);
+    const sourceImage = { height: 1200, release: jest.fn(), width: 1600 };
+    const outputImage = {
+      release: jest.fn(),
+      saveAsync: jest.fn(async () => ({ height: 1024, uri: normalizedUri, width: 1024 })),
+    };
+    const sourceContext = { release: jest.fn(), renderAsync: jest.fn(async () => sourceImage) };
+    const outputContext = {
+      crop: jest.fn(),
+      release: jest.fn(),
+      renderAsync: jest.fn(async () => outputImage),
+      resize: jest.fn(),
+    };
+    outputContext.crop.mockReturnValue(outputContext);
+    outputContext.resize.mockReturnValue(outputContext);
+    ImageManipulator.manipulate
+      .mockReturnValueOnce(sourceContext)
+      .mockReturnValueOnce(outputContext);
+    fileStorage.createInternalEntry.mockResolvedValue({ id: storedId, origin: 'internal' });
+    const storage = createUserContentImageStorage(createEntries());
+
+    await expect(storage.create(sourceUri)).resolves.toBe(storedId);
+
+    expect(outputContext.crop).toHaveBeenCalledWith({
+      height: 1200,
+      originX: 200,
+      originY: 0,
+      width: 1200,
+    });
+    expect(outputContext.resize).toHaveBeenCalledWith({ height: 1024, width: 1024 });
+    expect(outputImage.saveAsync).toHaveBeenCalledWith({ compress: 0.82, format: 'webp' });
+    expect(fileStorage.createInternalEntry).toHaveBeenCalledWith(expect.any(Object), {
+      cleanupPolicy: 'manual',
+      name: 'avatar.webp',
+      source: 'uri',
+      uri: normalizedUri,
+    });
+    expect(fileSystemState.files.has(normalizedUri)).toBe(false);
+  });
+
+  it('rejects oversized picker files before decoding them', async () => {
+    fileSystemState.files.set(sourceUri, 10 * 1024 * 1024 + 1);
+    const storage = createUserContentImageStorage(createEntries());
+
+    await expect(storage.create(sourceUri)).rejects.toThrow('exceeds the 10 MB limit');
+
+    expect(ImageManipulator.manipulate).not.toHaveBeenCalled();
+    expect(fileStorage.createInternalEntry).not.toHaveBeenCalled();
+  });
+});
+
+function createEntries(): Parameters<typeof createUserContentImageStorage>[0] {
+  return {
+    create: jest.fn(),
+    delete: jest.fn(),
+    findById: jest.fn(),
+  } as unknown as Parameters<typeof createUserContentImageStorage>[0];
+}

--- a/src/backend/services/file/userContentImageStorage.ts
+++ b/src/backend/services/file/userContentImageStorage.ts
@@ -1,0 +1,138 @@
+import { type FileEntryId, FileEntryIdSchema } from '@cherrystudio/universal/data/types/file';
+import { File } from 'expo-file-system';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+
+import type { FileEntryService } from '@/backend/data/services/FileEntryService';
+import { loggerService } from '@/shared/core/logger/LoggerService';
+
+import { createInternalEntry, discardInternalEntries, getFileUri } from './fileStorage';
+
+const logger = loggerService.withContext('UserContentImageStorage');
+const MAX_SOURCE_BYTES = 10 * 1024 * 1024;
+const MAX_STORED_BYTES = 2 * 1024 * 1024;
+// The mobile profile photo expands into a large hero, so thumbnail-sized output
+// is visibly soft even though compact assistant avatars use the same asset.
+const AVATAR_DIMENSION = 1024;
+const WEBP_QUALITY = 0.82;
+
+type UserContentImageEntries = Pick<FileEntryService, 'create' | 'delete' | 'findById'>;
+
+export type UserContentImageStorage = {
+  create(sourceUri: string): Promise<FileEntryId>;
+  remove(id: FileEntryId): Promise<boolean>;
+  resolve(id: FileEntryId): Promise<string | undefined>;
+};
+
+/**
+ * Managed storage for images selected by the user. Picker and camera URIs are
+ * transient inputs; callers persist only the returned FileEntry id.
+ */
+export function createUserContentImageStorage(
+  entries: UserContentImageEntries,
+): UserContentImageStorage {
+  return {
+    create: async (sourceUri) => {
+      let normalizedUri: string | undefined;
+
+      try {
+        normalizedUri = await normalizeAvatarImage(sourceUri);
+        const entry = await createInternalEntry(entries, {
+          cleanupPolicy: 'manual',
+          name: 'avatar.webp',
+          source: 'uri',
+          uri: normalizedUri,
+        });
+        return entry.id;
+      } finally {
+        if (normalizedUri) {
+          deleteTemporaryImage(normalizedUri);
+        }
+      }
+    },
+    remove: async (id) => {
+      const safeId = FileEntryIdSchema.parse(id);
+      const entry = await entries.findById(safeId);
+
+      if (!entry || entry.origin !== 'internal') {
+        return false;
+      }
+
+      await discardInternalEntries(entries, [entry]);
+      return true;
+    },
+    resolve: (id) => getFileUri(entries, FileEntryIdSchema.parse(id)),
+  };
+}
+
+async function normalizeAvatarImage(sourceUri: string): Promise<string> {
+  const sourceFile = new File(sourceUri);
+  assertUsableFile(sourceFile, MAX_SOURCE_BYTES, 'Selected image');
+
+  const sourceContext = ImageManipulator.manipulate(sourceUri);
+  let sourceImage: Awaited<ReturnType<typeof sourceContext.renderAsync>> | undefined;
+  let outputContext: ReturnType<typeof ImageManipulator.manipulate> | undefined;
+  let outputImage: Awaited<ReturnType<typeof sourceContext.renderAsync>> | undefined;
+  let outputUri: string | undefined;
+
+  try {
+    sourceImage = await sourceContext.renderAsync();
+    const cropSize = Math.min(sourceImage.width, sourceImage.height);
+
+    if (!Number.isFinite(cropSize) || cropSize <= 0) {
+      throw new Error('Selected image has invalid dimensions');
+    }
+
+    outputContext = ImageManipulator.manipulate(sourceImage);
+    outputContext
+      .crop({
+        height: cropSize,
+        originX: Math.floor((sourceImage.width - cropSize) / 2),
+        originY: Math.floor((sourceImage.height - cropSize) / 2),
+        width: cropSize,
+      })
+      .resize({ height: AVATAR_DIMENSION, width: AVATAR_DIMENSION });
+    outputImage = await outputContext.renderAsync();
+    const result = await outputImage.saveAsync({
+      compress: WEBP_QUALITY,
+      format: SaveFormat.WEBP,
+    });
+    outputUri = result.uri;
+    assertUsableFile(new File(outputUri), MAX_STORED_BYTES, 'Normalized image');
+    return outputUri;
+  } catch (error) {
+    if (outputUri) {
+      deleteTemporaryImage(outputUri);
+    }
+    throw error;
+  } finally {
+    outputImage?.release();
+    outputContext?.release();
+    sourceImage?.release();
+    sourceContext.release();
+  }
+}
+
+function assertUsableFile(file: File, maxBytes: number, label: string): void {
+  if (!file.exists) {
+    throw new Error(`${label} does not exist`);
+  }
+
+  const size = file.size;
+  if (size === null || !Number.isSafeInteger(size) || size < 0) {
+    throw new Error(`${label} has an invalid size`);
+  }
+  if (size > maxBytes) {
+    throw new Error(`${label} exceeds the ${Math.floor(maxBytes / 1024 / 1024)} MB limit`);
+  }
+}
+
+function deleteTemporaryImage(uri: string): void {
+  try {
+    const file = new File(uri);
+    if (file.exists) {
+      file.delete();
+    }
+  } catch (error) {
+    logger.warn('Failed to delete a normalized temporary image', error as Error, { uri });
+  }
+}

--- a/src/backend/services/profile/__tests__/createProfileModule.test.ts
+++ b/src/backend/services/profile/__tests__/createProfileModule.test.ts
@@ -7,7 +7,9 @@ describe('createProfileModule', () => {
     const dependencies: ProfileModuleDependencies = {
       avatars: {
         replace: jest.fn(async (_source, _previous, persist) => persist('file:next')),
-        resolve: jest.fn((avatar) => (avatar === 'file:next' ? 'file:///next.png' : undefined)),
+        resolve: jest.fn(async (avatar) =>
+          avatar === 'file:next' ? 'file:///next.png' : undefined,
+        ),
       },
       preferences: {
         readAvatar: jest.fn(() => 'file:previous'),
@@ -24,6 +26,6 @@ describe('createProfileModule', () => {
       expect.any(Function),
     );
     expect(dependencies.preferences.writeAvatar).toHaveBeenCalledWith('file:next');
-    expect(backend.resolveAvatar('file:next')).toBe('file:///next.png');
+    await expect(backend.resolveAvatar('file:next')).resolves.toBe('file:///next.png');
   });
 });

--- a/src/backend/services/profile/__tests__/userAvatarStorage.test.ts
+++ b/src/backend/services/profile/__tests__/userAvatarStorage.test.ts
@@ -1,9 +1,11 @@
+import { type FileEntryId, FileEntryIdSchema } from '@cherrystudio/universal/data/types/file';
+
+import type { UserContentImageStorage } from '@/backend/services/file/userContentImageStorage';
+
 import { replaceUserAvatar, resolveUserAvatarUri } from '../userAvatarStorage';
 
 jest.mock('expo-file-system', () => {
-  const directories = new Set<string>();
   const files = new Set<string>();
-  const copies: { destination: string; source: string }[] = [];
   const joinUri = (parts: (string | { uri: string })[], isDirectory: boolean) => {
     const [first, ...rest] = parts.map((part) => (typeof part === 'string' ? part : part.uri));
     let uri = first?.replace(/\/+$/, '') ?? '';
@@ -21,14 +23,6 @@ jest.mock('expo-file-system', () => {
     constructor(...parts: (string | { uri: string })[]) {
       this.uri = joinUri(parts, true);
     }
-
-    get exists() {
-      return directories.has(this.uri);
-    }
-
-    create() {
-      directories.add(this.uri);
-    }
   }
 
   class MockFile {
@@ -42,11 +36,6 @@ jest.mock('expo-file-system', () => {
       return files.has(this.uri);
     }
 
-    async copy(destination: MockFile) {
-      copies.push({ destination: destination.uri, source: this.uri });
-      files.add(destination.uri);
-    }
-
     delete() {
       files.delete(this.uri);
     }
@@ -56,87 +45,108 @@ jest.mock('expo-file-system', () => {
     Directory: MockDirectory,
     File: MockFile,
     Paths: { document: { uri: 'file:///documents/' } },
-    testState: { copies, directories, files },
+    testState: { files },
   };
 });
 
-type FileSystemTestState = {
-  copies: { destination: string; source: string }[];
-  directories: Set<string>;
-  files: Set<string>;
-};
+const fileIds = [
+  FileEntryIdSchema.parse('00000000-0000-4000-8000-000000000001'),
+  FileEntryIdSchema.parse('00000000-0000-4000-8000-000000000002'),
+];
 
-const { testState } = jest.requireMock<{ testState: FileSystemTestState }>('expo-file-system');
+const { testState } = jest.requireMock<{ testState: { files: Set<string> } }>('expo-file-system');
 
 describe('userAvatarStorage', () => {
   beforeEach(() => {
-    testState.copies.length = 0;
-    testState.directories.clear();
     testState.files.clear();
   });
 
-  it('stores a picked image behind a path-resilient file reference', async () => {
+  it('stores a picked image behind a managed file reference', async () => {
+    const images = createImageStorage();
     let avatar = '';
 
-    await replaceUserAvatar('file:///picker/avatar.jpg', '', async (nextAvatar) => {
+    await replaceUserAvatar(images, 'file:///picker/avatar.jpg', '', async (nextAvatar) => {
       avatar = nextAvatar;
     });
 
-    expect(avatar).toMatch(
-      /^file:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
-    expect(testState.copies).toEqual([
-      {
-        destination: `file:///documents/user-avatars/${avatar.slice('file:'.length)}`,
-        source: 'file:///picker/avatar.jpg',
-      },
-    ]);
-    expect(resolveUserAvatarUri(avatar)).toBe(
-      `file:///documents/user-avatars/${avatar.slice('file:'.length)}`,
+    expect(avatar).toBe(`file:${fileIds[0]}`);
+    expect(images.create).toHaveBeenCalledWith('file:///picker/avatar.jpg');
+    await expect(resolveUserAvatarUri(images, avatar)).resolves.toBe(
+      `file:///managed/${fileIds[0]}.webp`,
     );
   });
 
   it('deletes the previous managed file only after persisting its replacement', async () => {
+    const images = createImageStorage();
     let previousAvatar = '';
-    await replaceUserAvatar('file:///picker/first.jpg', '', async (nextAvatar) => {
+    await replaceUserAvatar(images, 'file:///picker/first.jpg', '', async (nextAvatar) => {
       previousAvatar = nextAvatar;
     });
 
     let nextAvatar = '';
-    await replaceUserAvatar('file:///picker/second.jpg', previousAvatar, async (value) => {
+    await replaceUserAvatar(images, 'file:///picker/second.jpg', previousAvatar, async (value) => {
       nextAvatar = value;
-      expect(resolveUserAvatarUri(previousAvatar)).toBeDefined();
+      await expect(resolveUserAvatarUri(images, previousAvatar)).resolves.toBeDefined();
     });
 
-    expect(resolveUserAvatarUri(previousAvatar)).toBeUndefined();
-    expect(resolveUserAvatarUri(nextAvatar)).toBeDefined();
+    await expect(resolveUserAvatarUri(images, previousAvatar)).resolves.toBeUndefined();
+    await expect(resolveUserAvatarUri(images, nextAvatar)).resolves.toBeDefined();
   });
 
   it('compensates the new file and preserves the previous avatar when persistence fails', async () => {
+    const images = createImageStorage();
     let previousAvatar = '';
-    await replaceUserAvatar('file:///picker/first.jpg', '', async (nextAvatar) => {
+    await replaceUserAvatar(images, 'file:///picker/first.jpg', '', async (nextAvatar) => {
       previousAvatar = nextAvatar;
     });
 
     let rejectedAvatar = '';
     await expect(
-      replaceUserAvatar('file:///picker/second.jpg', previousAvatar, async (nextAvatar) => {
+      replaceUserAvatar(images, 'file:///picker/second.jpg', previousAvatar, async (nextAvatar) => {
         rejectedAvatar = nextAvatar;
         throw new Error('preference write failed');
       }),
     ).rejects.toThrow('preference write failed');
 
-    expect(resolveUserAvatarUri(previousAvatar)).toBeDefined();
-    expect(resolveUserAvatarUri(rejectedAvatar)).toBeUndefined();
+    await expect(resolveUserAvatarUri(images, previousAvatar)).resolves.toBeDefined();
+    await expect(resolveUserAvatarUri(images, rejectedAvatar)).resolves.toBeUndefined();
   });
 
-  it('keeps legacy image URIs and rejects non-image or unresolved values', () => {
-    expect(resolveUserAvatarUri('https://example.com/avatar.png')).toBe(
+  it('keeps legacy references readable until their separate cleanup', async () => {
+    const images = createImageStorage();
+    const legacyRef = `file:${fileIds[0]}`;
+    testState.files.add(`file:///documents/user-avatars/${fileIds[0]}`);
+
+    await expect(resolveUserAvatarUri(images, legacyRef)).resolves.toBe(
+      `file:///documents/user-avatars/${fileIds[0]}`,
+    );
+    await expect(resolveUserAvatarUri(images, 'https://example.com/avatar.png')).resolves.toBe(
       'https://example.com/avatar.png',
     );
-    expect(resolveUserAvatarUri('data:image/png;base64,abc')).toBe('data:image/png;base64,abc');
-    expect(resolveUserAvatarUri('file:///legacy/avatar.png')).toBe('file:///legacy/avatar.png');
-    expect(resolveUserAvatarUri('😀')).toBeUndefined();
-    expect(resolveUserAvatarUri('file:00000000-0000-4000-8000-000000000000')).toBeUndefined();
+    await expect(resolveUserAvatarUri(images, 'data:image/png;base64,abc')).resolves.toBe(
+      'data:image/png;base64,abc',
+    );
+    await expect(resolveUserAvatarUri(images, 'file:///legacy/avatar.png')).resolves.toBe(
+      'file:///legacy/avatar.png',
+    );
+    await expect(resolveUserAvatarUri(images, '😀')).resolves.toBeUndefined();
   });
 });
+
+function createImageStorage(): UserContentImageStorage {
+  const uris = new Map<FileEntryId, string>();
+  let nextId = 0;
+
+  return {
+    create: jest.fn(async () => {
+      const id = fileIds[nextId++];
+      if (!id) {
+        throw new Error('No test FileEntry id available');
+      }
+      uris.set(id, `file:///managed/${id}.webp`);
+      return id;
+    }),
+    remove: jest.fn(async (id) => uris.delete(id)),
+    resolve: jest.fn(async (id) => uris.get(id)),
+  };
+}

--- a/src/backend/services/profile/createProfileModule.ts
+++ b/src/backend/services/profile/createProfileModule.ts
@@ -11,7 +11,7 @@ type UserAvatarStorage = {
     previousAvatar: string,
     persist: (avatar: string) => Promise<void>,
   ): Promise<void>;
-  resolve(avatar: string): string | undefined;
+  resolve(avatar: string): Promise<string | undefined>;
 };
 
 export type ProfileModuleDependencies = {

--- a/src/backend/services/profile/userAvatarStorage.ts
+++ b/src/backend/services/profile/userAvatarStorage.ts
@@ -1,43 +1,38 @@
+import {
+  type FileEntryId,
+  FileEntryIdSchema,
+  STORED_FILE_REF_PREFIX,
+  tagStoredFileRef,
+} from '@cherrystudio/universal/data/types/file';
 import { loggerService } from '@logger';
-import { randomUUID } from 'expo-crypto';
 import { Directory, File, Paths } from 'expo-file-system';
 
+import type { UserContentImageStorage } from '@/backend/services/file/userContentImageStorage';
+
 const logger = loggerService.withContext('UserAvatarStorage');
-const AVATAR_DIRECTORY_NAME = 'user-avatars';
-const STORED_FILE_REF_PREFIX = 'file:';
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_AVATAR_DIRECTORY_NAME = 'user-avatars';
 const LEGACY_IMAGE_URI_PATTERN = /^(?:blob:|content:\/\/|data:image\/|file:\/\/|https?:\/\/)/i;
 
 type PersistAvatar = (avatar: string) => Promise<void>;
 
-function avatarDirectory(): Directory {
-  return new Directory(Paths.document, AVATAR_DIRECTORY_NAME);
+function legacyAvatarDirectory(): Directory {
+  return new Directory(Paths.document, LEGACY_AVATAR_DIRECTORY_NAME);
 }
 
-function ensureAvatarDirectory(): Directory {
-  const directory = avatarDirectory();
-
-  if (!directory.exists) {
-    directory.create({ intermediates: true });
-  }
-
-  return directory;
+function legacyAvatarFile(fileId: FileEntryId): File {
+  return new File(legacyAvatarDirectory(), fileId);
 }
 
-function avatarFile(fileId: string): File {
-  return new File(avatarDirectory(), fileId);
-}
-
-function storedFileId(avatar: string): string | undefined {
+function storedFileId(avatar: string): FileEntryId | undefined {
   if (!avatar.startsWith(STORED_FILE_REF_PREFIX) || avatar.startsWith('file://')) {
     return undefined;
   }
 
-  const fileId = avatar.slice(STORED_FILE_REF_PREFIX.length);
-  return UUID_PATTERN.test(fileId) ? fileId : undefined;
+  const parsed = FileEntryIdSchema.safeParse(avatar.slice(STORED_FILE_REF_PREFIX.length));
+  return parsed.success ? parsed.data : undefined;
 }
 
-function deleteStoredAvatar(avatar: string): void {
+async function deleteStoredAvatar(images: UserContentImageStorage, avatar: string): Promise<void> {
   const fileId = storedFileId(avatar);
 
   if (!fileId) {
@@ -45,10 +40,13 @@ function deleteStoredAvatar(avatar: string): void {
   }
 
   try {
-    const file = avatarFile(fileId);
+    if (await images.remove(fileId)) {
+      return;
+    }
 
-    if (file.exists) {
-      file.delete();
+    const legacyFile = legacyAvatarFile(fileId);
+    if (legacyFile.exists) {
+      legacyFile.delete();
     }
   } catch (error) {
     logger.warn('Failed to delete stored user avatar', error as Error, { avatar });
@@ -56,54 +54,58 @@ function deleteStoredAvatar(avatar: string): void {
 }
 
 /**
- * Resolve the preference value into an image URI for this device. New avatars
- * use a path-resilient `file:<uuid>` reference; legacy image URIs still render.
+ * Resolve the preference value into an image URI for this device. Managed
+ * FileEntry references are canonical; the former user-avatars directory and
+ * direct image URIs remain read-compatible until their separate cleanup PR.
  */
-export function resolveUserAvatarUri(avatar: string): string | undefined {
+export async function resolveUserAvatarUri(
+  images: UserContentImageStorage,
+  avatar: string,
+): Promise<string | undefined> {
   const fileId = storedFileId(avatar);
 
   if (fileId) {
-    const file = avatarFile(fileId);
-    return file.exists ? file.uri : undefined;
+    const managedUri = await images.resolve(fileId);
+    if (managedUri) {
+      return managedUri;
+    }
+
+    const legacyFile = legacyAvatarFile(fileId);
+    return legacyFile.exists ? legacyFile.uri : undefined;
   }
 
   return LEGACY_IMAGE_URI_PATTERN.test(avatar) ? avatar : undefined;
 }
 
-async function storeUserAvatar(sourceUri: string): Promise<string> {
-  ensureAvatarDirectory();
-
-  const fileId = randomUUID();
-  const destination = avatarFile(fileId);
-
-  try {
-    await new File(sourceUri).copy(destination);
-  } catch (error) {
-    deleteStoredAvatar(`${STORED_FILE_REF_PREFIX}${fileId}`);
-    throw error;
-  }
-
-  return `${STORED_FILE_REF_PREFIX}${fileId}`;
-}
-
 /**
- * Replace the stored avatar without exposing a temporary picker URI. The new
- * file is compensated if the preference write fails; the old file is removed
- * only after the new preference value is durable.
+ * Create the new managed image before switching the preference. Preference
+ * failure compensates the new file; the previous file is removed only after
+ * the new reference is durable.
  */
 export async function replaceUserAvatar(
+  images: UserContentImageStorage,
   sourceUri: string,
   previousAvatar: string,
   persistAvatar: PersistAvatar,
 ): Promise<void> {
-  const nextAvatar = await storeUserAvatar(sourceUri);
+  const nextFileId = await images.create(sourceUri);
 
   try {
-    await persistAvatar(nextAvatar);
+    await persistAvatar(tagStoredFileRef(nextFileId));
   } catch (error) {
-    deleteStoredAvatar(nextAvatar);
+    try {
+      await images.remove(nextFileId);
+    } catch (cleanupError) {
+      logger.error(
+        'Failed to delete a new user avatar after preference write failed',
+        cleanupError as Error,
+        {
+          fileId: nextFileId,
+        },
+      );
+    }
     throw error;
   }
 
-  deleteStoredAvatar(previousAvatar);
+  await deleteStoredAvatar(images, previousAvatar);
 }

--- a/src/bootstrap/composition/createBackend.ts
+++ b/src/bootstrap/composition/createBackend.ts
@@ -4,6 +4,7 @@ import type { McpServerMutations } from '@/backend/data/api/handlers/mcpServers'
 import type { DbService } from '@/backend/data/db/DbService';
 import { materializeRemoteModels } from '@/backend/data/services/materializeRemoteModels';
 import { canDeleteProvider } from '@/backend/data/services/ProviderService';
+import { createUserContentImageStorage } from '@/backend/services/file/userContentImageStorage';
 import { createMcpModule } from '@/backend/services/mcp/createMcpModule';
 import { createModelsModule } from '@/backend/services/models/createModelsModule';
 import { createPaintingsModule } from '@/backend/services/paintings/createPaintingsModule';
@@ -105,10 +106,12 @@ export function createBackend(
       set: (key, value) => services.preference.set(key, value),
     },
   });
+  const userContentImages = createUserContentImageStorage(services.fileEntry);
   const profile = createProfileModule({
     avatars: {
-      replace: replaceUserAvatar,
-      resolve: resolveUserAvatarUri,
+      replace: (sourceUri, previousAvatar, persist) =>
+        replaceUserAvatar(userContentImages, sourceUri, previousAvatar, persist),
+      resolve: (avatar) => resolveUserAvatarUri(userContentImages, avatar),
     },
     preferences: {
       readAvatar: () => services.preference.readCached('app.user.avatar'),

--- a/src/frontend/components/avatar/README.md
+++ b/src/frontend/components/avatar/README.md
@@ -9,6 +9,8 @@ Cherry product data and presentation rules before composing that primitive.
 - `BrandAvatar`, `BrandAvatarIcon`, and `BrandAvatarPhoto` apply provider/model brand fallback and
   icon inset rules.
 - `ModelAvatar` resolves a model icon from its model and provider records.
+- `AvatarImagePicker` owns the shared camera/library and square-crop interaction while leaving
+  persistence to its caller.
 - `ProfileAvatarImage` resolves the persisted user avatar for display-only surfaces.
 - `ProfileEditableAvatar` adds a camera or pencil badge for avatar-editing surfaces.
 

--- a/src/frontend/components/avatar/components/AvatarImagePicker.tsx
+++ b/src/frontend/components/avatar/components/AvatarImagePicker.tsx
@@ -1,0 +1,109 @@
+import { Menu, type MenuItem } from '@cherrystudio/ui/components';
+import * as ImagePicker from 'expo-image-picker';
+import { type ReactElement, useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
+
+type AvatarImagePickerProps = {
+  accessibilityLabel: string;
+  children: ReactElement;
+  onBeforeOpen?: () => void;
+  onError: (error: unknown) => void;
+  onSelect: (sourceUri: string) => Promise<void> | void;
+  size: number;
+};
+
+type PickerSource = 'camera' | 'photos';
+
+/**
+ * Shared camera/library entry point for user-customizable avatars. This owns
+ * acquisition and square cropping only; the receiving domain owns persistence.
+ */
+export function AvatarImagePicker({
+  accessibilityLabel,
+  children,
+  onBeforeOpen,
+  onError,
+  onSelect,
+  size,
+}: AvatarImagePickerProps) {
+  const { t } = useTranslation();
+  const isSelectingRef = useRef(false);
+
+  const selectImage = useCallback(
+    async (source: PickerSource) => {
+      if (isSelectingRef.current) {
+        return;
+      }
+
+      isSelectingRef.current = true;
+      try {
+        const permission =
+          source === 'camera'
+            ? await ImagePicker.requestCameraPermissionsAsync()
+            : await ImagePicker.requestMediaLibraryPermissionsAsync(false);
+
+        if (!permission.granted) {
+          return;
+        }
+
+        const commonOptions = {
+          allowsEditing: true,
+          aspect: [1, 1] as [number, number],
+          mediaTypes: ['images'] as ImagePicker.MediaType[],
+          quality: 1,
+        };
+        const result =
+          source === 'camera'
+            ? await ImagePicker.launchCameraAsync(commonOptions)
+            : await ImagePicker.launchImageLibraryAsync({
+                ...commonOptions,
+                selectionLimit: 1,
+              });
+        const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
+
+        if (assetUri) {
+          await onSelect(assetUri);
+        }
+      } catch (error) {
+        onError(error);
+      } finally {
+        isSelectingRef.current = false;
+      }
+    },
+    [onError, onSelect],
+  );
+  const menuItems = useMemo<readonly MenuItem[]>(
+    () => [
+      {
+        id: 'camera',
+        label: t('chat.media.camera'),
+        onPress: () => void selectImage('camera'),
+        systemImage: 'camera',
+      },
+      {
+        id: 'photos',
+        label: t('chat.media.photos'),
+        onPress: () => void selectImage('photos'),
+        systemImage: 'photo',
+      },
+    ],
+    [selectImage, t],
+  );
+
+  return (
+    <Menu items={menuItems} trigger="tap">
+      <View
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="button"
+        onStartShouldSetResponderCapture={() => {
+          onBeforeOpen?.();
+          return false;
+        }}
+        style={{ height: size, width: size }}
+      >
+        {children}
+      </View>
+    </Menu>
+  );
+}

--- a/src/frontend/components/avatar/index.ts
+++ b/src/frontend/components/avatar/index.ts
@@ -1,3 +1,4 @@
+export { AvatarImagePicker } from './components/AvatarImagePicker';
 export { BrandAvatar, BrandAvatarIcon, BrandAvatarPhoto } from './components/BrandAvatar';
 export { ModelAvatar } from './components/ModelAvatar';
 export {

--- a/src/frontend/features/settings/ProfileSettingsScreen.tsx
+++ b/src/frontend/features/settings/ProfileSettingsScreen.tsx
@@ -1,19 +1,11 @@
-import {
-  Input,
-  Label,
-  Menu,
-  type MenuItem,
-  TextField,
-  useAlert,
-} from '@cherrystudio/ui/components';
+import { Input, Label, TextField, useAlert } from '@cherrystudio/ui/components';
 import { loggerService } from '@logger';
-import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, ScrollView, TextInput, View } from 'react-native';
 
-import { ProfileEditableAvatar } from '@/frontend/components/avatar';
+import { AvatarImagePicker, ProfileEditableAvatar } from '@/frontend/components/avatar';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { useBackendModule } from '@/frontend/data';
 import { usePreference } from '@/frontend/data/hooks';
@@ -40,55 +32,6 @@ export default function ProfileSettingsScreen() {
     },
     [alert, t],
   );
-
-  const selectAvatarFromCamera = useCallback(async () => {
-    try {
-      const permission = await ImagePicker.requestCameraPermissionsAsync();
-
-      if (!permission.granted) {
-        return;
-      }
-
-      const result = await ImagePicker.launchCameraAsync({
-        allowsEditing: true,
-        aspect: [1, 1],
-        mediaTypes: ['images'],
-        quality: 1,
-      });
-
-      const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
-      if (assetUri) {
-        await persistSelectedAvatar(assetUri);
-      }
-    } catch (error) {
-      reportAvatarSaveError(error);
-    }
-  }, [persistSelectedAvatar, reportAvatarSaveError]);
-
-  const selectAvatarFromPhotoLibrary = useCallback(async () => {
-    try {
-      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
-
-      if (!permission.granted) {
-        return;
-      }
-
-      const result = await ImagePicker.launchImageLibraryAsync({
-        allowsEditing: true,
-        aspect: [1, 1],
-        mediaTypes: ['images'],
-        quality: 1,
-        selectionLimit: 1,
-      });
-
-      const assetUri = result.canceled ? undefined : result.assets[0]?.uri;
-      if (assetUri) {
-        await persistSelectedAvatar(assetUri);
-      }
-    } catch (error) {
-      reportAvatarSaveError(error);
-    }
-  }, [persistSelectedAvatar, reportAvatarSaveError]);
 
   const blurInput = useCallback(() => {
     inputRef.current?.blur();
@@ -125,15 +68,19 @@ export default function ProfileSettingsScreen() {
       >
         <View className="gap-8 px-6 py-8">
           <View className="items-center">
-            <MenuAvatarTrigger
+            <AvatarImagePicker
               accessibilityLabel={t('settings.profile.changeAvatar')}
-              cameraLabel={t('chat.media.camera')}
-              onPress={blurInput}
-              onSelectCamera={selectAvatarFromCamera}
-              onSelectPhotos={selectAvatarFromPhotoLibrary}
-              photosLabel={t('chat.media.photos')}
+              onBeforeOpen={blurInput}
+              onError={reportAvatarSaveError}
+              onSelect={persistSelectedAvatar}
               size={profileAvatarSize}
-            />
+            >
+              <ProfileEditableAvatar
+                accessibilityLabel={t('settings.profile.changeAvatar')}
+                icon="camera"
+                size={profileAvatarSize}
+              />
+            </AvatarImagePicker>
           </View>
           <TextField>
             <Label>{t('settings.profile.userName')}</Label>
@@ -151,59 +98,5 @@ export default function ProfileSettingsScreen() {
         </View>
       </ScrollView>
     </>
-  );
-}
-
-type MenuAvatarTriggerProps = {
-  accessibilityLabel: string;
-  cameraLabel: string;
-  onPress: () => void;
-  onSelectCamera: () => Promise<void>;
-  onSelectPhotos: () => Promise<void>;
-  photosLabel: string;
-  size: number;
-};
-
-function MenuAvatarTrigger({
-  accessibilityLabel,
-  cameraLabel,
-  onPress,
-  onSelectCamera,
-  onSelectPhotos,
-  photosLabel,
-  size,
-}: MenuAvatarTriggerProps) {
-  const menuItems = useMemo<readonly MenuItem[]>(
-    () => [
-      {
-        id: 'camera',
-        label: cameraLabel,
-        onPress: () => void onSelectCamera(),
-        systemImage: 'camera',
-      },
-      {
-        id: 'photos',
-        label: photosLabel,
-        onPress: () => void onSelectPhotos(),
-        systemImage: 'photo',
-      },
-    ],
-    [cameraLabel, onSelectCamera, onSelectPhotos, photosLabel],
-  );
-
-  return (
-    <Menu items={menuItems} trigger="tap">
-      <View
-        accessibilityLabel={accessibilityLabel}
-        accessibilityRole="button"
-        onStartShouldSetResponderCapture={() => {
-          onPress();
-          return false;
-        }}
-        style={{ height: size, width: size }}
-      >
-        <ProfileEditableAvatar accessibilityLabel={accessibilityLabel} icon="camera" size={size} />
-      </View>
-    </Menu>
   );
 }

--- a/src/frontend/hooks/useAvatar.ts
+++ b/src/frontend/hooks/useAvatar.ts
@@ -1,3 +1,5 @@
+import { useQuery } from '@tanstack/react-query';
+
 import { useBackendModule } from '@/frontend/data';
 import { usePreference } from '@/frontend/data/hooks';
 
@@ -7,6 +9,12 @@ const defaultAvatarSource = require('@/assets/icon.png');
 export function useAvatar(): string | number {
   const [avatar] = usePreference('app.user.avatar');
   const profile = useBackendModule('profile');
+  const avatarUriQuery = useQuery({
+    queryFn: async () => (await profile.resolveAvatar(avatar)) ?? null,
+    queryKey: ['profile-avatar', avatar],
+    retry: false,
+    staleTime: Infinity,
+  });
 
-  return profile.resolveAvatar(avatar) ?? defaultAvatarSource;
+  return avatarUriQuery.data ?? defaultAvatarSource;
 }

--- a/src/shared/contracts/profile.ts
+++ b/src/shared/contracts/profile.ts
@@ -1,4 +1,4 @@
 export interface ProfileModule {
   persistAvatar(sourceUri: string): Promise<void>;
-  resolveAvatar(avatar: string): string | undefined;
+  resolveAvatar(avatar: string): Promise<string | undefined>;
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

- User avatars were copied directly from picker URIs into a profile-specific directory.
- Avatar acquisition lived inside the profile screen and could not be reused for assistant avatars.
- Uploaded images kept their original dimensions and encoding.

After this PR:

- Adds a reusable `AvatarImagePicker` for camera and photo-library acquisition with square cropping.
- Normalizes user-selected images to a 1024 × 1024 WebP with input and stored-size limits.
- Stores custom avatars as managed internal `file_entry` records and persists path-resilient `file:<id>` references.
- Preserves safe replacement semantics: a failed preference write removes the new image, while a successful replacement removes the previous managed image.
- Resolves managed avatar references asynchronously and falls back cleanly when no avatar exists.

### Screenshots or videos

Captured during local iOS verification. They will be uploaded before this draft is marked ready for review.

### Why we need it and why it was done in this way

This creates one storage and acquisition path for user-customizable images. The profile avatar is the first consumer, while future assistant-avatar support can reuse the same picker and managed image storage without persisting temporary picker URIs or duplicating image-processing rules.

The following tradeoffs were made:

- Images are normalized once at ingestion to keep rendering predictable and storage bounded.
- Files use manual cleanup because their lifecycle is controlled by the owning profile preference rather than message reference counting.
- Legacy avatar references remain read-compatible in this PR; removal of old data is intentionally deferred to a separate cleanup change.

The following alternatives were considered:

- Persisting base64 or emoji values was rejected because it increases database size or produces a poor avatar experience.
- Persisting absolute file paths was rejected because application container paths are not durable across reinstalls and migrations.

### Breaking changes

None.

### Special notes for your reviewer

Local verification:

- `pnpm format:check` passed.
- `pnpm typecheck` passed.
- Focused Oxlint and Expo ESLint checks passed for all changed source files.
- Full `pnpm lint` remains blocked by existing unresolved `@cherrystudio/ai-core` imports outside this change.
- iOS manual flow passed: choose photo, crop, normalize, persist, render, and relaunch the app.
- The stored result was verified as a 1024 × 1024 WebP `file_entry` referenced by `app.user.avatar`.
- Unit tests were not run in accordance with the workspace verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: Screenshots will be attached before this draft is marked ready
- [x] Code: The implementation is scoped to reusable avatar acquisition and managed image storage
- [x] Upgrade: Legacy avatar reads remain compatible; cleanup is deferred to a separate PR
- [x] Documentation: The avatar component README documents the reusable picker
- [x] Self-review: The staged diff and iOS workflow were reviewed locally

### Release note

```release-note
Add reusable photo-based custom avatars with managed local storage.
```
