### PR TITLE
chore(desktop-sync): retire data-domain alignment governance

### DIFF
--- a/desktop-sync-manifest.json
+++ b/desktop-sync-manifest.json
@@ -23,42 +23,6 @@
         "opencode": "general/open-code"
       }
     },
-    "schema": {
-      "strategy": "opaque-retention",
-      "status": "unbaselined",
-      "sourcePaths": ["src/main/data/db/schemas", "migrations/sqlite-drizzle/meta"],
-      "targetPaths": ["src/backend/data/db/schemas", "migrations/sqlite-drizzle/meta"],
-      "sourceCommit": null,
-      "sourceSha256": null,
-      "explicitExclusions": []
-    },
-    "shared-data": {
-      "strategy": "semantic-port",
-      "status": "unbaselined",
-      "sourcePaths": ["src/shared/data"],
-      "targetPaths": ["packages/universal/src/data"],
-      "sourceCommit": null,
-      "sourceSha256": null,
-      "explicitExclusions": [
-        "src/shared/data/bootConfig/**",
-        "src/shared/data/migration/**",
-        "src/shared/data/presets/binaryTools.ts",
-        "src/shared/data/presets/claudeCode.ts",
-        "src/shared/data/presets/codex.ts",
-        "src/shared/data/presets/grokCli.ts",
-        "src/shared/data/presets/localEmbedding.ts",
-        "src/shared/data/presets/localModel.ts",
-        "src/shared/data/types/fileProcessing.ts",
-        "src/shared/data/types/settingsPath.ts"
-      ],
-      "shapeOnlyPorts": [
-        {
-          "path": "src/shared/data/preference/preferenceTypes.ts",
-          "keeps": "Value types for the preference keys mobile reads",
-          "drops": "The generated preferenceSchemas.ts key set and every type that only described it; mobile's preference schema is hand-maintained and deliberately diverged, so there is no key-level alignment left to audit"
-        }
-      ]
-    },
     "shared-portable": {
       "strategy": "semantic-port",
       "status": "unbaselined",
@@ -92,24 +56,6 @@
           "drops": "OpenAIVerbosity/ValidOpenAIVerbosity/OpenAIReasoningSummary/OpenAICompletionsStreamOptions, which alias into the @cherrystudio/openai SDK that mobile does not depend on; backend/ai/utils/options.ts re-declares the verbosity union it needs as a literal type"
         }
       ]
-    },
-    "data-main": {
-      "strategy": "semantic-port",
-      "status": "unbaselined",
-      "sourcePaths": ["src/main/data"],
-      "targetPaths": ["src/backend/data"],
-      "sourceCommit": null,
-      "sourceSha256": null,
-      "explicitExclusions": ["src/main/data/migration/v2/**"]
-    },
-    "data-renderer": {
-      "strategy": "semantic-port",
-      "status": "unbaselined",
-      "sourcePaths": ["src/renderer/data"],
-      "targetPaths": ["src/frontend/data"],
-      "sourceCommit": null,
-      "sourceSha256": null,
-      "explicitExclusions": []
     },
     "ai-core": {
       "strategy": "mirror",
@@ -252,20 +198,6 @@
       "sourceCommit": null,
       "sourceSha256": null,
       "explicitExclusions": []
-    },
-    "backup": {
-      "strategy": "opaque-retention",
-      "status": "blocked",
-      "sourcePaths": [
-        "src/main/services/LegacyBackupManager.ts",
-        "src/main/data/db/restore",
-        "src/main/data/CacheService.ts"
-      ],
-      "targetPaths": ["src/backend/data", "src/backend/services"],
-      "sourceCommit": null,
-      "sourceSha256": null,
-      "explicitExclusions": [],
-      "blocker": "Desktop v7 direct backups archive Data/cherrystudio.sqlite, resources, cache.json, and the desktop migration chain; mobile currently uses cherry.db, a different migration chain, and MMKV cache, so it cannot produce or restore that archive losslessly."
     }
   }
 }

--- a/docs/references/code-organization.md
+++ b/docs/references/code-organization.md
@@ -18,7 +18,7 @@ independent consumer creates a broader owner.
 | Backend persistence and Data API implementation | `src/backend/data` |
 | Backend workflow, platform, and external capability | `src/backend/services` |
 | Mobile-native pure contract or helper used by frontend and backend | `src/shared` |
