### PR TITLE
fix(user-avatar): persist replacements without flicker

### DIFF
--- a/src/backend/services/file/__tests__/userContentImageStorage.test.ts
+++ b/src/backend/services/file/__tests__/userContentImageStorage.test.ts
@@ -45,8 +45,15 @@ jest.mock('expo-file-system', () => {
       return files.get(this.uri) ?? null;
     }
 
-    copy(destination: MockFile) {
-      files.set(destination.uri, files.get(this.uri) ?? 0);
+    async copy(destination: MockFile) {
+      await Promise.resolve();
+
+      const sourceSize = files.get(this.uri);
+      if (sourceSize === undefined) {
+        throw new Error(`Source file does not exist: ${this.uri}`);
+      }
+
+      files.set(destination.uri, sourceSize);
     }
 
     delete() {

--- a/src/backend/services/file/userContentImageStorage.ts
+++ b/src/backend/services/file/userContentImageStorage.ts
@@ -36,7 +36,7 @@ export function createUserContentImageStorage(): UserContentImageStorage {
       try {
         normalizedUri = await normalizeAvatarImage(sourceUri);
         const storedName = `${randomUUID()}.webp`;
-        new File(normalizedUri).copy(new File(ensureAvatarDirectory(), storedName));
+        await new File(normalizedUri).copy(new File(ensureAvatarDirectory(), storedName));
         return storedName;
       } finally {
         if (normalizedUri) {

--- a/src/frontend/hooks/__tests__/useAvatar.test.tsx
+++ b/src/frontend/hooks/__tests__/useAvatar.test.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { useAvatar } from '../useAvatar';
+
+let mockAvatarPreference = 'avatar-file:first.webp';
+const mockResolveAvatar = jest.fn(
+  async (_avatar: string): Promise<string | undefined> => undefined,
+);
+
+jest.mock('@/frontend/data', () => ({
+  useBackendModule: () => ({ resolveAvatar: mockResolveAvatar }),
+}));
+
+jest.mock('@/frontend/data/hooks', () => ({
+  usePreference: () => [mockAvatarPreference, jest.fn()],
+}));
+
+let avatarSource: ReturnType<typeof useAvatar> | undefined;
+let queryClient: QueryClient;
+let renderer: ReactTestRenderer | undefined;
+
+function Probe() {
+  const source = useAvatar();
+
+  useEffect(() => {
+    avatarSource = source;
+  }, [source]);
+
+  return null;
+}
+
+describe('useAvatar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    avatarSource = undefined;
+    mockAvatarPreference = 'avatar-file:first.webp';
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+    queryClient.clear();
+  });
+
+  it('keeps the previous avatar visible while a replacement URI resolves', async () => {
+    const nextAvatar = deferred<string | undefined>();
+    mockResolveAvatar.mockImplementation((avatar) => {
+      if (avatar === 'avatar-file:first.webp') {
+        return Promise.resolve('file:///documents/user-avatar/first.webp');
+      }
+      return nextAvatar.promise;
+    });
+
+    await renderHook();
+    expect(avatarSource).toBe('file:///documents/user-avatar/first.webp');
+
+    mockAvatarPreference = 'avatar-file:second.webp';
+    await updateHook();
+
+    expect(avatarSource).toBe('file:///documents/user-avatar/first.webp');
+
+    await act(async () => {
+      nextAvatar.resolve('file:///documents/user-avatar/second.webp');
+      await nextAvatar.promise;
+    });
+    await flushQueryNotifications();
+
+    expect(avatarSource).toBe('file:///documents/user-avatar/second.webp');
+  });
+});
+
+async function renderHook() {
+  await act(async () => {
+    renderer = create(
+      <QueryClientProvider client={queryClient}>
+        <Probe />
+      </QueryClientProvider>,
+    );
+  });
+  await flushQueryNotifications();
+}
+
+async function updateHook() {
+  await act(async () => {
+    renderer?.update(
+      <QueryClientProvider client={queryClient}>
+        <Probe />
+      </QueryClientProvider>,
+    );
+  });
+}
+
+async function flushQueryNotifications() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}

--- a/src/frontend/hooks/useAvatar.ts
+++ b/src/frontend/hooks/useAvatar.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { useBackendModule } from '@/frontend/data';
 import { usePreference } from '@/frontend/data/hooks';
@@ -12,6 +12,7 @@ export function useAvatar(): string | number {
   const avatarUriQuery = useQuery({
     queryFn: async () => (await profile.resolveAvatar(avatar)) ?? null,
     queryKey: ['profile-avatar', avatar],
+    placeholderData: keepPreviousData,
     retry: false,
     staleTime: Infinity,
   });


### PR DESCRIPTION
## Summary

- await the asynchronous avatar file copy before deleting its normalized temporary source
- keep the previous resolved avatar visible while a replacement URI is loading
- add regression coverage for asynchronous storage and avatar replacement rendering

## Root cause

Expo FileSystem File.copy returns a promise. The previous implementation started the copy and immediately deleted the normalized source in a finally block, allowing avatar persistence to race with cleanup. Separately, changing the persisted avatar reference changed the React Query key and briefly exposed undefined data, which rendered the bundled default avatar.

## Validation

- pnpm format:check passed
- pnpm typecheck passed
- focused Oxfmt, Oxlint, and Expo lint passed for changed files
- full pnpm lint remains blocked by three existing unresolved @cherrystudio/ai-core/provider imports outside this change
- tests and device verification were not run in accordance with the workspace verification policy

## Release note

Fix custom avatar saving and prevent the default avatar from flashing during replacement.