### PR TITLE
refactor(mcp): replace the hand-rolled timeout race with SDK abort signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@ai-sdk/google-vertex": "^4.0.112",
     "@ai-sdk/groq": "^3.0.39",
     "@ai-sdk/huggingface": "^1.0.50",
-    "@ai-sdk/mcp": "1.0.64",
+    "@ai-sdk/mcp": "1.0.71",
     "@ai-sdk/mistral": "^3.0.37",
     "@ai-sdk/openai": "^3.0.53",
     "@ai-sdk/openai-compatible": "2.0.62",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.0.50
         version: 1.0.50(zod@4.4.3)
       '@ai-sdk/mcp':
-        specifier: 1.0.64
-        version: 1.0.64(zod@4.4.3)
+        specifier: 1.0.71
+        version: 1.0.71(zod@4.4.3)
       '@ai-sdk/mistral':
         specifier: ^3.0.37
         version: 3.0.37(zod@4.4.3)
@@ -908,8 +908,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  '@ai-sdk/mcp@1.0.64':
-    resolution: {integrity: sha512-n6fZiIsiK0TWdJa7bdcjiQxOmg+GRa1wk8ns01gfzaiZbnNwIjmgt1oFMDIzLzgOjVq/LqktbXfxvBFlQ8RDnQ==}
+  '@ai-sdk/mcp@1.0.71':
+    resolution: {integrity: sha512-woKUwm/yiqxEC+E863tqAjEpiyWCERmy//k9pdNYP8Ta6+PF6Ge2X6p99e72BdBovB+/McUWgbJ4+Fiht+41WQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9756,7 +9756,7 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/mcp@1.0.64(zod@4.4.3)':
+  '@ai-sdk/mcp@1.0.71(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)

--- a/src/backend/ai/mcp/McpRuntimeService.ts
+++ b/src/backend/ai/mcp/McpRuntimeService.ts
@@ -26,10 +26,10 @@ const logger = loggerService.withContext('McpRuntimeService');
 const TOOLS_CACHE_TTL_MS = 5 * 60 * 1000;
 const ENABLED_PREWARM_CONCURRENCY = 3;
 const ASSISTANT_WARM_TIMEOUT_MS = 3 * 1000;
-/** Ceiling for connect + tools/list. `@ai-sdk/mcp` implements no request timeout
- * of its own: `RequestOptions.timeout` is declared but never read, and neither
- * `initialize` nor `tools()` forwards a signal. Without this a server that
- * accepts the socket then stalls would pin a client slot indefinitely. */
+/** Ceiling for connect + tools/list, enforced through abort signals the SDK
+ * forwards to the transport (native support since `@ai-sdk/mcp@1.0.66`).
+ * Without it a server that accepts the socket then stalls would pin a client
+ * slot indefinitely. */
 const TOOLS_FETCH_TIMEOUT_MS = 15 * 1000;
 /** Backoff after a failed refresh, doubling per consecutive failure. Without it
  * a permanently-rejecting server costs a full connect attempt on every message,
@@ -69,6 +69,9 @@ type McpServerRuntimeSnapshot = Omit<McpServerRuntimeSummary, 'lastError' | 'sta
 };
 
 type ServerRuntimeState = {
+  /** Cancels every in-flight request of the current generation; replaced on
+   * reset so later work runs under a fresh signal. */
+  abort: AbortController;
   client?: MCPClient;
   connectionPromise?: Promise<MCPClient>;
   endpointUrl: string;
@@ -77,7 +80,6 @@ type ServerRuntimeState = {
   refreshPromise?: Promise<void>;
   runtimeError?: string;
   serverId: string;
-  timeoutCancellations: Set<() => void>;
   toolsCache?: ToolsCacheEntry;
 };
 
@@ -104,13 +106,16 @@ function toolDescription(tool: Tool): string | undefined {
   return typeof tool.description === 'string' ? tool.description : undefined;
 }
 
-async function listAllTools(client: MCPClient): Promise<ToolSet> {
+async function listAllTools(client: MCPClient, signal: AbortSignal): Promise<ToolSet> {
   const definitions: ListToolsResult['tools'] = [];
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
 
   while (true) {
-    const page = await client.listTools(cursor ? { params: { cursor } } : undefined);
+    const page = await client.listTools({
+      options: { signal },
+      ...(cursor ? { params: { cursor } } : {}),
+    });
     definitions.push(...page.tools);
 
     if (!page.nextCursor) {
@@ -126,9 +131,12 @@ async function listAllTools(client: MCPClient): Promise<ToolSet> {
   return castMcpToolSet(client.toolsFromDefinitions({ tools: definitions }));
 }
 
-function createHttpClient(config: McpConnectionConfig): Promise<MCPClient> {
+/** On failure — including an aborted initialize — the SDK closes its own
+ * transport before rethrowing, so callers never inherit a half-open client. */
+function createHttpClient(config: McpConnectionConfig, signal: AbortSignal): Promise<MCPClient> {
   return createMCPClient({
     clientName: 'Cherry Studio',
+    initializationOptions: { signal },
     transport: {
       type: 'http',
       url: config.endpointUrl,
@@ -142,57 +150,41 @@ function hasRunnableUrl(server: McpServer): boolean {
 }
 
 /**
- * Race a promise against a wall clock, running `onTimeout` when it wins.
+ * A timeout signal composed with the upstream signals a request must also obey
+ * (state eviction, the chat turn's own abort).
  *
- * Not `AbortSignal.timeout` — Expo's winter runtime does install it, but the
- * awaited work here (`client.tools()`, `rawTool.execute`) exposes no seam to
- * pass a signal into, and eviction has to happen as a side effect either way.
+ * The SDK forwards the composed signal to the transport, so timing out — or
+ * evicting — genuinely cancels the network request. Rejections are then
+ * classified by inspecting our own signals rather than the SDK's error types,
+ * which are not exported and are free to change across SDK majors.
+ *
+ * `AbortSignal.timeout`/`AbortSignal.any` are installed on the native runtime
+ * by Expo's winter `installAbortSignalPatch`.
  */
-function withTimeout<T>(
-  promise: Promise<T>,
+type BoundedSignal = {
+  didTimeout: () => boolean;
+  /** Settle the bound: clears the pending timer once the work is over. */
+  done: () => void;
+  signal: AbortSignal;
+};
+
+function boundedSignal(
   timeoutMs: number,
-  label: string,
-  onTimeout: () => void,
-  cancellations?: Set<() => void>,
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    let settled = false;
-    let handle: ReturnType<typeof setTimeout>;
-    const cleanup = () => {
-      clearTimeout(handle);
-      cancellations?.delete(cancel);
-    };
-    const cancel = () => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(new McpEvictedError(`${label} was invalidated`));
-    };
+  ...upstream: readonly (AbortSignal | undefined)[]
+): BoundedSignal {
+  const timeoutController = new AbortController();
+  let timedOut = false;
+  const handle = setTimeout(() => {
+    timedOut = true;
+    timeoutController.abort();
+  }, timeoutMs);
 
-    handle = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      onTimeout();
-      reject(new McpTimeoutError(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    cancellations?.add(cancel);
-
-    promise.then(
-      (value) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        resolve(value);
-      },
-      (error) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        reject(error);
-      },
-    );
-  });
+  const signals = [timeoutController.signal, ...upstream.filter((signal) => signal !== undefined)];
+  return {
+    didTimeout: () => timedOut,
+    done: () => clearTimeout(handle),
+    signal: signals.length === 1 ? timeoutController.signal : AbortSignal.any(signals),
+  };
 }
 
 /**
@@ -380,7 +372,11 @@ export class McpRuntimeService extends BaseService {
    * enters the pool.
    */
   async testConnection(config: McpConnectionConfig): Promise<McpToolSummary[]> {
-    const rawTools = await this.withTemporaryClient(config, 'MCP connection test', listAllTools);
+    const rawTools = await this.withTemporaryClient(
+      config,
+      'MCP connection test',
+      (client, signal) => listAllTools(client, signal),
+    );
     return Object.entries(rawTools).map(([name, tool]) => ({
       description: toolDescription(tool),
       name,
@@ -451,10 +447,10 @@ export class McpRuntimeService extends BaseService {
     }
 
     const state: ServerRuntimeState = {
+      abort: new AbortController(),
       endpointUrl: server.endpointUrl,
       generation,
       serverId: server.id,
-      timeoutCancellations: new Set(),
     };
     this.runtimeStates.set(server.id, state);
     return state;
@@ -583,7 +579,11 @@ export class McpRuntimeService extends BaseService {
     state.runtimeError = errorMessage(error);
   }
 
-  private async getClient(server: McpServer, state: ServerRuntimeState): Promise<MCPClient> {
+  private async getClient(
+    server: McpServer,
+    state: ServerRuntimeState,
+    signal: AbortSignal,
+  ): Promise<MCPClient> {
     if (!this.isCurrentState(state)) {
       throw new McpEvictedError(`MCP server ${server.name} was invalidated`);
     }
@@ -596,7 +596,7 @@ export class McpRuntimeService extends BaseService {
     }
 
     const generation = state.generation;
-    const initPromise: Promise<MCPClient> = createHttpClient(server)
+    const initPromise: Promise<MCPClient> = createHttpClient(server, signal)
       .then((client) => {
         if (state.connectionPromise !== initPromise || !this.isCurrentState(state, generation)) {
           this.closeQuietly(client);
@@ -622,36 +622,23 @@ export class McpRuntimeService extends BaseService {
   private async withTemporaryClient<TValue>(
     config: McpConnectionConfig,
     label: string,
-    operation: (client: MCPClient) => Promise<TValue> | TValue,
+    operation: (client: MCPClient, signal: AbortSignal) => Promise<TValue> | TValue,
   ): Promise<TValue> {
+    const bound = boundedSignal(TOOLS_FETCH_TIMEOUT_MS);
     let client: MCPClient | undefined;
-    let acceptClient = true;
-    const request = createHttpClient(config).then(async (createdClient) => {
-      if (!acceptClient) {
-        this.closeQuietly(createdClient);
-        throw new McpEvictedError(`${label} already ended`);
-      }
-      client = createdClient;
-      return operation(createdClient);
-    });
-
     try {
-      return await withTimeout(request, TOOLS_FETCH_TIMEOUT_MS, label, () => {
-        acceptClient = false;
-      });
+      client = await createHttpClient(config, bound.signal);
+      return await operation(client, bound.signal);
+    } catch (error) {
+      if (bound.didTimeout()) {
+        throw new McpTimeoutError(`${label} timed out after ${TOOLS_FETCH_TIMEOUT_MS}ms`);
+      }
+      throw error;
     } finally {
-      acceptClient = false;
+      bound.done();
       if (client) {
         this.closeQuietly(client);
       }
-    }
-  }
-
-  private cancelTimeouts(state: ServerRuntimeState): void {
-    const cancellations = [...state.timeoutCancellations];
-    state.timeoutCancellations.clear();
-    for (const cancel of cancellations) {
-      cancel();
     }
   }
 
@@ -661,7 +648,8 @@ export class McpRuntimeService extends BaseService {
     }
 
     state.generation += 1;
-    this.cancelTimeouts(state);
+    state.abort.abort();
+    state.abort = new AbortController();
     state.connectionPromise = undefined;
     state.toolsCache = undefined;
     if (state.client) {
@@ -675,7 +663,7 @@ export class McpRuntimeService extends BaseService {
       this.runtimeStates.delete(state.serverId);
     }
     state.generation += 1;
-    this.cancelTimeouts(state);
+    state.abort.abort();
     state.connectionPromise = undefined;
     state.refreshPromise = undefined;
     state.failure = undefined;
@@ -716,16 +704,30 @@ export class McpRuntimeService extends BaseService {
 
   private async fetchRawTools(server: McpServer, state: ServerRuntimeState): Promise<ToolSet> {
     const generation = state.generation;
-    const rawTools = await withTimeout(
-      (async () => {
-        const client = await this.getClient(server, state);
-        return listAllTools(client);
-      })(),
-      TOOLS_FETCH_TIMEOUT_MS,
-      `MCP server ${server.name}`,
-      () => this.resetConnection(state),
-      state.timeoutCancellations,
-    );
+    // One bound covers connect + full pagination, matching the old wall-clock
+    // ceiling. Eviction rides the same composed signal.
+    const bound = boundedSignal(TOOLS_FETCH_TIMEOUT_MS, state.abort.signal);
+    let rawTools: ToolSet;
+    try {
+      const client = await this.getClient(server, state, bound.signal);
+      rawTools = await listAllTools(client, bound.signal);
+    } catch (error) {
+      if (error instanceof McpEvictedError) {
+        throw error;
+      }
+      if (!this.isCurrentState(state, generation)) {
+        throw new McpEvictedError(`MCP server ${server.name} was invalidated while listing tools`);
+      }
+      if (bound.didTimeout()) {
+        this.resetConnection(state);
+        throw new McpTimeoutError(
+          `MCP server ${server.name} timed out after ${TOOLS_FETCH_TIMEOUT_MS}ms`,
+        );
+      }
+      throw error;
+    } finally {
+      bound.done();
+    }
     if (!this.isCurrentState(state, generation)) {
       throw new McpEvictedError(`MCP server ${server.name} was invalidated while listing tools`);
     }
@@ -785,7 +787,8 @@ export class McpRuntimeService extends BaseService {
     }
 
     const wrappedExecute = async (
-      ...callArgs: Parameters<typeof execute>
+      input: Parameters<typeof execute>[0],
+      callOptions: Parameters<typeof execute>[1],
     ): Promise<McpCallToolResult & { metadata: McpResultSource }> => {
       const current = await this.assertToolStillAllowed(server, rawToolName);
       if (this.getRuntimeState(current) !== state) {
@@ -793,32 +796,39 @@ export class McpRuntimeService extends BaseService {
       }
 
       const label = `${current.name}/${rawToolName}`;
+      const callerSignal = callOptions?.abortSignal;
+      const bound = boundedSignal(TOOL_CALL_TIMEOUT_MS, state.abort.signal, callerSignal);
 
       let result: McpCallToolResult;
       try {
-        result = (await withTimeout(
-          Promise.resolve(execute(...callArgs)),
-          TOOL_CALL_TIMEOUT_MS,
-          `MCP tool ${label}`,
-          // A timed-out connection may be wedged — don't let later calls reuse it.
-          () => this.resetConnection(state),
-          state.timeoutCancellations,
-        )) as McpCallToolResult;
+        result = (await execute(input, {
+          ...callOptions,
+          abortSignal: bound.signal,
+        })) as McpCallToolResult;
+        bound.done();
       } catch (error) {
+        bound.done();
+        if (callerSignal?.aborted) {
+          // The chat turn itself was aborted. The transport cancelled this one
+          // request cleanly, so the pooled client is not suspect.
+          throw error;
+        }
         // Any transport/protocol failure means the pooled client is suspect;
         // dropping here is what keeps a dead session from sticking around for
         // the rest of the cache TTL. The call itself is not retried — MCP tool
         // calls are not guaranteed idempotent.
         this.resetConnection(state);
         this.recordRuntimeError(state, error);
-        if (error instanceof McpTimeoutError) {
-          // Nothing was cancelled: no signal reaches the server, so the work may
-          // still be running. Say so, or the model retries a write it already made.
+        if (bound.didTimeout()) {
+          // Cancelled client-side only — the server may have received the
+          // request and still be working. Say so, or the model retries a write
+          // it already made.
           throw new Error(
-            `${error.message}. The server may still be processing it — do not repeat this call without checking its effect first.`,
+            `MCP tool ${label} timed out after ${TOOL_CALL_TIMEOUT_MS}ms. The server may still be processing it — do not repeat this call without checking its effect first.`,
+            { cause: error },
           );
         }
-        throw new Error(`MCP tool ${label} failed: ${errorMessage(error)}`);
+        throw new Error(`MCP tool ${label} failed: ${errorMessage(error)}`, { cause: error });
       }
 
       if (result === undefined || result === null) {

--- a/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -12,8 +12,66 @@ jest.mock('expo/fetch', () => ({ fetch: jest.fn() }));
 
 const mockCreateMCPClient = jest.fn();
 jest.mock('@ai-sdk/mcp', () => ({
-  createMCPClient: (...args: unknown[]) => mockCreateMCPClient(...args),
+  createMCPClient: (...args: unknown[]) => mockSdkInitContract(...args),
 }));
+
+/**
+ * Settle `promise` normally, but reject as soon as `signal` aborts — the
+ * request-level contract the real SDK implements (verified against 1.0.71).
+ * Built without `Promise.race` so the losing branch never becomes an
+ * unhandled rejection.
+ */
+function abortable<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+  message: string,
+  onAbort?: () => void,
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => {
+      reject(new Error(message));
+      onAbort?.();
+    };
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener('abort', abort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', abort);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * The real factory owns cleanup before it resolves: an initialize aborted via
+ * `initializationOptions.signal` rejects, and a transport that finishes
+ * connecting after that is closed by the SDK itself, never handed out.
+ */
+function mockSdkInitContract(...args: unknown[]): Promise<unknown> {
+  const config = args[0] as { initializationOptions?: { signal?: AbortSignal } } | undefined;
+  const connect = Promise.resolve(mockCreateMCPClient(...args));
+  return abortable(
+    connect,
+    config?.initializationOptions?.signal,
+    'MCP client initialization was aborted',
+    () => {
+      void connect
+        .then((client) => (client as { close?: () => Promise<void> } | undefined)?.close?.())
+        .catch(() => undefined);
+    },
+  );
+}
 
 type FakeClient = {
   close: jest.Mock;
@@ -67,15 +125,22 @@ function makeAssistant(): Assistant {
   };
 }
 
+/** The abort contract a real MCP tool's execute honors via its transport. */
+function abortableExecute(run: () => Promise<unknown>) {
+  return jest.fn((_input: unknown, options?: { abortSignal?: AbortSignal }) =>
+    abortable(run(), options?.abortSignal, 'Request was aborted'),
+  );
+}
+
 function makeRawTools(names: string[]): ToolSet {
   return Object.fromEntries(
     names.map((name) => [
       name,
       {
         description: `desc ${name}`,
-        execute: jest.fn(async () => {
+        execute: abortableExecute(async () => {
           // A macrotask, not just a microtask, so a call that outlives a tick
-          // still has to beat the timeout race rather than winning it for free.
+          // still has to beat the timeout bound rather than winning it for free.
           await new Promise((resolve) => setTimeout(resolve, 5));
           return { content: [{ text: `ok ${name}`, type: 'text' }] };
         }),
@@ -89,7 +154,12 @@ function makeRawTools(names: string[]): ToolSet {
 /** A tool whose execute resolves with whatever the caller supplies. */
 function makeRawTool(name: string, execute: () => Promise<unknown>): ToolSet {
   return {
-    [name]: { description: name, execute: jest.fn(execute), inputSchema: {}, type: 'dynamic' },
+    [name]: {
+      description: name,
+      execute: abortableExecute(execute),
+      inputSchema: {},
+      type: 'dynamic',
+    },
   } as unknown as ToolSet;
 }
 
@@ -111,9 +181,13 @@ function makeClient(tools: ToolSet): FakeClient {
     tools: jest.fn(async () => tools),
     toolsFromDefinitions: jest.fn(),
   };
-  client.listTools.mockImplementation(async () => ({
-    tools: makeToolDefinitions(await client.tools()),
-  }));
+  client.listTools.mockImplementation((args?: { options?: { signal?: AbortSignal } }) =>
+    abortable(
+      (async () => ({ tools: makeToolDefinitions(await client.tools()) }))(),
+      args?.options?.signal,
+      'Request was aborted',
+    ),
+  );
   client.toolsFromDefinitions.mockImplementation(
     ({ tools: definitions }: { tools: ReturnType<typeof makeToolDefinitions> }) =>
       Object.fromEntries(definitions.map((definition) => [definition.name, definition.rawTool])),
@@ -924,8 +998,13 @@ describe('listToolsForServer', () => {
         toolCount: 2,
       },
     });
-    expect(client.listTools).toHaveBeenNthCalledWith(1, undefined);
-    expect(client.listTools).toHaveBeenNthCalledWith(2, { params: { cursor: 'page-2' } });
+    expect(client.listTools).toHaveBeenNthCalledWith(1, {
+      options: { signal: expect.any(AbortSignal) },
+    });
+    expect(client.listTools).toHaveBeenNthCalledWith(2, {
+      options: { signal: expect.any(AbortSignal) },
+      params: { cursor: 'page-2' },
+    });
   });
 
   it('shares an in-flight warm with an explicit settings listing', async () => {


### PR DESCRIPTION
## 概述

`@ai-sdk/mcp` 从 1.0.64 提升到 **1.0.71**（ai-v6 维护线尾版，精确 pin），并删除 `McpRuntimeService` 中手写的 wall-clock 超时竞速层，改用 SDK 原生的 abort 信号。

## 背景

竞速层存在的理由是「SDK 声明了 timeout 但从不读」。1.0.66 起该前提不再成立：

- 1.0.66 回移植了原生请求超时（"Honor MCP request deadlines and support bounding or aborting client initialization"），`MCPClientConfig.initializationOptions` 接受 `RequestOptions`（`signal`/`timeout`/`maxTotalTimeout`）。
- 1.0.60 起工具调用透传 `options.abortSignal` 到 transport，可中断 in-flight 请求。
- 升级前已用本地 Streamable HTTP fixture（accept-then-stall / slow-list / slow-tool 三种故障模式）逐项实证以上行为真实生效。

## 改动

- 删除 `withTimeout` 竞速函数、`timeoutCancellations` 集合与 `cancelTimeouts`；超时不再是「外层 promise 先输」，而是信号真取消网络请求。
- 每个 `ServerRuntimeState` 持有一只随代际走的 `AbortController`：驱逐/重置连接时 `abort()`，替代原来的竞速假取消。
- 新增 `boundedSignal` 组合器（timeout + 状态驱逐 + 调用方 abort 的组合信号）；用自有信号分类超时/驱逐/调用方中止，**零依赖 SDK 错误类型**（`MCPClientError` 未导出，这一设计本身就是 v7 兼容性）。
- 调用方主动中止不再触发连接重置（原竞速层无法区分这两种情况）。
- 行为保持不变：init/list 15s 总上限、工具调用 60s 上限、超时文案（server may still be processing）、fail-and-drop 重连一次、工具调用永不重放、stale-while-refresh、失败退避曲线。

## 验证

- 全量测试 317 suites / 2854 tests 通过；`McpRuntimeService.test.ts` 56 用例改为断言信号传参与 SDK init 信号契约仿真。
- 模拟器全流程验收（本地 fixture server + 假 LLM）：添加服务器自动命名 → 列工具 → 禁用单个工具 → 对话中 tool_call → 审批批准真实执行 → 拒绝写终态且对话继续 → 杀掉服务器出 error 态、重连一次后入退避。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
