### PR TITLE
refactor(mcp)!: drop the desktop-ported tool cache

### DIFF
--- a/src/backend/ai/mcp/McpRuntimeService.ts
+++ b/src/backend/ai/mcp/McpRuntimeService.ts
@@ -24,27 +24,14 @@ import type { McpServer } from '@/shared/data/types/mcpServer';
 
 const logger = loggerService.withContext('McpRuntimeService');
 
-const TOOLS_CACHE_TTL_MS = 5 * 60 * 1000;
-const ENABLED_PREWARM_CONCURRENCY = 3;
-const ASSISTANT_WARM_TIMEOUT_MS = 3 * 1000;
 /** Ceiling for connect + tools/list, enforced through abort signals the SDK
  * forwards to the transport (native support since `@ai-sdk/mcp@1.0.66`).
  * Without it a server that accepts the socket then stalls would pin a client
  * slot indefinitely. */
 const TOOLS_FETCH_TIMEOUT_MS = 15 * 1000;
-/** Backoff after a failed refresh, doubling per consecutive failure. Without it
- * a permanently-rejecting server costs a full connect attempt on every message,
- * forever, on a phone. */
-const REFRESH_BACKOFF_BASE_MS = 30 * 1000;
-const REFRESH_BACKOFF_MAX_MS = 10 * 60 * 1000;
 /** Ceiling for one tool call. Fixed application policy: the table stores the
  * connection, not per-server tuning. */
 const TOOL_CALL_TIMEOUT_MS = 60 * 1000;
-
-type ToolsCacheEntry = {
-  fetchedAt: number;
-  rawTools: ToolSet;
-};
 
 /**
  * Stamped on every MCP result, mirroring what desktop's `mcpTools.ts` puts on
@@ -58,13 +45,6 @@ type McpResultSource = {
   type: 'mcp';
 };
 
-/** Refresh-failure streak for a server, kept so `readCachedTools` backs off
- * instead of retrying a dead one on every message. */
-type ToolsRefreshFailure = {
-  consecutive: number;
-  failedAt: number;
-};
-
 type McpServerRuntimeSnapshot = Omit<McpServerRuntimeSummary, 'lastError' | 'state'> & {
   endpointUrl: string;
 };
