### PR TITLE
refactor(data-types): delete dead vocabulary

### DIFF
--- a/packages/universal/src/data/types/message.ts
+++ b/packages/universal/src/data/types/message.ts
@@ -152,82 +152,6 @@ export type {
   UITools,
 };
 
-export enum ReferenceCategory {
-  CITATION = 'citation',
-  MENTION = 'mention',
-}
-
-export enum CitationType {
-  KNOWLEDGE = 'knowledge',
-  MEMORY = 'memory',
-  WEB = 'web',
-}
-
-export interface BaseReference {
-  category: ReferenceCategory;
-  marker?: string;
-  range?: { end: number; start: number };
-}
-
-interface BaseCitationReference extends BaseReference {
-  category: ReferenceCategory.CITATION;
-  citationType: CitationType;
-}
-
-export interface WebCitationReference extends BaseCitationReference {
-  citationType: CitationType.WEB;
-  content: {
-    results?: unknown;
-    source: unknown;
-  };
-}
-
-export interface KnowledgeCitationReference extends BaseCitationReference {
-  citationType: CitationType.KNOWLEDGE;
-  content: {
-    content: string;
-    file?: unknown;
-    id: number;
-    metadata?: Record<string, unknown>;
-    sourceUrl: string;
-    type: string;
-  }[];
-}
-
-export interface MemoryCitationReference extends BaseCitationReference {
-  citationType: CitationType.MEMORY;
-  content: {
-    createdAt?: string;
-    hash?: string;
-    id: string;
-    memory: string;
-    metadata?: Record<string, unknown>;
-    score?: number;
-    updatedAt?: string;
-  }[];
-}
-
-export type CitationReference =
-  | KnowledgeCitationReference
-  | MemoryCitationReference
-  | WebCitationReference;
-
-export interface MentionReference extends BaseReference {
-  category: ReferenceCategory.MENTION;
-  displayName?: string;
-  modelId: string;
-}
-
-export type ContentReference = CitationReference | MentionReference;
-
-export interface SerializedErrorData {
-  cause?: unknown;
-  code?: string;
-  message: string;
-  name?: string;
-  stack?: string;
-}
-
 export const MessageDataSchema: z.ZodType<MessageData> = z.strictObject({
   parts: z.array(z.custom<CherryMessagePart>()).optional(),
   turnOptions: z
@@ -262,9 +186,6 @@ export type ContentMessageRole = z.infer<typeof ContentMessageRoleSchema>;
 
 export const TOPIC_MESSAGE_SEARCH_ROLES = ['user', 'assistant'] as const;
 export type TopicMessageSearchRole = (typeof TOPIC_MESSAGE_SEARCH_ROLES)[number];
-
-export const AGENT_SESSION_MESSAGE_SEARCH_ROLES = ['user', 'assistant', 'system'] as const;
-export type AgentSessionMessageSearchRole = (typeof AGENT_SESSION_MESSAGE_SEARCH_ROLES)[number];
 
 export function coerceSearchRole<TRole extends MessageRole>(
   role: string,

--- a/packages/universal/src/data/types/uiParts.ts
+++ b/packages/universal/src/data/types/uiParts.ts
@@ -1,3 +1,14 @@
+/**
+ * Cherry UI part vocabulary and per-part `providerMetadata.cherry` shapes.
+ *
+ * MOBILE SYNC DIVERGENCE: `CherryFileMeta` is mobile's, not desktop's. Mobile
+ * file parts carry `fileEntryId` / `fileTokenSourceId` / `composerFileKind`,
+ * and a managed FileUIPart's `url` holds the `cherry://file/<fileEntryId>`
+ * sentinel that the file storage layer resolves at send time — desktop
+ * addresses files by path and has none of this. The rest of the part
+ * vocabulary still parallels desktop's uiParts.ts.
+ */
+
 import * as z from 'zod';
 
 import type { CherryMessagePart } from './message';

--- a/src/shared/data/api/types.ts
+++ b/src/shared/data/api/types.ts
@@ -4,16 +4,6 @@ import type { ApiSchemas } from './schemas/apiSchemas';
 export type HttpMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
 
 /**
- * Offset-based pagination parameters.
- */
-export interface OffsetPaginationParams {
-  /** Page number (1-based). */
-  page?: number;
-  /** Items per page. */
-  limit?: number;
-}
-
-/**
  * Cursor-based pagination parameters.
  */
 export interface CursorPaginationParams {
@@ -21,15 +11,6 @@ export interface CursorPaginationParams {
   cursor?: string;
   /** Items per page. */
   limit?: number;
-}
-
-export interface SortParams {
-  sortBy?: string;
-  sortOrder?: 'asc' | 'desc';
-}
-
-export interface SearchParams {
-  search?: string;
 }
 
 /**
@@ -56,20 +37,11 @@ export interface CursorPaginationResponse<T> {
   nextCursor?: string;
 }
 
-export type PaginationResponse<T> = CursorPaginationResponse<T> | OffsetPaginationResponse<T>;
-
 export type InferPaginationMode<R> =
   R extends OffsetPaginationResponse<unknown>
     ? 'offset'
     : R extends CursorPaginationResponse<unknown>
       ? 'cursor'
-      : never;
-
-export type InferPaginationItem<R> =
-  R extends OffsetPaginationResponse<infer T>
-    ? T
-    : R extends CursorPaginationResponse<infer T>
-      ? T
       : never;
 
 export interface ApiClient {
@@ -138,12 +110,3 @@ export type HandlersFor<Schemas> = Pick<
   ApiImplementation,
   Extract<keyof Schemas, keyof ApiImplementation>
 >;
-
-export interface ServiceOptions {
-  /** Database transaction to use. */
-  transaction?: unknown;
-  /** User context for authorization. */
-  user?: unknown;
-  /** Additional service-specific options. */
-  metadata?: Record<string, unknown>;
-}


### PR DESCRIPTION
## Summary

Deletes three groups of zero-consumer type vocabulary (verified by repo-wide symbol search including `packages/ai-runtime`):

- **`data/types/message.ts`** (transitional universal module): the references subsystem — `ReferenceCategory`, `CitationType`, the citation/mention interface family, `ContentReference` — plus `SerializedErrorData` and the `AGENT_SESSION_*` search roles. Desktop concepts nothing on mobile reads; the agent host (#576) uses its own store.
- **`src/shared/data/api/types.ts`**: `ServiceOptions`, `OffsetPaginationParams`, `SortParams`, `SearchParams`, `PaginationResponse`, `InferPaginationItem`. `InferPaginationMode` and both pagination response shapes stay — `useDataApi` consumes them.
- **`data/types/uiParts.ts`**: adds a `MOBILE SYNC DIVERGENCE` header recording the mobile-native file identity (`CherryFileMeta`'s `fileEntryId` / `fileTokenSourceId` / `composerFileKind`, and the `cherry://file/<fileEntryId>` URL sentinel resolved by file storage at send time) — no desktop counterpart.

**Deviation from the planned cut list**: `aiUsageRecord`'s `'legacy-aggregate'` and `'agent-session'` enum values are kept. Verification showed both are live — `legacy-aggregate` backs the `record_kind` CHECK constraint, three aggregation sites, and migrated historical rows; `agent-session` feeds the `message_kind` CHECK (generated from this zod enum) and ai-runtime's `usageCapture`, and is the recording kind for agent-host sessions.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean
- Targeted suites green (message/uiParts/useDataApi/apiClient — 26 suites / 161 tests)

Stacked on #582; part of the mobile data-layer split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)