### PR TITLE
docs(testing): add Android device isolation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Guides are task-oriented procedures for changing or extending the application.
 | --- | --- |
 | [Extending Cherry Mobile](./guides/extending.md) | Add resource endpoints, workflows, persistence, backend behavior, and UI |
 | [Git Workflow](./guides/git-workflow.md) | Commits, stacked PRs, review readiness, and case-only renames |
-| [Parallel Device Testing](./guides/parallel-device-testing.md) | Conductor port and iOS simulator isolation and cleanup |
+| [Parallel Device Testing](./guides/parallel-device-testing.md) | Conductor port, iOS simulator, and Android emulator isolation and cleanup |
 | [Testing And CI](./guides/testing-and-ci.md) | Focused checks, test value, local PR gates, and remote CI |
 | [UI Development](./guides/ui-development.md) | CherryUI ownership and reusable React component composition |
 

--- a/docs/guides/git-workflow.md
+++ b/docs/guides/git-workflow.md
@@ -31,8 +31,8 @@ own bottom PR and the feature integration in the PR above it. See
 
 1. Run the local gates in [Testing And CI](./testing-and-ci.md).
 2. Create a normal PR as a draft, or submit an entire stack with `gh stack submit --auto`.
-3. After successful PR or stack creation, release the workspace simulator and its allocated port
-   range using [Parallel Device Testing](./parallel-device-testing.md).
+3. After successful PR or stack creation, release the workspace's simulators or emulators and
+   allocated port range using [Parallel Device Testing](./parallel-device-testing.md).
 4. Rerun local gates after later draft changes, then mark the final head ready for review.
 5. Treat the remote CI result as the complete-suite gate.
 

--- a/docs/guides/parallel-device-testing.md
+++ b/docs/guides/parallel-device-testing.md
@@ -1,7 +1,7 @@
 # Parallel Device Testing
 
-This guide defines iOS simulator and Metro isolation for concurrent Conductor worktrees. Android
-emulator provisioning is outside this workflow.
+This guide defines iOS simulator, Android emulator, and Metro isolation for concurrent Conductor
+worktrees. Physical devices are outside this workflow.
 
 ## Workspace Resources
 
@@ -26,6 +26,25 @@ agent-device devices --platform ios
 agent-device device status --platform ios
 ```
 
+Each worktree also uses a dedicated Android emulator named:
+
+```text
+CherryStudio API 36 ($CONDUCTOR_WORKSPACE_NAME)
+```
+
+Provision it lazily for the workspace and never substitute a physical device or another
+workspace's emulator. After the emulator boots, record its expected name, current serial, and
+`kind: emulator` under that workspace's `.context`. An Android serial such as `emulator-5554` can
+change across boots, so refresh the ownership record before each app session. If the dedicated
+emulator cannot be provisioned, stop and report the blocker.
+
+Before opening the Android app, inspect devices and active sessions:
+
+```bash
+agent-device devices --platform android
+agent-device session list
+```
+
 ## Metro And App Session
 
 Start Metro on the allocated base port:
@@ -38,6 +57,16 @@ Use a workspace-unique session, explicit simulator, and explicit Metro hint:
 
 ```bash
 agent-device open com.cherry-ai.cherry-studio-app --session "$CONDUCTOR_WORKSPACE_NAME" --platform ios --device "iPhone 17 Pro ($CONDUCTOR_WORKSPACE_NAME)" --metro-host 127.0.0.1 --metro-port "$CONDUCTOR_PORT" --relaunch
+```
+
+For Android, relaunch the installed development client on the dedicated emulator, then open the
+exact development-client URL printed by this workspace's Metro process. Do not derive or reuse a
+URL from another workspace. Opening that URL through `agent-device` configures Android-to-host
+reachability for its Metro port.
+
+```bash
+agent-device open com.cherry_ai.cherry_studio_app --session "${CONDUCTOR_WORKSPACE_NAME}-android" --platform android --serial "$ANDROID_SERIAL" --relaunch
+agent-device open "$DEV_CLIENT_URL" --session "${CONDUCTOR_WORKSPACE_NAME}-android" --platform android --serial "$ANDROID_SERIAL"
 ```
 
 Keep commands for one session serial. Different sessions may run concurrently only when their
@@ -54,5 +83,19 @@ After a PR or complete stack is created:
 4. Remove the workspace simulator metadata after deletion succeeds or the recorded device is
    already absent.
 
+Clean up Android with the same ownership guarantees:
+
+1. Reinspect Android devices and confirm the recorded serial still resolves to the expected
+   workspace-specific name and `kind: emulator`.
+2. Close the workspace session with `agent-device close --session
+   "${CONDUCTOR_WORKSPACE_NAME}-android" --platform android --shutdown`.
+3. Delete only the AVD whose recorded serial and expected workspace-specific name both match, using
+   the same provisioner that created it. Never delete an Android device by serial alone.
+4. Remove the workspace emulator metadata after deletion succeeds or the recorded device is
+   already absent.
+
 The local Conductor archive script repeats this cleanup as a fallback. Cleanup must be idempotent and
 must refuse to delete an unrecorded or name-mismatched simulator.
+
+The same fallback and idempotency requirements apply to Android cleanup, which must also refuse to
+delete a physical device.


### PR DESCRIPTION
### What this PR does

Before this PR:

The parallel device testing guide covered only iOS simulator and Metro isolation. Android emulator
provisioning was explicitly outside the workflow.

After this PR:

The guide keeps the existing iOS workflow unchanged and adds matching Android isolation rules:

- provision one `CherryStudio API 36 ($CONDUCTOR_WORKSPACE_NAME)` AVD per workspace;
- record and refresh the emulator name, runtime serial, and emulator kind under `.context`;
- launch the Android development client in a workspace-specific `agent-device` session using the
  current workspace's Metro URL;
- verify ownership before shutdown and deletion, and refuse physical or mismatched devices.

The documentation index and PR cleanup workflow now cover both platforms.

### Screenshots or videos

N/A — this is a documentation-only change with no user-facing UI effect.

### Why we need it and why it was done in this way

Android device acceptance needs the same worktree isolation guarantees already documented for iOS.
Using a workspace-specific AVD prevents concurrent Conductor worktrees from sharing app state or
targeting the wrong device, while Conductor's allocated port range keeps Metro isolated.

The following tradeoffs were made:

- Android serials are recorded per boot because values such as `emulator-5554` are not stable.
- Android uses the exact development-client URL emitted by Metro because `agent-device` can use it
  to configure emulator-to-host reachability.
- The existing iOS procedure and command examples remain unchanged.

The following alternatives were considered:

- A shared Android emulator was rejected because it cannot provide safe concurrent workspace
  ownership.
- Selecting devices by serial alone was rejected because serials can change and do not prove AVD
  ownership.

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `pnpm format:check` passed.
- `git diff --check` passed.
- `pnpm lint` reported existing unresolved `@cherrystudio/ai-core` imports and unrelated warnings
  in files outside this documentation change.
- Typecheck, tests, and device acceptance were not run for this documentation-only change.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: This change has no visible product effect, so screenshots are not applicable
- [x] Code: The documentation is scoped to the Android workflow and keeps the iOS procedure intact
- [x] Documentation: This PR is the required repository guide update
- [x] Self-review: The final diff was reviewed before publication

### Release note

```release-note
NONE
```
