### PR TITLE
fix(ui): give a content-sized bottom sheet a viewport it can fill

### DIFF
--- a/packages/ui/src/components/bottom-sheet/README.md
+++ b/packages/ui/src/components/bottom-sheet/README.md
@@ -23,9 +23,16 @@ components explicitly compose the native modal card, fixed chrome, scrolling vie
 `onOpenChange` when feature state controls it. `Content` owns detents, card geometry, native close
 gestures, and the close-settle callback.
 
-`Body` provides a bounded `flex: 1` viewport but does not scroll. This lets `LegendList` and other
-virtualized controls own scrolling directly. Use `BottomSheet.ScrollView` instead for ordinary
-scrolling content. `Header`, `SearchField`, and `Footer` stay pinned as siblings of that viewport.
+`Body` provides a viewport but does not scroll. This lets `LegendList` and other virtualized
+controls own scrolling directly. Use `BottomSheet.ScrollView` instead for ordinary scrolling
+content. `Header`, `SearchField`, and `Footer` stay pinned as siblings of that viewport.
+
+Give `Content` a `height` and the viewport is bounded: it takes whatever the pinned chrome leaves,
+so a virtualized list or a `ScrollView` inside it scrolls. Omit `height` and the card measures to
+its content instead, so the viewport does too and nothing inside it scrolls — pick the mode from
+whether the content has a natural end. Content-sized cards reach the bottom of the screen, so
+whatever sits last in them owns its own home-indicator clearance; read it off
+`useBottomSheet().geometry`.
 
 `BottomSheet.Selection` is the explicit single-choice variant. It commits its selection only after
 the close animation settles. Callers pass translated labels; CherryUI owns no product language.

