### PR TITLE
refactor(data-search): collapse content search to its single source

### DIFF
--- a/packages/universal/src/ai/transport/stream.ts
+++ b/packages/universal/src/ai/transport/stream.ts
@@ -1,3 +1,4 @@
+import type { ReasoningEffortOption } from '@shared/types/aiSdk';
 import type { UIMessageChunk } from 'ai';
 
 import type {
@@ -6,7 +7,6 @@ import type {
   CherryUIMessage,
 } from '../../data/types/message';
 import type { UniqueModelId } from '../../data/types/model';
-import type { ReasoningEffortOption } from '../../types/aiSdk';
 import type { SerializedError } from '../../types/error';
 
 export interface AiChatRequestBody extends AssistantTurnOptions {

--- a/packages/universal/src/data/types/assistant.ts
+++ b/packages/universal/src/data/types/assistant.ts
@@ -1,6 +1,6 @@
+import { ReasoningEffortOptionSchema } from '@shared/types/aiSdk';
 import * as z from 'zod';
 
-import { ReasoningEffortOptionSchema } from '../../types/aiSdk';
 import { UniqueModelIdSchema } from './model';
 
 export const McpModeSchema = z.enum(['disabled', 'auto', 'manual']);

--- a/src/backend/data/services/ContentSearchService.ts
+++ b/src/backend/data/services/ContentSearchService.ts
@@ -6,20 +6,12 @@ import { loggerService } from '@logger';
 import { sql } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
+import { toDataApiError } from '@/shared/data/api/errors';
 import {
-  DataApiErrorFactory,
-  ErrorCode,
-  isDataApiError,
-  toDataApiError,
-} from '@/shared/data/api/errors';
-import {
-  CONTENT_SEARCH_DEFAULT_LIMIT_PER_SOURCE,
-  CONTENT_SEARCH_MAX_LIMIT_PER_SOURCE,
-  type ContentSearchGroup,
+  CONTENT_SEARCH_DEFAULT_LIMIT,
+  CONTENT_SEARCH_MAX_LIMIT,
   type ContentSearchQuery,
   type ContentSearchResponse,
-  type ContentSearchSourceType,
-  contentSearchSourceTypes,
   type TopicMessageContentSearchItem,
 } from '@/shared/data/api/schemas/search';
 
@@ -45,33 +37,6 @@ type TopicMessageSearchRow = {
   topicUpdatedAt: number;
 };
 
-function toSourceCursorError(sourceType: ContentSearchSourceType, error: unknown): unknown {
-  if (!isDataApiError(error) || error.code !== ErrorCode.VALIDATION_ERROR) return error;
-  const details = error.details as { fieldErrors?: Record<string, string[]> } | undefined;
-  const cursorErrors = details?.fieldErrors?.cursor;
-  if (!cursorErrors) return error;
-  return DataApiErrorFactory.validation({ [`cursors.${sourceType}`]: cursorErrors }, error.message);
-}
-
-function withSourceContext(sourceType: ContentSearchSourceType, error: unknown) {
-  const sourcedError = toSourceCursorError(sourceType, error);
-  if (!isDataApiError(sourcedError)) {
-    return toDataApiError(sourcedError, `content search source ${sourceType}`);
-  }
-  const details = sourcedError.details as { fieldErrors?: Record<string, string[]> } | undefined;
-  if (
-    sourcedError.code === ErrorCode.VALIDATION_ERROR &&
-    details?.fieldErrors?.[`cursors.${sourceType}`]
-  ) {
-    return sourcedError;
-  }
-  return DataApiErrorFactory.create(
-    sourcedError.code,
-    `content search source ${sourceType} failed: ${sourcedError.message}`,
-    sourcedError.details,
-  );
-}
-
 export class ContentSearchService {
   /**
    * Resolved per call rather than injected once, so the instance holds no
@@ -87,47 +52,19 @@ export class ContentSearchService {
   }
 
   async search(query: ContentSearchQuery): Promise<ContentSearchResponse> {
-    const requestedSources = new Set(query.sources ?? contentSearchSourceTypes);
-    const sources = contentSearchSourceTypes.filter((sourceType) =>
-      requestedSources.has(sourceType),
-    );
-    const limit = Math.min(
-      query.limitPerSource ?? CONTENT_SEARCH_DEFAULT_LIMIT_PER_SOURCE,
-      CONTENT_SEARCH_MAX_LIMIT_PER_SOURCE,
-    );
-    const groups: ContentSearchGroup[] = [];
-
-    for (const sourceType of sources) {
-      try {
-        groups.push(await this.searchSource(sourceType, query, limit));
-      } catch (error) {
-        logger.error('content search source failed', error as Error, { sourceType });
-        throw withSourceContext(sourceType, error);
-      }
-    }
-    return { groups, query: query.q };
-  }
-
-  private async searchSource(
-    sourceType: ContentSearchSourceType,
-    query: ContentSearchQuery,
-    limit: number,
-  ): Promise<ContentSearchGroup> {
-    switch (sourceType) {
-      case 'topic-message': {
-        const result = await this.searchTopicMessages({
-          createdAtFrom: query.createdAtFrom,
-          cursor: query.cursors?.[sourceType],
-          limit,
-          q: query.q,
-          topicId: query.filters?.[sourceType]?.topicId,
-        });
-        return { ...result, sourceType };
-      }
-      default: {
-        const exhaustive: never = sourceType;
-        throw new Error(`Unknown content search source: ${exhaustive}`);
-      }
+    const limit = Math.min(query.limit ?? CONTENT_SEARCH_DEFAULT_LIMIT, CONTENT_SEARCH_MAX_LIMIT);
+    try {
+      const result = await this.searchTopicMessages({
+        createdAtFrom: query.createdAtFrom,
+        cursor: query.cursor,
+        limit,
+        q: query.q,
+        topicId: query.topicId,
+      });
+      return { ...result, query: query.q };
+    } catch (error) {
+      logger.error('content search failed', error as Error);
+      throw toDataApiError(error, 'content search');
     }
   }
 

--- a/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
+++ b/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
@@ -109,9 +109,8 @@ describe('auxiliary Data API integration', () => {
 
     const contentResult = await contentSearchService.search({
       q: 'needle',
-      sources: ['topic-message'],
     });
-    expect(contentResult.groups[0]?.items).toEqual([
+    expect(contentResult.items).toEqual([
       expect.objectContaining({
         messageId: last.id,
         snippet: 'needle answer',

--- a/src/backend/data/services/__tests__/SearchServices.test.ts
+++ b/src/backend/data/services/__tests__/SearchServices.test.ts
@@ -87,16 +87,15 @@ describe('ContentSearchService', () => {
     });
     const service = new ContentSearchService();
 
-    const result = await service.search({ limitPerSource: 2, q: 'needle' });
+    const result = await service.search({ limit: 2, q: 'needle' });
 
-    expect(result.groups.map((group) => group.sourceType)).toEqual(['topic-message']);
-    expect(result.groups[0].items[0]).toMatchObject({
+    expect(result.items[0]).toMatchObject({
       messageId: 'message-1',
       snippet: 'needle topic',
     });
   });
 
-  test('rewrites malformed cursor errors onto the source-specific field', async () => {
+  test('rejects a malformed cursor as a field validation error', async () => {
     await installTestHost({
       DbService: { getDb: () => ({ all: jest.fn() }) } as unknown as DbService,
     });
@@ -104,15 +103,14 @@ describe('ContentSearchService', () => {
 
     await expect(
       service.search({
-        cursors: { 'topic-message': 'not-a-cursor' },
+        cursor: 'not-a-cursor',
         q: 'needle',
-        sources: ['topic-message'],
       }),
     ).rejects.toMatchObject({
       code: 'VALIDATION_ERROR',
       details: {
         fieldErrors: {
-          'cursors.topic-message': ['must be a valid search cursor'],
+          cursor: ['must be a valid search cursor'],
         },
       },
     });

--- a/src/backend/services/webSearch/WebSearchService.ts
+++ b/src/backend/services/webSearch/WebSearchService.ts
@@ -1,8 +1,9 @@
 import { BaseService, DependsOn, Injectable } from '@/backend/core/lifecycle';
 import type { PreferenceService } from '@/backend/data/PreferenceService';
 import { loggerService } from '@/shared/core/logger/LoggerService';
-import type { WebSearchCapability, WebSearchProvider } from '@/shared/data/preference';
 import type {
+  WebSearchCapability,
+  WebSearchProvider,
   WebSearchCheckProviderRequest,
   WebSearchCheckProviderResponse,
   WebSearchExecutionConfig,

--- a/src/backend/services/webSearch/providers/api/__tests__/BochaProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/BochaProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import bochaResponse from '../../__tests__/fixtures/bocha-response.json';

--- a/src/backend/services/webSearch/providers/api/__tests__/ExaProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/ExaProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import exaResponseFixture from '../../__tests__/fixtures/exa-response.json';

--- a/src/backend/services/webSearch/providers/api/__tests__/FirecrawlProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/FirecrawlProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import firecrawlResponse from '../../__tests__/fixtures/firecrawl-response.json';

--- a/src/backend/services/webSearch/providers/api/__tests__/JinaProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/JinaProvider.test.ts
@@ -1,6 +1,5 @@
 import { ApiKeyRotationState } from '@/backend/services/webSearch/utils/provider';
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { JinaProvider } from '../JinaProvider';
 

--- a/src/backend/services/webSearch/providers/api/__tests__/QueritProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/QueritProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import queritResponse from '../../__tests__/fixtures/querit-response.json';

--- a/src/backend/services/webSearch/providers/api/__tests__/SearxngProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/SearxngProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import searxngSearchResponse from '../../__tests__/fixtures/searxng-search-response.json';

--- a/src/backend/services/webSearch/providers/api/__tests__/TavilyProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/TavilyProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import tavilyResponse from '../../__tests__/fixtures/tavily-response.json';

--- a/src/backend/services/webSearch/providers/api/__tests__/ZhipuProvider.test.ts
+++ b/src/backend/services/webSearch/providers/api/__tests__/ZhipuProvider.test.ts
@@ -1,5 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import zhipuResponseFixture from '../../__tests__/fixtures/zhipu-response.json';

--- a/src/backend/services/webSearch/providers/base/BaseWebSearchProvider.ts
+++ b/src/backend/services/webSearch/providers/base/BaseWebSearchProvider.ts
@@ -1,7 +1,7 @@
 import type * as z from 'zod';
 
 import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
-import type { WebSearchCapability, WebSearchProvider } from '@/shared/data/preference';
+import type { WebSearchCapability, WebSearchProvider } from '@/shared/data/types/webSearch';
 
 import type { ApiKeyRotationState } from '../../utils/provider';
 import { resolveProviderApiHost } from '../../utils/provider';

--- a/src/backend/services/webSearch/providers/factory.ts
+++ b/src/backend/services/webSearch/providers/factory.ts
@@ -1,5 +1,8 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig, WebSearchResponse } from '@/shared/data/types/webSearch';
+import type {
+  WebSearchProvider,
+  WebSearchExecutionConfig,
+  WebSearchResponse,
+} from '@/shared/data/types/webSearch';
 
 import type { ApiKeyRotationState } from '../utils/provider';
 import type { BaseWebSearchProvider } from './base/BaseWebSearchProvider';

--- a/src/backend/services/webSearch/providers/mcp/__tests__/ExaMcpProvider.test.ts
+++ b/src/backend/services/webSearch/providers/mcp/__tests__/ExaMcpProvider.test.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import type { WebSearchProvider } from '@/shared/data/preference';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type { WebSearchProvider, WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
 
 import { ApiKeyRotationState } from '../../../utils/provider';
 import { ExaMcpProvider } from '../ExaMcpProvider';

--- a/src/backend/services/webSearch/providers/registry.ts
+++ b/src/backend/services/webSearch/providers/registry.ts
@@ -1,4 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
+import type { WebSearchProvider } from '@/shared/data/types/webSearch';
 
 import type { ApiKeyRotationState } from '../utils/provider';
 import { BochaProvider } from './api/BochaProvider';

--- a/src/backend/services/webSearch/utils/__tests__/provider.test.ts
+++ b/src/backend/services/webSearch/utils/__tests__/provider.test.ts
@@ -1,4 +1,4 @@
-import type { WebSearchProvider } from '@/shared/data/preference';
+import type { WebSearchProvider } from '@/shared/data/types/webSearch';
 
 import { WebSearchConfigError } from '../../WebSearchConfigError';
 import { ApiKeyRotationState, resolveProviderApiHost } from '../provider';

--- a/src/backend/services/webSearch/utils/config.ts
+++ b/src/backend/services/webSearch/utils/config.ts
@@ -1,15 +1,14 @@
-import type {
-  PreferenceSchema,
-  PreferenceKeyType,
-  WebSearchCapability,
-  WebSearchProvider,
-  WebSearchProviderOverrides,
-} from '@/shared/data/preference';
+import type { PreferenceSchema, PreferenceKeyType } from '@/shared/data/preference';
 import {
   WEB_SEARCH_PROVIDER_PRESET_MAP,
   type WebSearchProviderPreset,
 } from '@/shared/data/presets/webSearchProviders';
-import type { WebSearchExecutionConfig } from '@/shared/data/types/webSearch';
+import type {
+  WebSearchCapability,
+  WebSearchProvider,
+  WebSearchProviderOverrides,
+  WebSearchExecutionConfig,
+} from '@/shared/data/types/webSearch';
 import { normalizeWebSearchCutoffLimit } from '@/shared/data/types/webSearch';
 
 import { WebSearchConfigError } from '../WebSearchConfigError';

--- a/src/backend/services/webSearch/utils/provider.ts
+++ b/src/backend/services/webSearch/utils/provider.ts
@@ -1,4 +1,4 @@
-import type { WebSearchCapability, WebSearchProvider } from '@/shared/data/preference';
+import type { WebSearchCapability, WebSearchProvider } from '@/shared/data/types/webSearch';
 
 import { WebSearchConfigError } from '../WebSearchConfigError';
 

--- a/src/frontend/features/settings/WebSearchScreen/apiService/hooks/useWebSearchProviderCheck.ts
+++ b/src/frontend/features/settings/WebSearchScreen/apiService/hooks/useWebSearchProviderCheck.ts
@@ -4,12 +4,12 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useBackendModule } from '@/frontend/data';
+import type { WebSearchProviderPreset } from '@/shared/data/presets/webSearchProviders';
 import type {
   WebSearchCapability,
   WebSearchProvider,
   WebSearchProviderOverride,
-} from '@/shared/data/preference';
-import type { WebSearchProviderPreset } from '@/shared/data/presets/webSearchProviders';
+} from '@/shared/data/types/webSearch';
 
 export function useWebSearchProviderCheck(
   provider: WebSearchProviderPreset,

--- a/src/frontend/features/settings/WebSearchScreen/components/WebSearchApiManagementSection.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/components/WebSearchApiManagementSection.tsx
@@ -3,13 +3,13 @@ import { useRouter } from 'expo-router';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { WebSearchProviderPreset } from '@/shared/data/presets/webSearchProviders';
 import type {
   WebSearchCapability,
   WebSearchProviderId,
   WebSearchProviderOverride,
   WebSearchProviderOverrides,
-} from '@/shared/data/preference';
-import type { WebSearchProviderPreset } from '@/shared/data/presets/webSearchProviders';
+} from '@/shared/data/types/webSearch';
 
 import { WebSearchApiServiceFieldGroup } from '../apiService/components/WebSearchApiServiceFields';
 import {

--- a/src/frontend/features/settings/WebSearchScreen/context/WebSearchApiManagementContext.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/context/WebSearchApiManagementContext.tsx
@@ -1,12 +1,12 @@
 import { createContext, use } from 'react';
 import type { useTranslation } from 'react-i18next';
 
+import type { WebSearchProviderPreset } from '@/shared/data/presets/webSearchProviders';
 import type {
   WebSearchCapability,
   WebSearchProviderId,
   WebSearchProviderOverride,
-} from '@/shared/data/preference';
-import type { WebSearchProviderPreset } from '@/shared/data/presets/webSearchProviders';
+} from '@/shared/data/types/webSearch';
 
 export type WebSearchApiManagementContextValue = {
   actions: {

--- a/src/frontend/features/settings/WebSearchScreen/utils/providerIcons.ts
+++ b/src/frontend/features/settings/WebSearchScreen/utils/providerIcons.ts
@@ -1,6 +1,6 @@
 import { resolveProviderIcon } from '@cherrystudio/ui/icons';
 
-import type { WebSearchProviderId } from '@/shared/data/preference';
+import type { WebSearchProviderId } from '@/shared/data/types/webSearch';
 
 export function resolveWebSearchProviderIcon(providerId: WebSearchProviderId) {
   if (providerId === 'fetch') {

--- a/src/frontend/features/settings/WebSearchScreen/utils/providerSettings.ts
+++ b/src/frontend/features/settings/WebSearchScreen/utils/providerSettings.ts
@@ -1,14 +1,14 @@
-import type {
-  WebSearchCapability,
-  WebSearchProviderId,
-  WebSearchProviderOverride,
-  WebSearchProviderOverrides,
-} from '@/shared/data/preference';
 import {
   MOBILE_SUPPORTED_WEB_SEARCH_PROVIDERS,
   WEB_SEARCH_PROVIDER_PRESET_MAP,
   type WebSearchProviderPreset,
 } from '@/shared/data/presets/webSearchProviders';
+import type {
+  WebSearchCapability,
+  WebSearchProviderId,
+  WebSearchProviderOverride,
+  WebSearchProviderOverrides,
+} from '@/shared/data/types/webSearch';
 
 export type WebSearchProviderCapability = WebSearchProviderPreset['capabilities'][number];
 

--- a/src/frontend/features/settings/hooks/useWebSearchProviderPreferences.ts
+++ b/src/frontend/features/settings/hooks/useWebSearchProviderPreferences.ts
@@ -2,15 +2,15 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMultiplePreferences } from '@/frontend/data/hooks';
-import type {
-  WebSearchCompressionMethod,
-  WebSearchProviderId,
-  WebSearchProviderOverride,
-} from '@/shared/data/preference';
 import {
   getMobileSupportedWebSearchProvidersByCapability,
   type WebSearchProviderPreset,
 } from '@/shared/data/presets/webSearchProviders';
+import type {
+  WebSearchCompressionMethod,
+  WebSearchProviderId,
+  WebSearchProviderOverride,
+} from '@/shared/data/types/webSearch';
 
 import type { SettingOption } from '../settingOptions';
 import { mergeWebSearchProviderOverride } from '../WebSearchScreen/utils/providerSettings';

--- a/src/shared/data/api/schemas/search.ts
+++ b/src/shared/data/api/schemas/search.ts
@@ -58,37 +58,19 @@ export type EntitySearchSchemas = {
   };
 };
 
-export const contentSearchSourceTypes = ['topic-message'] as const satisfies readonly string[];
-export type ContentSearchSourceType = (typeof contentSearchSourceTypes)[number];
-export const ContentSearchSourceTypeSchema = z.enum(contentSearchSourceTypes);
+export const CONTENT_SEARCH_DEFAULT_LIMIT = 50;
+export const CONTENT_SEARCH_MAX_LIMIT = 1000;
 
-export const CONTENT_SEARCH_DEFAULT_LIMIT_PER_SOURCE = 50;
-export const CONTENT_SEARCH_MAX_LIMIT_PER_SOURCE = 1000;
-const ContentSearchCursorSchema = z.string().min(1);
-
-export const TopicMessageContentSearchFilterSchema = z.strictObject({
-  topicId: z.string().min(1).optional(),
-});
-export type TopicMessageContentSearchFilter = z.output<
-  typeof TopicMessageContentSearchFilterSchema
->;
-
-export const ContentSearchFiltersSchema = z.strictObject({
-  'topic-message': TopicMessageContentSearchFilterSchema.optional(),
-});
-export type ContentSearchFilters = z.output<typeof ContentSearchFiltersSchema>;
-
+/**
+ * Content search reads one source — topic messages over FTS. The former
+ * multi-source shell (`sources` array, per-source cursor/filter records)
+ * described desktop surfaces mobile never had.
+ */
 export const ContentSearchQuerySchema = z.strictObject({
   q: z.string().trim().min(1),
-  sources: z.array(ContentSearchSourceTypeSchema).min(1).optional(),
-  cursors: z.partialRecord(ContentSearchSourceTypeSchema, ContentSearchCursorSchema).optional(),
-  filters: ContentSearchFiltersSchema.optional(),
-  limitPerSource: z.coerce
-    .number()
-    .int()
-    .positive()
-    .max(CONTENT_SEARCH_MAX_LIMIT_PER_SOURCE)
-    .optional(),
+  cursor: z.string().min(1).optional(),
+  topicId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(CONTENT_SEARCH_MAX_LIMIT).optional(),
   createdAtFrom: z.iso.datetime().optional(),
 });
 export type ContentSearchQueryParams = z.input<typeof ContentSearchQuerySchema>;
@@ -106,17 +88,10 @@ export interface TopicMessageContentSearchItem {
   createdAt: string;
 }
 
-export type TopicMessageContentSearchGroup = {
-  sourceType: 'topic-message';
-  items: TopicMessageContentSearchItem[];
-  nextCursor?: string;
-};
-
-export type ContentSearchGroup = TopicMessageContentSearchGroup;
-
 export type ContentSearchResponse = {
   query: string;
-  groups: ContentSearchGroup[];
+  items: TopicMessageContentSearchItem[];
+  nextCursor?: string;
 };
 
 export type ContentSearchSchemas = {

--- a/src/shared/data/preference/index.ts
+++ b/src/shared/data/preference/index.ts
@@ -11,19 +11,6 @@ export type {
   PreferenceSchema,
 } from './preference-schema';
 export { FONT_SIZE_STEPS, PreferenceDefaults } from './preference-schema';
-export type {
-  LanguageVarious,
-  PermissionMode,
-  PreferenceUpdateOptions,
-  WebSearchCapability,
-  WebSearchCompressionMethod,
-  WebSearchProvider,
-  WebSearchProviderCapabilityOverride,
-  WebSearchProviderCapabilityOverrides,
-  WebSearchProviderId,
-  WebSearchProviderOverride,
-  WebSearchProviderOverrides,
-  WebSearchProviderType,
-} from './preferenceTypes';
-export { ThemeMode, WEB_SEARCH_PROVIDER_IDS } from './preferenceTypes';
+export type { LanguageVarious, PermissionMode, PreferenceUpdateOptions } from './preferenceTypes';
+export { ThemeMode } from './preferenceTypes';
 export { getDefaultValue, getPreferenceKeys, isPreferenceKey } from './preferenceUtils';

--- a/src/shared/data/preference/preference-schema.ts
+++ b/src/shared/data/preference/preference-schema.ts
@@ -12,12 +12,12 @@
  */
 
 import type {
-  LanguageVarious,
-  PermissionMode,
   WebSearchCompressionMethod,
   WebSearchProviderId,
   WebSearchProviderOverrides,
-} from './preferenceTypes';
+} from '@/shared/data/types/webSearch';
+
+import type { LanguageVarious, PermissionMode } from './preferenceTypes';
 import { ThemeMode } from './preferenceTypes';
 
 export const FONT_SIZE_STEPS = [0, 1, 2] as const;

--- a/src/shared/data/preference/preferenceTypes.ts
+++ b/src/shared/data/preference/preferenceTypes.ts
@@ -1,6 +1,7 @@
 /**
- * Value types for the preference keys in `preferenceSchema.ts`, plus the
- * web-search provider vocabulary those keys are written in.
+ * Value types for the preference keys in `preferenceSchema.ts`. The web-search
+ * provider vocabulary some keys are written in lives in
+ * `@/shared/data/types/webSearch`, below this module in the layering.
  */
 
 export type PreferenceUpdateOptions = {
@@ -29,83 +30,3 @@ export type LanguageVarious =
   | 'ro-RO'
   | 'ru-RU'
   | 'vi-VN';
-
-// ============================================================================
-// WebSearch Types
-// ============================================================================
-
-export const WEB_SEARCH_PROVIDER_TYPES = ['api', 'mcp'] as const;
-
-export type WebSearchProviderType = (typeof WEB_SEARCH_PROVIDER_TYPES)[number];
-
-export const WEB_SEARCH_PROVIDER_IDS = [
-  'zhipu',
-  'tavily',
-  'searxng',
-  'exa',
-  'exa-mcp',
-  'bocha',
-  'querit',
-  'fetch',
-  'jina',
-  'firecrawl',
-] as const;
-
-export type WebSearchProviderId = (typeof WEB_SEARCH_PROVIDER_IDS)[number];
-
-export const WEB_SEARCH_CAPABILITIES = ['searchKeywords', 'fetchUrls'] as const;
-
-export type WebSearchCapability = (typeof WEB_SEARCH_CAPABILITIES)[number];
-
-export type WebSearchProviderCapabilityOverride = {
-  apiHost?: string;
-};
-
-export type WebSearchProviderCapabilityOverrides = Partial<
-  Record<WebSearchCapability, WebSearchProviderCapabilityOverride>
->;
-
-export type WebSearchProviderOverride = {
-  apiKeys?: string[];
-  capabilities?: WebSearchProviderCapabilityOverrides;
-  engines?: string[];
-  basicAuthUsername?: string;
-  basicAuthPassword?: string;
-};
-
-export type WebSearchProviderOverrides = Partial<
-  Record<WebSearchProviderId, WebSearchProviderOverride>
->;
-
-/**
- * Full WebSearch Provider configuration
- * Generated at runtime by merging preset with user overrides
- */
-export interface WebSearchProvider {
-  /** Unique provider identifier */
-  id: WebSearchProviderId;
-  /** Display name (from preset) */
-  name: string;
-  /** Provider type (from preset) */
-  type: WebSearchProviderType;
-  /** API keys (from user overrides) */
-  apiKeys: string[];
-  /** Capability API settings (user override merged into preset capabilities) */
-  capabilities: Array<{
-    feature: WebSearchCapability;
-    /** Can be empty for self-hosted or hostless providers; resolve and validate via resolveProviderApiHost. */
-    apiHost?: string;
-  }>;
-  /** Search engines (from user overrides) */
-  engines: string[];
-  /** Basic auth username (from user overrides) */
-  basicAuthUsername: string;
-  /** Basic auth password (from user overrides) */
-  basicAuthPassword: string;
-}
-
-/**
- * Compression method type
- * Stored in chat.web_search.compression.method
- */
-export type WebSearchCompressionMethod = 'none' | 'cutoff';

--- a/src/shared/data/presets/webSearchProviders.ts
+++ b/src/shared/data/presets/webSearchProviders.ts
@@ -8,8 +8,8 @@ import type {
   WebSearchProviderOverride,
   WebSearchProviderOverrides,
   WebSearchProviderType,
-} from '@/shared/data/preference';
-import { WEB_SEARCH_PROVIDER_IDS } from '@/shared/data/preference';
+} from '@/shared/data/types/webSearch';
+import { WEB_SEARCH_PROVIDER_IDS } from '@/shared/data/types/webSearch';
 
 export const WebSearchProviderIdSchema = z.enum(WEB_SEARCH_PROVIDER_IDS);
 export const WebSearchProviderCapabilityOverrideSchema: z.ZodType<WebSearchProviderCapabilityOverride> =

--- a/src/shared/data/types/webSearch.ts
+++ b/src/shared/data/types/webSearch.ts
@@ -1,10 +1,86 @@
-import type {
-  WebSearchCapability,
-  WebSearchCompressionMethod,
-  WebSearchProvider,
-  WebSearchProviderId,
-  WebSearchProviderOverrides,
-} from '@/shared/data/preference';
+// ============================================================================
+// Provider Vocabulary
+// ============================================================================
+
+export const WEB_SEARCH_PROVIDER_TYPES = ['api', 'mcp'] as const;
+
+export type WebSearchProviderType = (typeof WEB_SEARCH_PROVIDER_TYPES)[number];
+
+export const WEB_SEARCH_PROVIDER_IDS = [
+  'zhipu',
+  'tavily',
+  'searxng',
+  'exa',
+  'exa-mcp',
+  'bocha',
+  'querit',
+  'fetch',
+  'jina',
+  'firecrawl',
+] as const;
+
+export type WebSearchProviderId = (typeof WEB_SEARCH_PROVIDER_IDS)[number];
+
+export const WEB_SEARCH_CAPABILITIES = ['searchKeywords', 'fetchUrls'] as const;
+
+export type WebSearchCapability = (typeof WEB_SEARCH_CAPABILITIES)[number];
+
+export type WebSearchProviderCapabilityOverride = {
+  apiHost?: string;
+};
+
+export type WebSearchProviderCapabilityOverrides = Partial<
+  Record<WebSearchCapability, WebSearchProviderCapabilityOverride>
+>;
+
+export type WebSearchProviderOverride = {
+  apiKeys?: string[];
+  capabilities?: WebSearchProviderCapabilityOverrides;
+  engines?: string[];
+  basicAuthUsername?: string;
+  basicAuthPassword?: string;
+};
+
+export type WebSearchProviderOverrides = Partial<
+  Record<WebSearchProviderId, WebSearchProviderOverride>
+>;
+
+/**
+ * Full WebSearch Provider configuration
+ * Generated at runtime by merging preset with user overrides
+ */
+export interface WebSearchProvider {
+  /** Unique provider identifier */
+  id: WebSearchProviderId;
+  /** Display name (from preset) */
+  name: string;
+  /** Provider type (from preset) */
+  type: WebSearchProviderType;
+  /** API keys (from user overrides) */
+  apiKeys: string[];
+  /** Capability API settings (user override merged into preset capabilities) */
+  capabilities: {
+    feature: WebSearchCapability;
+    /** Can be empty for self-hosted or hostless providers; resolve and validate via resolveProviderApiHost. */
+    apiHost?: string;
+  }[];
+  /** Search engines (from user overrides) */
+  engines: string[];
+  /** Basic auth username (from user overrides) */
+  basicAuthUsername: string;
+  /** Basic auth password (from user overrides) */
+  basicAuthPassword: string;
+}
+
+/**
+ * Compression method type
+ * Stored in chat.web_search.compression.method
+ */
+export type WebSearchCompressionMethod = 'none' | 'cutoff';
+
+// ============================================================================
+// Runtime Config And Wire Types
+// ============================================================================
 
 export const DEFAULT_WEB_SEARCH_CUTOFF_LIMIT = 2000;
 


### PR DESCRIPTION
## Summary

Content search reads exactly one source — topic messages over FTS — but its contract kept desktop's multi-source shell. This collapses it to the mobile reality:

- Query: flat `cursor` / `topicId` / `limit` params replace the `sources` array, the per-source `cursors` / `filters` records, and `limitPerSource`.
- Response: a flat `items` + `nextCursor` list replaces the single-element `groups` array.
- `ContentSearchService` loses the source dispatch switch and the error rewriter that remapped cursor validation failures onto `cursors.topic-message` — the flat `cursor` field error now matches the query param directly.

The FTS query, cursor semantics, and snippet building are untouched. Entity search keeps its two genuine types (assistant, topic).

Two layering fixes ride along, closing out the cleanup sequence:

- **Web-search vocabulary moves below preference.** The provider vocabulary (ids, capabilities, overrides, `WebSearchProvider`) lived in `preferenceTypes.ts`, so `types/webSearch` imported the preference module — upside down. The vocabulary now lives in `@/shared/data/types/webSearch`; preference imports it for its key value types, and consumers import it from its owner instead of through the preference barrel.
- **`types/aiSdk` import spelling unified** inside `packages/universal` on the `@shared` alias (two files used relative paths).

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean
- Search suites green (SearchServices, AuxiliaryData integration over real sqlite/FTS, ftsSearch); webSearch + preference suites green after the vocabulary move
- Full suite at stack tip: 318 suites / 2857 tests pass
- `desktop:sync:audit` status unchanged vs `upstream/v0.2` (the delegated-AI-runtime coverage failure pre-exists on the clean baseline and tracks desktop-repo drift, not this stack)

Stacked on #586; part of the mobile data-layer split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)