### PR TITLE
docs(ui-components): define the imposed-versus-chosen platform rule

### DIFF
--- a/docs/references/ui-components.md
+++ b/docs/references/ui-components.md
@@ -1,7 +1,43 @@
 # UI Components
 
-This reference defines current shared component ownership and platform boundaries. Follow
-[UI Development](../guides/ui-development.md) when creating or changing product UI.
+This reference defines the shared component design, ownership, and platform boundaries for Cherry
+Studio Mobile. Follow [UI Development](../guides/ui-development.md) when creating or changing
+product UI.
+
+## Design Direction
+
+One rule governs every platform decision:
+
+> Respect a platform difference the platform imposes. Do not introduce one it does not.
+
+A difference is **imposed** when the operating system, a native API, a system-rendered surface, or
+the platform bundle requires it: the shared source cannot express the behavior, or expressing it in
+shared source would be incorrect. Imposed differences are respected in full, including the system's
+own appearance, gestures, and accessibility behavior. Reproducing a system surface in JavaScript to
+keep the source uniform is a worse outcome than splitting it.
+
+A difference is **chosen** when shared source could express it correctly and the argument for
+splitting is that one platform's result would look or feel more conventional. Chosen differences are
+not introduced. Cherry Studio has one product identity across iOS and Android; platform design
+conventions are input to the design, not a reason to maintain separate Cupertino and Material
+component families.
+
+The test is whether the shared implementation would be *wrong*, not whether it would be
+*unfamiliar*. Ordinary product components have no imposed difference and do not fork.
+
+Use this decision order:
+
+1. If the operating system or a provider renders the surface, expose a shared gateway and let the
+   platform render it, including its native appearance and gestures.
+2. If a native API, lifecycle, or bundling constraint cannot be represented safely in shared source,
+   split only the private adapter and preserve the shared product contract.
+3. If only a value, callback, or system behavior differs, keep one implementation and adapt the
+   difference behind the component or navigation boundary.
+4. Otherwise, use one shared implementation.
+
+Existing `.ios.tsx` and `.android.tsx` files are implementation inventory, not precedent. Reassess
+their boundary when substantially changing the component, but do not migrate unrelated components
+incidentally.
 
 ## Ownership
 
@@ -26,10 +62,98 @@ Direct `heroui-native` and `@expo/ui` usage remains limited to capabilities whos
 third-party behavior is itself part of the contract. A package-owned CherryUI wrapper is the public
 surface once the app standardizes behavior around such a dependency.
 
