### PR TITLE
refactor(data-types): give the shared entity types their src home

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,21 @@ const retiredRootPatterns = [
   'utils',
 ].flatMap((root) => [`@/${root}`, `@/${root}/*`, `@/${root}/*/**`]);
 
+const universalDataTombstone = {
+  group: [
+    '@cherrystudio/universal/data/api/*',
+    '@cherrystudio/universal/data/api/*/**',
+    '@cherrystudio/universal/data/cache/*',
+    '@cherrystudio/universal/data/preference',
+    '@cherrystudio/universal/data/preference/*',
+    '@cherrystudio/universal/data/presets/*',
+    '@cherrystudio/universal/data/types',
+    '@cherrystudio/universal/data/types/*',
+  ],
+  message:
+    'The mobile data layer moved out of packages/universal. Import @/shared/data/* instead; the entity types packages/ai-runtime still shares are re-exported from @/shared/data/types.',
+};
+
 const tombstonePatterns = [
   {
     group: retiredRootPatterns,
@@ -49,23 +64,7 @@ const tombstonePatterns = [
     message:
       'The generic shared domain root was retired. Use @cherrystudio/universal/ai for AI rules, @/shared/data for data vocabulary, or @cherrystudio/universal/utils and @/shared/utils for pure helpers.',
   },
-  {
-    group: [
-      '@cherrystudio/universal/data/api/*',
-      '@cherrystudio/universal/data/api/*/**',
-      '@cherrystudio/universal/data/cache/*',
-      '@cherrystudio/universal/data/preference',
-      '@cherrystudio/universal/data/preference/*',
-      '@cherrystudio/universal/data/presets/*',
-      '@cherrystudio/universal/data/types/file',
-      '@cherrystudio/universal/data/types/webSearch',
-      '@cherrystudio/universal/data/types/topic',
-      '@cherrystudio/universal/data/types/painting',
-      '@cherrystudio/universal/data/types/trace',
-    ],
-    message:
-      'The mobile data layer moved out of packages/universal. Import @/shared/data/* instead; only the transitional entity types (model, provider, assistant, message, uiParts, aiUsageRecord, mcpServer) remain under @cherrystudio/universal/data/types.',
-  },
+  universalDataTombstone,
   {
     group: ['@/screens', '@/screens/*', '@/screens/*/**'],
     message: 'Screens moved to @/frontend/features/<name>.',
@@ -263,6 +262,21 @@ module.exports = defineConfig([
     files: ['src/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': ['error', { paths: retiredImports, patterns: tombstonePatterns }],
+    },
+  },
+  {
+    // src/shared/data/types re-exports the entity declarations that stay in
+    // packages/universal while packages/ai-runtime imports them, so it is the
+    // one place allowed to spell that path. Every other tombstone still applies.
+    files: ['src/shared/data/types/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: retiredImports,
+          patterns: tombstonePatterns.filter((pattern) => pattern !== universalDataTombstone),
+        },
+      ],
     },
   },
   restrictedImports(

--- a/packages/universal/src/data/README.md
+++ b/packages/universal/src/data/README.md
@@ -8,7 +8,8 @@ remainder that cannot move yet.
 
 `packages/ai-runtime` imports the entity vocabulary below, and workspace packages must not import
 app code. Until the AI-runtime vocabulary finds its final home (candidate: `packages/ai-runtime`
-itself), these modules stay importable as `@cherrystudio/universal/data/types/*`:
+itself), these modules stay importable as `@cherrystudio/universal/data/types/*` — but only for
+package-side consumers:
 
 - `types/model.ts`
 - `types/provider.ts`
@@ -20,5 +21,10 @@ itself), these modules stay importable as `@cherrystudio/universal/data/types/*`
 
 They are mobile-owned all the same — the desktop-sync audit does not track them, and each follows
 "mobile persists what mobile reads".
+
+App code no longer spells this path: `src/shared/data/types` re-exports each module under its final
+name, and an ESLint tombstone keeps `src` off the package path. Dissolving this directory is
+therefore a paste into the matching `src/shared/data/types/*.ts` file plus repointing
+`packages/ai-runtime`, with no import migration in `src`.
 
 Do not add new modules here; put new mobile data contracts in `src/shared/data`.

--- a/src/backend/ai/AiService.ts
+++ b/src/backend/ai/AiService.ts
@@ -19,11 +19,6 @@ import {
   splitImageParamValues,
 } from '@cherrystudio/ai-runtime/utils';
 import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
-import type { ServingCredentialReceipt } from '@cherrystudio/universal/data/types/aiUsageRecord';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import { parseUniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { type LanguageModelUsage, type ModelMessage, type UIMessageChunk } from 'ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
@@ -44,7 +39,12 @@ import {
 import { providerService, type ProviderService } from '@/backend/data/services/ProviderService';
 import { fileContent } from '@/backend/services/file/fileContent';
 import { devicePermissions } from '@/backend/services/permissions';
+import type { ServingCredentialReceipt } from '@/shared/data/types/aiUsageRecord';
+import type { Assistant } from '@/shared/data/types/assistant';
 import type { FileEntryId } from '@/shared/data/types/file';
+import type { Model } from '@/shared/data/types/model';
+import { parseUniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { createAiUsagePlugin } from './hooks/billingHook';
 import { resolveUIMessageFileUrls } from './messages/attachmentRouting';

--- a/src/backend/ai/__tests__/AiService.test.ts
+++ b/src/backend/ai/__tests__/AiService.test.ts
@@ -5,20 +5,13 @@ import {
   type RuntimeProviderCallEvent,
 } from '@cherrystudio/ai-core';
 import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
-import {
-  createUniqueModelId,
-  type Model,
-  type UniqueModelId,
-} from '@cherrystudio/universal/data/types/model';
-import type { AuthConfig, Provider } from '@cherrystudio/universal/data/types/provider';
 import { InvalidToolInputError, type ToolSet } from 'ai';
 
 import { AiService, type AiServiceDependencies } from '@/backend/ai/AiService';
 import { createWebSearchTool } from '@/backend/ai/tools/adapters/aiSdk/builtin/WebSearchTool';
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import { createUniqueModelId, type Model, type UniqueModelId } from '@/shared/data/types/model';
+import type { AuthConfig, Provider } from '@/shared/data/types/provider';
 
 const mockGenerate = jest.fn(async () => ({ text: 'ok', usage: undefined }));
 const mockStream = jest.fn(

--- a/src/backend/ai/__tests__/_harness/contracts.ts
+++ b/src/backend/ai/__tests__/_harness/contracts.ts
@@ -1,6 +1,7 @@
 import type { ImageModelV3CallOptions, LanguageModelV3CallOptions } from '@ai-sdk/provider';
-import type { CherryUIMessage } from '@cherrystudio/universal/data/types/message';
 import { readUIMessageStream, type UIMessageChunk } from 'ai';
+
+import type { CherryUIMessage } from '@/shared/data/types/message';
 
 export function projectLanguageCall(call: LanguageModelV3CallOptions) {
   const value = {

--- a/src/backend/ai/__tests__/_harness/services.ts
+++ b/src/backend/ai/__tests__/_harness/services.ts
@@ -1,14 +1,11 @@
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 
 import type { AiServiceDependencies } from '@/backend/ai/AiService';
 import type { ToolEntry } from '@/backend/ai/tools';
 import { ToolResolver } from '@/backend/ai/tools/ToolResolver';
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 type ContractFixtureOptions = {
   assistantPrompt?: string;

--- a/src/backend/ai/__tests__/behavior/AiService.streamText.test.ts
+++ b/src/backend/ai/__tests__/behavior/AiService.streamText.test.ts
@@ -1,9 +1,9 @@
 import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import type { CherryUIMessage } from '@cherrystudio/universal/data/types/message';
 import { MockLanguageModelV3 } from 'ai/test';
 import * as Crypto from 'expo-crypto';
 
 import { AiService } from '@/backend/ai/AiService';
+import type { CherryUIMessage } from '@/shared/data/types/message';
 
 import {
   collectStreamContract,

--- a/src/backend/ai/agentHost/agentDefinitions.ts
+++ b/src/backend/ai/agentHost/agentDefinitions.ts
@@ -8,10 +8,9 @@
  * deliberately absent because V1 executes tool-less turns.
  */
 
-import { parseUniqueModelId, type UniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import type { RuntimeModel } from '@/backend/ai/agent';
 import { assistantService } from '@/backend/data/services/AssistantService';
+import { parseUniqueModelId, type UniqueModelId } from '@/shared/data/types/model';
 
 export type AgentDefinition = {
   id: string;

--- a/src/backend/ai/agentHost/aiSdkModelResolver.ts
+++ b/src/backend/ai/agentHost/aiSdkModelResolver.ts
@@ -10,7 +10,6 @@
 
 import { createExecutor } from '@cherrystudio/ai-core';
 import type { AppProviderSettingsMap } from '@cherrystudio/ai-runtime/provider';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 
 import type {
   AiSdkModelResolution,
@@ -21,6 +20,7 @@ import type {
 import { resolveProviderAiSdkConfig } from '@/backend/ai/provider/config';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 export function createAiSdkModelResolver(): AiSdkRuntimeDependencies {
   return {

--- a/src/backend/ai/mcp/McpRuntimeService.ts
+++ b/src/backend/ai/mcp/McpRuntimeService.ts
@@ -4,8 +4,6 @@ import { resolveServersForAssistant } from '@cherrystudio/ai-runtime/tools';
 import type { McpCallToolResult } from '@cherrystudio/universal/ai/tools/mcpResult';
 import { mcpResultToTextSummary } from '@cherrystudio/universal/ai/tools/mcpResult';
 import { buildFunctionCallToolName } from '@cherrystudio/universal/ai/tools/mcpToolName';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import type { Tool, ToolSet } from 'ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
@@ -20,6 +18,8 @@ import type {
 } from '@/shared/contracts';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { DataApiError, ErrorCode } from '@/shared/data/api/errors';
+import type { Assistant } from '@/shared/data/types/assistant';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 const logger = loggerService.withContext('McpRuntimeService');
 

--- a/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -1,10 +1,10 @@
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import type { ToolSet } from 'ai';
 
 import { mcpServerService } from '@/backend/data/services/McpServerService';
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
+import type { Assistant } from '@/shared/data/types/assistant';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { McpRuntimeService } from '../McpRuntimeService';
 

--- a/src/backend/ai/messages/fileProcessor.ts
+++ b/src/backend/ai/messages/fileProcessor.ts
@@ -6,12 +6,12 @@
  * rewrites those with Node fs; mobile uses Expo FileSystem to produce data URLs.
  */
 
-import type { FileUIPart } from '@cherrystudio/universal/data/types/message';
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 import { File } from 'expo-file-system';
 
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { parseFileEntryUrl } from '@/shared/data/types/file';
+import type { FileUIPart } from '@/shared/data/types/message';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 import {
   imageMediaTypeFromExtension,
   isAiSupportedImageMediaType,

--- a/src/backend/ai/provider/__tests__/config.test.ts
+++ b/src/backend/ai/provider/__tests__/config.test.ts
@@ -1,8 +1,8 @@
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
-import type { AuthConfig, Provider } from '@cherrystudio/universal/data/types/provider';
 
 import type { ResolvedProviderApiKey } from '@/backend/data/services/ProviderService';
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import type { AuthConfig, Provider } from '@/shared/data/types/provider';
 
 import { providerToAiSdkConfig, resolveProviderAiSdkConfig } from '../config';
 

--- a/src/backend/ai/provider/__tests__/listModels.test.ts
+++ b/src/backend/ai/provider/__tests__/listModels.test.ts
@@ -1,5 +1,6 @@
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+
+import type { Provider } from '@/shared/data/types/provider';
 
 import { listModels } from '../listModels';
 

--- a/src/backend/ai/provider/config.ts
+++ b/src/backend/ai/provider/config.ts
@@ -33,13 +33,13 @@ import {
 } from '@cherrystudio/ai-runtime/provider';
 import type { CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider';
 import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import type { ServingCredentialReceipt } from '@cherrystudio/universal/data/types/aiUsageRecord';
-import type { EndpointType, Model } from '@cherrystudio/universal/data/types/model';
-import type { AuthConfig, Provider } from '@cherrystudio/universal/data/types/provider';
 
 import { generateSignature } from '@/backend/ai/provider/cherryai';
 import type { ResolvedProviderApiKey } from '@/backend/data/services/ProviderService';
 import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
+import type { ServingCredentialReceipt } from '@/shared/data/types/aiUsageRecord';
+import type { EndpointType, Model } from '@/shared/data/types/model';
+import type { AuthConfig, Provider } from '@/shared/data/types/provider';
 
 // Config dispatch reads the extension registry before Agent construction.
 registerProviderExtensions();

--- a/src/backend/ai/provider/listModels.ts
+++ b/src/backend/ai/provider/listModels.ts
@@ -2,10 +2,10 @@ import {
   listModels as listPortableModels,
   type ModelListContext as PortableModelListContext,
 } from '@cherrystudio/ai-runtime/provider';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 
 import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 export type ModelListContext = Omit<PortableModelListContext, 'appHeaders'>;
 

--- a/src/backend/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/backend/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -1,12 +1,12 @@
 import type { CallOverrides } from '@cherrystudio/ai-runtime/runtime';
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 
 import { providerRegistryService } from '@/backend/data/services/ProviderRegistryService';
+import type { Assistant } from '@/shared/data/types/assistant';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { buildAgentParams } from '../buildAgentParams';
 

--- a/src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -41,13 +41,6 @@ import {
   endpointImpliedCapability,
   MODEL_CAPABILITY,
 } from '@cherrystudio/provider-registry';
-import type { ServingCredentialReceipt } from '@cherrystudio/universal/data/types/aiUsageRecord';
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { isAnthropicModel, isFunctionCallingModel } from '@cherrystudio/universal/utils/model';
 import { type ToolCallRepairFunction, type ToolSet } from 'ai';
 import * as Crypto from 'expo-crypto';
@@ -58,6 +51,10 @@ import {
   providerRegistryService,
 } from '@/backend/data/services/ProviderRegistryService';
 import type { ProviderService } from '@/backend/data/services/ProviderService';
+import type { ServingCredentialReceipt } from '@/shared/data/types/aiUsageRecord';
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { resolveProviderAiSdkConfig } from '../../../provider/config';
 import type { ToolResolver } from '../../../tools';

--- a/src/backend/ai/streamManager/ChatRuntime.ts
+++ b/src/backend/ai/streamManager/ChatRuntime.ts
@@ -14,17 +14,6 @@ import type {
   TopicStatusSnapshotEntry,
   TopicStreamStatus,
 } from '@cherrystudio/universal/ai/transport';
-import type {
-  CherryMessagePart,
-  CherryUIMessage,
-  Message,
-  MessageData,
-  MessageRuntimeStatsInput,
-  MessageSnapshot,
-  ModelSnapshot,
-} from '@cherrystudio/universal/data/types/message';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import { isUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import {
   buildFirstUserMessageTitle,
   sanitizeConversationTitle,
@@ -72,6 +61,17 @@ import { NEW_TOPIC_SNAPSHOT_KEY } from '@/shared/contracts';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import type { PreferenceKeyType } from '@/shared/data/preference';
 import type { FileEntry } from '@/shared/data/types/file';
+import type {
+  CherryMessagePart,
+  CherryUIMessage,
+  Message,
+  MessageData,
+  MessageRuntimeStatsInput,
+  MessageSnapshot,
+  ModelSnapshot,
+} from '@/shared/data/types/message';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import { isUniqueModelId } from '@/shared/data/types/model';
 import type { Topic } from '@/shared/data/types/topic';
 
 import type { ChatRuntimeDependencies, ChatRuntimeServices } from './ChatRuntimeDependencies';

--- a/src/backend/ai/streamManager/ChatRuntimeDependencies.ts
+++ b/src/backend/ai/streamManager/ChatRuntimeDependencies.ts
@@ -1,14 +1,3 @@
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
-import type {
-  CherryMessagePart,
-  CherryUIMessage,
-  Message,
-  MessageData,
-  MessageRuntimeStatsInput,
-  MessageRuntimeTimingSink,
-} from '@cherrystudio/universal/data/types/message';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 import type { UIMessageChunk } from 'ai';
 
@@ -20,7 +9,18 @@ import type {
 } from '@/shared/data/api/schemas/messages';
 import type { BranchMessagesResponse } from '@/shared/data/api/schemas/messages';
 import type { CreateTopicDto, UpdateTopicDto } from '@/shared/data/api/schemas/topics';
+import type { Assistant } from '@/shared/data/types/assistant';
 import type { FileEntry } from '@/shared/data/types/file';
+import type {
+  CherryMessagePart,
+  CherryUIMessage,
+  Message,
+  MessageData,
+  MessageRuntimeStatsInput,
+  MessageRuntimeTimingSink,
+} from '@/shared/data/types/message';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 import type { Topic } from '@/shared/data/types/topic';
 
 export type ChatStreamRequest = {

--- a/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
+++ b/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
@@ -1,14 +1,4 @@
 import type { ComposerQueuedMessagePayload } from '@cherrystudio/universal/ai/transport';
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
-import type {
-  CherryMessagePart,
-  CherryUIMessage,
-  Message,
-} from '@cherrystudio/universal/data/types/message';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import type { UIMessageChunk } from 'ai';
 
 import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
@@ -20,7 +10,10 @@ import type {
 } from '@/backend/services/backgroundReply';
 import { NEW_TOPIC_SNAPSHOT_KEY } from '@/shared/contracts';
 import { loggerService } from '@/shared/core/logger/LoggerService';
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 import { type FileEntry, FileEntrySchema } from '@/shared/data/types/file';
+import type { CherryMessagePart, CherryUIMessage, Message } from '@/shared/data/types/message';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 import { ChatRuntime, type ChatRuntimeConfig } from '../ChatRuntime';
 import type { ChatRuntimeServices, ChatStreamRequest } from '../ChatRuntimeDependencies';

--- a/src/backend/ai/streamManager/__tests__/topicNaming.test.ts
+++ b/src/backend/ai/streamManager/__tests__/topicNaming.test.ts
@@ -1,7 +1,6 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@/shared/data/presets/cherryai';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 import {
   extractMainText,

--- a/src/backend/ai/streamManager/topicNaming.ts
+++ b/src/backend/ai/streamManager/topicNaming.ts
@@ -8,8 +8,6 @@
  * variant that has no mobile equivalent).
  */
 
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { isUniqueModelId, parseUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import {
   buildFirstUserMessageTitle,
   normalizeConversationTitle,
@@ -18,6 +16,8 @@ import {
 
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@/shared/data/presets/cherryai';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { isUniqueModelId, parseUniqueModelId } from '@/shared/data/types/model';
 
 import type { ChatRuntimeServices } from './ChatRuntimeDependencies';
 

--- a/src/backend/ai/tools/ToolResolver.ts
+++ b/src/backend/ai/tools/ToolResolver.ts
@@ -1,5 +1,4 @@
 import { applyDeferExposition, ToolRegistry } from '@cherrystudio/ai-runtime/tools';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import type { ToolSet } from 'ai';
 import { Platform } from 'react-native';
 
@@ -8,6 +7,7 @@ import type { DevicePermissions } from '@/backend/services/permissions';
 import type { WebSearchService } from '@/backend/services/webSearch/WebSearchService';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import type { PermissionPreferenceKey } from '@/shared/data/preference';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 import type { McpRuntimeService } from '../mcp';
 import { registerBuiltinTools } from './adapters/aiSdk/builtin/registerBuiltinTools';

--- a/src/backend/ai/tools/__tests__/ToolResolver.test.ts
+++ b/src/backend/ai/tools/__tests__/ToolResolver.test.ts
@@ -1,9 +1,7 @@
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
 import { tool } from 'ai';
 import * as z from 'zod';
+
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 
 import { ToolResolver } from '../ToolResolver';
 import type { ToolEntry } from '../types';

--- a/src/backend/ai/tools/types.ts
+++ b/src/backend/ai/tools/types.ts
@@ -1,9 +1,9 @@
 import type { ToolEntry as RuntimeToolEntry } from '@cherrystudio/ai-runtime/tools';
 import type { RequestContext as RuntimeRequestContext } from '@cherrystudio/ai-runtime/tools';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 
 import type { SystemPermissionState } from '@/backend/services/permissions';
 import type { PermissionPreferenceKey } from '@/shared/data/preference';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 export type { ToolDefer } from '@cherrystudio/ai-runtime/tools';
 

--- a/src/backend/ai/utils/__tests__/reasoningCatalog.test.ts
+++ b/src/backend/ai/utils/__tests__/reasoningCatalog.test.ts
@@ -10,7 +10,6 @@ import {
   type ReasoningWireProfile,
 } from '@cherrystudio/provider-registry';
 import { MobileRegistryLoader } from '@cherrystudio/provider-registry/mobile';
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 
 import {
@@ -18,6 +17,7 @@ import {
   providerRegistryService,
   resolveReasoningProfileFromRegistry,
 } from '@/backend/data/services/ProviderRegistryService';
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 
 type WireLeaf = string | number | boolean;
 type FlatWire = Record<string, WireLeaf>;

--- a/src/backend/data/api/handlers/mcpServers.ts
+++ b/src/backend/data/api/handlers/mcpServers.ts
@@ -1,5 +1,3 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
-
 import type { McpServerService } from '@/backend/data/services/McpServerService';
 import type {
   CreateMcpServerDto,
@@ -8,6 +6,7 @@ import type {
   UpdateMcpServerDto,
 } from '@/shared/data/api/schemas/mcpServers';
 import type { HandlersFor } from '@/shared/data/api/types';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 export type McpServerMutations = {
   createServer(input: CreateMcpServerDto): Promise<McpServer>;

--- a/src/backend/data/api/handlers/models.ts
+++ b/src/backend/data/api/handlers/models.ts
@@ -1,5 +1,3 @@
-import { isUniqueModelId, parseUniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import type { ModelService } from '@/backend/data/services/ModelService';
 import { providerRegistryService } from '@/backend/data/services/ProviderRegistryService';
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
@@ -14,6 +12,7 @@ import {
   UpdateModelSchema,
 } from '@/shared/data/api/schemas/models';
 import type { HandlersFor } from '@/shared/data/api/types';
+import { isUniqueModelId, parseUniqueModelId } from '@/shared/data/types/model';
 
 function parseUniqueId(uniqueModelId: string) {
   if (!isUniqueModelId(uniqueModelId)) {

--- a/src/backend/data/db/schemas/aiUsageRecord.ts
+++ b/src/backend/data/db/schemas/aiUsageRecord.ts
@@ -1,3 +1,14 @@
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
+
 import {
   type AiUsageCostBreakdown,
   type AiUsagePricingSnapshot,
@@ -15,18 +26,8 @@ import {
   AiUsageRecordModalitySchema,
   type AiUsageRecordSourceType,
   AiUsageRecordSourceTypeSchema,
-} from '@cherrystudio/universal/data/types/aiUsageRecord';
-import { CURRENCY, type Currency, objectValues } from '@cherrystudio/universal/data/types/model';
-import { sql } from 'drizzle-orm';
-import {
-  check,
-  index,
-  integer,
-  real,
-  sqliteTable,
-  text,
-  uniqueIndex,
-} from 'drizzle-orm/sqlite-core';
+} from '@/shared/data/types/aiUsageRecord';
+import { CURRENCY, type Currency, objectValues } from '@/shared/data/types/model';
 
 import { uuidPrimaryKeyOrdered } from './_columnHelpers';
 

--- a/src/backend/data/db/schemas/assistant.ts
+++ b/src/backend/data/db/schemas/assistant.ts
@@ -1,5 +1,6 @@
-import type { AssistantSettings } from '@cherrystudio/universal/data/types/assistant';
 import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import type { AssistantSettings } from '@/shared/data/types/assistant';
 
 import {
   createUpdateDeleteTimestamps,

--- a/src/backend/data/db/schemas/message.ts
+++ b/src/backend/data/db/schemas/message.ts
@@ -1,8 +1,3 @@
-import type {
-  MessageData,
-  MessageSnapshot,
-  MessageStats,
-} from '@cherrystudio/universal/data/types/message';
 import { sql } from 'drizzle-orm';
 import {
   check,
@@ -13,6 +8,8 @@ import {
   text,
   uniqueIndex,
 } from 'drizzle-orm/sqlite-core';
+
+import type { MessageData, MessageSnapshot, MessageStats } from '@/shared/data/types/message';
 
 import { createUpdateDeleteTimestamps, uuidPrimaryKeyOrdered } from './_columnHelpers';
 import { topicTable } from './topic';

--- a/src/backend/data/db/schemas/userModel.ts
+++ b/src/backend/data/db/schemas/userModel.ts
@@ -1,3 +1,6 @@
+import { sql } from 'drizzle-orm';
+import { check, index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
 /**
  * User Model table schema
  *
@@ -9,7 +12,7 @@
  * - Single PK: id = "providerId::modelId" (deterministic UniqueModelId)
  * - providerId FK → user_provider (ON DELETE CASCADE)
  *
- * Type definitions are sourced from @cherrystudio/universal/data/types/model
+ * Type definitions are sourced from @/shared/data/types/model
  */
 import type {
   EndpointType,
@@ -18,9 +21,7 @@ import type {
   ParameterSupport,
   ReasoningConfig,
   RuntimeModelPricing,
-} from '@cherrystudio/universal/data/types/model';
-import { sql } from 'drizzle-orm';
-import { check, index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+} from '@/shared/data/types/model';
 
 import { createUpdateTimestamps, orderKeyColumns, scopedOrderKeyIndex } from './_columnHelpers';
 import { userProviderTable } from './userProvider';

--- a/src/backend/data/db/schemas/userProvider.ts
+++ b/src/backend/data/db/schemas/userProvider.ts
@@ -10,15 +10,16 @@
  *
  */
 
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import type { EndpointType } from '@/shared/data/types/model';
 import type {
   ApiFeatures,
   ApiKeyEntry,
   AuthConfig,
   EndpointConfigOverride,
   ProviderSettings,
-} from '@cherrystudio/universal/data/types/provider';
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+} from '@/shared/data/types/provider';
 
 import { createUpdateTimestamps, orderKeyColumns, orderKeyIndex } from './_columnHelpers';
 

--- a/src/backend/data/db/seeding/seeders/CherryAiDefaultModelSeeder.ts
+++ b/src/backend/data/db/seeding/seeders/CherryAiDefaultModelSeeder.ts
@@ -1,5 +1,4 @@
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import type { ModelCapability } from '@cherrystudio/universal/data/types/model';
 import { loggerService } from '@logger';
 import { eq } from 'drizzle-orm';
 
@@ -20,6 +19,7 @@ import {
   CHERRYAI_PROVIDER_ID,
   CHERRYAI_PROVIDER_NAME,
 } from '@/shared/data/presets/cherryai';
+import type { ModelCapability } from '@/shared/data/types/model';
 
 import { hashObject } from '../hashObject';
 import type { DatabaseSeeder } from '../types';

--- a/src/backend/data/db/seeding/seeders/PresetProviderSeeder.ts
+++ b/src/backend/data/db/seeding/seeders/PresetProviderSeeder.ts
@@ -1,9 +1,9 @@
 import type { ProtoProviderConfig } from '@cherrystudio/provider-registry';
 import { buildRuntimeEndpointConfigs, ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import type { ApiFeatures, AuthConfig } from '@cherrystudio/universal/data/types/provider';
 
 import { providerRegistryService } from '@/backend/data/services/ProviderRegistryService';
 import { type CreateProviderInput, providerService } from '@/backend/data/services/ProviderService';
+import type { ApiFeatures, AuthConfig } from '@/shared/data/types/provider';
 
 import type { DatabaseSeeder } from '../types';
 

--- a/src/backend/data/db/seeding/seeders/__tests__/DefaultAssistantSeeder.test.ts
+++ b/src/backend/data/db/seeding/seeders/__tests__/DefaultAssistantSeeder.test.ts
@@ -1,10 +1,10 @@
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
 import { getLocales } from 'expo-localization';
 
 import type { DbService } from '@/backend/data/db/DbService';
 import { createRootMessageTx } from '@/backend/data/services/MessageService';
 import { insertWithOrderKey } from '@/backend/data/services/utils/orderKey';
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@/shared/data/presets/cherryai';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 
 import { DefaultAssistantSeeder } from '../DefaultAssistantSeeder';
 

--- a/src/backend/data/fixtures/chat.ts
+++ b/src/backend/data/fixtures/chat.ts
@@ -1,8 +1,8 @@
 import type { ModelCapability } from '@cherrystudio/provider-registry';
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
-import { type CherryMessagePart, type Message } from '@cherrystudio/universal/data/types/message';
 import { generateNKeysBetween } from 'fractional-indexing';
 
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import { type CherryMessagePart, type Message } from '@/shared/data/types/message';
 import type { Topic } from '@/shared/data/types/topic';
 
 const baseDateMs = Date.parse('2026-05-15T00:00:00.000Z');

--- a/src/backend/data/fixtures/layoutBench.ts
+++ b/src/backend/data/fixtures/layoutBench.ts
@@ -11,9 +11,9 @@
 
 import type { ModelCapability } from '@cherrystudio/provider-registry';
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
 
 import type { CreateProviderInput } from '@/backend/data/services/ProviderService';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 import { LAYOUT_BENCH_ASSISTANT_ID } from '@/shared/devBench/layoutBenchProbe';
 
 /** provider 行 id；`buildOpenAICompatibleConfig` 会把它原样写进 `providerSettings.name`。 */

--- a/src/backend/data/services/AiUsageRecordService.ts
+++ b/src/backend/data/services/AiUsageRecordService.ts
@@ -1,16 +1,3 @@
-import type {
-  AiUsageCostBreakdown,
-  AiUsagePricingSnapshot,
-  AiUsageRecordAttribution,
-  AiUsageRecordEntry,
-  AiUsageRecordMessageKind,
-  AiUsageRecordModality,
-  AiUsageRecordSourceType,
-  ServingCredentialReceipt,
-} from '@cherrystudio/universal/data/types/aiUsageRecord';
-import { getAiUsageRecordTotalTokens } from '@cherrystudio/universal/data/types/aiUsageRecord';
-import type { MessageStats } from '@cherrystudio/universal/data/types/message';
-import type { Currency } from '@cherrystudio/universal/data/types/model';
 import { loggerService } from '@logger';
 import {
   and,
@@ -60,6 +47,19 @@ import {
   AiUsageRecordStatsQuerySchema,
   AiUsageRecordTimelineQuerySchema,
 } from '@/shared/data/api/schemas/aiUsageRecords';
+import type {
+  AiUsageCostBreakdown,
+  AiUsagePricingSnapshot,
+  AiUsageRecordAttribution,
+  AiUsageRecordEntry,
+  AiUsageRecordMessageKind,
+  AiUsageRecordModality,
+  AiUsageRecordSourceType,
+  ServingCredentialReceipt,
+} from '@/shared/data/types/aiUsageRecord';
+import { getAiUsageRecordTotalTokens } from '@/shared/data/types/aiUsageRecord';
+import type { MessageStats } from '@/shared/data/types/message';
+import type { Currency } from '@/shared/data/types/model';
 
 import { timestampToISO } from './utils/rowMappers';
 

--- a/src/backend/data/services/AssistantService.ts
+++ b/src/backend/data/services/AssistantService.ts
@@ -1,8 +1,3 @@
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { and, asc, desc, eq, gte, inArray, isNull, or, type SQL, sql } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
@@ -23,6 +18,8 @@ import {
 } from '@/shared/data/api/schemas/assistants';
 import type { OrderRequest } from '@/shared/data/api/schemas/endpointHelpers';
 import type { OffsetPaginationResponse } from '@/shared/data/api/types';
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 import { modelService } from './ModelService';
 import { topicService } from './TopicService';

--- a/src/backend/data/services/ContentSearchService.ts
+++ b/src/backend/data/services/ContentSearchService.ts
@@ -1,7 +1,3 @@
-import {
-  coerceSearchRole,
-  TOPIC_MESSAGE_SEARCH_ROLES,
-} from '@cherrystudio/universal/data/types/message';
 import { loggerService } from '@logger';
 import { sql } from 'drizzle-orm';
 
@@ -14,6 +10,7 @@ import {
   type ContentSearchResponse,
   type TopicMessageContentSearchItem,
 } from '@/shared/data/api/schemas/search';
+import { coerceSearchRole, TOPIC_MESSAGE_SEARCH_ROLES } from '@/shared/data/types/message';
 
 import { type SearchFetchContext, searchWithCursor } from './utils/ftsSearch';
 import { timestampToISO } from './utils/rowMappers';

--- a/src/backend/data/services/McpServerService.ts
+++ b/src/backend/data/services/McpServerService.ts
@@ -6,7 +6,6 @@
  * there is no transport to branch on and no projection to normalize.
  */
 
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { and, asc, eq, ne, type SQL, sql } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
@@ -21,6 +20,7 @@ import {
   UpdateMcpServerSchema,
 } from '@/shared/data/api/schemas/mcpServers';
 import type { OffsetPaginationResponse } from '@/shared/data/api/types';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { timestampToISO } from './utils/rowMappers';
 

--- a/src/backend/data/services/MessageService.ts
+++ b/src/backend/data/services/MessageService.ts
@@ -4,14 +4,6 @@ import {
   countPendingToolApprovals,
   finalizeDanglingToolApprovals,
 } from '@cherrystudio/universal/ai/transport/toolApprovals';
-import type {
-  CherryMessagePart,
-  Message,
-  MessageData,
-  MessageRuntimeStatsInput,
-  MessageStats,
-} from '@cherrystudio/universal/data/types/message';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { isToolUIPart } from 'ai';
 import { and, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 
@@ -30,6 +22,14 @@ import type {
   TreeResponse,
   UpdateMessageDto,
 } from '@/shared/data/api/schemas/messages';
+import type {
+  CherryMessagePart,
+  Message,
+  MessageData,
+  MessageRuntimeStatsInput,
+  MessageStats,
+} from '@/shared/data/types/message';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 import { type MessageRow, messageTable, topicTable } from '../db/schemas';
 import { createOrderedUuid } from '../db/schemas/_columnHelpers';

--- a/src/backend/data/services/ModelService.ts
+++ b/src/backend/data/services/ModelService.ts
@@ -1,10 +1,3 @@
-import {
-  createUniqueModelId,
-  type EndpointType,
-  type Model,
-  parseUniqueModelId,
-  type UniqueModelId,
-} from '@cherrystudio/universal/data/types/model';
 import { and, asc, eq, inArray, type SQL } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
@@ -21,6 +14,13 @@ import {
   CHERRYAI_PROVIDER_ID,
   isManagedCherryAiDefaultModel,
 } from '@/shared/data/presets/cherryai';
+import {
+  createUniqueModelId,
+  type EndpointType,
+  type Model,
+  parseUniqueModelId,
+  type UniqueModelId,
+} from '@/shared/data/types/model';
 import { deepEqual } from '@/shared/utils/deepEqual';
 
 import {

--- a/src/backend/data/services/PaintingService.ts
+++ b/src/backend/data/services/PaintingService.ts
@@ -1,4 +1,3 @@
-import { createUniqueModelId, isUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { and, asc, eq, gt, inArray, or } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
@@ -7,6 +6,7 @@ import { fileEntryTable, type PaintingRow, paintingTable } from '@/backend/data/
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
 import type { CursorPaginationResponse } from '@/shared/data/api/types';
 import type { FileEntryId } from '@/shared/data/types/file';
+import { createUniqueModelId, isUniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import { computeNewOrderKey, insertWithOrderKey } from './utils/orderKey';

--- a/src/backend/data/services/ProviderRegistryService.ts
+++ b/src/backend/data/services/ProviderRegistryService.ts
@@ -25,13 +25,14 @@ import {
   getMobileRegistryLoader,
   type MobileRegistryLoader,
 } from '@cherrystudio/provider-registry/mobile';
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 import type {
   ApiFeatures,
   ProviderAuthMethod,
   ProviderModelListSource,
   ProviderWebsites,
-} from '@cherrystudio/universal/data/types/provider';
+} from '@/shared/data/types/provider';
 
 const chatReasoningEndpointPriority: EndpointType[] = [
   ENDPOINT_TYPE.OPENAI_RESPONSES,

--- a/src/backend/data/services/ProviderService.ts
+++ b/src/backend/data/services/ProviderService.ts
@@ -1,19 +1,4 @@
 import { inferAdapterFamily } from '@cherrystudio/provider-registry';
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
-import type {
-  ApiKeyEntry,
-  AuthConfig,
-  AuthType,
-  EndpointConfig,
-  EndpointConfigs,
-  Provider,
-  ProviderSettings,
-  RuntimeApiFeatures,
-} from '@cherrystudio/universal/data/types/provider';
-import {
-  DEFAULT_API_FEATURES as DEFAULT_FEATURES,
-  DEFAULT_PROVIDER_SETTINGS,
-} from '@cherrystudio/universal/data/types/provider';
 import { asc, eq, inArray } from 'drizzle-orm';
 import * as Crypto from 'expo-crypto';
 
@@ -24,6 +9,21 @@ import type {
 } from '@/backend/data/db/schemas/userProvider';
 import { userProviderTable } from '@/backend/data/db/schemas/userProvider';
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
+import type { EndpointType } from '@/shared/data/types/model';
+import type {
+  ApiKeyEntry,
+  AuthConfig,
+  AuthType,
+  EndpointConfig,
+  EndpointConfigs,
+  Provider,
+  ProviderSettings,
+  RuntimeApiFeatures,
+} from '@/shared/data/types/provider';
+import {
+  DEFAULT_API_FEATURES as DEFAULT_FEATURES,
+  DEFAULT_PROVIDER_SETTINGS,
+} from '@/shared/data/types/provider';
 
 import { providerRegistryService } from './ProviderRegistryService';
 import { insertManyWithOrderKey, insertWithOrderKey } from './utils/orderKey';

--- a/src/backend/data/services/TopicService.ts
+++ b/src/backend/data/services/TopicService.ts
@@ -1,4 +1,3 @@
-import type { MessageStats } from '@cherrystudio/universal/data/types/message';
 import { and, asc, desc, eq, inArray, isNull, type SQL, sql } from 'drizzle-orm';
 import * as Crypto from 'expo-crypto';
 
@@ -15,6 +14,7 @@ import type {
   UpdateTopicDto,
 } from '@/shared/data/api/schemas/topics';
 import type { CursorPaginationResponse } from '@/shared/data/api/types';
+import type { MessageStats } from '@/shared/data/types/message';
 import type { Topic } from '@/shared/data/types/topic';
 
 import {

--- a/src/backend/data/services/__tests__/AssistantService.test.ts
+++ b/src/backend/data/services/__tests__/AssistantService.test.ts
@@ -1,8 +1,7 @@
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
-
 import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
 import type { DbService } from '@/backend/data/db/DbService';
 import type { AssistantRow } from '@/backend/data/db/schemas';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 
 import type { PreferenceService } from '../../PreferenceService';
 import { assistantService } from '../AssistantService';

--- a/src/backend/data/services/__tests__/MessageService.integration.test.ts
+++ b/src/backend/data/services/__tests__/MessageService.integration.test.ts
@@ -2,12 +2,12 @@ import { randomUUID as mockRandomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { DatabaseSync } from 'node:sqlite';
 
-import type { CherryMessagePart, Message } from '@cherrystudio/universal/data/types/message';
 import { drizzle } from 'drizzle-orm/sqlite-proxy';
 
 import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
 import type { Database, DbService } from '@/backend/data/db/DbService';
 import { schema } from '@/backend/data/db/schemas';
+import type { CherryMessagePart, Message } from '@/shared/data/types/message';
 
 import { AiUsageRecordService } from '../AiUsageRecordService';
 import { messageService } from '../MessageService';

--- a/src/backend/data/services/__tests__/MessageService.test.ts
+++ b/src/backend/data/services/__tests__/MessageService.test.ts
@@ -1,8 +1,7 @@
-import type { Message, MessageData } from '@cherrystudio/universal/data/types/message';
-
 import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
 import type { DbService } from '@/backend/data/db/DbService';
 import { messageTable } from '@/backend/data/db/schemas';
+import type { Message, MessageData } from '@/shared/data/types/message';
 
 import { registerDataService } from '../dataServiceRegistry';
 import { messageService } from '../MessageService';

--- a/src/backend/data/services/__tests__/ModelService.test.ts
+++ b/src/backend/data/services/__tests__/ModelService.test.ts
@@ -1,8 +1,7 @@
-import { REASONING_EFFORT } from '@cherrystudio/universal/data/types/model';
-
 import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
 import type { DbService } from '@/backend/data/db/DbService';
 import { userModelTable } from '@/backend/data/db/schemas/userModel';
+import { REASONING_EFFORT } from '@/shared/data/types/model';
 
 import type { PreferenceService } from '../../PreferenceService';
 import { ModelService } from '../ModelService';

--- a/src/backend/data/services/__tests__/ProviderService.test.ts
+++ b/src/backend/data/services/__tests__/ProviderService.test.ts
@@ -1,9 +1,8 @@
-import type { ApiKeyEntry, ProviderSettings } from '@cherrystudio/universal/data/types/provider';
-
 import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
 import { CacheService, createInMemoryBackendCacheStorage } from '@/backend/data/CacheService';
 import type { DbService } from '@/backend/data/db/DbService';
 import type { UserProviderRow } from '@/backend/data/db/schemas/userProvider';
+import type { ApiKeyEntry, ProviderSettings } from '@/shared/data/types/provider';
 
 import { providerRegistryService } from '../ProviderRegistryService';
 import { canDeleteProvider, ProviderService } from '../ProviderService';

--- a/src/backend/data/services/__tests__/materializeRemoteModels.test.ts
+++ b/src/backend/data/services/__tests__/materializeRemoteModels.test.ts
@@ -1,12 +1,12 @@
 import { MODEL_CAPABILITY, REASONING_FORMAT_PROFILES } from '@cherrystudio/provider-registry';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 
 import { materializeRemoteModels } from '@/backend/data/services/materializeRemoteModels';
 import {
   mergePresetModel,
   providerRegistryService,
 } from '@/backend/data/services/ProviderRegistryService';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 jest.mock('@/backend/data/services/ProviderRegistryService', () => ({
   mergePresetModel: jest.fn(),

--- a/src/backend/data/services/materializeRemoteModels.ts
+++ b/src/backend/data/services/materializeRemoteModels.ts
@@ -1,14 +1,9 @@
 import {
-  createUniqueModelId,
-  type Model,
-  type UniqueModelId,
-} from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
-
-import {
   mergePresetModel,
   providerRegistryService,
 } from '@/backend/data/services/ProviderRegistryService';
+import { createUniqueModelId, type Model, type UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 export function materializeRemoteModels(
   provider: Provider,

--- a/src/backend/data/services/utils/messageStats.ts
+++ b/src/backend/data/services/utils/messageStats.ts
@@ -3,7 +3,7 @@ import type {
   MessageRuntimeStatsInput,
   MessageRuntimeTiming,
   MessageStats,
-} from '@cherrystudio/universal/data/types/message';
+} from '@/shared/data/types/message';
 
 function mergeRuntimeSpan(
   existing: MessageRuntimeSpan,

--- a/src/backend/services/backgroundReply/__tests__/deriveBackgroundReplyContent.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/deriveBackgroundReplyContent.test.ts
@@ -1,7 +1,4 @@
-import type {
-  CherryMessagePart,
-  CherryUIMessage,
-} from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart, CherryUIMessage } from '@/shared/data/types/message';
 
 import {
   deriveBackgroundReplyContent,

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -1,6 +1,5 @@
-import type { CherryUIMessage } from '@cherrystudio/universal/data/types/message';
-
 import type { BackgroundReplyPhase } from '@/shared/backgroundActivity/chatReply';
+import type { CherryUIMessage } from '@/shared/data/types/message';
 
 // The feature contract lives in shared so the service and activity
 // registration agree on props; these re-exports keep the service-local import

--- a/src/backend/services/backgroundReply/deriveBackgroundReplyContent.ts
+++ b/src/backend/services/backgroundReply/deriveBackgroundReplyContent.ts
@@ -1,12 +1,8 @@
 import type {
-  CherryMessagePart,
-  CherryUIMessage,
-} from '@cherrystudio/universal/data/types/message';
-
-import type {
   BackgroundReplyContent,
   BackgroundReplyPhase,
 } from '@/shared/backgroundActivity/chatReply';
+import type { CherryMessagePart, CherryUIMessage } from '@/shared/data/types/message';
 
 import type { BackgroundReplyOutcome } from './backgroundReplyTypes';
 

--- a/src/backend/services/file/__tests__/fileStorage.test.ts
+++ b/src/backend/services/file/__tests__/fileStorage.test.ts
@@ -1,8 +1,7 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
-
 import type { FileEntryService } from '@/backend/data/services/FileEntryService';
 import { type FileEntry, FileEntrySchema, fileEntryUrl } from '@/shared/data/types/file';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 
 import {
   createInternalEntry,

--- a/src/backend/services/file/fileStorage.ts
+++ b/src/backend/services/file/fileStorage.ts
@@ -1,5 +1,3 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { readCherryMeta, withCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 import { Directory, File, Paths } from 'expo-file-system';
 
 import { createOrderedUuid } from '@/backend/data/db/schemas/_columnHelpers';
@@ -17,6 +15,8 @@ import {
   SafeExtSchema,
   SafeNameSchema,
 } from '@/shared/data/types/file';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { readCherryMeta, withCherryMeta } from '@/shared/data/types/uiParts';
 import { generatedImageExtension } from '@/shared/utils/imageFileTypes';
 
 const DATA_DIRECTORY_NAME = 'Data';

--- a/src/backend/services/mcp/__tests__/createMcpModule.test.ts
+++ b/src/backend/services/mcp/__tests__/createMcpModule.test.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { createMcpModule, type McpModuleDependencies } from '../createMcpModule';
 

--- a/src/backend/services/mcp/createMcpModule.ts
+++ b/src/backend/services/mcp/createMcpModule.ts
@@ -1,5 +1,3 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
-
 import type { McpServerMutations } from '@/backend/data/api/handlers/mcpServers';
 import type {
   McpModule,
@@ -13,6 +11,7 @@ import type {
   McpUpdateServerResult,
   UpdateMcpServerDto,
 } from '@/shared/data/api/schemas/mcpServers';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 type McpServerData = {
   create(input: CreateMcpServerDto): Promise<McpServer>;

--- a/src/backend/services/models/__tests__/createModelsModule.test.ts
+++ b/src/backend/services/models/__tests__/createModelsModule.test.ts
@@ -1,12 +1,7 @@
-import {
-  createUniqueModelId,
-  type Model,
-  type UniqueModelId,
-} from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
-
 import type { ModelsModule } from '@/shared/contracts';
 import { ModelPullTimeoutError } from '@/shared/contracts';
+import { createUniqueModelId, type Model, type UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { createModelsModule, type ModelsModuleDependencies } from '../createModelsModule';
 

--- a/src/backend/services/models/createModelsModule.ts
+++ b/src/backend/services/models/createModelsModule.ts
@@ -1,6 +1,3 @@
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
-
 import type {
   CheckModelsHealthInput,
   ModelHealthResult,
@@ -12,6 +9,8 @@ import type {
 import { ModelPullTimeoutError } from '@/shared/contracts';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import type { AddModelInput, ModelListQuery } from '@/shared/data/api/schemas/models';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 const defaultPullTimeoutMs = 10_000;
 const defaultHealthTimeoutMs = 15_000;

--- a/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
+++ b/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
@@ -1,8 +1,7 @@
-import { createUniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import type { Database } from '@/backend/data/db/DbService';
 import type { PaintingsModule } from '@/shared/contracts';
 import { type FileEntry, type FileEntryId, FileEntrySchema } from '@/shared/data/types/file';
+import { createUniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import { createPaintingsModule, type PaintingsModuleDependencies } from '../createPaintingsModule';

--- a/src/backend/services/paintings/createPaintingsModule.ts
+++ b/src/backend/services/paintings/createPaintingsModule.ts
@@ -1,5 +1,3 @@
-import { parseUniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import type { Database } from '@/backend/data/db/DbService';
 import type {
   PaintingGenerationInput,
@@ -9,6 +7,7 @@ import type {
   ResolvedPaintingFiles,
 } from '@/shared/contracts';
 import type { FileEntry, FileEntryId } from '@/shared/data/types/file';
+import { parseUniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import type {

--- a/src/backend/services/paintings/tasks/__tests__/paintingGenerateJobHandler.test.ts
+++ b/src/backend/services/paintings/tasks/__tests__/paintingGenerateJobHandler.test.ts
@@ -1,7 +1,6 @@
 import { randomUUID as mockRandomUUID } from 'node:crypto';
 import { DatabaseSync } from 'node:sqlite';
 
-import { createUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { loggerService } from '@logger';
 
 import { uninstallTestHost } from '@/backend/core/application/testHost';
@@ -9,6 +8,7 @@ import { createTestRuntime, type TestRuntime } from '@/backend/services/jobs/__t
 import { jobHandlerEntry } from '@/backend/services/jobs/JobHandlerRegistry';
 import type { JobContext } from '@/backend/services/jobs/types';
 import { type FileEntry, type FileEntryId, FileEntrySchema } from '@/shared/data/types/file';
+import { createUniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import {

--- a/src/backend/services/paintings/tasks/paintingGenerateJobHandler.ts
+++ b/src/backend/services/paintings/tasks/paintingGenerateJobHandler.ts
@@ -1,6 +1,5 @@
 import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
 import type { BackgroundActivityIcon } from '@cherrystudio/ui/background-activity';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { loggerService } from '@logger';
 
 import type {
@@ -14,6 +13,7 @@ import type {
 } from '@/shared/backgroundActivity/painting';
 import type { PaintingGenerationResult } from '@/shared/contracts';
 import type { FileEntry, FileEntryId } from '@/shared/data/types/file';
+import type { UniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import type { CreateInternalEntryInput } from '../../file/fileStorage';

--- a/src/backend/services/providers/createProvidersModule.ts
+++ b/src/backend/services/providers/createProvidersModule.ts
@@ -1,6 +1,5 @@
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
-
 import type { ProvidersModule } from '@/shared/contracts';
+import type { Provider } from '@/shared/data/types/provider';
 
 type ProviderAvatarStorage = {
   persist(providerId: string, sourceUri: string): Promise<string>;

--- a/src/bootstrap/composition/createBackend.ts
+++ b/src/bootstrap/composition/createBackend.ts
@@ -1,5 +1,3 @@
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import type { McpServerMutations } from '@/backend/data/api/handlers/mcpServers';
 import type { DbService } from '@/backend/data/db/DbService';
 import { materializeRemoteModels } from '@/backend/data/services/materializeRemoteModels';
@@ -23,6 +21,7 @@ import {
 } from '@/backend/services/providers/providerAvatarStorage';
 import type { BackendServices } from '@/bootstrap/composition/createBackendServices';
 import type { Backend } from '@/shared/contracts';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 export type BackendComposition = {
   backend: Backend;

--- a/src/frontend/components/avatar/components/ModelAvatar.tsx
+++ b/src/frontend/components/avatar/components/ModelAvatar.tsx
@@ -1,7 +1,8 @@
 import { resolveIcon } from '@cherrystudio/ui/icons';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { useUniwind } from 'uniwind';
+
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { BrandAvatar, BrandAvatarIcon } from './BrandAvatar';
 

--- a/src/frontend/components/composer/utils/__tests__/composerAttachments.test.ts
+++ b/src/frontend/components/composer/utils/__tests__/composerAttachments.test.ts
@@ -1,4 +1,4 @@
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 
 import {
   appendComposerAttachments,

--- a/src/frontend/components/composer/utils/composerAttachments.ts
+++ b/src/frontend/components/composer/utils/composerAttachments.ts
@@ -1,8 +1,8 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { withCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 import type { DocumentPickerAsset } from 'expo-document-picker';
 
 import { type FileEntryId, fileEntryUrl } from '@/shared/data/types/file';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { withCherryMeta } from '@/shared/data/types/uiParts';
 import {
   imageMediaTypeFromExtension,
   isAiSupportedImageMediaType,

--- a/src/frontend/components/headers/MainHeader/MainHeaderAssistantButton.tsx
+++ b/src/frontend/components/headers/MainHeader/MainHeaderAssistantButton.tsx
@@ -1,9 +1,9 @@
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback } from 'react';
 import { Pressable, Text } from 'react-native';
 
 import { useAssistantApiById, useTopic } from '@/frontend/hooks/chat';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 export function useMainHeaderAssistant() {
   const router = useRouter();

--- a/src/frontend/components/headers/MainHeader/__tests__/MainHeaderAssistantButton.test.tsx
+++ b/src/frontend/components/headers/MainHeader/__tests__/MainHeaderAssistantButton.test.tsx
@@ -1,9 +1,7 @@
-import {
-  type Assistant,
-  DEFAULT_ASSISTANT_SETTINGS,
-} from '@cherrystudio/universal/data/types/assistant';
 import { Pressable } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 
 import { MainHeaderAssistantButton, useMainHeaderAssistant } from '../MainHeaderAssistantButton';
 

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -1,9 +1,10 @@
-import type { Message } from '@cherrystudio/universal/data/types/message';
 import type { LegendListRef } from '@legendapp/list/react-native';
 import type { ReactNode, Ref } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { Message } from '@/shared/data/types/message';
 
 import { MessageList } from '../../MessageList';
 import type { MessageSlideInFlight } from '../../motion/useMessageSlideInFlight';

--- a/src/frontend/components/messages/parts/CodePart.tsx
+++ b/src/frontend/components/messages/parts/CodePart.tsx
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { PartMarkdown } from './PartMarkdown';
 

--- a/src/frontend/components/messages/parts/CompactPart.tsx
+++ b/src/frontend/components/messages/parts/CompactPart.tsx
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { PartMarkdown } from './PartMarkdown';
 

--- a/src/frontend/components/messages/parts/ErrorPart.tsx
+++ b/src/frontend/components/messages/parts/ErrorPart.tsx
@@ -1,6 +1,7 @@
 import { MessagePart } from '@cherrystudio/ui/components';
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import { useTranslation } from 'react-i18next';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 type ErrorPartProps = {
   part: Extract<CherryMessagePart, { type: 'data-error' }>;

--- a/src/frontend/components/messages/parts/FilePart.tsx
+++ b/src/frontend/components/messages/parts/FilePart.tsx
@@ -1,8 +1,7 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
-
 import { FileEntryPreview } from '@/frontend/components/FileEntryPreview';
 import type { FileEntryId } from '@/shared/data/types/file';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 
 type FilePartProps = {
   part: Extract<CherryMessagePart, { type: 'file' }>;

--- a/src/frontend/components/messages/parts/MessagePartRenderer.tsx
+++ b/src/frontend/components/messages/parts/MessagePartRenderer.tsx
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import type { ResolvedCitationText } from './citations';
 import { CodePart } from './CodePart';

--- a/src/frontend/components/messages/parts/ReasoningPart.tsx
+++ b/src/frontend/components/messages/parts/ReasoningPart.tsx
@@ -1,8 +1,9 @@
 import { MessagePart } from '@cherrystudio/ui/components';
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 
 import { PartMarkdown } from './PartMarkdown';
 import { useThinkingTimerMs } from './useThinkingTimerMs';

--- a/src/frontend/components/messages/parts/SourceUrlPart.tsx
+++ b/src/frontend/components/messages/parts/SourceUrlPart.tsx
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { SourceLink } from './SourceLink';
 

--- a/src/frontend/components/messages/parts/TextPart.tsx
+++ b/src/frontend/components/messages/parts/TextPart.tsx
@@ -1,8 +1,8 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import { useMemo } from 'react';
 import { Text } from 'react-native';
 
 import { splitToolMentions } from '@/frontend/utils/toolMentions';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import type { ResolvedCitationText } from './citations';
 import type { MessagePartRenderMode } from './MessageParts';

--- a/src/frontend/components/messages/parts/TranslationPart.tsx
+++ b/src/frontend/components/messages/parts/TranslationPart.tsx
@@ -1,5 +1,6 @@
 import { MessagePart } from '@cherrystudio/ui/components';
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { PartMarkdown } from './PartMarkdown';
 

--- a/src/frontend/components/messages/parts/__tests__/FilePart.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/FilePart.test.tsx
@@ -1,6 +1,7 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import type { ReactElement } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { FilePart } from '../FilePart';
 

--- a/src/frontend/components/messages/parts/__tests__/MessagePartRenderer.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/MessagePartRenderer.test.tsx
@@ -1,5 +1,6 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { MessagePartRenderer } from '../MessagePartRenderer';
 

--- a/src/frontend/components/messages/parts/__tests__/MessageParts.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/MessageParts.test.tsx
@@ -1,6 +1,7 @@
-import type { MessageStatus } from '@cherrystudio/universal/data/types/message';
 import type { ReactElement } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { MessageStatus } from '@/shared/data/types/message';
 
 import type { MessageListItem } from '../../types';
 import { MessageParts } from '../MessageParts';

--- a/src/frontend/components/messages/parts/__tests__/citations.test.ts
+++ b/src/frontend/components/messages/parts/__tests__/citations.test.ts
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { resolveMessageCitationText } from '../citations';
 

--- a/src/frontend/components/messages/parts/citations.ts
+++ b/src/frontend/components/messages/parts/citations.ts
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 const CITABLE_TOOL_NAMES = new Set(['web_search', 'web_fetch', 'kb_search', 'kb_read']);
 const MARKDOWN_CODE_PATTERN = /```[\s\S]*?```|`[^`\n]*`/gm;

--- a/src/frontend/components/messages/parts/tools/McpToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/McpToolPart.tsx
@@ -4,14 +4,15 @@ import {
   normalizeMcpResult,
 } from '@cherrystudio/universal/ai/tools/mcpResult';
 import { parseFunctionCallToolName } from '@cherrystudio/universal/ai/tools/mcpToolName';
+import { Image } from 'expo-image';
+import { useTranslation } from 'react-i18next';
+import { Text, View } from 'react-native';
+
 import {
   type CherryToolMeta,
   readCherryMeta,
   readCherryToolMetadata,
-} from '@cherrystudio/universal/data/types/uiParts';
-import { Image } from 'expo-image';
-import { useTranslation } from 'react-i18next';
-import { Text, View } from 'react-native';
+} from '@/shared/data/types/uiParts';
 
 import {
   getToolDisplayState,

--- a/src/frontend/components/messages/parts/tools/__tests__/ToolPartRenderer.test.tsx
+++ b/src/frontend/components/messages/parts/tools/__tests__/ToolPartRenderer.test.tsx
@@ -1,5 +1,6 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { ToolPartRenderer } from '../ToolPartRenderer';
 import type { ToolMessagePart } from '../toolPartState';

--- a/src/frontend/components/messages/parts/tools/__tests__/ToolParts.test.tsx
+++ b/src/frontend/components/messages/parts/tools/__tests__/ToolParts.test.tsx
@@ -1,7 +1,8 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import type { ReactElement, ReactNode } from 'react';
 import { Text, View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { GenericToolPart } from '../GenericToolPart';
 import { McpToolPart } from '../McpToolPart';

--- a/src/frontend/components/messages/parts/tools/toolPartState.ts
+++ b/src/frontend/components/messages/parts/tools/toolPartState.ts
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 export type ToolMessagePart = Extract<
   CherryMessagePart,

--- a/src/frontend/components/messages/rows/__tests__/UserMessage.test.tsx
+++ b/src/frontend/components/messages/rows/__tests__/UserMessage.test.tsx
@@ -1,7 +1,8 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
 import type { ReactElement, ReactNode } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import type { MessageListItem } from '../../types';
 import { UserMessage } from '../UserMessage';

--- a/src/frontend/components/messages/rows/__tests__/partitionUserMessageParts.test.ts
+++ b/src/frontend/components/messages/rows/__tests__/partitionUserMessageParts.test.ts
@@ -1,4 +1,4 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import type { MessageListItem } from '../../types';
 import { partitionUserMessageParts } from '../partitionUserMessageParts';

--- a/src/frontend/components/messages/rows/partitionUserMessageParts.ts
+++ b/src/frontend/components/messages/rows/partitionUserMessageParts.ts
@@ -1,5 +1,5 @@
-import type { CherryMessagePart } from '@cherrystudio/universal/data/types/message';
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 
 import type { MessageListItem } from '../types';
 

--- a/src/frontend/components/messages/types.ts
+++ b/src/frontend/components/messages/types.ts
@@ -1,6 +1,7 @@
-import type { Message } from '@cherrystudio/universal/data/types/message';
 import type { ReactNode } from 'react';
 import type { SharedValue } from 'react-native-reanimated';
+
+import type { Message } from '@/shared/data/types/message';
 
 export type MessageListItem = Readonly<
   Pick<Message, 'data' | 'id' | 'status'> & {

--- a/src/frontend/components/modelPicker/components/ModelPickerIcon.tsx
+++ b/src/frontend/components/modelPicker/components/ModelPickerIcon.tsx
@@ -1,9 +1,10 @@
 import { Image } from '@cherrystudio/ui/components';
 import { resolveIcon } from '@cherrystudio/ui/icons';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
+
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 type ModelPickerIconProps = {
   model: Model;

--- a/src/frontend/components/modelPicker/hooks/useModelSettingSelections.ts
+++ b/src/frontend/components/modelPicker/hooks/useModelSettingSelections.ts
@@ -1,7 +1,7 @@
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useCallback } from 'react';
 
 import { useMultiplePreferences } from '@/frontend/data/hooks';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 import type { ModelSettingKind } from '../utils/modelSettings';
 import { MODEL_SETTING_PREFERENCE_KEYS } from '../utils/modelSettings';

--- a/src/frontend/components/modelPicker/utils/__tests__/modelPickerData.test.ts
+++ b/src/frontend/components/modelPicker/utils/__tests__/modelPickerData.test.ts
@@ -1,14 +1,11 @@
 import { ENDPOINT_TYPE, MODALITY, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import {
-  createUniqueModelId,
-  type Model,
-  type ModelCapability,
-} from '@cherrystudio/universal/data/types/model';
+
+import { createUniqueModelId, type Model, type ModelCapability } from '@/shared/data/types/model';
 import {
   DEFAULT_API_FEATURES,
   DEFAULT_PROVIDER_SETTINGS,
   type Provider,
-} from '@cherrystudio/universal/data/types/provider';
+} from '@/shared/data/types/provider';
 
 import {
   buildModelPickerGroups,

--- a/src/frontend/components/modelPicker/utils/__tests__/modelTypeFilter.test.ts
+++ b/src/frontend/components/modelPicker/utils/__tests__/modelTypeFilter.test.ts
@@ -1,5 +1,6 @@
 import { ENDPOINT_TYPE, MODALITY, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 
 import { filterModelsByType, getModelTypeCounts, matchesModelTypeFilter } from '../modelTypeFilter';
 

--- a/src/frontend/components/modelPicker/utils/modelPickerData.ts
+++ b/src/frontend/components/modelPicker/utils/modelPickerData.ts
@@ -1,6 +1,7 @@
 import { MODALITY, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 export type ModelPickerModelItem = {
   key: string;

--- a/src/frontend/components/modelPicker/utils/modelSettings.ts
+++ b/src/frontend/components/modelPicker/utils/modelSettings.ts
@@ -1,6 +1,5 @@
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import type { PreferenceKeyType } from '@/shared/data/preference';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 export const MODEL_SETTING_KINDS = ['default', 'fast', 'translate'] as const;
 

--- a/src/frontend/components/modelPicker/utils/modelTypeFilter.ts
+++ b/src/frontend/components/modelPicker/utils/modelTypeFilter.ts
@@ -4,7 +4,8 @@ import {
   MODALITY,
   MODEL_CAPABILITY,
 } from '@cherrystudio/provider-registry';
-import type { Model } from '@cherrystudio/universal/data/types/model';
+
+import type { Model } from '@/shared/data/types/model';
 
 /**
  * The pull screen filters by what a model is *for*, not by the overlapping

--- a/src/frontend/features/assistants/AssistantDetailScreen.tsx
+++ b/src/frontend/features/assistants/AssistantDetailScreen.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@cherrystudio/ui/components';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +9,7 @@ import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/head
 import { ModelPickerIcon, useModelPickerData } from '@/frontend/components/modelPicker';
 import { useAssistantApiById } from '@/frontend/hooks/chat';
 import { screenBottomActionInset } from '@/frontend/utils/constants';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 export default function AssistantDetailScreen() {
   const { t } = useTranslation();

--- a/src/frontend/features/assistants/AssistantEditScreen.tsx
+++ b/src/frontend/features/assistants/AssistantEditScreen.tsx
@@ -8,13 +8,6 @@ import {
   TextField,
   useAlert,
 } from '@cherrystudio/ui/components';
-import {
-  type Assistant,
-  type AssistantSettings,
-  DEFAULT_ASSISTANT_SETTINGS,
-  type McpMode,
-} from '@cherrystudio/universal/data/types/assistant';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
@@ -29,6 +22,13 @@ import { useAssistantApiById, useAssistantMutations } from '@/frontend/hooks/cha
 import { useMcpServersApi } from '@/frontend/hooks/mcp/useMcpServers';
 import { keyboardBottomOffset } from '@/frontend/utils/constants';
 import type { CreateAssistantDto } from '@/shared/data/api/schemas/assistants';
+import {
+  type Assistant,
+  type AssistantSettings,
+  DEFAULT_ASSISTANT_SETTINGS,
+  type McpMode,
+} from '@/shared/data/types/assistant';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 import { EmojiPickerBottomSheet } from './components/EmojiPickerBottomSheet';
 

--- a/src/frontend/features/assistants/AssistantListScreen.tsx
+++ b/src/frontend/features/assistants/AssistantListScreen.tsx
@@ -1,6 +1,5 @@
 import { BotIcon, CheckIcon, EllipsisIcon } from '@cherrystudio/app-icons';
 import { type MenuItem, useAlert } from '@cherrystudio/ui/components';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,6 +16,7 @@ import {
 } from '@/frontend/components/selection';
 import { SelectionToolbar } from '@/frontend/components/selection/SelectionToolbar/SelectionToolbar';
 import { useAssistantMutations, useAssistantsApi } from '@/frontend/hooks/chat';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 import { AssistantListSearchBar } from './AssistantListSearchBar/AssistantListSearchBar';
 

--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -1,5 +1,4 @@
 import { Composer } from '@cherrystudio/ui/components';
-import { isUniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
@@ -37,6 +36,7 @@ import {
 } from '@/frontend/hooks/chat/utils/modelReconcile';
 import { type ToolMentionId, toolMentions, toolMentionUrl } from '@/frontend/utils/toolMentions';
 import { loggerService } from '@/shared/core/logger/LoggerService';
+import { isUniqueModelId } from '@/shared/data/types/model';
 
 import { useChatTopic } from '../runtime';
 import { ChatInputEffortOverlay } from './components/ChatInputEffortOverlay';

--- a/src/frontend/features/chat/input/hooks/useChatInputReasoningEfforts.ts
+++ b/src/frontend/features/chat/input/hooks/useChatInputReasoningEfforts.ts
@@ -1,5 +1,6 @@
-import type { Model } from '@cherrystudio/universal/data/types/model';
 import { useMemo } from 'react';
+
+import type { Model } from '@/shared/data/types/model';
 
 import { getChatInputReasoningEffortsForModel } from '../utils/chatInputReasoning';
 

--- a/src/frontend/features/chat/input/utils/__tests__/chatInputReasoning.test.ts
+++ b/src/frontend/features/chat/input/utils/__tests__/chatInputReasoning.test.ts
@@ -1,5 +1,6 @@
 import { REASONING_EFFORT } from '@cherrystudio/provider-registry';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
+
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 import {
   CHAT_INPUT_DEFAULT_REASONING_EFFORT,

--- a/src/frontend/features/chat/input/utils/chatInputReasoning.ts
+++ b/src/frontend/features/chat/input/utils/chatInputReasoning.ts
@@ -4,8 +4,9 @@ import {
   type ReasoningEffort,
 } from '@cherrystudio/provider-registry';
 import { deriveThinkingOptions, nearestThinkingOption } from '@cherrystudio/universal/ai/reasoning';
-import type { Model } from '@cherrystudio/universal/data/types/model';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
+
+import type { Model } from '@/shared/data/types/model';
 
 export const CHAT_INPUT_DEFAULT_REASONING_EFFORT = 'default';
 

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -1,5 +1,4 @@
 import type { ComposerQueuedMessagePayload } from '@cherrystudio/universal/ai/transport';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'expo-router';
 import {
@@ -23,6 +22,7 @@ import type {
   ChatTopicSnapshot,
 } from '@/shared/contracts';
 import { NEW_TOPIC_SNAPSHOT_KEY } from '@/shared/contracts';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 type ChatTopicValue = ChatTopicSnapshot & {
   abort: () => void;

--- a/src/frontend/features/chat/runtime/__tests__/chatRuntimeProjection.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/chatRuntimeProjection.test.ts
@@ -1,4 +1,4 @@
-import type { CherryMessagePart, Message } from '@cherrystudio/universal/data/types/message';
+import type { CherryMessagePart, Message } from '@/shared/data/types/message';
 
 import { getPendingToolApprovals, mergeMessagesWithOverlay } from '../chatRuntimeProjection';
 

--- a/src/frontend/features/chat/runtime/chatRuntimeProjection.ts
+++ b/src/frontend/features/chat/runtime/chatRuntimeProjection.ts
@@ -1,5 +1,5 @@
-import type { CherryMessagePart, Message } from '@cherrystudio/universal/data/types/message';
-import { readCherryToolMetadata } from '@cherrystudio/universal/data/types/uiParts';
+import type { CherryMessagePart, Message } from '@/shared/data/types/message';
+import { readCherryToolMetadata } from '@/shared/data/types/uiParts';
 
 type ToolMessagePart = Extract<CherryMessagePart, { type: 'dynamic-tool' | `tool-${string}` }>;
 

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -1,5 +1,4 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { Message } from '@cherrystudio/universal/data/types/message';
 import { useHeaderHeight } from 'expo-router/react-navigation';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +9,7 @@ import { MessageList, type MessageListItem } from '@/frontend/components/message
 import { resolveHeaderContentInset } from '@/frontend/components/navigation/headerContentInset/headerContentInset';
 import type { MessagesViewModel } from '@/frontend/hooks/chat';
 import { loggerService } from '@/shared/core/logger/LoggerService';
+import type { Message } from '@/shared/data/types/message';
 
 import { ToolApprovalSheet } from '../approval/ToolApprovalSheet';
 import { useChat, useChatTopic } from '../runtime/ChatProvider';

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -1,8 +1,8 @@
-import type { Message } from '@cherrystudio/universal/data/types/message';
 import type { SharedValue } from 'react-native-reanimated';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import type { MessageListProps } from '@/frontend/components/messages';
+import type { Message } from '@/shared/data/types/message';
 
 import { ChatWorkspace } from '../ChatWorkspace';
 

--- a/src/frontend/features/paintings/components/PaintingInput.tsx
+++ b/src/frontend/features/paintings/components/PaintingInput.tsx
@@ -1,7 +1,6 @@
 import { Settings2Icon } from '@cherrystudio/app-icons';
 import { type ImageGenerationMode, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import { Composer } from '@cherrystudio/ui/components';
-import { isUniqueModelId, type UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -21,6 +20,7 @@ import {
   type ModelPickerModelItem,
 } from '@/frontend/components/modelPicker';
 import { useModelById, useModels, useProviders } from '@/frontend/hooks/chat';
+import { isUniqueModelId, type UniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import type {

--- a/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
+++ b/src/frontend/features/paintings/hooks/usePaintingGeneration.ts
@@ -1,5 +1,4 @@
 import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -10,6 +9,7 @@ import type {
   PaintingGenerationOutput,
 } from '@/shared/contracts';
 import { isTerminalStatus } from '@/shared/data/api/schemas/jobs';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 import { imageParamsAspectRatio } from '../utils/imageGenerationParams';
 import {

--- a/src/frontend/features/paintings/utils/__tests__/paintingMessages.test.ts
+++ b/src/frontend/features/paintings/utils/__tests__/paintingMessages.test.ts
@@ -1,4 +1,4 @@
-import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
 
 import type { ResolvedPaintingAttachment } from '../../hooks/usePaintings';
 import { createPaintingMessages } from '../paintingMessages';

--- a/src/frontend/features/settings/McpScreen/McpScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpScreen.tsx
@@ -1,6 +1,5 @@
 import { PlusIcon } from '@cherrystudio/app-icons';
 import { Button } from '@cherrystudio/ui/components';
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +8,7 @@ import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { useMcpServerRuntimeSummaries, useMcpServersApi } from '@/frontend/hooks/mcp/useMcpServers';
 import type { McpServerRuntimeSummary } from '@/shared/contracts';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { SettingsServiceRow } from '../components/SettingsServiceRow';
 

--- a/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
@@ -1,5 +1,4 @@
 import { Button, Input, Label, TextField, useAlert } from '@cherrystudio/ui/components';
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useToast } from 'heroui-native/toast';
 import { useCallback, useMemo, useState } from 'react';
@@ -13,6 +12,7 @@ import { useMcpServerApiById, useMcpServerMutations } from '@/frontend/hooks/mcp
 import { keyboardBottomOffset } from '@/frontend/utils/constants';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { DataApiError, ErrorCode } from '@/shared/data/api/errors';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { McpServerChrome } from './components/McpServerChrome/McpServerChrome';
 import { McpServerTabs } from './components/McpServerTabs/McpServerTabs';

--- a/src/frontend/features/settings/McpScreen/components/McpToolsSection.tsx
+++ b/src/frontend/features/settings/McpScreen/components/McpToolsSection.tsx
@@ -1,11 +1,11 @@
 import { Button, Spinner, Switch } from '@cherrystudio/ui/components';
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
 
 import { queryKeys, useBackendModule } from '@/frontend/data';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 type McpToolsSectionProps = {
   isDisabled?: boolean;

--- a/src/frontend/features/settings/ProviderScreen/NewProviderScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/NewProviderScreen.tsx
@@ -1,5 +1,4 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { ApiKeyEntry } from '@cherrystudio/universal/data/types/provider';
 import * as Crypto from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo } from 'react';
@@ -10,6 +9,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
 import { useMutation } from '@/frontend/data';
 import { keyboardBottomOffset } from '@/frontend/utils/constants';
+import type { ApiKeyEntry } from '@/shared/data/types/provider';
 
 import { useProviderAvatarActions } from '../components/providerAvatarStore';
 import {

--- a/src/frontend/features/settings/ProviderScreen/ProviderModelAddScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/ProviderModelAddScreen.tsx
@@ -1,8 +1,6 @@
 import { ChevronDownIcon, ChevronUpIcon, SaveIcon } from '@cherrystudio/app-icons';
 import { FieldError, Input, Label, TextField } from '@cherrystudio/ui/components';
 import { cn } from '@cherrystudio/ui/utils';
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +11,8 @@ import {
 } from 'react-native-keyboard-controller';
 
 import { BackHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
+import type { EndpointType } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { useProviderDetailSettings } from './detail';
 import { useProviderModelAdd } from './models/hooks/useProviderModelAdd';

--- a/src/frontend/features/settings/ProviderScreen/ProviderModelPullScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/ProviderModelPullScreen.tsx
@@ -1,6 +1,4 @@
 import { Section, Spinner } from '@cherrystudio/ui/components';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
 import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
@@ -15,6 +13,8 @@ import {
   ModelTypeFilterBar,
   type ModelTypeFilter,
 } from '@/frontend/components/modelPicker';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { useProviderDetailSettings } from './detail';
 import { ProviderModelPullChrome } from './models/components/ProviderModelPullChrome/ProviderModelPullChrome';

--- a/src/frontend/features/settings/ProviderScreen/apiService/hooks/useProviderApiServiceQueries.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/hooks/useProviderApiServiceQueries.ts
@@ -1,4 +1,3 @@
-import type { ApiKeyEntry } from '@cherrystudio/universal/data/types/provider';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
@@ -8,6 +7,7 @@ import {
   updateQueriesOptimistically,
 } from '@/frontend/data/utils/optimisticQueryUpdate';
 import type { UpdateProviderInput } from '@/shared/data/api/schemas/providers';
+import type { ApiKeyEntry } from '@/shared/data/types/provider';
 
 export function useProviderApiServiceQueries(providerId: string) {
   const queryClient = useQueryClient();

--- a/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceApiKeys.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceApiKeys.ts
@@ -1,5 +1,6 @@
-import type { ApiKeyEntry } from '@cherrystudio/universal/data/types/provider';
 import * as Crypto from 'expo-crypto';
+
+import type { ApiKeyEntry } from '@/shared/data/types/provider';
 
 function createApiKeyEntryId(): string {
   return Crypto.randomUUID();

--- a/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceAuth.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceAuth.ts
@@ -1,4 +1,4 @@
-import type { AuthConfig, Provider } from '@cherrystudio/universal/data/types/provider';
+import type { AuthConfig, Provider } from '@/shared/data/types/provider';
 
 export function emptyAuthConfigFor(type: AuthConfig['type']): AuthConfig {
   switch (type) {

--- a/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceEndpointDraft.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceEndpointDraft.ts
@@ -1,5 +1,5 @@
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+import type { EndpointType } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import {
   getConfigurableEndpointTypesForProvider,

--- a/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceEndpointRules.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceEndpointRules.ts
@@ -1,11 +1,12 @@
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
+
+import type { EndpointType } from '@/shared/data/types/model';
 import type {
   AuthType,
   EndpointConfig,
   EndpointConfigs,
   Provider,
-} from '@cherrystudio/universal/data/types/provider';
+} from '@/shared/data/types/provider';
 
 export const CUSTOM_PROVIDER_TEXT_ENDPOINT_TYPES = [
   ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,

--- a/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceSave.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/utils/providerApiServiceSave.ts
@@ -1,5 +1,5 @@
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
-import type { EndpointConfigs, Provider } from '@cherrystudio/universal/data/types/provider';
+import type { EndpointType } from '@/shared/data/types/model';
+import type { EndpointConfigs, Provider } from '@/shared/data/types/provider';
 
 import type { EndpointDraft } from './providerApiServiceEndpointDraft';
 import {

--- a/src/frontend/features/settings/ProviderScreen/components/ProviderModelList.tsx
+++ b/src/frontend/features/settings/ProviderScreen/components/ProviderModelList.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@cherrystudio/ui/components';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { useDeferredValue, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, Text, View } from 'react-native';
+
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { type ProviderModelListSelection } from '../models/components/ProviderModelListContent';
 import { ProviderModelListLayout } from '../models/components/ProviderModelListLayout/ProviderModelListLayout';

--- a/src/frontend/features/settings/ProviderScreen/detail/components/ProviderDetailBanner.tsx
+++ b/src/frontend/features/settings/ProviderScreen/detail/components/ProviderDetailBanner.tsx
@@ -1,7 +1,8 @@
 import { Switch } from '@cherrystudio/ui/components';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
+
+import type { Provider } from '@/shared/data/types/provider';
 
 import { ProviderAvatar } from '../../../components/ProviderAvatar';
 

--- a/src/frontend/features/settings/ProviderScreen/hooks/useProviderDeletion.ts
+++ b/src/frontend/features/settings/ProviderScreen/hooks/useProviderDeletion.ts
@@ -1,5 +1,4 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { useToast } from 'heroui-native/toast';
@@ -12,6 +11,7 @@ import {
   restoreQuerySnapshot,
   updateQueriesOptimistically,
 } from '@/frontend/data/utils/optimisticQueryUpdate';
+import type { Provider } from '@/shared/data/types/provider';
 
 /**
  * Deleting the provider, from wherever the action is offered — currently the

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelCheckSection.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelCheckSection.tsx
@@ -1,7 +1,5 @@
 import { ChevronDownIcon } from '@cherrystudio/app-icons';
 import { Button, Section } from '@cherrystudio/ui/components';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { ApiKeyEntry, Provider } from '@cherrystudio/universal/data/types/provider';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
@@ -11,6 +9,8 @@ import {
   ModelPickerIcon,
   type ModelPickerModelItem,
 } from '@/frontend/components/modelPicker';
+import type { Model } from '@/shared/data/types/model';
+import type { ApiKeyEntry, Provider } from '@/shared/data/types/provider';
 
 import { useProviderModelCheck } from '../hooks/useProviderModelCheck';
 

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelListContent.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelListContent.tsx
@@ -1,8 +1,9 @@
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { memo, type ReactElement, useCallback, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
+
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { ProviderModelRow, providerModelRowEstimatedHeight } from './ProviderModelRow';
 

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelRow.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelRow.tsx
@@ -1,11 +1,11 @@
 import { CheckIcon } from '@cherrystudio/app-icons';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import type { ReactNode } from 'react';
 import { Pressable, Text, View } from 'react-native';
 
 import { ModelAvatar } from '@/frontend/components/avatar';
 import { getModelPickerRowTags, ModelPickerTagChip } from '@/frontend/components/modelPicker';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 /** `py-2` around the tallest thing in the row, which is the 26 avatar. */
 export const providerModelRowEstimatedHeight = 42;

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelSelectList.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelSelectList.tsx
@@ -1,5 +1,3 @@
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import {
   LegendList,
   type LegendListRef,
@@ -7,6 +5,9 @@ import {
 } from '@legendapp/list/react-native';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import { ProviderModelRow, providerModelRowEstimatedHeight } from './ProviderModelRow';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelCheck.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelCheck.test.tsx
@@ -1,6 +1,7 @@
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
-import type { ApiKeyEntry } from '@cherrystudio/universal/data/types/provider';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import type { ApiKeyEntry } from '@/shared/data/types/provider';
 
 import { useProviderModelCheck } from '../useProviderModelCheck';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelPullSelection.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelPullSelection.test.tsx
@@ -1,5 +1,6 @@
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 
 import type { ProviderModelPullPreview } from '../../utils/providerModelPullPreview';
 import {

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelSelection.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelSelection.test.tsx
@@ -1,5 +1,6 @@
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 import { useProviderModelSelection } from '../useProviderModelSelection';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelAdd.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelAdd.ts
@@ -1,11 +1,11 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { useToast } from 'heroui-native/toast';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMutation, useQuery } from '@/frontend/data';
+import type { EndpointType } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import {
   buildProviderModelAddInputs,

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelCheck.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelCheck.ts
@@ -1,12 +1,12 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { Model } from '@cherrystudio/universal/data/types/model';
-import type { ApiKeyEntry } from '@cherrystudio/universal/data/types/provider';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from 'heroui-native/toast';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { queryKeys, useBackendModule } from '@/frontend/data';
+import type { Model } from '@/shared/data/types/model';
+import type { ApiKeyEntry } from '@/shared/data/types/provider';
 
 import { resolveProviderModelCheckModel } from '../utils/providerModelCheckSelection';
 import {

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPull.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPull.ts
@@ -1,5 +1,4 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from 'heroui-native/toast';
 import { useCallback, useState } from 'react';
@@ -7,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { queryKeys, useBackendModule } from '@/frontend/data';
 import { isModelPullTimeoutError } from '@/shared/contracts';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 import type { ProviderModelPullPreview } from '../utils/providerModelPullPreview';
 import { refreshProviderModelQueries } from '../utils/refreshProviderModelQueries';

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPullSelection.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPullSelection.ts
@@ -1,5 +1,6 @@
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useCallback, useMemo, useState } from 'react';
+
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 import type { ProviderModelPullPreview } from '../utils/providerModelPullPreview';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelRemove.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelRemove.ts
@@ -1,10 +1,10 @@
 import { useAlert } from '@cherrystudio/ui/components';
-import type { Model } from '@cherrystudio/universal/data/types/model';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMutation } from '@/frontend/data';
 import { usePreference } from '@/frontend/data/hooks';
+import type { Model } from '@/shared/data/types/model';
 
 /**
  * Removing models from their provider. The list removes by selection rather

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelSelection.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelSelection.ts
@@ -1,5 +1,6 @@
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import { useCallback, useState } from 'react';
+
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 const noneSelected: ReadonlySet<UniqueModelId> = new Set();
 

--- a/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelAdd.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelAdd.test.ts
@@ -1,6 +1,7 @@
 import { ENDPOINT_TYPE, MODALITY, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import {
   buildProviderModelAddInputs,

--- a/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelHealthCheck.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelHealthCheck.test.ts
@@ -1,4 +1,4 @@
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 
 import { createProviderModelHealthPendingStatuses } from '../providerModelHealthCheck';
 

--- a/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelPullPreview.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelPullPreview.test.ts
@@ -1,4 +1,4 @@
-import { createUniqueModelId, type Model } from '@cherrystudio/universal/data/types/model';
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 
 import {
   buildProviderModelPullListItems,

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelAdd.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelAdd.ts
@@ -1,13 +1,13 @@
 import { ENDPOINT_TYPE, MODALITY, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+
+import type { CreateModelDto } from '@/shared/data/api/schemas/models';
 import {
   createUniqueModelId,
   type EndpointType,
   type Model,
   type UniqueModelId,
-} from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
-
-import type { CreateModelDto } from '@/shared/data/api/schemas/models';
+} from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 export type ProviderModelAddFormState = {
   contextWindow: string;

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelCheckSelection.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelCheckSelection.ts
@@ -1,4 +1,4 @@
-import type { Model } from '@cherrystudio/universal/data/types/model';
+import type { Model } from '@/shared/data/types/model';
 
 /**
  * The model is picked on a screen of its own and travels back as a route param,

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelHealthCheck.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelHealthCheck.ts
@@ -1,6 +1,5 @@
-import type { Model } from '@cherrystudio/universal/data/types/model';
-
 import type { ModelHealthResult } from '@/shared/contracts';
+import type { Model } from '@/shared/data/types/model';
 
 export const providerModelCheckTimeoutMs = 15_000;
 

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelPullPreview.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelPullPreview.ts
@@ -1,6 +1,5 @@
-import type { Model } from '@cherrystudio/universal/data/types/model';
-
 import type { ModelPullPreview } from '@/shared/contracts';
+import type { Model } from '@/shared/data/types/model';
 
 export type ProviderModelPullPreview = ModelPullPreview;
 

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelSearch.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelSearch.ts
@@ -1,4 +1,4 @@
-import type { Model } from '@cherrystudio/universal/data/types/model';
+import type { Model } from '@/shared/data/types/model';
 
 export function filterModelsByKeywords(searchText: string, models: Model[]): Model[] {
   const keywords = searchText

--- a/src/frontend/features/settings/ProviderScreen/providerForm/__tests__/providerFormValues.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/providerForm/__tests__/providerFormValues.test.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+import type { Provider } from '@/shared/data/types/provider';
 
 import {
   createEmptyProviderFormValues,

--- a/src/frontend/features/settings/ProviderScreen/providerForm/components/ProviderFormEndpoints.tsx
+++ b/src/frontend/features/settings/ProviderScreen/providerForm/components/ProviderFormEndpoints.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@cherrystudio/ui/components';
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
 import { useTranslation } from 'react-i18next';
+
+import type { EndpointType } from '@/shared/data/types/model';
 
 import { useProviderForm } from '../context';
 import { ProviderFormField } from './ProviderFormField';

--- a/src/frontend/features/settings/ProviderScreen/providerForm/context.ts
+++ b/src/frontend/features/settings/ProviderScreen/providerForm/context.ts
@@ -1,5 +1,6 @@
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
 import { createContext, use } from 'react';
+
+import type { EndpointType } from '@/shared/data/types/model';
 
 import type { ProviderFormValues } from './utils/providerFormValues';
 

--- a/src/frontend/features/settings/ProviderScreen/providerForm/hooks/useProviderFormDraft.ts
+++ b/src/frontend/features/settings/ProviderScreen/providerForm/hooks/useProviderFormDraft.ts
@@ -1,5 +1,6 @@
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
 import { useCallback, useMemo, useState } from 'react';
+
+import type { EndpointType } from '@/shared/data/types/model';
 
 import type { ProviderForm, ProviderFormActions } from '../context';
 import { isProviderFormDirty, type ProviderFormValues } from '../utils/providerFormValues';

--- a/src/frontend/features/settings/ProviderScreen/providerForm/utils/providerFormValues.ts
+++ b/src/frontend/features/settings/ProviderScreen/providerForm/utils/providerFormValues.ts
@@ -1,6 +1,7 @@
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+
+import type { EndpointType } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
 import {
   canEditProviderEndpoint,

--- a/src/frontend/features/topics/TopicList.tsx
+++ b/src/frontend/features/topics/TopicList.tsx
@@ -1,5 +1,4 @@
 import { CheckIcon } from '@cherrystudio/app-icons';
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +17,7 @@ import {
 import { useAssistantsApi } from '@/frontend/hooks/chat';
 import { useThemeColor } from '@/frontend/hooks/useThemeColor';
 import type { TopicListItem } from '@/shared/data/api/schemas/topics';
+import type { Assistant } from '@/shared/data/types/assistant';
 import type { Topic } from '@/shared/data/types/topic';
 
 import { useTopicActionAlerts } from './components/useTopicActionAlerts';

--- a/src/frontend/hooks/chat/__tests__/useAssistant.test.tsx
+++ b/src/frontend/hooks/chat/__tests__/useAssistant.test.tsx
@@ -1,10 +1,10 @@
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { DataApiProvider } from '@/frontend/data/DataApiProvider';
 import type { ApiClient } from '@/shared/data/api/types';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 import { useAssistantMutations, useAssistantsApi } from '../useAssistant';
 

--- a/src/frontend/hooks/chat/useAssistant.ts
+++ b/src/frontend/hooks/chat/useAssistant.ts
@@ -1,4 +1,3 @@
-import type { Assistant } from '@cherrystudio/universal/data/types/assistant';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -15,6 +14,7 @@ import type {
   UpdateAssistantDto,
 } from '@/shared/data/api/schemas/assistants';
 import type { OffsetPaginationResponse } from '@/shared/data/api/types';
+import type { Assistant } from '@/shared/data/types/assistant';
 
 const ASSISTANTS_LIST_LIMIT = 500;
 const EMPTY_ASSISTANTS: readonly Assistant[] = Object.freeze([]);

--- a/src/frontend/hooks/chat/useMessageHistoryWindow.ts
+++ b/src/frontend/hooks/chat/useMessageHistoryWindow.ts
@@ -1,8 +1,8 @@
-import type { Message } from '@cherrystudio/universal/data/types/message';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useInfiniteQuery } from '@/frontend/data';
 import type { BranchMessagesResponse } from '@/shared/data/api/schemas/messages';
+import type { Message } from '@/shared/data/types/message';
 
 import { useMessageRenderWindow } from './useMessageRenderWindow';
 import { getOlderLoadAction } from './utils/messageHistoryWindowStrategy';

--- a/src/frontend/hooks/chat/useMessageRenderWindow.ts
+++ b/src/frontend/hooks/chat/useMessageRenderWindow.ts
@@ -1,5 +1,6 @@
-import type { Message } from '@cherrystudio/universal/data/types/message';
 import { startTransition, useCallback, useMemo, useState } from 'react';
+
+import type { Message } from '@/shared/data/types/message';
 
 import { messageWindowPolicy } from './utils/messageWindowPolicy';
 

--- a/src/frontend/hooks/chat/useModel.ts
+++ b/src/frontend/hooks/chat/useModel.ts
@@ -1,7 +1,6 @@
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
-
 import { useQuery } from '@/frontend/data';
 import type { ListModelsQuery } from '@/shared/data/api/schemas/models';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 const EMPTY_MODELS: readonly Model[] = Object.freeze([]);
 

--- a/src/frontend/hooks/chat/useProvider.ts
+++ b/src/frontend/hooks/chat/useProvider.ts
@@ -1,7 +1,7 @@
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import { useMemo } from 'react';
 
 import { useQuery } from '@/frontend/data';
+import type { Provider } from '@/shared/data/types/provider';
 
 const EMPTY_PROVIDERS: readonly Provider[] = Object.freeze([]);
 

--- a/src/frontend/hooks/chat/utils/__tests__/modelReconcile.test.ts
+++ b/src/frontend/hooks/chat/utils/__tests__/modelReconcile.test.ts
@@ -1,6 +1,7 @@
 import { MODEL_CAPABILITY, REASONING_EFFORT } from '@cherrystudio/provider-registry';
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
+
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 import { reconcileReasoningEffortForModel, reconcileWebSearchForModel } from '../modelReconcile';
 

--- a/src/frontend/hooks/chat/utils/modelReconcile.ts
+++ b/src/frontend/hooks/chat/utils/modelReconcile.ts
@@ -1,12 +1,13 @@
 import { resolveReasoningEffortForModel } from '@cherrystudio/universal/ai/reasoning';
-import type { AssistantSettings } from '@cherrystudio/universal/data/types/assistant';
-import type { Model } from '@cherrystudio/universal/data/types/model';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 import {
   isFunctionCallingModel,
   isOpenRouterBuiltInWebSearchModel,
   isWebSearchModel,
 } from '@cherrystudio/universal/utils/model';
+
+import type { AssistantSettings } from '@/shared/data/types/assistant';
+import type { Model } from '@/shared/data/types/model';
 
 export type ReasoningEffortPatch = {
   reasoning_effort?: ReasoningEffortOption;

--- a/src/frontend/hooks/mcp/__tests__/useMcpServers.test.tsx
+++ b/src/frontend/hooks/mcp/__tests__/useMcpServers.test.tsx
@@ -1,4 +1,3 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
@@ -6,6 +5,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { queryKeys } from '@/frontend/data';
 import { DataApiProvider } from '@/frontend/data/DataApiProvider';
 import type { ApiClient } from '@/shared/data/api/types';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { useMcpServerMutations } from '../useMcpServers';
 

--- a/src/frontend/hooks/mcp/useMcpServers.ts
+++ b/src/frontend/hooks/mcp/useMcpServers.ts
@@ -1,4 +1,3 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
 import { useQueryClient, useQuery as useTanStackQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -11,6 +10,7 @@ import {
 } from '@/frontend/data/utils/optimisticQueryUpdate';
 import type { McpServerRuntimeSummary } from '@/shared/contracts';
 import type { CreateMcpServerDto, UpdateMcpServerDto } from '@/shared/data/api/schemas/mcpServers';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 const EMPTY_MCP_SERVERS: readonly McpServer[] = Object.freeze([]);
 const EMPTY_MCP_RUNTIME_SUMMARIES: Readonly<Record<string, McpServerRuntimeSummary>> =

--- a/src/shared/contracts/chat.ts
+++ b/src/shared/contracts/chat.ts
@@ -2,9 +2,10 @@ import type {
   ComposerQueuedMessagePayload,
   TopicStatusSnapshotEntry,
 } from '@cherrystudio/universal/ai/transport';
-import type { CherryMessagePart, Message } from '@cherrystudio/universal/data/types/message';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
+
+import type { CherryMessagePart, Message } from '@/shared/data/types/message';
+import type { UniqueModelId } from '@/shared/data/types/model';
 
 export const NEW_TOPIC_SNAPSHOT_KEY = '__new_topic__';
 

--- a/src/shared/contracts/mcp.ts
+++ b/src/shared/contracts/mcp.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
+import type { McpServer } from '@/shared/data/types/mcpServer';
 
 export type McpConnectionConfig = {
   endpointUrl: string;

--- a/src/shared/contracts/models.ts
+++ b/src/shared/contracts/models.ts
@@ -1,4 +1,4 @@
-import type { Model, UniqueModelId } from '@cherrystudio/universal/data/types/model';
+import type { Model, UniqueModelId } from '@/shared/data/types/model';
 
 export type ModelPullPreview = {
   added: Model[];

--- a/src/shared/contracts/paintings.ts
+++ b/src/shared/contracts/paintings.ts
@@ -1,7 +1,7 @@
 import type { ImageGenerationMode, ParamValues } from '@cherrystudio/provider-registry';
-import type { UniqueModelId } from '@cherrystudio/universal/data/types/model';
 
 import type { FileEntryId } from '@/shared/data/types/file';
+import type { UniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 
 import type { ResolvedFile } from './file';

--- a/src/shared/contracts/providers.ts
+++ b/src/shared/contracts/providers.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '@cherrystudio/universal/data/types/provider';
+import type { Provider } from '@/shared/data/types/provider';
 
 export interface ProvidersModule {
   canRemove(provider: Pick<Provider, 'id' | 'presetProviderId'>): boolean;

--- a/src/shared/data/README.md
+++ b/src/shared/data/README.md
@@ -7,10 +7,14 @@ deliberate omission, not a gap.
 
 ## Scope
 
-- `types`: entity and value types with no package-side consumer (`FileEntry`, `Topic`, `Painting`,
-  web search, trace). The entity types `packages/ai-runtime` still imports (model, provider,
-  assistant, message, uiParts, aiUsageRecord, mcpServer) remain temporarily under
-  `@cherrystudio/universal/data/types`; see that package's `src/data/README.md` ledger.
+- `types`: entity and value types. Most are declared here (`FileEntry`, `Topic`, `Painting`, web
+  search, trace). Seven — model, provider, assistant, message, uiParts, aiUsageRecord, mcpServer —
+  are one-line re-exports of declarations that stay in `@cherrystudio/universal/data/types` because
+  `packages/ai-runtime` imports them and a workspace package must not import app code. App code
+  imports every entity type from here regardless, so dissolving universal means pasting those
+  declarations into files that already exist at the right path. Re-exporting rather than copying
+  keeps one declaration: two copies of the same zod schema across the app/package boundary would
+  drift silently. See that package's `src/data/README.md` ledger.
 - `api`: endpoint DTO schemas, pagination shapes, data errors, and `ApiClient` — the
   platform-neutral resource interface shared by frontend endpoint hooks and the backend in-process
   `DataApiService` implementation.

--- a/src/shared/data/api/schemas/aiUsageRecords.ts
+++ b/src/shared/data/api/schemas/aiUsageRecords.ts
@@ -1,14 +1,14 @@
 /** Read-only query contracts for best-effort AI usage records. */
 
+import * as z from 'zod';
+
+import type { CursorPaginationParams, CursorPaginationResponse } from '@/shared/data/api/types';
 import {
   type AiUsageRecordAttribution,
   type AiUsageRecordEntry,
   AiUsageRecordMessageKindSchema,
-} from '@cherrystudio/universal/data/types/aiUsageRecord';
-import { CURRENCY, type Currency, objectValues } from '@cherrystudio/universal/data/types/model';
-import * as z from 'zod';
-
-import type { CursorPaginationParams, CursorPaginationResponse } from '@/shared/data/api/types';
+} from '@/shared/data/types/aiUsageRecord';
+import { CURRENCY, type Currency, objectValues } from '@/shared/data/types/model';
 
 export const AI_USAGE_RECORD_DEFAULT_LIMIT = 50;
 export const AI_USAGE_RECORD_MAX_LIMIT = 200;

--- a/src/shared/data/api/schemas/assistants.ts
+++ b/src/shared/data/api/schemas/assistants.ts
@@ -1,11 +1,11 @@
+import * as z from 'zod';
+
+import type { OffsetPaginationResponse } from '@/shared/data/api/types';
 import {
   type Assistant,
   AssistantSchema,
   AssistantSettingsSchema,
-} from '@cherrystudio/universal/data/types/assistant';
-import * as z from 'zod';
-
-import type { OffsetPaginationResponse } from '@/shared/data/api/types';
+} from '@/shared/data/types/assistant';
 
 import { type OrderEndpoints } from './endpointHelpers';
 

--- a/src/shared/data/api/schemas/mcpServers.ts
+++ b/src/shared/data/api/schemas/mcpServers.ts
@@ -1,6 +1,7 @@
-import type { McpServer } from '@cherrystudio/universal/data/types/mcpServer';
-import { McpServerSchema } from '@cherrystudio/universal/data/types/mcpServer';
 import * as z from 'zod';
+
+import type { McpServer } from '@/shared/data/types/mcpServer';
+import { McpServerSchema } from '@/shared/data/types/mcpServer';
 
 const MCP_SERVER_MUTABLE_FIELDS = {
   disabledTools: true,

--- a/src/shared/data/api/schemas/messages.ts
+++ b/src/shared/data/api/schemas/messages.ts
@@ -5,21 +5,16 @@
  * Includes endpoints for tree visualization and conversation view.
  */
 
-import type {
-  Message,
-  MessageData,
-  MessageRole,
-  MessageStatus,
-} from '@cherrystudio/universal/data/types/message';
+import * as z from 'zod';
+
+import type { CursorPaginationParams, CursorPaginationResponse } from '@/shared/data/api/types';
+import type { Message, MessageData, MessageRole, MessageStatus } from '@/shared/data/types/message';
 import {
   ContentMessageRoleSchema,
   MessageDataSchema,
   MessageSnapshotSchema,
   MessageStatusSchema,
-} from '@cherrystudio/universal/data/types/message';
-import * as z from 'zod';
-
-import type { CursorPaginationParams, CursorPaginationResponse } from '@/shared/data/api/types';
+} from '@/shared/data/types/message';
 
 export interface TreeNode {
   createdAt: string;

--- a/src/shared/data/api/schemas/models.ts
+++ b/src/shared/data/api/schemas/models.ts
@@ -1,3 +1,5 @@
+import * as z from 'zod';
+
 import {
   ENDPOINT_TYPE,
   type ImageGenerationSupport,
@@ -11,8 +13,7 @@ import {
   RuntimeModelPricingSchema,
   type UniqueModelId,
   UniqueModelIdSchema,
-} from '@cherrystudio/universal/data/types/model';
-import * as z from 'zod';
+} from '@/shared/data/types/model';
 
 export const ListModelsQuerySchema = z.object({
   capability: z.enum(objectValues(MODEL_CAPABILITY)).optional(),

--- a/src/shared/data/api/schemas/providers.ts
+++ b/src/shared/data/api/schemas/providers.ts
@@ -1,4 +1,4 @@
-import type { EndpointType } from '@cherrystudio/universal/data/types/model';
+import type { EndpointType } from '@/shared/data/types/model';
 import type {
   ApiFeatures,
   ApiKeyEntry,
@@ -7,7 +7,7 @@ import type {
   Provider,
   ProviderSettings,
   RuntimeApiFeatures,
-} from '@cherrystudio/universal/data/types/provider';
+} from '@/shared/data/types/provider';
 
 export type CreateProviderInput = {
   apiFeatures?: ApiFeatures | null;

--- a/src/shared/data/api/schemas/search.ts
+++ b/src/shared/data/api/schemas/search.ts
@@ -5,8 +5,9 @@
  * Content search is full-text-oriented and keeps per-source cursor semantics.
  */
 
-import type { TopicMessageSearchRole } from '@cherrystudio/universal/data/types/message';
 import * as z from 'zod';
+
+import type { TopicMessageSearchRole } from '@/shared/data/types/message';
 
 export type EntitySearchTarget =
   | { type: 'assistant'; target: { assistantId: string } }

--- a/src/shared/data/presets/cherryai.ts
+++ b/src/shared/data/presets/cherryai.ts
@@ -1,4 +1,4 @@
-import { createUniqueModelId } from '@cherrystudio/universal/data/types/model';
+import { createUniqueModelId } from '@/shared/data/types/model';
 
 export const CHERRYAI_PROVIDER_ID = 'cherryai' as const;
 export const CHERRYAI_PROVIDER_NAME = 'CherryAI' as const;

--- a/src/shared/data/presets/defaultAssistant.ts
+++ b/src/shared/data/presets/defaultAssistant.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ASSISTANT_SETTINGS } from '@cherrystudio/universal/data/types/assistant';
+import { DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from './cherryai';
 

--- a/src/shared/data/types/aiUsageRecord.ts
+++ b/src/shared/data/types/aiUsageRecord.ts
@@ -1,0 +1,10 @@
+/**
+ * AI usage records and pricing snapshots — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/aiUsageRecord';

--- a/src/shared/data/types/assistant.ts
+++ b/src/shared/data/types/assistant.ts
@@ -1,0 +1,10 @@
+/**
+ * Assistant configuration — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/assistant';

--- a/src/shared/data/types/mcpServer.ts
+++ b/src/shared/data/types/mcpServer.ts
@@ -1,0 +1,10 @@
+/**
+ * MCP server entities — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/mcpServer';

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -1,0 +1,10 @@
+/**
+ * Message entities and their runtime timing sinks — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/message';

--- a/src/shared/data/types/model.ts
+++ b/src/shared/data/types/model.ts
@@ -1,0 +1,10 @@
+/**
+ * Model and provider-model catalog — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/model';

--- a/src/shared/data/types/provider.ts
+++ b/src/shared/data/types/provider.ts
@@ -1,0 +1,10 @@
+/**
+ * Provider configuration and auth — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/provider';

--- a/src/shared/data/types/uiParts.ts
+++ b/src/shared/data/types/uiParts.ts
@@ -1,0 +1,10 @@
+/**
+ * UI message parts and serialized errors — mobile-owned, still declared in `packages/universal`.
+ *
+ * `packages/ai-runtime` imports this module and a workspace package must not
+ * import app code, so the declarations cannot move yet. App code imports this
+ * path — the final home — so dissolving universal is a paste into this file
+ * rather than another import migration, and until then there is exactly one
+ * declaration rather than two copies that can drift.
+ */
+export * from '@cherrystudio/universal/data/types/uiParts';


### PR DESCRIPTION
## Summary

Seven entity types (model, provider, assistant, message, uiParts, aiUsageRecord, mcpServer) stayed in `packages/universal/src/data/types` when the data layer moved to `src/shared/data`, because `packages/ai-runtime` imports them and a workspace package must not import app code. That constraint is about the *package* side — app code had no reason to keep spelling the package path.

`src/shared/data/types` now carries a module per entity that re-exports the universal declaration, and all app-side imports (186 files, 267 references) point at `@/shared/data/types/*`. The ESLint tombstone covers the whole `@cherrystudio/universal/data/types` subtree, with the re-export modules as the one scoped exemption — every other tombstone still applies to them.

**Why re-export instead of copy.** These modules carry zod schemas and enum arrays, not just types. Two copies either side of the app/package boundary drift silently and structural typing hides it — the same failure mode as the duplicated `DataApiError` class fixed in #581. One declaration, two spellings, is the safe version.

**What this buys.** Dissolving universal becomes a paste into files that already exist at the right path plus repointing `packages/ai-runtime`; `src` needs no import migration at all. Both README ledgers (`src/shared/data`, `packages/universal/src/data`) now say so.

## Verification

- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format` clean
- Full suite: 318 suites / 2857 tests pass
- Tombstone proven live: a probe file importing the package path errors, while the re-export module lints clean
- `src` has no remaining `@cherrystudio/universal/data/types` reference outside the seven re-export modules

Stacked on #588; part of the mobile data-layer split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)