@@ -76,12 +56,9 @@ type ServerRuntimeState = {
   client?: MCPClient;
   connectionPromise?: Promise<MCPClient>;
   endpointUrl: string;
-  failure?: ToolsRefreshFailure;
   generation: number;
-  refreshPromise?: Promise<void>;
   runtimeError?: string;
   serverId: string;
-  toolsCache?: ToolsCacheEntry;
 };
 
 /** Distinguishes "we gave up waiting" from a real transport error, so the
@@ -191,14 +168,29 @@ function boundedSignal(
 /**
  * Runtime MCP client manager (remote Streamable HTTP servers only).
  *
- * The chat hot path serves existing tools cache-only. A cold cache gets one
- * bounded warm before the request is built; dead or slow servers can delay the
- * first request by at most `ASSISTANT_WARM_TIMEOUT_MS`. Connecting is otherwise
- * owned by background refresh and by `listTools`, which the settings screen
- * calls. All live reads are timeout-bounded.
+ * Every read fetches `tools/list` live, bounded by `TOOLS_FETCH_TIMEOUT_MS`.
+ * Fetches reconnect once; tool calls are never replayed.
  *
- * Background refresh preserves the last good cache and backs off after failure.
- * Explicit tool listings reconnect once; tool calls are never replayed.
+ * ## TODO: design a mobile caching strategy
+ *
+ * The tool cache this service used to carry was ported from desktop
+ * (`MCPService.ts`'s `withCache(..., 5 * 60 * 1000)`) and then patched with
+ * mobile-only behaviour — stale-while-revalidate, failure backoff, startup and
+ * post-save prewarming, a cache-only chat path. That stack was never designed
+ * against mobile constraints, so it was removed wholesale rather than tuned.
+ * What replaces it has to answer, for a phone on cellular:
+ * - `getToolEntriesForAssistant` runs on every message. A live `initialize` +
+ *   `tools/list` per enabled server now sits in front of every send, and an
+ *   unreachable server costs the full `TOOLS_FETCH_TIMEOUT_MS` each time.
+ * - The settings list reports `connected` off a live client, so a row that has
+ *   never been read this session shows `connecting` until something reads it.
+ * - Nothing rate-limits a dead server anymore; that was the backoff's job.
+ *
+ * Connection reuse (`runtimeStates`) deliberately stayed: the SDK builds each
+ * tool's `execute` as a closure over its client, and one send can run up to 20
+ * tool steps, so the client has to outlive the ToolSet that borrowed it.
+ * Replacing the pool means giving connections a request-scoped lifetime with an
+ * explicit dispose, which is a design change rather than a deletion.
  *
  * ## AI SDK v7 migration seams
  *
@@ -217,14 +209,13 @@ function boundedSignal(
 export class McpRuntimeService extends BaseService implements McpModule {
   private readonly runtimeStates = new Map<string, ServerRuntimeState>();
   private readonly runtimeSnapshots = new Map<string, McpServerRuntimeSnapshot>();
-  private enabledPrewarmPromise?: Promise<void>;
 
   /**
    * Request-scoped registry entries keyed `mcp__{server}__{tool}`.
    *
-   * Gives cold servers one shared, bounded warm before reading the cache. Stale
-   * tools are returned immediately while they refresh in the background.
-   * Returns an empty list when nothing applies and never surfaces MCP failures.
+   * Fetches every server's tools live and in parallel. A server that fails or
+   * times out drops out of this turn rather than failing the send, so MCP
+   * problems never surface as chat errors.
    */
   async getToolEntriesForAssistant(
     assistant: Assistant,
@@ -241,30 +232,38 @@ export class McpRuntimeService extends BaseService implements McpModule {
     // Outside the try: this is a pure filter over what we just read, so a throw
     // from it is a bug, not an unreachable server, and must not be swallowed.
     const servers = resolveServersForAssistant(assistant, enabledServers).filter(hasRunnableUrl);
-    const preparedServers = servers.map((server) => ({
-      server,
-      state: this.getRuntimeState(server),
-    }));
-    await this.warmColdToolCaches(preparedServers);
+    const fetched = await Promise.all(
+      servers.map(async (server) => {
+        const state = this.getRuntimeState(server);
+        try {
+          // One attempt only: a reconnect would double what an unreachable
+          // server costs the send. The settings screen retries, this does not.
+          return { rawTools: await this.fetchRawTools(server, state), server, state };
+        } catch (error) {
+          if (!(error instanceof McpEvictedError)) {
+            logger.warn('MCP tools unavailable for this turn', { error, server: server.name });
+          }
+          return undefined;
+        }
+      }),
+    );
 
     const selectedToolIdSet = selectedToolIds ? new Set(selectedToolIds) : undefined;
     const entries: ToolEntry[] = [];
     const registeredNames = new Set<string>();
-    for (const { server, state } of preparedServers) {
-      // A save/disable while the bounded warm was running invalidates this
-      // request's transport snapshot. The next request will read the new row.
-      if (!this.isCurrentState(state)) {
+    for (const entry of fetched) {
+      if (!entry) {
         continue;
       }
-      const cached = this.readCachedTools(server, state);
-      if (!cached) {
+      const { rawTools, server, state } = entry;
+      // A save or disable during the fetch retires this request's transport.
+      // The next request reads the new row.
+      if (!this.isCurrentState(state)) {
         continue;
       }
 
       const disabledTools = new Set(server.disabledTools);
-      for (const [rawName, rawTool] of Object.entries(cached.rawTools)) {
-        // Filtered here rather than at the cache: the cache mirrors what the
-        // server offers, and a re-enabled tool must not need a refetch.
+      for (const [rawName, rawTool] of Object.entries(rawTools)) {
         if (disabledTools.has(rawName)) {
           continue;
         }
@@ -286,7 +285,7 @@ export class McpRuntimeService extends BaseService implements McpModule {
           description: toolDescription(rawTool) ?? rawName,
           name: key,
           namespace: `mcp:${server.name}`,
-          tool: this.wrapTool(rawTool, server, rawName, cached.state),
+          tool: this.wrapTool(rawTool, server, rawName, state),
         });
       }
     }
@@ -294,89 +293,23 @@ export class McpRuntimeService extends BaseService implements McpModule {
     return entries;
   }
 
-  /**
-   * Warm the tool cache for every enabled server so the next chat request can
-   * offer their tools. Calls share one concurrency-limited run and failures are
-   * logged rather than surfaced.
-   */
-  prewarmEnabledServers(): Promise<void> {
-    if (this.enabledPrewarmPromise) {
-      return this.enabledPrewarmPromise;
-    }
-
-    const task = (async () => {
-      try {
-        const { items } = await mcpServerService.list({ isEnabled: true });
-        const servers = items.filter(hasRunnableUrl);
-        for (let index = 0; index < servers.length; index += ENABLED_PREWARM_CONCURRENCY) {
-          const batch = servers.slice(index, index + ENABLED_PREWARM_CONCURRENCY);
-          await Promise.allSettled(batch.map((server) => this.warmToolsCache(server)));
-        }
-      } catch (error) {
-        logger.warn('Failed to prewarm MCP servers', { error });
-      }
-    })().finally(() => {
-      if (this.enabledPrewarmPromise === task) {
-        this.enabledPrewarmPromise = undefined;
-      }
-    });
-    this.enabledPrewarmPromise = task;
-    return task;
-  }
-
-  /** Runtime metadata for the settings list. Enabled servers share the existing
-   * concurrency-limited prewarm instead of opening one connection per row. */
-  async getRuntimeSummaries(
+  /** Runtime metadata for the settings list, reported from live client state. */
+  getRuntimeSummaries(
     servers: readonly McpServer[],
   ): Promise<Record<string, McpServerRuntimeSummary>> {
-    if (servers.some((server) => server.isEnabled && hasRunnableUrl(server))) {
-      await this.prewarmEnabledServers();
-    }
-
-    return Object.fromEntries(servers.map((server) => [server.id, this.getRuntimeSummary(server)]));
+    return Promise.resolve(
+      Object.fromEntries(servers.map((server) => [server.id, this.getRuntimeSummary(server)])),
+    );
   }
 
-  /** Warm one stored server without exposing transport failures to callers. */
-  async warmToolsCache(server: McpServer): Promise<void> {
-    if (!server.isEnabled || !hasRunnableUrl(server)) {
-      return;
-    }
-
-    const state = this.getRuntimeState(server);
-    const cache = state.toolsCache;
-    if (cache && Date.now() - cache.fetchedAt < TOOLS_CACHE_TTL_MS) {
-      return;
-    }
-
-    await this.refreshToolsInBackground(server, state);
-  }
-
-  /** Tool list for the server edit screen — connects, unlike the chat path. */
+  /** Tool list for the server edit screen. */
   async listTools(serverId: string): Promise<McpToolSummary[]> {
     const server = await mcpServerService.getById(serverId);
-    return this.listToolsForServer(server);
-  }
-
-  private async listToolsForServer(server: McpServer): Promise<McpToolSummary[]> {
     if (!hasRunnableUrl(server)) {
       throw new Error(`MCP server ${server.name} has no valid HTTP URL`);
     }
-    const state = this.getRuntimeState(server);
-    const cacheBeforeRefresh = state.toolsCache;
-    if (state.refreshPromise) {
-      await state.refreshPromise;
-      if (!this.isCurrentState(state)) {
-        throw new McpEvictedError(`MCP server ${server.name} was invalidated while listing tools`);
-      }
-    }
 
-    // Reuse a successful in-flight warm. If that warm failed, do one explicit
-    // reconnect attempt so the settings screen still surfaces the live error.
-    const rawTools =
-      state.toolsCache && state.toolsCache !== cacheBeforeRefresh
-        ? state.toolsCache.rawTools
-        : await this.fetchToolsWithRetry(server);
-
+    const rawTools = await this.fetchToolsWithRetry(server, this.getRuntimeState(server));
     return Object.entries(rawTools).map(([name, tool]) => ({
       description: toolDescription(tool),
       name,
@@ -393,17 +326,8 @@ export class McpRuntimeService extends BaseService implements McpModule {
   }
 
   /**
-   * Warming the caches is the whole of this service's startup, and it is
-   * deliberately not on the gate: the chat path reads tools cache-only, so a
-   * dead or slow server must never delay first paint.
-   */
-  protected onInit(): Promise<void> {
-    return this.prewarmEnabledServers();
-  }
-
-  /**
-   * Drop every server's runtime. Without it the pooled clients stay open and
-   * the refresh timers keep firing against a service nothing will read again.
+   * Drop every server's runtime. Without it the pooled clients stay open
+   * against a service nothing will read again.
    */
   protected onStop(): void {
     for (const state of [...this.runtimeStates.values()]) {
@@ -411,7 +335,6 @@ export class McpRuntimeService extends BaseService implements McpModule {
     }
 
     this.runtimeSnapshots.clear();
-    this.enabledPrewarmPromise = undefined;
   }
 
   /** Drop one server's runtime after transport change, disable, or delete. */
@@ -480,99 +403,10 @@ export class McpRuntimeService extends BaseService implements McpModule {
     if (state?.runtimeError) {
       return { ...snapshot, lastError: state.runtimeError, state: 'error' };
     }
-    if (state?.toolsCache) {
+    if (state?.client) {
       return { ...snapshot, state: 'connected' };
     }
     return { ...snapshot, state: 'connecting' };
-  }
-
-  /** Cached tools if we have any, serving stale while a refresh runs. */
-  private readCachedTools(
-    server: McpServer,
-    state = this.getRuntimeState(server),
-  ): { rawTools: ToolSet; state: ServerRuntimeState } | undefined {
-    const entry = state.toolsCache;
-    if (!entry || Date.now() - entry.fetchedAt >= TOOLS_CACHE_TTL_MS) {
-      this.refreshToolsInBackground(server, state);
-    }
-    return entry ? { rawTools: entry.rawTools, state } : undefined;
-  }
-
-  /** Cold-cache warm shared by all of an assistant's servers. The underlying
-   * refreshes survive the cap; only the current request stops waiting. */
-  private async warmColdToolCaches(
-    servers: readonly { server: McpServer; state: ServerRuntimeState }[],
-  ): Promise<void> {
-    const coldServers = servers.filter(({ state }) => !state.toolsCache);
-    if (coldServers.length === 0) {
-      return;
-    }
-
-    const warm = Promise.all(coldServers.map(({ server }) => this.warmToolsCache(server)));
-    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<void>((resolve) => {
-      timeoutHandle = setTimeout(resolve, ASSISTANT_WARM_TIMEOUT_MS);
-    });
-
-    await Promise.race([warm.then(() => undefined), timeout]);
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-  }
-
-  private refreshToolsInBackground(
-    server: McpServer,
-    state = this.getRuntimeState(server),
-  ): Promise<void> | undefined {
-    if (state.refreshPromise) {
-      return state.refreshPromise;
-    }
-    if (this.isBackingOff(state)) {
-      return undefined;
-    }
-
-    const refresh = this.fetchRawTools(server, state)
-      .then(() => undefined)
-      .catch((error: unknown) => {
-        if (error instanceof McpEvictedError) {
-          return;
-        }
-        if (!this.isCurrentState(state)) {
-          return;
-        }
-        this.recordFailure(state, error);
-        logger.warn('MCP tools refresh failed', { error, server: server.name });
-        // Keep the last good cache and its client through transient refresh
-        // failures; tool-call failures and timeouts reset both.
-      })
-      .finally(() => {
-        if (state.refreshPromise === refresh) {
-          state.refreshPromise = undefined;
-        }
-      });
-
-    state.refreshPromise = refresh;
-    return refresh;
-  }
-
-  private isBackingOff(state: ServerRuntimeState): boolean {
-    const failure = state.failure;
-    if (!failure) {
-      return false;
-    }
-    const wait = Math.min(
-      REFRESH_BACKOFF_BASE_MS * 2 ** (failure.consecutive - 1),
-      REFRESH_BACKOFF_MAX_MS,
-    );
-    return Date.now() - failure.failedAt < wait;
-  }
-
-  private recordFailure(state: ServerRuntimeState, error: unknown): void {
-    state.failure = {
-      consecutive: (state.failure?.consecutive ?? 0) + 1,
-      failedAt: Date.now(),
-    };
-    state.runtimeError = errorMessage(error);
   }
 
   private recordRuntimeError(state: ServerRuntimeState, error: unknown): void {
@@ -651,7 +485,6 @@ export class McpRuntimeService extends BaseService implements McpModule {
     state.abort.abort();
     state.abort = new AbortController();
     state.connectionPromise = undefined;
-    state.toolsCache = undefined;
     if (state.client) {
       this.closeQuietly(state.client);
       state.client = undefined;
@@ -665,9 +498,6 @@ export class McpRuntimeService extends BaseService implements McpModule {
     state.generation += 1;
     state.abort.abort();
     state.connectionPromise = undefined;
-    state.refreshPromise = undefined;
-    state.failure = undefined;
-    state.toolsCache = undefined;
     if (state.client) {
       this.closeQuietly(state.client);
       state.client = undefined;
@@ -678,8 +508,10 @@ export class McpRuntimeService extends BaseService implements McpModule {
     return this.runtimeStates.get(state.serverId) === state && state.generation === generation;
   }
 
-  private async fetchToolsWithRetry(server: McpServer): Promise<ToolSet> {
-    const state = this.getRuntimeState(server);
+  private async fetchToolsWithRetry(
+    server: McpServer,
+    state: ServerRuntimeState,
+  ): Promise<ToolSet> {
     try {
       return await this.fetchRawTools(server, state);
     } catch (error) {
@@ -732,13 +564,10 @@ export class McpRuntimeService extends BaseService implements McpModule {
       throw new McpEvictedError(`MCP server ${server.name} was invalidated while listing tools`);
     }
 
-    const fetchedAt = Date.now();
     const client = state.client;
-    state.failure = undefined;
     state.runtimeError = undefined;
-    state.toolsCache = { fetchedAt, rawTools };
     this.runtimeSnapshots.set(server.id, {
-      lastConnectedAt: fetchedAt,
+      lastConnectedAt: Date.now(),
       endpointUrl: state.endpointUrl,
       serverName: client?.serverInfo.name,
       serverTitle: client?.serverInfo.title,
@@ -814,9 +643,9 @@ export class McpRuntimeService extends BaseService implements McpModule {
           throw error;
         }
         // Any transport/protocol failure means the pooled client is suspect;
-        // dropping here is what keeps a dead session from sticking around for
-        // the rest of the cache TTL. The call itself is not retried — MCP tool
-        // calls are not guaranteed idempotent.
+        // dropping it here keeps a dead session from being handed to the next
+        // caller. The call itself is not retried — MCP tool calls are not
+        // guaranteed idempotent.
         this.resetConnection(state);
         this.recordRuntimeError(state, error);
         if (bound.didTimeout()) {

--- a/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -211,13 +211,6 @@ function makeService(servers: McpServer[]) {
   return { mcpServer: { getById, list }, service: new McpRuntimeService() };
 }
 
-/** Cold cache → warm it the way the chat path does, then read it back. */
-async function warmedToolSet(service: McpRuntimeService, assistant = makeAssistant()) {
-  await getProjectedToolSet(service, assistant);
-  await flush();
-  return getProjectedToolSet(service, assistant);
-}
-
 async function getProjectedToolSet(
   service: McpRuntimeService,
   assistant: Assistant,
@@ -248,8 +241,8 @@ describe('assistant tool preparation', () => {
     expect(mockCreateMCPClient).not.toHaveBeenCalled();
   });
 
-  it('waits at most three seconds for a cold server', async () => {
-    // Fake timers so the refresh's 15s guard doesn't outlive the test.
+  it('gives up on a stalling server once the fetch bound expires', async () => {
+    // Fake timers so the fetch's 15s guard doesn't outlive the test.
     jest.useFakeTimers({ doNotFake: ['setImmediate'] });
     try {
       // A server that accepts the connect and then stalls forever — the shape
@@ -264,8 +257,8 @@ describe('assistant tool preparation', () => {
       });
       await flush();
 
-      jest.advanceTimersByTime(2999);
-      await Promise.resolve();
+      jest.advanceTimersByTime(15 * 1000 - 1);
+      await flush();
       expect(settled).toBe(false);
 
       jest.advanceTimersByTime(1);
@@ -276,7 +269,7 @@ describe('assistant tool preparation', () => {
     }
   });
 
-  it('includes tools in the first request when the cold warm completes in time', async () => {
+  it('fetches tools live for the request', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { service } = makeService([makeServer()]);
 
@@ -303,26 +296,25 @@ describe('assistant tool preparation', () => {
     expect(Object.keys(tools ?? {})).toEqual(['mcp__serverone__search']);
   });
 
-  it('offers a re-enabled tool from the warm cache, without reconnecting', async () => {
+  it('offers a re-enabled tool on the next request', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search', 'read'])));
     const servers = [makeServer({ disabledTools: ['read'] })];
     const { service } = makeService(servers);
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
 
     servers[0] = makeServer({ disabledTools: [] });
     const tools = await getProjectedToolSet(service, makeAssistant());
 
     expect(Object.keys(tools ?? {})).toEqual(['mcp__serverone__search', 'mcp__serverone__read']);
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
   });
 
-  it('uses one three-second budget for all servers and keeps late refreshes for the next request', async () => {
+  it('keeps a slow server from holding up the ones that answered', async () => {
     jest.useFakeTimers({ doNotFake: ['setImmediate'] });
     try {
       const slowConnect = deferred<FakeClient>();
       mockCreateMCPClient
         .mockReturnValueOnce(slowConnect.promise)
-        .mockResolvedValueOnce(makeClient(makeRawTools(['fast'])));
+        .mockResolvedValue(makeClient(makeRawTools(['fast'])));
       const { service } = makeService([
         makeServer({ id: 'slow', name: 'Slow' }),
         makeServer({ endpointUrl: 'https://fast.example/mcp', id: 'fast', name: 'Fast' }),
@@ -330,40 +322,36 @@ describe('assistant tool preparation', () => {
 
       const request = getProjectedToolSet(service, makeAssistant());
       await flush();
-      jest.advanceTimersByTime(3 * 1000);
+      // The slow server burns its bound; the fast one already answered and must
+      // still make it into the request.
+      jest.advanceTimersByTime(15 * 1000);
 
       expect(Object.keys((await request) ?? {})).toEqual(['mcp__fast__fast']);
-
-      slowConnect.resolve(makeClient(makeRawTools(['late'])));
-      await flush();
-      expect(Object.keys((await getProjectedToolSet(service, makeAssistant())) ?? {})).toEqual([
-        'mcp__slow__late',
-        'mcp__fast__fast',
-      ]);
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();
     }
   });
 
-  it('reuses the cache instead of reconnecting', async () => {
+  it('relists tools on every request instead of trusting a previous read', async () => {
     const client = makeClient(makeRawTools(['search']));
     mockCreateMCPClient.mockResolvedValue(client);
     const { service } = makeService([makeServer()]);
 
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
     await getProjectedToolSet(service, makeAssistant());
 
+    // The connection is pooled, the tool list is not.
     expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
-    expect(client.tools).toHaveBeenCalledTimes(1);
+    expect(client.listTools).toHaveBeenCalledTimes(2);
   });
 
-  it('renames without reconnecting or relisting tools', async () => {
+  it('renames without reconnecting', async () => {
     const client = makeClient(makeRawTools(['search']));
     mockCreateMCPClient.mockResolvedValue(client);
     const servers = [makeServer()];
     const { service } = makeService(servers);
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
 
     servers[0] = makeServer({ name: 'Renamed' });
 
@@ -371,7 +359,6 @@ describe('assistant tool preparation', () => {
       'mcp__renamed__search',
     ]);
     expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
-    expect(client.tools).toHaveBeenCalledTimes(1);
     expect(client.close).not.toHaveBeenCalled();
   });
 
@@ -381,7 +368,7 @@ describe('assistant tool preparation', () => {
     mockCreateMCPClient.mockResolvedValueOnce(original).mockResolvedValue(replacement);
     const servers = [makeServer()];
     const { service } = makeService(servers);
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
 
     servers[0] = makeServer({ endpointUrl: 'https://new.example/mcp' });
     expect(Object.keys((await getProjectedToolSet(service, makeAssistant())) ?? {})).toEqual([
@@ -391,29 +378,7 @@ describe('assistant tool preparation', () => {
     expect(mockCreateMCPClient).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps serving stale tools while revalidating past the TTL', async () => {
-    jest.useFakeTimers({ doNotFake: ['setImmediate'] });
-    try {
-      const client = makeClient(makeRawTools(['search']));
-      mockCreateMCPClient.mockResolvedValue(client);
-      const { service } = makeService([makeServer()]);
-      await warmedToolSet(service);
-      expect(client.tools).toHaveBeenCalledTimes(1);
-
-      jest.advanceTimersByTime(6 * 60 * 1000);
-      const tools = await getProjectedToolSet(service, makeAssistant());
-      await flush();
-
-      expect(Object.keys(tools ?? {})).toEqual(['mcp__serverone__search']);
-      // Stale reads must also *trigger* the refresh, or a dead server's tool
-      // list would be served forever.
-      expect(client.tools).toHaveBeenCalledTimes(2);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('fetches once when two requests race on a cold cache', async () => {
+  it('opens one connection when two requests race', async () => {
     const client = makeClient(makeRawTools(['search']));
     mockCreateMCPClient.mockResolvedValue(client);
     const { service } = makeService([makeServer()]);
@@ -425,7 +390,6 @@ describe('assistant tool preparation', () => {
     await flush();
 
     expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
-    expect(client.tools).toHaveBeenCalledTimes(1);
   });
 
   it('returns undefined instead of rejecting when the server list read fails', async () => {
@@ -437,35 +401,15 @@ describe('assistant tool preparation', () => {
     await expect(getProjectedToolSet(service, makeAssistant())).resolves.toBeUndefined();
   });
 
-  it('keeps the last good tools when a refresh fails, and backs off', async () => {
-    jest.useFakeTimers({ doNotFake: ['setImmediate'] });
-    try {
-      const client = makeClient(makeRawTools(['search']));
-      mockCreateMCPClient.mockResolvedValue(client);
-      const { service } = makeService([makeServer()]);
-      await warmedToolSet(service);
+  it('drops a server whose listing fails rather than failing the send', async () => {
+    const client = makeClient(makeRawTools(['search']));
+    mockCreateMCPClient.mockResolvedValue(client);
+    const { service } = makeService([makeServer()]);
+    await getProjectedToolSet(service, makeAssistant());
 
-      client.tools.mockRejectedValue(new Error('401 unauthorized'));
-      jest.advanceTimersByTime(6 * 60 * 1000);
-      await getProjectedToolSet(service, makeAssistant());
-      await flush();
-      expect(client.tools).toHaveBeenCalledTimes(2);
+    client.tools.mockRejectedValue(new Error('401 unauthorized'));
 
-      // Read *after* the failure has landed: a blip must not silently strip a
-      // working server's tools, and the cached handles are bound to a client
-      // that is still open.
-      const tools = await getProjectedToolSet(service, makeAssistant());
-      expect(Object.keys(tools ?? {})).toEqual(['mcp__serverone__search']);
-      expect(client.close).not.toHaveBeenCalled();
-
-      // Still inside the backoff window: no third attempt.
-      jest.advanceTimersByTime(10 * 1000);
-      await getProjectedToolSet(service, makeAssistant());
-      await flush();
-      expect(client.tools).toHaveBeenCalledTimes(2);
-    } finally {
-      jest.useRealTimers();
-    }
+    await expect(getProjectedToolSet(service, makeAssistant())).resolves.toBeUndefined();
   });
 
   it('gives up on a server that accepts the socket and then stalls', async () => {
@@ -478,14 +422,11 @@ describe('assistant tool preparation', () => {
 
       const request = getProjectedToolSet(service, makeAssistant());
       await flush();
-      jest.advanceTimersByTime(3 * 1000);
+      jest.advanceTimersByTime(15 * 1000);
       await expect(request).resolves.toBeUndefined();
-      jest.advanceTimersByTime(12 * 1000);
-      await flush();
 
       // The wedged client is closed rather than pinning the pool slot forever.
       expect(client.close).toHaveBeenCalled();
-      expect(await getProjectedToolSet(service, makeAssistant())).toBeUndefined();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();
@@ -501,7 +442,7 @@ describe('assistant tool preparation', () => {
       makeServer({ endpointUrl: 'https://up.example/mcp', id: 'up', name: 'Up' }),
     ]);
 
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     expect(Object.keys(tools ?? {})).toEqual(['mcp__up__ping']);
   });
@@ -517,7 +458,7 @@ describe('assistant tool preparation', () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { service } = makeService([makeServer()]);
 
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     expect(tools?.mcp__serverone__search.metadata).toEqual({
       // The wire key above lowercased the server name and cannot be reversed,
@@ -534,7 +475,7 @@ describe('tool approval policy', () => {
   it('gates every tool behind approval and never defers one', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['read', 'write'])));
     const { service } = makeService([makeServer()]);
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
 
     const entries = await service.getToolEntriesForAssistant(makeAssistant());
 
@@ -548,101 +489,9 @@ describe('tool approval policy', () => {
   });
 });
 
-describe('prewarmEnabledServers', () => {
-  it('does not connect to a server whose endpoint is not http(s)', async () => {
-    const { service } = makeService([makeServer({ endpointUrl: 'ftp://a.example/mcp' })]);
-
-    await service.prewarmEnabledServers();
-
-    expect(mockCreateMCPClient).not.toHaveBeenCalled();
-  });
-
-  it('fills the cache so the first chat request already has tools', async () => {
-    mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
-    const { service } = makeService([makeServer()]);
-
-    await service.prewarmEnabledServers();
-    await flush();
-
-    expect(Object.keys((await getProjectedToolSet(service, makeAssistant())) ?? {})).toEqual([
-      'mcp__serverone__search',
-    ]);
-  });
-
-  it('warms enabled servers in batches of three', async () => {
-    const releases: (() => void)[] = [];
-    let active = 0;
-    let maxActive = 0;
-    mockCreateMCPClient.mockImplementation(async () => {
-      const client = makeClient(makeRawTools(['search']));
-      client.tools.mockImplementation(
-        () =>
-          new Promise<ToolSet>((resolve) => {
-            active += 1;
-            maxActive = Math.max(maxActive, active);
-            releases.push(() => {
-              active -= 1;
-              resolve(makeRawTools(['search']));
-            });
-          }),
-      );
-      return client;
-    });
-    const servers = Array.from({ length: 6 }, (_, index) =>
-      makeServer({
-        endpointUrl: `https://${index}.example/mcp`,
-        id: `server-${index}`,
-        name: `Server${index}`,
-      }),
-    );
-    const { service } = makeService(servers);
-
-    const prewarm = service.prewarmEnabledServers();
-    await flush();
-    expect(releases).toHaveLength(3);
-
-    releases.slice(0, 3).forEach((release) => {
-      release();
-    });
-    await flush();
-    expect(releases).toHaveLength(6);
-    expect(maxActive).toBe(3);
-
-    releases.slice(3).forEach((release) => {
-      release();
-    });
-    await prewarm;
-  });
-
-  it('shares one prewarm run across concurrent callers', async () => {
-    const tools = deferred<ToolSet>();
-    const client = makeClient(makeRawTools(['search']));
-    client.tools.mockReturnValue(tools.promise);
-    mockCreateMCPClient.mockResolvedValue(client);
-    const { service } = makeService([makeServer()]);
-
-    const first = service.prewarmEnabledServers();
-    const second = service.prewarmEnabledServers();
-    expect(second).toBe(first);
-    await flush();
-
-    tools.resolve(makeRawTools(['search']));
-    await Promise.all([first, second]);
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
-    expect(client.tools).toHaveBeenCalledTimes(1);
-  });
-
-  it('never rejects when listing servers fails', async () => {
-    jest.spyOn(mcpServerService, 'list').mockRejectedValue(new Error('db down'));
-    const service = new McpRuntimeService();
-
-    await expect(service.prewarmEnabledServers()).resolves.toBeUndefined();
-  });
-});
-
 describe('tool execution', () => {
   async function executeTool(service: McpRuntimeService, key: string) {
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
     const tool = tools?.[key];
     return (tool?.execute as (args: unknown, opts: unknown) => Promise<unknown>)({}, {});
   }
@@ -650,7 +499,7 @@ describe('tool execution', () => {
   it('does not blame a deleted server when the lookup itself fails', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { mcpServer, service } = makeService([makeServer()]);
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     mcpServer.getById.mockRejectedValue(new Error('database is locked'));
 
@@ -665,7 +514,7 @@ describe('tool execution', () => {
   it('re-checks the server before running, so a mid-turn disable is honored', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { mcpServer, service } = makeService([makeServer()]);
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     // Disabled through the mock rather than by mutating the wrap-time row, so
     // only a genuine re-read can observe it.
@@ -683,7 +532,7 @@ describe('tool execution', () => {
   it('reports a deleted server from execute rather than from the approval gate', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { mcpServer, service } = makeService([makeServer()]);
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     mcpServer.getById.mockRejectedValue(DataApiErrorFactory.notFound('McpServer', 'server-1'));
 
@@ -756,7 +605,7 @@ describe('tool execution', () => {
   it('compresses output to text for the model', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { service } = makeService([makeServer()]);
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     const modelOutput = tools?.mcp__serverone__search.toModelOutput?.({
       input: {},
@@ -776,7 +625,7 @@ describe('tool execution', () => {
   it('emits a string for the model even when the output is missing', async () => {
     mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
     const { service } = makeService([makeServer()]);
-    const tools = await warmedToolSet(service);
+    const tools = await getProjectedToolSet(service, makeAssistant());
 
     const modelOutput = tools?.mcp__serverone__search.toModelOutput?.({
       input: {},
@@ -804,7 +653,7 @@ describe('tool execution', () => {
       const client = makeClient(makeRawTool('slow', () => new Promise(() => undefined)));
       mockCreateMCPClient.mockResolvedValue(client);
       const { service } = makeService([makeServer()]);
-      const tools = await warmedToolSet(service);
+      const tools = await getProjectedToolSet(service, makeAssistant());
 
       const call = (
         tools?.mcp__serverone__slow.execute as (a: unknown, o: unknown) => Promise<unknown>
@@ -830,7 +679,7 @@ describe('tool execution', () => {
       const client = makeClient(makeRawTool('slow', () => new Promise(() => undefined)));
       mockCreateMCPClient.mockResolvedValue(client);
       const { mcpServer, service } = makeService([makeServer()]);
-      const tools = await warmedToolSet(service);
+      const tools = await getProjectedToolSet(service, makeAssistant());
       mcpServer.getById.mockResolvedValue(makeServer({ name: 'Renamed' }));
 
       const call = (
@@ -960,7 +809,7 @@ describe('listTools', () => {
     });
   });
 
-  it('shares an in-flight warm with an explicit settings listing', async () => {
+  it('reuses one pooled connection across concurrent listings', async () => {
     const tools = deferred<ToolSet>();
     const client = makeClient(makeRawTools(['search']));
     client.tools.mockReturnValue(tools.promise);
@@ -968,34 +817,13 @@ describe('listTools', () => {
     const server = makeServer();
     const { service } = makeService([server]);
 
-    const warm = service.warmToolsCache(server);
+    const first = service.listTools(server.id);
     await flush();
-    const listing = service.listTools(server.id);
+    const second = service.listTools(server.id);
     tools.resolve(makeRawTools(['search']));
 
-    await expect(warm).resolves.toBeUndefined();
-    await expect(listing).resolves.toEqual([{ description: 'desc search', name: 'search' }]);
-    expect(client.tools).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not restart an old transport when a shared warm is invalidated', async () => {
-    const tools = deferred<ToolSet>();
-    const client = makeClient(makeRawTools(['search']));
-    client.tools.mockReturnValue(tools.promise);
-    mockCreateMCPClient.mockResolvedValue(client);
-    const server = makeServer();
-    const { service } = makeService([server]);
-
-    const warm = service.warmToolsCache(server);
-    await flush();
-    const listing = service.listTools(server.id);
-    // Let the listing re-read its row and join the in-flight warm before the
-    // config change lands — the interleaving this test is about.
-    await flush();
-    service.invalidateServer(server.id);
-
-    await expect(warm).resolves.toBeUndefined();
-    await expect(listing).rejects.toThrow('was invalidated while listing tools');
+    await expect(first).resolves.toEqual([{ description: 'desc search', name: 'search' }]);
+    await expect(second).resolves.toEqual([{ description: 'desc search', name: 'search' }]);
     expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
   });
 
@@ -1030,12 +858,27 @@ describe('listTools', () => {
 });
 
 describe('runtime summaries', () => {
-  it('reports connection failures without rejecting the list query', async () => {
+  it('reports a server nothing has read yet without connecting to it', async () => {
+    mockCreateMCPClient.mockResolvedValue(makeClient(makeRawTools(['search'])));
+    const server = makeServer();
+    const { service } = makeService([server]);
+
+    // TODO(mcp-cache): the list no longer prewarms, so a row stays `connecting`
+    // until something reads it. A replacement strategy has to answer this.
+    await expect(service.getRuntimeSummaries([server])).resolves.toEqual({
+      [server.id]: { state: 'connecting' },
+    });
+    expect(mockCreateMCPClient).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure recorded by an earlier read without rejecting', async () => {
     const client = makeClient(makeRawTools([]));
     client.tools.mockRejectedValue(new Error('401 unauthorized'));
     mockCreateMCPClient.mockResolvedValue(client);
     const server = makeServer();
     const { service } = makeService([server]);
+
+    await expect(service.listTools(server.id)).rejects.toThrow('401 unauthorized');
 
     await expect(service.getRuntimeSummaries([server])).resolves.toEqual({
       [server.id]: {
@@ -1051,7 +894,7 @@ describe('runtime summaries', () => {
     const server = makeServer();
     const { service } = makeService([server]);
 
-    await service.getRuntimeSummaries([server]);
+    await service.listTools(server.id);
     service.invalidateServer(server.id, { preserveSnapshot: true });
 
     await expect(
@@ -1083,7 +926,8 @@ describe('invalidateServer', () => {
 
       const request = getProjectedToolSet(service, makeAssistant());
       await flush();
-      expect(jest.getTimerCount()).toBe(2);
+      // The fetch bound, and nothing else — no warm budget, no refresh timer.
+      expect(jest.getTimerCount()).toBe(1);
       service.invalidateServer('server-1');
       await request;
       expect(jest.getTimerCount()).toBe(0);
@@ -1091,7 +935,7 @@ describe('invalidateServer', () => {
       await flush();
 
       // The evicted connect closed itself instead of landing in the pool, and it
-      // was never asked for tools, so nothing could refill the cleared cache.
+      // was never asked for tools.
       expect(client.close).toHaveBeenCalled();
       expect(client.tools).not.toHaveBeenCalled();
     } finally {
@@ -1183,7 +1027,7 @@ describe('dispose', () => {
     const client = makeClient(makeRawTools(['search']));
     mockCreateMCPClient.mockResolvedValue(client);
     const { service } = makeService([makeServer()]);
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
 
     await service._doStop();
 
@@ -1204,7 +1048,7 @@ describe('dispose', () => {
 
       const request = getProjectedToolSet(service, makeAssistant());
       await flush();
-      expect(jest.getTimerCount()).toBe(2);
+      expect(jest.getTimerCount()).toBe(1);
 
       await service._doStop();
       await request;
@@ -1224,7 +1068,7 @@ describe('dispose', () => {
     mockCreateMCPClient.mockResolvedValue(client);
     const server = makeServer();
     const { service } = makeService([server]);
-    await warmedToolSet(service);
+    await getProjectedToolSet(service, makeAssistant());
     service.invalidateServer(server.id, { preserveSnapshot: true });
     expect(retainedSnapshotCount(service)).toBe(1);
 

--- a/src/backend/data/api/handlers/__tests__/mcpServers.test.ts
+++ b/src/backend/data/api/handlers/__tests__/mcpServers.test.ts
@@ -22,10 +22,7 @@ function server(overrides: Partial<McpServer> = {}): McpServer {
 
 function createMutationsSubject() {
   const current = server();
-  const runtime = {
-    invalidateServer: jest.fn(),
-    warmToolsCache: jest.fn(async () => undefined),
-  };
+  const runtime = { invalidateServer: jest.fn() };
   const servers = {
     create: jest.fn(async () => current),
     delete: jest.fn(async () => undefined),
@@ -36,28 +33,30 @@ function createMutationsSubject() {
 }
 
 describe('createMcpServerMutations', () => {
-  it('warms an enabled server after creation', async () => {
-    const { mutations, runtime } = createMutationsSubject();
+  it('creates without touching the runtime', async () => {
+    const { mutations, runtime, servers } = createMutationsSubject();
 
-    const created = await mutations.createServer({
+    await mutations.createServer({
       endpointUrl: 'https://example.com/mcp',
       isEnabled: true,
       name: 'Server',
     });
 
-    expect(runtime.warmToolsCache).toHaveBeenCalledWith(created);
+    expect(servers.create).toHaveBeenCalled();
+    expect(runtime.invalidateServer).not.toHaveBeenCalled();
   });
 
-  it('invalidates the transport and warms after a URL change', async () => {
+  it('reports changed tools after a URL change without notifying the runtime', async () => {
     const { mutations, runtime } = createMutationsSubject();
 
     const result = await mutations.updateServer('server-1', {
       endpointUrl: 'https://example.com/new-mcp',
     });
 
+    // The runtime keys its pooled client on the endpoint, so the next read
+    // retires the old one; only the client's own cache needs telling.
     expect(result.toolsChanged).toBe(true);
-    expect(runtime.invalidateServer).toHaveBeenCalledWith('server-1');
-    expect(runtime.warmToolsCache).toHaveBeenCalledWith(result.server);
+    expect(runtime.invalidateServer).not.toHaveBeenCalled();
   });
 
   it('preserves the last runtime snapshot when a server is disabled', async () => {
@@ -68,7 +67,6 @@ describe('createMcpServerMutations', () => {
     expect(runtime.invalidateServer).toHaveBeenCalledWith('server-1', {
       preserveSnapshot: true,
     });
-    expect(runtime.warmToolsCache).not.toHaveBeenCalled();
   });
 
   it('reports unchanged tools when a rename skips the runtime', async () => {
@@ -79,7 +77,6 @@ describe('createMcpServerMutations', () => {
     });
     expect(servers.getById).not.toHaveBeenCalled();
     expect(runtime.invalidateServer).not.toHaveBeenCalled();
-    expect(runtime.warmToolsCache).not.toHaveBeenCalled();
   });
 
   it('invalidates runtime state after removing a server', async () => {

--- a/src/backend/data/api/handlers/mcpServers.ts
+++ b/src/backend/data/api/handlers/mcpServers.ts
@@ -16,19 +16,17 @@ export type McpServerMutations = {
 
 type McpMutationRuntime = {
   invalidateServer(serverId: string, options?: { preserveSnapshot?: boolean }): void;
-  warmToolsCache(server: McpServer): Promise<void>;
 };
 
-type McpMutationData = {
-  create(input: CreateMcpServerDto): Promise<McpServer>;
-  delete(id: string): Promise<void>;
-  getById(id: string): Promise<McpServer>;
-  update(id: string, input: UpdateMcpServerDto): Promise<McpServer>;
-};
+type McpMutationData = Pick<McpServerService, 'create' | 'delete' | 'getById' | 'update'>;
 
 /**
- * Server mutations with their runtime side effects: a row change is only half
- * a mutation — the pooled connection and tools cache must follow the row.
+ * Server mutations with the runtime side effects a row change cannot express.
+ *
+ * Only connection release lives here. A changed URL needs no notification: the
+ * runtime keys its pooled client on the endpoint, so the next read retires the
+ * old one on its own. A deleted or disabled server never gets that next read,
+ * which is why those two have to say so.
  */
 export function createMcpServerMutations(dependencies: {
   runtime: McpMutationRuntime;
@@ -37,12 +35,8 @@ export function createMcpServerMutations(dependencies: {
   const { runtime, servers } = dependencies;
 
   return {
-    async createServer(input) {
-      const server = await servers.create(input);
-      if (server.isEnabled) {
-        void runtime.warmToolsCache(server);
-      }
-      return server;
+    createServer(input) {
+      return servers.create(input);
     },
 
     async removeServer(id) {
@@ -51,29 +45,15 @@ export function createMcpServerMutations(dependencies: {
     },
 
     async updateServer(id, input) {
-      if (!id) {
-        throw new Error('updateServer requires a server id');
-      }
-
       const previous = hasRuntimeRelevantPatch(input) ? await servers.getById(id) : undefined;
       const server = await servers.update(id, input);
 
-      let toolsChanged = false;
-      if (previous) {
-        const endpointChanged = previous.endpointUrl !== server.endpointUrl;
-        toolsChanged = endpointChanged;
-        const becameEnabled = !previous.isEnabled && server.isEnabled;
-        const becameDisabled = previous.isEnabled && !server.isEnabled;
-
-        if (endpointChanged) {
-          runtime.invalidateServer(id);
-        } else if (becameDisabled) {
-          runtime.invalidateServer(id, { preserveSnapshot: true });
-        }
-
-        if (server.isEnabled && (endpointChanged || becameEnabled)) {
-          void runtime.warmToolsCache(server);
-        }
+      // Reported so the client can drop its own cached tool list for this row.
+      const toolsChanged = previous ? previous.endpointUrl !== server.endpointUrl : false;
+      if (previous?.isEnabled && !server.isEnabled) {
+        // The snapshot outlives the connection so the settings row can still
+        // report what the server last offered.
+        runtime.invalidateServer(id, { preserveSnapshot: true });
       }
 
       return { server, toolsChanged };


### PR DESCRIPTION
## 概述

移除从桌面移植来的 MCP 工具缓存及其上后来叠加的移动端补丁层，为按移动端约束重新设计让路。**这是行为变更，不是等价重构。**

## 背景

工具缓存的地基是桌面 `MCPService.ts` 的 `withCache(this.listToolsImpl, ..., 5 * 60 * 1000)`，5 分钟 TTL 逐字照搬。桌面那份是简单的 read-through 缓存；移动端在它上面陆续长出了桌面没有的东西：

| | 桌面 | 移动端 |
|---|---|---|
| 5 分钟 TTL | ✓ | ✓ 照搬 |
| stale-while-revalidate | ✗ | ✓ 后加 |
| 失败退避 30s→10min | ✗ | ✓ 后加 |
| 启动/保存后预热、3s 冷缓存上限 | ✗ | ✓ 后加 |
| cache-only 聊天热路径 | ✗ | ✓ 后加 |

地基照搬、补丁叠加，整体从未按移动端约束设计过。与其继续调参，不如整体移除并把重新设计的约束记录下来。

## 改动

- 删除：工具缓存 + TTL、stale-while-revalidate、失败退避、`prewarmEnabledServers` / `warmToolsCache` / `warmColdToolCaches`、cache-only 热路径。
- 每次读都实时拉 `tools/list`，沿用既有的 15 秒 abort 上限。聊天热路径并发拉取该助手的所有服务器，失败的那个从本轮掉队，**不会让发送失败**；热路径只尝试一次（设置页仍重试一次），因为重连会让不可达服务器对每条消息的开销翻倍。
- 写侧编排收缩到只剩「释放连接」：删除和禁用必须通知（它们等不到下一次读），改 URL 不必（运行时以 endpoint 为连接身份，下次读自行退休旧连接）。
- `McpRuntimeService` 头部写入 TODO，列明重新设计必须回答的问题。

## 保留连接复用（不是遗漏）

SDK 把每个工具的 `execute` 造成绑定其 client 的闭包（`self.callTool`），而一次发送最多跑 20 步工具调用，client 必须活得比借用它的 ToolSet 久。替换连接池 = 给连接引入请求作用域生命周期 + 显式 dispose，属于设计改动而非删除，留给重新设计。

## 行为变化（评审重点）

1. 每条消息都会对每个启用的服务器做一次 `initialize` + `tools/list`
2. 服务器不可达时，每条消息都会付一次超时，且**没有任何限流**（退避已删）
3. 设置页列表在没有东西读过该行之前显示 `connecting` —— 这条用带 `TODO(mcp-cache)` 标记的测试钉住，避免被误当 bug 逐个修补

## 验证

- 全量 317 suites / 2848 tests 通过；typecheck、lint（0 errors）、format 均通过。
- 净删 350 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