-| Desktop-mirrored portable contract or helper | `packages/universal` |
+| Desktop-mirrored portable AI contract or helper | `packages/universal` (dissolving; do not add new modules) |
 | Reusable platform-neutral product interaction component | `packages/ui` |
 | Global or generated declaration | `src/types` |
 
@@ -53,7 +53,7 @@ Repeated bucket names express different owners:
 | Path | Ownership |
 | --- | --- |
 | `src/frontend/data` | Frontend providers, endpoint query keys, data hooks, and UI cache state |
-| `packages/universal/src/data` | Desktop-mirrored entities, DTO schemas, preferences, and data errors |
+| `packages/universal/src/data` | Mobile-owned data contracts in a transitional home; moving to `src/shared/data` |
 | `src/backend/data` | Backend cache, preferences, SQLite, migrations, and persistence services |
 | `src/frontend/utils` | Pure helpers used by independent frontend domains |
 | `src/backend/utils` | Pure helpers used by independent backend domains |

--- a/docs/references/data/README.md
+++ b/docs/references/data/README.md
@@ -45,9 +45,9 @@ concrete service graph. Frontend tests inject an `ApiClient`, `PreferenceClient`
 
 ## Shared Data
 
-`packages/universal/src/data` (`@cherrystudio/universal/data`) contains values both sides may know. The
-package mirrors the cross-platform subset of Cherry Desktop's `src/shared`, so its contents stay
-desktop-compatible:
+`packages/universal/src/data` (`@cherrystudio/universal/data`) contains values both sides may know.
+It is mobile-owned and independent of Cherry Desktop — schemas, fields, and routes exist only while
+mobile code reads them (see the package's `src/data/README.md` for the transitional-home ledger):
 
 - `api`: endpoint DTO schemas, pagination shapes, data errors, and `ApiClient`.
 - `preference`: preference keys, value schemas, defaults, pure helpers, and `PreferenceClient`.

--- a/docs/references/universal-package.md
+++ b/docs/references/universal-package.md
@@ -1,51 +1,61 @@
 # Universal Package
 
-`packages/universal` (`@cherrystudio/universal`) is the cross-platform subset of Cherry Desktop's
-`src/shared`, extracted into a workspace package so the desktop mirror is a visible boundary
-instead of being mixed into mobile-native code, and so a future desktop/mobile monorepo can consume
-it as-is.
+`packages/universal` (`@cherrystudio/universal`) was extracted as the cross-platform subset of
+Cherry Desktop's `src/shared`, so the desktop mirror is a visible boundary instead of being mixed
+into mobile-native code.
 
 It is named `universal` rather than `shared` because three different "shared" scopes are in play —
 desktop's process-shared `src/shared`, this cross-platform subset, and the mobile-native remainder
 in `src/shared`. The package name keeps every import site unambiguous.
 
-## Scope
+## Dissolution
+
+The package is dissolving. The mobile data layer is independent of desktop, so nothing under
+`src/data` is a mirror anymore, and mobile-owned code is moving back into app space:
+
+- `src/data/{api,cache,preference,presets}` and the entity types with no package-side consumer move
+  to `src/shared/data`.
+- `src/data/types/{model,provider,assistant,message,uiParts,aiUsageRecord,mcpServer}.ts` and
+  `src/types/aiSdk.ts` stay temporarily: `packages/ai-runtime` imports them, and workspace packages
+  must not import app code. They move in a later round together with a decision on the AI-runtime
+  vocabulary's final home (candidate: `packages/ai-runtime`).
+- `src/ai/transport/toolApprovals.ts` is a mobile extension with no desktop counterpart; it stays
+  only because `packages/ai-runtime` consumes it.
+- `src/utils/model.ts` has forked in both directions (mobile-only detection helpers, desktop-only
+  registry queries) and is no longer a candidate for verbatim alignment.
+
+New cross-layer mobile contracts belong in `src/shared`, not here.
+
+## Remaining Mirror Scope
 
 Desktop's `src/shared` means "shared between the Electron main and renderer processes", not
-"cross-platform". This package holds only the subset that is genuinely platform-independent:
+"cross-platform". The directories still synchronized against desktop:
 
 | Directory | Contents |
 |---|---|
-| `src/data` | Entities, endpoint DTO schemas, `ApiClient`, preferences, `PreferenceClient`, presets, cache schemas, and data errors |
 | `src/ai` | Cross-layer AI tool and transport rules |
-| `src/types` | Portable value types (`aiSdk`, `codeCli`, `error`, `serializable`) |
-| `src/utils` | Portable pure helpers (`conversationTitle`, `keywordSearch`, `model`, `shortcut`, `text`, `url`, plus the mobile-only `fnv1a` used by `mcpToolName`) |
+| `src/types` | Portable value types (`aiSdk`, `error`, `serializable`) |
+| `src/utils` | Portable pure helpers (`conversationTitle`, `keywordSearch`, `model`, `text`, `url`, plus the mobile-only `fnv1a` used by `mcpToolName`) |
 
-The directory layout maps one-to-one onto desktop `src/shared/{data,ai,types,utils}`.
-Mobile-native shared code stays in `src/shared`: `contracts/` (in-process API boundary, the mobile
-counterpart of desktop IPC) and `core/logger`.
+`src/data` is mobile-owned and excluded from synchronization; see `packages/universal/src/data/README.md`.
 
 ## Admission Criteria
 
-Apply these when deciding whether a desktop `src/shared` file belongs in the package:
+Apply these when deciding whether a desktop `src/shared` file belongs in the remaining mirror:
 
 1. Reject files that name Electron surfaces (windows, IPC channels, settings routes, boot config,
    the v1→v2 migration wizard).
 2. Reject files that encode host-OS capabilities mobile cannot have (binary tool installation,
    local ONNX runtimes, OCR file processing).
-3. Admit pure logic consumed by the mobile runtime, or shapes of data that mobile persists, backs
-   up, or exchanges with desktop.
+3. Admit pure logic consumed by the mobile runtime. Data shapes are not admitted: the mobile data
+   layer is independent of desktop and lives in app space.
 4. Check the import graph: a file whose only consumers are desktop-process-only files is not
    admitted, whatever its own contents look like.
-5. Split welded hybrids surgically: keep the serialized shape, drop the desktop capability logic,
+5. Split welded hybrids surgically: keep the portable logic, drop the desktop capability logic,
    and register the trim as a `shapeOnlyPorts` entry in `desktop-sync-manifest.json` (see
    `ai/prompts.ts`).
 
 Rejected files become `explicitExclusions` in the Manifest.
-
-Preferences are the exception to all of the above: mobile's preference schema is hand-maintained in
-`data/preference/preference-schema.ts` and holds only the keys mobile reads, so a desktop key is not
-admitted by being serialized data. There is no preference-parity invariant to satisfy.
 
 ## Imports And Aliasing
 
@@ -60,10 +70,9 @@ admitted by being serialized data. There is no preference-parity invariant to sa
 
 ## Sync
 
-The `sync-cherry-desktop` skill owns desktop parity. `desktop-sync-manifest.json` maps the
-`shared-data`, `shared-ai`, and `shared-portable` domains onto `packages/universal/src`, carries the
-`explicitExclusions`, and registers every `shapeOnlyPorts` trim that must be re-applied on each
-sync. `pnpm desktop:sync:audit` compares both repositories against that manifest.
-
-In a future desktop/mobile monorepo, both apps consume this package directly; desktop keeps its
-process-only `src/shared` remainder (IPC, window, command, and file concerns) beside it.
+The `sync-cherry-desktop` skill owns desktop parity for the remaining mirror.
+`desktop-sync-manifest.json` maps the `shared-ai` and `shared-portable` domains onto
+`packages/universal/src`, carries the `explicitExclusions`, and registers every `shapeOnlyPorts`
+trim that must be re-applied on each sync. `pnpm desktop:sync:audit` compares both repositories
+against that manifest. The data domains were retired deliberately: mobile persists what mobile
+reads, and auditing a non-mirror only manufactures drift reports.

--- a/packages/universal/src/data/README.md
+++ b/packages/universal/src/data/README.md
@@ -1,20 +1,33 @@
-# Shared Data
+# Data
 
-Data entities, preferences, DTO schemas, pagination shapes, and data errors shared by the mobile
-frontend and backend. The layout follows Cherry Desktop's `src/shared/data` vocabulary.
+Mobile-owned data entities, preferences, DTO schemas, pagination shapes, and data errors shared by
+the mobile frontend and backend. This directory is **not** a Cherry Desktop mirror: the desktop-sync
+audit no longer tracks it, and its contents follow one rule — mobile persists what mobile reads. A
+desktop schema, field, or route with no mobile consumer is a deliberate omission, not a gap.
 
 ## Scope
 
-- Keep entity schemas, limits, comments, and exported type names aligned with desktop unless mobile
-  has a documented runtime compatibility reason to diverge.
-- API-shaped DTO schemas, pagination shapes, and data errors live under `src/shared/data/api`.
+- Entity and value types live under `types`; API-shaped DTO schemas, pagination shapes, and data
+  errors live under `api`.
 - `ApiClient` is the platform-neutral resource interface shared by frontend endpoint hooks and the
   backend in-process `DataApiService` implementation.
 - DB-backed preference value types, defaults, and the separate `PreferenceClient` interface live
-  under `src/shared/data/preference`.
-- Cache schemas and pure cache-key helpers live under `src/shared/data/cache`; concrete cache
-  implementations remain with their runtime owner.
-- Entity and value types live under `src/shared/data/types`.
-- Excluded desktop domains are not migrated here yet: agent sessions, knowledge, jobs, translate,
-  miniapps, and agent workspaces. MCP, file, and painting types are present because their mobile
-  domains are implemented.
+  under `preference`. The preference schema is hand-maintained and holds only the keys mobile reads.
+- Cache schemas and pure cache-key helpers live under `cache`; concrete cache implementations remain
+  with their runtime owner.
+
+## Transitional Home
+
+`packages/universal` is dissolving: code that is mobile-owned belongs in `src/`, and this data
+layer's destination is `src/shared/data`. It has not all moved at once because
+`packages/ai-runtime` imports the entity vocabulary, and workspace packages must not import app
+code.
+
+- **Staying here for now** — `types/{model,provider,assistant,message,uiParts,aiUsageRecord,mcpServer}.ts`
+  (plus `../types/aiSdk.ts`): consumed by `packages/ai-runtime` and by `../ai`. These move in a
+  later round, together with a decision on where the AI-runtime vocabulary finally lives
+  (candidate: `packages/ai-runtime` itself).
+- **Moving to `src/shared/data`** — everything else: `api`, `cache`, `preference`, `presets`, and
+  the types with no package-side consumer.
+
+Do not add new modules here; put new mobile data contracts in `src/shared/data`.

--- a/packages/universal/src/data/api/README.md
+++ b/packages/universal/src/data/api/README.md
@@ -1,6 +1,7 @@
-# Shared Data API
+# Data API
 
-Platform-neutral endpoint schemas, `ApiClient`, pagination types, and data errors live here. These
-modules describe resource calls across the in-process frontend/backend seam; they do not implement
-transport, persistence, React Query, or handlers. Mobile deliberately reuses Cherry Desktop's Data
-API vocabulary without adding IPC, HTTP, or serialization.
+Mobile-owned endpoint schemas, `ApiClient`, pagination types, and data errors. These modules
+describe resource calls across the in-process frontend/backend seam; they do not implement
+transport, persistence, React Query, or handlers, and they add no IPC, HTTP, or serialization.
+Endpoints exist only while a mobile consumer reads them — an endpoint family with no caller is
+deleted, not kept for desktop parity.

--- a/scripts/__tests__/desktopSyncAudit.test.ts
+++ b/scripts/__tests__/desktopSyncAudit.test.ts
@@ -8,9 +8,7 @@ import type { DesktopSyncDomain, DesktopSyncManifest } from '../desktopSyncAudit
 import {
   auditDesignCatalog,
   auditRepositories,
-  compareSchemaState,
   extractObjectKeys,
-  extractSqliteTableNames,
   hashTrackedFiles,
   parseArguments,
   pathMatchesGlob,
@@ -144,7 +142,7 @@ describe('parseArguments', () => {
         '--desktop-root',
         './from-cli',
         '--domain',
-        'schema',
+        'services',
         '--domain=ai-core',
         '--json',
         '--check',
@@ -155,7 +153,7 @@ describe('parseArguments', () => {
     expect(parsed).toMatchObject({
       check: true,
       desktopRoot: resolve('./from-cli'),
-      domains: ['schema', 'ai-core'],
+      domains: ['services', 'ai-core'],
       json: true,
     });
   });
@@ -224,18 +222,6 @@ describe('validateManifest', () => {
 });
 
 describe('structured source extraction', () => {
-  test('extracts sqliteTable calls without treating comments or unrelated calls as tables', () => {
-    const source = `
-      import { sqliteTable } from 'drizzle-orm/sqlite-core';
-      // sqliteTable('comment_only', {});
-      export const topic = sqliteTable('topic', {});
-      export const agent = sqliteTable("agent", {});
-      export const ignored = anotherFactory('not_a_table', {});
-    `;
-
-    expect(extractSqliteTableNames(source, 'schema.ts')).toEqual(['agent', 'topic']);
-  });
-
   test('extracts quoted and identifier catalog keys from the requested object only', () => {
     const source = `
       const unrelated = { ignored: true };
@@ -587,40 +573,6 @@ describe('auditRepositories', () => {
       'UnrelatedService.ts',
       'src/main/services/oauth/runtime/providers/codex.ts',
     ]);
-  });
-});
-
-describe('schema audit', () => {
-  test('reports which tables each side persists alone', async () => {
-    const table = { columns: { id: { name: 'id', type: 'text' } } };
-    const desktopRoot = createRepository('schema-desktop-fixture', {
-      'migrations/sqlite-drizzle/meta/0001_snapshot.json': JSON.stringify({
-        tables: { agent: table, knowledge: table, topic: table },
-      }),
-      'src/main/data/db/schemas/schema.ts': `
-        export const agent = sqliteTable('agent', {});
-        export const knowledge = sqliteTable('knowledge', {});
-        export const topic = sqliteTable('topic', {});
-      `,
-    });
-    const mobileRoot = createRepository('schema-mobile-fixture', {
-      'migrations/sqlite-drizzle/meta/0001_snapshot.json': JSON.stringify({
-        tables: { job: table, topic: table },
-      }),
-      'src/backend/data/db/schemas/schema.ts': `
-        export const job = sqliteTable('job', {});
-        export const topic = sqliteTable('topic', {});
-      `,
-    });
-
-    await expect(compareSchemaState(desktopRoot, mobileRoot)).resolves.toMatchObject({
-      ast: { desktopMatchesSnapshot: true, mobileMatchesSnapshot: true },
-      changed: [],
-      desktopOnly: ['agent', 'knowledge'],
-      desktopTables: ['agent', 'knowledge', 'topic'],
-      mobileOnly: ['job'],
-      mobileTables: ['job', 'topic'],
-    });
   });
 });
 

--- a/scripts/desktopSyncAudit.ts
+++ b/scripts/desktopSyncAudit.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { access, readdir, readFile, realpath, stat } from 'node:fs/promises';
+import { access, readFile, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import ts from 'typescript';
@@ -615,61 +615,6 @@ export function extractObjectKeys(
   return (keys as string[]).sort();
 }
 
-export function extractSqliteTableNames(source: string, fileName = 'schema.ts'): string[] {
-  const sourceFile = sourceFileFor(source, fileName);
-  const names = new Set<string>();
-  const visit = (node: ts.Node): void => {
-    if (
-      ts.isCallExpression(node) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === 'sqliteTable' &&
-      node.arguments[0] &&
-      ts.isStringLiteralLike(node.arguments[0])
-    ) {
-      names.add(node.arguments[0].text);
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return [...names].sort();
-}
-
-function routeValue(node: ts.Node): ts.Node | null {
-  if (ts.isPropertyAssignment(node)) return unwrapExpression(node.initializer);
-  if (ts.isPropertySignature(node)) return node.type ?? null;
-  return null;
-}
-
-export function extractRouteMethods(source: string, fileName = 'routes.ts'): string[] {
-  const sourceFile = sourceFileFor(source, fileName);
-  const routes = new Set<string>();
-  const visit = (node: ts.Node): void => {
-    if (ts.isPropertyAssignment(node) || ts.isPropertySignature(node)) {
-      const route = propertyNameText(node.name);
-      if (route?.startsWith('/')) {
-        const value = routeValue(node);
-        const members = value
-          ? ts.isObjectLiteralExpression(value)
-            ? value.properties
-            : ts.isTypeLiteralNode(value)
-              ? value.members
-              : []
-          : [];
-        const methods = members
-          .map((member) => propertyNameText(member.name)?.toUpperCase())
-          .filter((method): method is string =>
-            ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'].includes(method ?? ''),
-          );
-        if (methods.length === 0) routes.add(`* ${route}`);
-        for (const method of methods) routes.add(`${method} ${route}`);
-      }
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return [...routes].sort();
-}
-
 export function extractRegistryModules(
   source: string,
   variableName: string,
@@ -1014,135 +959,6 @@ async function loadDelegatedServiceClassifications(
   return classifications;
 }
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (!isRecord(value)) return value;
-  return Object.fromEntries(
-    Object.keys(value)
-      .sort()
-      .map((key) => [key, canonicalize(value[key])]),
-  );
-}
-
-async function latestSnapshot(root: string): Promise<string> {
-  const metaRoot = path.join(root, 'migrations/sqlite-drizzle/meta');
-  const snapshot = (await readdir(metaRoot))
-    .filter((file) => /^\d+_snapshot\.json$/.test(file))
-    .sort()
-    .at(-1);
-  if (!snapshot) throw new Error('[desktop-sync-audit] no Drizzle snapshot found');
-  return path.join(metaRoot, snapshot);
-}
-
-async function schemaAstTables(root: string, schemaPath: string): Promise<string[]> {
-  const tables = new Set<string>();
-  for (const file of trackedFiles(root, [schemaPath])) {
-    if (!/\.tsx?$/.test(file) || file.includes('/__tests__/')) continue;
-    const source = await readFile(path.join(root, file), 'utf8');
-    for (const table of extractSqliteTableNames(source, file)) tables.add(table);
-  }
-  return [...tables].sort();
-}
-
-export async function compareSchemaState(desktopRoot: string, mobileRoot: string) {
-  const [desktopSnapshotPath, mobileSnapshotPath, desktopAst, mobileAst] = await Promise.all([
-    latestSnapshot(desktopRoot),
-    latestSnapshot(mobileRoot),
-    schemaAstTables(desktopRoot, 'src/main/data/db/schemas'),
-    schemaAstTables(mobileRoot, 'src/backend/data/db/schemas'),
-  ]);
-  const [desktopSnapshot, mobileSnapshot] = await Promise.all([
-    readJson(desktopSnapshotPath),
-    readJson(mobileSnapshotPath),
-  ]);
-  if (!isRecord(desktopSnapshot) || !isRecord(desktopSnapshot.tables)) {
-    throw new Error('[desktop-sync-audit] invalid desktop Drizzle snapshot');
-  }
-  if (!isRecord(mobileSnapshot) || !isRecord(mobileSnapshot.tables)) {
-    throw new Error('[desktop-sync-audit] invalid mobile Drizzle snapshot');
-  }
-  const desktopTables = desktopSnapshot.tables;
-  const mobileTables = mobileSnapshot.tables;
-  const desktopNames = Object.keys(desktopTables).sort();
-  const mobileNames = Object.keys(mobileTables).sort();
-  const common = desktopNames.filter((name) => name in mobileTables);
-  const changed = common.filter(
-    (name) =>
-      JSON.stringify(canonicalize(desktopTables[name])) !==
-      JSON.stringify(canonicalize(mobileTables[name])),
-  );
-
-  return {
-    ast: {
-      desktop: desktopAst,
-      desktopMatchesSnapshot: JSON.stringify(desktopAst) === JSON.stringify(desktopNames),
-      mobile: mobileAst,
-      mobileMatchesSnapshot: JSON.stringify(mobileAst) === JSON.stringify(mobileNames),
-    },
-    changed,
-    desktopOnly: desktopNames.filter((name) => !(name in mobileTables)),
-    desktopSnapshot: path.basename(desktopSnapshotPath),
-    desktopTables: desktopNames,
-    mobileOnly: mobileNames.filter((name) => !(name in desktopTables)),
-    mobileSnapshot: path.basename(mobileSnapshotPath),
-    mobileTables: mobileNames,
-  };
-}
-
-async function directTrackedTypeScriptFiles(root: string, directory: string): Promise<string[]> {
-  return trackedFiles(root, [directory]).filter(
-    (file) => path.dirname(file) === directory && file.endsWith('.ts'),
-  );
-}
-
-async function routeMethods(root: string, directory: string): Promise<string[]> {
-  const routes = new Set<string>();
-  for (const file of await directTrackedTypeScriptFiles(root, directory)) {
-    const source = await readFile(path.join(root, file), 'utf8');
-    for (const route of extractRouteMethods(source, file)) routes.add(route);
-  }
-  return [...routes].sort();
-}
-
-async function auditSharedData(desktopRoot: string, mobileRoot: string) {
-  const desktopHandlerPath = 'src/main/data/api/handlers';
-  const mobileHandlerPath = 'src/backend/data/api/handlers';
-  const desktopSchemaPath = 'src/shared/data/api/schemas';
-  const mobileSchemaPath = 'packages/universal/src/data/api/schemas';
-  const [desktopHandlers, mobileHandlers, desktopRoutes, mobileRoutes] = await Promise.all([
-    directTrackedTypeScriptFiles(desktopRoot, desktopHandlerPath),
-    directTrackedTypeScriptFiles(mobileRoot, mobileHandlerPath),
-    routeMethods(desktopRoot, desktopHandlerPath),
-    routeMethods(mobileRoot, mobileHandlerPath),
-  ]);
-  const [desktopSchemaModules, mobileSchemaModules] = await Promise.all([
-    directTrackedTypeScriptFiles(desktopRoot, desktopSchemaPath),
-    directTrackedTypeScriptFiles(mobileRoot, mobileSchemaPath),
-  ]);
-  const desktopHandlerNames = desktopHandlers.map((file) => path.basename(file));
-  const mobileHandlerNames = mobileHandlers.map((file) => path.basename(file));
-  const desktopSchemaNames = desktopSchemaModules.map((file) => path.basename(file));
-  const mobileSchemaNames = mobileSchemaModules.map((file) => path.basename(file));
-
-  return {
-    dataApi: {
-      desktopHandlerModules: desktopHandlerNames.sort(),
-      desktopRoutes,
-      desktopSchemaModules: desktopSchemaNames.filter((file) => file !== 'apiSchemas.ts').sort(),
-      missingHandlerModules: desktopHandlerNames
-        .filter((file) => !mobileHandlerNames.includes(file))
-        .sort(),
-      missingRoutes: desktopRoutes.filter((route) => !mobileRoutes.includes(route)),
-      missingSchemaModules: desktopSchemaNames
-        .filter((file) => file !== 'apiSchemas.ts' && !mobileSchemaNames.includes(file))
-        .sort(),
-      mobileHandlerModules: mobileHandlerNames.sort(),
-      mobileRoutes,
-      mobileSchemaModules: mobileSchemaNames.filter((file) => file !== 'apiSchemas.ts').sort(),
-    },
-  };
-}
-
 async function providerRegistryIds(root: string): Promise<string[]> {
   const file = 'packages/provider-registry/src/providers/index.ts';
   return extractRegistryModules(await readFile(path.join(root, file), 'utf8'), 'PROVIDERS', file);
@@ -1340,35 +1156,6 @@ async function auditDomain(
     if (domain.blocker) blockers.push(domain.blocker);
   }
 
-  if (id === 'schema') {
-    // `desktopOnly` is reported, not blocked: mobile persists what mobile reads,
-    // so a desktop table without a mobile consumer is a deliberate omission.
-    const schema = await compareSchemaState(desktopRoot, mobileRoot);
-    details = schema;
-    addInvariant(invariants, {
-      domain: id,
-      id: 'desktop-schema-ast-matches-snapshot',
-      message: 'Desktop sqliteTable declarations must match the latest tracked snapshot.',
-      ok: schema.ast.desktopMatchesSnapshot,
-    });
-    addInvariant(invariants, {
-      domain: id,
-      id: 'mobile-schema-ast-matches-snapshot',
-      message: 'Mobile sqliteTable declarations must match the latest tracked snapshot.',
-      ok: schema.ast.mobileMatchesSnapshot,
-    });
-  }
-
-  if (id === 'shared-data') {
-    const sharedData = await auditSharedData(desktopRoot, mobileRoot);
-    details = sharedData;
-    addClassification(
-      classifications,
-      'blocked',
-      sharedData.dataApi.missingRoutes.map((route) => `route:${route}`),
-    );
-  }
-
   if (id === 'provider-registry') {
     const registry = await auditProviderRegistry(desktopRoot, mobileRoot);
     details = registry;
@@ -1439,17 +1226,6 @@ async function auditDomain(
       ok:
         sourceFiles.includes(ordinaryAgentFile) &&
         !classifications.mirror.some((file) => file.endsWith('src/core/agents/createAgent.ts')),
-    });
-  }
-
-  if (id === 'backup') {
-    addInvariant(invariants, {
-      domain: id,
-      id: 'desktop-backup-round-trip-compatible',
-      message:
-        domain.blocker ??
-        'Desktop-restorable table, relation, attachment, logo, preference, cache, and manifest fidelity is required.',
-      ok: false,
     });
   }
 

--- a/src/bootstrap/runtime/__tests__/createAppBootstrapRuntime.test.ts
+++ b/src/bootstrap/runtime/__tests__/createAppBootstrapRuntime.test.ts
@@ -5,6 +5,7 @@ const mockBackend = { kind: 'backend' };
 const mockDataApiDependencies = { kind: 'data-api-dependencies' };
 const mockDataApi = { kind: 'data-api' };
 const mockDataApiHandlers = { kind: 'handlers' };
+const mockAgent = { kind: 'agent' };
 const mockAi = { kind: 'ai' };
 const mockCache = { kind: 'cache' };
 const mockChat = { kind: 'chat' };
@@ -78,6 +79,7 @@ const createRuntime = () =>
     DbService: mockDb,
     JobRuntime: mockJobRuntime,
     McpRuntimeService: mockMcpRuntime,
+    MobileAgentHost: mockAgent,
     PreferenceService: mockPreference,
     WebSearchService: mockWebSearch,
   });
@@ -99,6 +101,7 @@ describe('createAppBootstrapRuntime', () => {
     // No `dbService`: the data services resolve it through `application`, so the
     // composition is only handed the infrastructure it cannot reach that way.
     expect(mockCreateBackendServices).toHaveBeenCalledWith({
+      agent: mockAgent,
       ai: mockAi,
       cache: mockCache,
       chat: mockChat,


### PR DESCRIPTION
## Summary

The mobile data layer is being fully decoupled from desktop (#573, #574, #577). This PR retires the desktop-alignment governance for the data domains, so the manifest and audit stop manufacturing drift reports against a mirror that no longer exists. No runtime code changes.

- `desktop-sync-manifest.json`: retire the five data-related domains (`shared-data`, `schema`, `data-main`, `data-renderer`, `backup`). `provider-registry`, `shared-ai`, `shared-portable`, and the delegated ai domains are untouched.
- `scripts/desktopSyncAudit.ts`: delete the schema/shared-data/backup audit paths (`auditSharedData`, `compareSchemaState`, route/table extraction helpers) and their tests, following the #573 precedent of deleting rather than redefining.
- `packages/universal/src/data/README.md` + `docs/references/universal-package.md`: rewrite the data scope as mobile-owned, and document the dissolution direction with a named transitional ledger (the seven entity-type modules `packages/ai-runtime` still imports, `toolApprovals` as a mobile extension, the two-way fork of `utils/model`).
- `docs/references/code-organization.md`, `docs/references/data/README.md`: ownership rows and alignment clauses updated to match.

Also carries a one-line test repair: #576 added the agent host to the backend composition without extending `createAppBootstrapRuntime.test.ts`'s exact-match assertion, so the suite fails on a clean checkout of `v0.2`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean
- `pnpm test` full suite green (316 suites / 2851 tests)
- `pnpm desktop:sync:audit` runs the remaining domains; retired domain ids now correctly error as unknown

Part of the data-layer split stack; the move itself lands in the PR above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)