+App-level singleton surfaces are owned by CherryUI, mounted once at the app root, and reached
+through one hook or component from `@cherrystudio/ui/components`. Toast, portal host, and global
+alert are singletons. Feature code does not import a third-party toast or dialog hook directly and
+does not mount a second host for the same surface.
+
+## Implementation Model
+
+The dependency direction is:
+
+```text
+product screen or feature
+        ↓
+shared CherryUI component or semantic platform gateway
+        ↓
+private iOS / Android adapter when required
+        ↓
+operating-system or store API
+```
+
+Feature screens do not import platform UI SDKs directly. Platform files follow
+[Platform Variants](./naming-conventions.md#platform-variants) and remain inside the smallest
+component or gateway family that owns the difference.
+
+Use a small conditional inside a shared component when only a value or callback differs. Use
+matching platform files only when shared source cannot safely represent the underlying native API,
+lifecycle, rendered system surface, or bundling boundary. An import that is unavailable on the other
+platform or would unnecessarily place a platform SDK in its bundle is a valid reason to isolate an
+adapter. Do not use platform files solely for color, spacing, radius, typography, shadow, or
+product-control geometry.
+
+## Component Classification
+
+### Shared Visuals And Implementation By Default
+
+The following component families normally use one design and one implementation on iOS and
+Android:
+
+- typography, icons, images, avatars, badges, chips, and dividers;
+- buttons, icon buttons, text fields, search fields, checkboxes, radio controls, switches, sliders,
+  segmented controls, and tabs;
+- cards, list rows, sections, surfaces, and product-drawn toolbars;
+- product-composed dialogs, bottom sheets, toasts, popovers, tooltips, and rich business menus;
+- progress indicators, skeletons, loading states, empty states, and error states; and
+- chat messages, composer parts, settings content, and account screens.
+
+A family in this list may still use a private platform adapter when it meets an exception in the
+implementation model. The exception does not change its shared public API or product specification.
+
+This rule includes visual tokens and motion. Color, typography, spacing, radius, elevation, opacity,
+and animation semantics come from the same Cherry design system on both platforms. General-purpose
+icons also use the shared Cherry icon registry; only platform brands or truly system-semantic
+artwork require an adapter.
+
+A control may still use a standard React Native or maintained third-party primitive internally.
+That dependency must preserve the shared Cherry contract and must not force feature code to branch
+by platform.
+
+### Shared Product Contract With Platform Behavior
+
+These capabilities keep one product-facing semantic API and surrounding flow while delegating
+system behavior or presentation where it differs:
+
+| Capability | Shared responsibility | Platform responsibility |
+| --- | --- | --- |
+| Back navigation | destinations, headers, and page composition | iOS interactive pop and Android system or predictive back |
+| Navigation chrome | titles, action semantics, icons, menu items, and page composition | how header actions and search fields are rendered into the native navigation bar |
+| Window insets | layout and spacing rules | safe-area and system-bar inset values |
+| Share and pickers | trigger and surrounding product flow | share sheet, photo picker, and document picker |
+| File preview | metadata, loading, error, and fallback states | Quick Look or the available Android viewer |
+| System alerts and action or context menus | semantic content, actions, roles, and state | native presentation, dismissal, and gesture dispatch |
+| Permissions | pre-permission explanation and denied-state recovery | the system authorization prompt |
+| Haptics and accessibility | intent, labels, state, and reduced-motion behavior | supported feedback and accessibility APIs |
+
+Do not recreate system back gestures in a general-purpose horizontal swipe component. Product
+gestures avoid system edge zones, while the navigation owner handles the platform back contract.
+
+A provider that owns its rendered control, such as a branded sign-in or wallet button, follows the
+same shape: one shared entry surface and flow, with the official control supplied by a private
+platform adapter. Cherry Mobile ships no such capability today, so this reference defines no
+concrete provider boundaries.
+
 ## Platform Boundaries
 
-- Platform features enhance the common interaction contract. iOS Liquid Glass may enhance
-  appearance; Android and older iOS retain a complete fallback.
+- Platform features enhance the common interaction contract without establishing a second product
+  visual language.
+- On iOS, system-rendered controls and navigation inherit the current platform appearance,
+  including Liquid Glass where supported. The owning platform adapter lets the system render this
+  material; product code does not reproduce it.
+- Liquid Glass is not a product-wide visual requirement. Cherry-owned content surfaces and
+  ordinary product components remain shared. A custom iOS-only glass treatment is optional
+  progressive enhancement, while Android and unsupported iOS versions retain the same hierarchy
+  and a complete fallback.
 - Expo Router and React Navigation top-bar actions use `headerRight`, `headerLeft`, or
   `Stack.Toolbar` with Cherry-owned content.
 - Android horizontal product gestures start outside system back-gesture edge zones.
@@ -38,6 +162,14 @@ surface once the app standardizes behavior around such a dependency.
 
 ## Acceptance
 
+- New or substantially changed ordinary product components use one visual specification and shared
+  source implementation across iOS and Android by default.
+- A platform-specific file names the imposed constraint — native API, lifecycle, system-rendered
+  surface, provider-owned control, or bundle — that prevents a correct shared implementation.
+  Familiarity and convention are not constraints.
+- A platform family shares one props type and one set of helpers, kept in the family directory
+  rather than restated in each platform file.
+- Platform gateways expose one semantic API and keep SDK types out of feature code.
 - Controls expose accessible labels, state, disabled/loading behavior, and usable touch targets.
 - Text scales and wraps without fixed dimensions clipping its content.
 - Platform enhancement failure leaves the control recognizable and usable.
@@ -45,3 +177,10 @@ surface once the app standardizes behavior around such a dependency.
   platform supports it.
 - Repeated product interaction behavior moves to CherryUI through the workflow in
   [UI Development](../guides/ui-development.md).
+
+## References
+
+- [React Native platform-specific code](https://reactnative.dev/docs/platform-specific-code.html)
+- [Apple Liquid Glass adoption guidance](https://developer.apple.com/documentation/technologyoverviews/adopting-liquid-glass)
+- [Apple Human Interface Guidelines: Materials](https://developer.apple.com/design/human-interface-guidelines/materials)
+- [Android app quality guidance](https://developer.android.com/quality/user-experience)

--- a/docs/references/ui-components.md
+++ b/docs/references/ui-components.md
@@ -1,10 +1,11 @@
 # UI Components
 
-This reference defines the shared component design, ownership, and platform boundaries for Cherry
-Studio Mobile. Follow [UI Development](../guides/ui-development.md) when creating or changing
-product UI.
+This reference defines what is true about shared components in Cherry Studio Mobile: who owns each
+surface, and where a platform difference is legitimate. [UI Development](../guides/ui-development.md)
+defines how to do the work — searching CherryUI first, composing component APIs, and promoting a
+feature component into the package.
 
-## Design Direction
+## The Platform Rule
 
 One rule governs every platform decision:
 
@@ -25,7 +26,7 @@ component families.
 The test is whether the shared implementation would be *wrong*, not whether it would be
 *unfamiliar*. Ordinary product components have no imposed difference and do not fork.
 
-Use this decision order:
+### Decision Order
 
 1. If the operating system or a provider renders the surface, expose a shared gateway and let the
    platform render it, including its native appearance and gestures.
@@ -35,6 +36,30 @@ Use this decision order:
    difference behind the component or navigation boundary.
 4. Otherwise, use one shared implementation.
 
+An import unavailable on the other platform, or one that would unnecessarily place a platform SDK in
+the other platform's bundle, satisfies step 2. Color, spacing, radius, typography, shadow, and
+product-control geometry never do.
+
+Splitting under step 1 or step 2 changes neither the shared public API nor the product
+specification; only the private adapter differs. A component may also use a React Native or
+maintained third-party primitive internally, provided that dependency preserves the shared contract
+and does not force feature code to branch by platform.
+
+### Applying The Rule
+
+Platform files follow [Platform Variants](./naming-conventions.md#platform-variants) and stay inside
+the smallest component or gateway family that owns the difference. The dependency direction is:
+
+```text
+product screen or feature
+        ↓
+shared CherryUI component or semantic platform gateway
+        ↓
+private iOS / Android adapter when required
+        ↓
+operating-system or provider API
+```
+
 Existing `.ios.tsx` and `.android.tsx` files are implementation inventory, not precedent. Reassess
 their boundary when substantially changing the component, but do not migrate unrelated components
 incidentally.
@@ -42,9 +67,8 @@ incidentally.
 ## Ownership
 
 `@cherrystudio/ui/components` is the public entry point for reusable, platform-neutral product
-interaction components. The package currently owns buttons, fields, menus, sheets, composer parts,
-surfaces, loading states, tabs, sliders, switches, sections, portals, and related primitives. Its
-[package README](../../packages/ui/README.md) is the component API reference.
+interaction components. Its [package README](../../packages/ui/README.md) is the component API
+reference and the authority on what the package currently provides.
 
 Runtime component imports use that entry point so Metro does not traverse icon registries:
 
@@ -54,80 +78,32 @@ import { Button, Section, TextField } from '@cherrystudio/ui/components';
 
 `@cherrystudio/app-icons` owns the cross-platform icon registry. Feature code owns business state,
 translations, query behavior, and workflow-specific composition. A local `Pressable` wrapper is
-appropriate only while its interaction remains specific to that feature. Shared navigation and
-platform adapters may remain under `src/frontend/components` when their contract depends on app
-navigation rather than a general product control.
+appropriate only while its interaction remains specific to that feature; repeated product
+interaction behavior moves into CherryUI through the workflow in
+[UI Development](../guides/ui-development.md). React Native `Button` is reserved for temporary
+examples and non-product test screens.
 
-Direct `heroui-native` and `@expo/ui` usage remains limited to capabilities whose native or
-third-party behavior is itself part of the contract. A package-owned CherryUI wrapper is the public
-surface once the app standardizes behavior around such a dependency.
+Shared navigation and platform adapters may remain under `src/frontend/components` when their
+contract depends on app navigation rather than a general product control. Feature screens do not
+import platform UI SDKs directly. Direct `heroui-native` and `@expo/ui` usage remains limited to
+capabilities whose native or third-party behavior is itself part of the contract; a package-owned
+CherryUI wrapper becomes the public surface once the app standardizes behavior around such a
+dependency.
 
 App-level singleton surfaces are owned by CherryUI, mounted once at the app root, and reached
 through one hook or component from `@cherrystudio/ui/components`. Toast, portal host, and global
 alert are singletons. Feature code does not import a third-party toast or dialog hook directly and
 does not mount a second host for the same surface.
 
-## Implementation Model
+## Platform Responsibilities
 
-The dependency direction is:
-
-```text
-product screen or feature
-        ↓
-shared CherryUI component or semantic platform gateway
-        ↓
-private iOS / Android adapter when required
-        ↓
-operating-system or store API
-```
-
-Feature screens do not import platform UI SDKs directly. Platform files follow
-[Platform Variants](./naming-conventions.md#platform-variants) and remain inside the smallest
-component or gateway family that owns the difference.
-
-Use a small conditional inside a shared component when only a value or callback differs. Use
-matching platform files only when shared source cannot safely represent the underlying native API,
-lifecycle, rendered system surface, or bundling boundary. An import that is unavailable on the other
-platform or would unnecessarily place a platform SDK in its bundle is a valid reason to isolate an
-adapter. Do not use platform files solely for color, spacing, radius, typography, shadow, or
-product-control geometry.
-
-## Component Classification
-
-### Shared Visuals And Implementation By Default
-
-The following component families normally use one design and one implementation on iOS and
-Android:
-
-- typography, icons, images, avatars, badges, chips, and dividers;
-- buttons, icon buttons, text fields, search fields, checkboxes, radio controls, switches, sliders,
-  segmented controls, and tabs;
-- cards, list rows, sections, surfaces, and product-drawn toolbars;
-- product-composed dialogs, bottom sheets, toasts, popovers, tooltips, and rich business menus;
-- progress indicators, skeletons, loading states, empty states, and error states; and
-- chat messages, composer parts, settings content, and account screens.
-
-A family in this list may still use a private platform adapter when it meets an exception in the
-implementation model. The exception does not change its shared public API or product specification.
-
-This rule includes visual tokens and motion. Color, typography, spacing, radius, elevation, opacity,
-and animation semantics come from the same Cherry design system on both platforms. General-purpose
-icons also use the shared Cherry icon registry; only platform brands or truly system-semantic
-artwork require an adapter.
-
-A control may still use a standard React Native or maintained third-party primitive internally.
-That dependency must preserve the shared Cherry contract and must not force feature code to branch
-by platform.
-
-### Shared Product Contract With Platform Behavior
-
-These capabilities keep one product-facing semantic API and surrounding flow while delegating
-system behavior or presentation where it differs:
+These capabilities keep one product-facing semantic API and surrounding flow while delegating system
+behavior or presentation where it differs:
 
 | Capability | Shared responsibility | Platform responsibility |
 | --- | --- | --- |
 | Back navigation | destinations, headers, and page composition | iOS interactive pop and Android system or predictive back |
-| Navigation chrome | titles, action semantics, icons, menu items, and page composition | how header actions and search fields are rendered into the native navigation bar |
+| Navigation chrome | titles, action semantics, icons, menu items, and page composition | how header actions and search fields render into the native navigation bar |
 | Window insets | layout and spacing rules | safe-area and system-bar inset values |
 | Share and pickers | trigger and surrounding product flow | share sheet, photo picker, and document picker |
 | File preview | metadata, loading, error, and fallback states | Quick Look or the available Android viewer |
@@ -135,32 +111,35 @@ system behavior or presentation where it differs:
 | Permissions | pre-permission explanation and denied-state recovery | the system authorization prompt |
 | Haptics and accessibility | intent, labels, state, and reduced-motion behavior | supported feedback and accessibility APIs |
 
-Do not recreate system back gestures in a general-purpose horizontal swipe component. Product
-gestures avoid system edge zones, while the navigation owner handles the platform back contract.
+Top-bar actions reach the native navigation bar through `headerLeft`, `headerRight`, or
+`Stack.Toolbar` with Cherry-owned content.
 
-A provider that owns its rendered control, such as a branded sign-in or wallet button, follows the
-same shape: one shared entry surface and flow, with the official control supplied by a private
-platform adapter. Cherry Mobile ships no such capability today, so this reference defines no
-concrete provider boundaries.
+System back gestures are never recreated in a general-purpose horizontal swipe component. Product
+gestures start outside system back-gesture edge zones, and the navigation owner handles the platform
+back contract.
 
-## Platform Boundaries
+## Visual System
 
-- Platform features enhance the common interaction contract without establishing a second product
-  visual language.
-- On iOS, system-rendered controls and navigation inherit the current platform appearance,
-  including Liquid Glass where supported. The owning platform adapter lets the system render this
-  material; product code does not reproduce it.
-- Liquid Glass is not a product-wide visual requirement. Cherry-owned content surfaces and
-  ordinary product components remain shared. A custom iOS-only glass treatment is optional
-  progressive enhancement, while Android and unsupported iOS versions retain the same hierarchy
-  and a complete fallback.
-- Expo Router and React Navigation top-bar actions use `headerRight`, `headerLeft`, or
-  `Stack.Toolbar` with Cherry-owned content.
-- Android horizontal product gestures start outside system back-gesture edge zones.
-- React Native `Button` is reserved for temporary examples and non-product test screens. Product UI
-  uses CherryUI or a feature-owned `Pressable` while the interaction remains local.
+Color, typography, spacing, radius, elevation, opacity, and animation semantics come from the same
+Cherry design system on both platforms. [Design Spec](../../DESIGN.md) owns the token pipeline and
+the rules for consuming tokens. General-purpose icons come from the shared Cherry icon registry;
+only platform brands and truly system-semantic artwork require an adapter.
+
+Platform features enhance the common interaction contract without establishing a second product
+visual language. On iOS, system-rendered controls and navigation inherit the current platform
+appearance, including Liquid Glass where supported: the owning platform adapter lets the system
+render that material, and product code does not reproduce it.
+
+Liquid Glass is not a product-wide visual requirement. Cherry-owned content surfaces and ordinary
+product components remain shared. A custom iOS-only glass treatment is optional progressive
+enhancement, while Android and unsupported iOS versions retain the same hierarchy and a complete
+fallback.
 
 ## Acceptance
+
+### Platform Boundary
+
+Reviewable from the change itself:
 
 - New or substantially changed ordinary product components use one visual specification and shared
   source implementation across iOS and Android by default.
@@ -170,13 +149,16 @@ concrete provider boundaries.
 - A platform family shares one props type and one set of helpers, kept in the family directory
   rather than restated in each platform file.
 - Platform gateways expose one semantic API and keep SDK types out of feature code.
+
+### Control Quality
+
+Reviewable by running the app:
+
 - Controls expose accessible labels, state, disabled/loading behavior, and usable touch targets.
 - Text scales and wraps without fixed dimensions clipping its content.
 - Platform enhancement failure leaves the control recognizable and usable.
 - Ambiguous icon-only actions provide an accessible label and tooltip or menu context where the
   platform supports it.
-- Repeated product interaction behavior moves to CherryUI through the workflow in
-  [UI Development](../guides/ui-development.md).
 
 ## References
 


### PR DESCRIPTION
## Why

Platform decisions in this reference had no decidable test. Two sections contradicted each other:
the shared-visuals list named `product navigation chrome` as shared by default, while
§ Platform Boundaries said the system renders navigation and product code must not reproduce it.
Navigation chrome is the most common split in the tree (headers, native search fields, context
menus, viewer toolbars), so the highest-frequency decision matched two opposite rules.

Separately, the reference described store billing, wallet payment, provider sign-in, store review,
biometrics, and purchase management as platform boundaries. None of those capabilities exist in the
app — no dependency, no code, no route. `docs/README.md` § Documentation Governance calls describing
an intended future as present "the one failure mode this rule exists to prevent."

## What changed

**One rule, with a test that decides cases.**

> Respect a platform difference the platform imposes. Do not introduce one it does not.

- **Imposed** — the OS, a native API, a system-rendered surface, or the platform bundle requires it:
  shared source cannot express the behavior, or expressing it there would be incorrect. Respected in
  full, including the system's own appearance, gestures, and accessibility behavior. Reproducing a
  system surface in JavaScript to keep source uniform is the worse outcome.
- **Chosen** — shared source could express it correctly, and the only argument is that one platform's
  result looks more conventional. Not introduced.
- The test: whether the shared implementation would be *wrong*, not whether it would be *unfamiliar*.

The decision order is rewritten around this, replacing the previous defensive phrasing about
native-looking controls.

**Navigation chrome moved to the shared-contract table.** Titles, action semantics, icons, menu
items, and page composition stay shared; only how actions and search fields render into the native
navigation bar varies. This matches `BackHeader`, where both platforms use the native
`Stack.Screen` header and the split is confined to the action-rendering adapter — iOS uses
`Stack.Toolbar` because `react-native-screens` exposes duplicate/mis-sized accessibility nodes for
the back button when bridging `headerLeft`/`headerRight` through `RNSScreenStackHeaderSubview`.
The shared-visuals list now says `product-drawn toolbars`.

**Two guardrails against drift**, since respecting real differences only works if the contract holds:
- a platform file must name its imposed constraint, and "familiarity and convention are not
  constraints";
- a platform family shares one props type and helper set in the family directory instead of
  restating them per platform.

**Toast, portal host, and global alert declared app-level singletons** owned by CherryUI, reached
through one entry point. `DynamicToast` already demonstrates the model correctly: shared props,
`inner-base`, and motion, with the split confined to the iOS `expo-blur` backdrop — a bundling
constraint, not a design divergence.

**Removed** the store/wallet/provider-sign-in table and its 12 policy links. `Permissions`, the only
implemented row, folded into the shared-contract table. A three-line generic rule covers
provider-owned controls and states plainly that the app ships no such capability today. Remaining
links are technical only.

## Scope

Documentation only. No behavior change, and no code migration — existing `.ios.tsx`/`.android.tsx`
files stay as they are; the reference already treats them as inventory, not precedent.

## Gates

- `pnpm docs:check-links` — pass (92 files)
- `pnpm format:check` — pass
- `pnpm typecheck` — pass
- `pnpm lint` — 9 pre-existing errors on `v0.2`, all `import/no-unresolved` for
  `@cherrystudio/ai-core` (the eslint resolver does not follow the package's `react-native` export
  condition; `dist/` is present). Unrelated to this change — the branch diff is one Markdown file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: structural rewrite

The first commit fixed *what the rules say*. This one fixes *where they live*.

## Why

The reference answered one question — "when does a component fork by platform?" — in **five places
using four vocabularies**:

| Section | Vocabulary |
|---|---|
| Design Direction decision order | imposed / chosen |
| Implementation Model | "cannot safely represent" / "solely for color, spacing…" |
| Shared Visuals list | "meets an exception in the implementation model" |
| Platform Boundaries bullets | Liquid Glass / progressive enhancement |
| Acceptance | "imposed constraint" / "familiarity and convention" |

A reader entering at any one of them missed the imposed-versus-chosen test the other four depend on,
and five copies of one rule drift independently. Three section names — Implementation Model,
Component Classification, Platform Boundaries — all partially answered the same question, so the
answer was unpredictable to locate.

## What changed

**Each section now owns one distinct question:**

- `The Platform Rule` — whether to fork. Stated once; Decision Order and Applying The Rule are
  subsections of it, not competing statements.
- `Ownership` — who holds a surface.
- `Platform Responsibilities` — the capability table, kept intact.
- `Visual System` — where appearance comes from.

**Deleted the open enumeration of component families that share by default.** It could not be
exhaustive, so anything unlisted was ambiguous; the sentence immediately after it granted an
exception to every entry, so it decided nothing; and the imposed-versus-chosen test already covers
it. Deleted the package-contents list in `Ownership` for the same reason — the package README is the
authority, and a second list would drift from it.

The capability table survives because it is the opposite kind of enumeration: closed, fixed columns,
one row per capability, and it actually assigns responsibility.

**Split `Acceptance` by review activity** — criteria readable from a diff versus criteria requiring
a running app. Different reviewers check these at different times.

**Also removed** in this commit: the provider paragraph whose content was "this capability does not
exist yet", the `Expo Router` top-bar bullet that duplicated the new Navigation chrome table row, and
a leftover `store API` reference in the dependency diagram.

**Added one link:** the token assertion previously said appearance comes from the Cherry design
system without saying where that is defined. It now links `DESIGN.md`, which owns the token pipeline.

## Verification

No rule changes meaning. Every removed line was traced to its new location; the only intentional
deletions are the two open enumerations and the speculative provider paragraph, all noted above.

187 → 168 lines, with one authoritative home per rule.

`pnpm docs:check-links` and `pnpm format:check` pass on the final head.