--- a/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
+++ b/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
@@ -268,6 +268,39 @@ describe('BottomSheet', () => {
   });
 
   test.each([
+    { expected: { flex: 1, minHeight: 0 }, height: 520, mode: 'bounded' },
+    // A zero flex basis contributes nothing to an auto height, so a body that
+    // flexed inside a content-sized card would collapse and take the card with
+    // it, leaving a sheet of nothing but chrome.
+    { expected: { flexShrink: 1, minHeight: 0 }, height: undefined, mode: 'content-sized' },
+  ])('gives a $mode card a viewport it can fill', ({ expected, height }) => {
+    act(() => {
+      renderer = create(
+        <BottomSheet defaultOpen>
+          <BottomSheet.Content height={height} onClose={jest.fn()}>
+            <BottomSheet.Body testID="sheet-body">
+              <Text>Body</Text>
+            </BottomSheet.Body>
+            <BottomSheet.ScrollView testID="sheet-scroll">
+              <Text>Scroll</Text>
+            </BottomSheet.ScrollView>
+          </BottomSheet.Content>
+        </BottomSheet>,
+      );
+    });
+
+    for (const testID of ['sheet-body', 'sheet-scroll']) {
+      // The composite wrapper carries the same testID, so read the style off the
+      // host instance the native side actually lays out.
+      const host = renderer?.root
+        .findAllByProps({ testID })
+        .find((node) => typeof node.type === 'string');
+
+      expect(StyleSheet.flatten(host?.props.style)).toMatchObject(expected);
+    }
+  });
+
+  test.each([
     { expected: 51, screenCornerRadius: 55 },
     { expected: 58, screenCornerRadius: 62 },
     { expected: 28, screenCornerRadius: 30 },

--- a/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
@@ -1,6 +1,13 @@
 import { type Detent, ModalBottomSheet } from '@swmansion/react-native-bottom-sheet';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useResolveClassNames } from 'uniwind';
 
@@ -10,6 +17,7 @@ import {
   BottomSheetContext,
   BottomSheetRootContext,
   controlledCloseReason,
+  useBottomSheet,
   useBottomSheetRoot,
 } from './bottom-sheet.context';
 import { bottomSheetLayout } from './bottom-sheet.layout';
@@ -153,6 +161,7 @@ export function BottomSheetContent({
       geometry: {
         bottomCornerRadius,
         insets,
+        isContentSized: height === undefined,
         outerInset: bottomSheetLayout.outerInset,
         sheetWidth,
         topCornerRadius: TOP_CORNER_RADIUS,
@@ -162,7 +171,16 @@ export function BottomSheetContent({
       requestClose,
       testID,
     }),
-    [bottomCornerRadius, insets, isCloseDisabled, isClosing, requestClose, sheetWidth, testID],
+    [
+      bottomCornerRadius,
+      height,
+      insets,
+      isCloseDisabled,
+      isClosing,
+      requestClose,
+      sheetWidth,
+      testID,
+    ],
   );
 
   return (
@@ -210,19 +228,36 @@ export function BottomSheetSearchField(props: BottomSheetSearchFieldProps) {
 }
 
 export function BottomSheetBody({ children, style, ...props }: BottomSheetBodyProps) {
+  const viewportStyle = useViewportStyle();
+
   return (
-    <View {...props} style={[styles.body, style]}>
+    <View {...props} style={[viewportStyle, style]}>
       {children}
     </View>
   );
 }
 
 export function BottomSheetScrollView({ children, style, ...props }: BottomSheetScrollViewProps) {
+  const viewportStyle = useViewportStyle();
+
   return (
-    <ScrollView {...props} style={[styles.body, style]}>
+    <ScrollView {...props} style={[viewportStyle, style]}>
       {children}
     </ScrollView>
   );
+}
+
+/**
+ * A card given a height bounds the viewport, so the body takes whatever the
+ * pinned chrome leaves it. A card measuring to its content has nothing to leave:
+ * `flex: 1` resolves to a zero flex basis, which contributes nothing to an auto
+ * height, so the card would measure to its chrome alone and the body would land
+ * at zero height. There the body has to size to its own content instead.
+ */
+function useViewportStyle(): ViewStyle {
+  const { geometry } = useBottomSheet();
+
+  return geometry.isContentSized ? styles.contentViewport : styles.boundedViewport;
 }
 
 export function BottomSheetFooter({ children, style, ...props }: BottomSheetFooterProps) {
@@ -234,8 +269,9 @@ export function BottomSheetFooter({ children, style, ...props }: BottomSheetFoot
 }
 
 const styles = StyleSheet.create({
-  body: { flex: 1, minHeight: 0 },
   bottomGap: { height: bottomSheetLayout.outerInset },
+  boundedViewport: { flex: 1, minHeight: 0 },
+  contentViewport: { flexShrink: 1, minHeight: 0 },
   footer: { flexShrink: 0 },
   layout: { alignItems: 'center' },
   sheet: {

--- a/packages/ui/src/components/bottom-sheet/bottom-sheet.types.ts
+++ b/packages/ui/src/components/bottom-sheet/bottom-sheet.types.ts
@@ -17,6 +17,8 @@ export type BottomSheetCloseReason = 'controlled' | 'dismiss' | (string & {});
 export type BottomSheetGeometry = {
   bottomCornerRadius: number;
   insets: EdgeInsets;
+  /** The card measures to its children instead of to a height `Content` imposed. */
+  isContentSized: boolean;
   outerInset: number;
   sheetWidth: number;
   topCornerRadius: number;

--- a/src/frontend/features/chat/approval/ToolApprovalSheet.tsx
+++ b/src/frontend/features/chat/approval/ToolApprovalSheet.tsx
@@ -1,4 +1,4 @@
-import { BottomSheet, Button } from '@cherrystudio/ui/components';
+import { BottomSheet, Button, useBottomSheet } from '@cherrystudio/ui/components';
 import { parseFunctionCallToolName } from '@cherrystudio/universal/ai/tools/mcpToolName';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +25,6 @@ type ToolApprovalSheetProps = {
 /** Shows one AI SDK tool approval at a time, regardless of the tool's source. */
 export function ToolApprovalSheet({ approvals, isOpen, onRespond }: ToolApprovalSheetProps) {
   const { t } = useTranslation();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   // Keep the last request mounted during the sheet's close animation.
   const [lastApproval, setLastApproval] = useState<PendingToolApproval | undefined>(approvals[0]);
   if (approvals[0] && approvals[0].approvalId !== lastApproval?.approvalId) {
@@ -36,6 +35,41 @@ export function ToolApprovalSheet({ approvals, isOpen, onRespond }: ToolApproval
   if (!approval) {
     return null;
   }
+
+  return (
+    <BottomSheet open={isOpen}>
+      <BottomSheet.Content isCloseDisabled onClose={ignoreClose}>
+        <BottomSheet.Header>
+          <BottomSheet.CloseButton accessibilityLabel={t('common.close')} />
+          <BottomSheet.Title>{t('chat.tool.approval.title')}</BottomSheet.Title>
+          <BottomSheet.HeaderSpacer />
+        </BottomSheet.Header>
+        <ToolApprovalSheetBody
+          approval={approval}
+          onRespond={onRespond}
+          pendingCount={approvals.length}
+        />
+      </BottomSheet.Content>
+    </BottomSheet>
+  );
+}
+
+function ToolApprovalSheetBody({
+  approval,
+  onRespond,
+  pendingCount,
+}: {
+  approval: PendingToolApproval;
+  onRespond: (input: ToolApprovalRespondInput) => Promise<void>;
+  pendingCount: number;
+}) {
+  const { t } = useTranslation();
+  const { geometry } = useBottomSheet();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // The buttons are the last thing in a card that measures to its content, so
+  // this padding is what keeps them clear of the home indicator: `insets.bottom`
+  // measured from the screen's bottom, minus the gap the card already leaves.
+  const bottomPadding = Math.max(16, geometry.insets.bottom - geometry.outerInset);
 
   const submit = async (approved: boolean) => {
     if (isSubmitting) {
@@ -55,49 +89,40 @@ export function ToolApprovalSheet({ approvals, isOpen, onRespond }: ToolApproval
   };
 
   return (
-    <BottomSheet open={isOpen}>
-      <BottomSheet.Content isCloseDisabled onClose={ignoreClose}>
-        <BottomSheet.Header>
-          <BottomSheet.CloseButton accessibilityLabel={t('common.close')} />
-          <BottomSheet.Title>{t('chat.tool.approval.title')}</BottomSheet.Title>
-          <BottomSheet.HeaderSpacer />
-        </BottomSheet.Header>
-        <BottomSheet.Body className="gap-4 px-4 pb-4">
-          <View className="gap-1">
-            <Text className="text-foreground-tertiary text-sm">
-              {t('chat.tool.approval.description')}
-            </Text>
-            <Text className="font-semibold text-base text-foreground" selectable>
-              {formatApprovalTitle(approval, t)}
-            </Text>
-            {approvals.length > 1 ? (
-              <Text className="text-foreground-tertiary text-xs">
-                {t('chat.tool.approval.pendingCount', { count: approvals.length })}
-              </Text>
-            ) : null}
-          </View>
-          <ApprovalArgumentsPreview input={approval.input} />
-          <View className="flex-row gap-3">
-            <Button
-              className="flex-1"
-              disabled={isSubmitting}
-              onPress={() => void submit(false)}
-              variant="destructive"
-            >
-              <Button.Label>{t('chat.tool.approval.deny')}</Button.Label>
-            </Button>
-            <Button
-              className="flex-1"
-              disabled={isSubmitting}
-              onPress={() => void submit(true)}
-              variant="default"
-            >
-              <Button.Label>{t('chat.tool.approval.allow')}</Button.Label>
-            </Button>
-          </View>
-        </BottomSheet.Body>
-      </BottomSheet.Content>
-    </BottomSheet>
+    <BottomSheet.Body className="gap-4 px-4" style={{ paddingBottom: bottomPadding }}>
+      <View className="gap-1">
+        <Text className="text-foreground-tertiary text-sm">
+          {t('chat.tool.approval.description')}
+        </Text>
+        <Text className="font-semibold text-base text-foreground" selectable>
+          {formatApprovalTitle(approval, t)}
+        </Text>
+        {pendingCount > 1 ? (
+          <Text className="text-foreground-tertiary text-xs">
+            {t('chat.tool.approval.pendingCount', { count: pendingCount })}
+          </Text>
+        ) : null}
+      </View>
+      <ApprovalArgumentsPreview input={approval.input} />
+      <View className="flex-row gap-3">
+        <Button
+          className="flex-1"
+          disabled={isSubmitting}
+          onPress={() => void submit(false)}
+          variant="destructive"
+        >
+          <Button.Label>{t('chat.tool.approval.deny')}</Button.Label>
+        </Button>
+        <Button
+          className="flex-1"
+          disabled={isSubmitting}
+          onPress={() => void submit(true)}
+          variant="default"
+        >
+          <Button.Label>{t('chat.tool.approval.allow')}</Button.Label>
+        </Button>
+      </View>
+    </BottomSheet.Body>
   );
 }
 

--- a/src/frontend/features/chat/approval/__tests__/ToolApprovalSheet.test.tsx
+++ b/src/frontend/features/chat/approval/__tests__/ToolApprovalSheet.test.tsx
@@ -1,6 +1,6 @@
 import { BottomSheet, Button } from '@cherrystudio/ui/components';
 import type { ReactNode } from 'react';
-import { ScrollView, Text } from 'react-native';
+import { ScrollView, StyleSheet, Text } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import type { PendingToolApproval } from '../../runtime/chatRuntimeProjection';
@@ -41,7 +41,23 @@ jest.mock('@cherrystudio/ui/components', () => {
     Title: component(),
   });
 
-  return { BottomSheet, Button: MockButton };
+  return {
+    BottomSheet,
+    Button: MockButton,
+    useBottomSheet: () => ({
+      geometry: {
+        bottomCornerRadius: 28,
+        insets: { bottom: 34, left: 0, right: 0, top: 59 },
+        isContentSized: true,
+        outerInset: 4,
+        sheetWidth: 380,
+        topCornerRadius: 28,
+      },
+      isCloseDisabled: true,
+      isClosing: false,
+      requestClose: () => undefined,
+    }),
+  };
 });
 
 jest.mock('@/frontend/components/messages', () => ({
@@ -162,6 +178,18 @@ describe('ToolApprovalSheet', () => {
       approved: false,
       messageId: 'assistant-1',
     });
+  });
+
+  test('keeps the decision buttons clear of the home indicator', () => {
+    render();
+
+    // The card measures to its content and reaches the bottom of the screen, so
+    // the buttons are the last thing above the indicator. Padding them by the
+    // safe inset less the gap the card already leaves is what a user needs to be
+    // able to press deny at all.
+    expect(
+      StyleSheet.flatten(renderer.root.findByType(BottomSheet.Body).props.style),
+    ).toMatchObject({ paddingBottom: 30 });
   });
 
   test('uses a solid danger action for denial', () => {


### PR DESCRIPTION
## 问题

`BottomSheet.Body` 和 `BottomSheet.ScrollView` 无条件带 `flex: 1`。

对于给了 `height` 的卡片这是对的——viewport 吃掉固定 chrome 剩下的空间。但默认的 `'content'` detent 下卡片是 auto height，`flex: 1` 解析成 flex basis 为 0，对 auto 高度贡献为零：卡片只量到 chrome，body 落到 0 高。

自 #567 引入这几个 part 起，**所有 content-sized 弹层都渲染成了一根光秃秃的标题条**：

- `ToolApprovalSheet` —— 用户根本看不到「允许／拒绝」按钮，**任何 MCP 工具调用都批不了**
- `PaintingTemplateBottomSheet` —— 预览图、提示词面板、「试试看」按钮全部消失

## 改动

`Content` 通过它本来就发布的 geometry 多报一个 `isContentSized`，两个 viewport 在卡片按内容measure时也按自身内容measure。

`bottom-sheet.test.tsx` 用一个两行 `test.each` 把两种模式各自钉住——两行断言的样式互斥，任何一个常量样式都不可能同时满足。

审批弹层那边：content-sized 卡片会一直贴到屏幕底部，所以按钮自己补上 home indicator 的避让，做法和 `PaintingTemplateSheetBody` 里已有的一致。

## 模拟器实证（含阳性对照）

| | 截图结论 |
|---|---|
| 修复后打开模板弹层 | 完整：头像名 + 预览图 + 提示词面板 + 试试看 |
| **临时改回旧样式**，冷启动重进 | **塌成只剩 `@0x00_Krypt` 一条标题** |
| 撤销对照 | 恢复完整 |
| 审批弹层（fixture MCP server） | 标题 + 说明 + `fixtureServer: echo` + 参数 JSON + 拒绝／允许 全部可见 |
| 按「允许」 | 工具真执行，落到 `TOOL SAID: "echo: hello from fixture"` |

## 门禁

typecheck ✓、lint 0 error（26 条存量 warning）、format ✓。全量 317 suites / 2860 tests，**1 条失败为存量**：`usePaintings › measures the primary output for the restored canvas frame`，已在干净的 `upstream/v0.2`（#594 的 tip）上用独立 worktree 复现，与本 PR 无关。

## 附带发现（本 PR 未改）

审批弹层因为 `isCloseDisabled` 而渲染了一个**永远点不动**的关闭按钮，`disabled:opacity-40` 让它显示为灰色。要么不渲染它、用 `HeaderSpacer` 占位保持标题居中，要么让它等价于「拒绝」——属于产品判断，留给单独决定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
