### PR TITLE
test(paintings): wait for aspect ratio query

### DIFF
--- a/src/frontend/features/paintings/hooks/__tests__/usePaintings.test.tsx
+++ b/src/frontend/features/paintings/hooks/__tests__/usePaintings.test.tsx
@@ -121,7 +121,7 @@ describe('useResolvedPaintingFiles', () => {
       );
     });
 
-    await waitForCondition(() => query?.data !== undefined);
+    await waitForCondition(() => query?.isLoading === false);
 
     expect(query?.data?.outputAspectRatio).toBeCloseTo(1664 / 928);
     expect(ExpoImage.loadAsync).toHaveBeenCalledWith('file:///generated.png');


### PR DESCRIPTION
## Summary

- wait for the combined resolved-file and image-aspect-ratio loading state before asserting the measured ratio
- remove the timing race that makes the paintings hook test fail under CI scheduling
- keep the change test-only with no runtime behavior changes

## Testing

- reproduced the focused failure on the current v0.2 head
- pnpm test:app -- src/frontend/features/paintings/hooks/__tests__/usePaintings.test.tsx --runInBand
- repeated the focused suite 10 times successfully
- pnpm lint
- pnpm format:check
- pnpm typecheck