### PR TITLE
fix(testing): resolve root asset aliases

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
     '^@cherrystudio/universal/(.*)$': '<rootDir>/packages/universal/src/$1',
     '^@cherrystudio/ai-runtime/(.*)$': '<rootDir>/packages/ai-runtime/src/$1/index.ts',
     '^@shared/(.*)$': '<rootDir>/packages/universal/src/$1',
+    '^@/assets/(.*)$': '<rootDir>/assets/$1',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@logger$': '<rootDir>/src/shared/core/logger/LoggerService.ts',
   },


### PR DESCRIPTION
## Summary

- resolve `@/assets/*` from the repository-level `assets/` directory before the catch-all `@/*` mapping
- restore the existing `useAvatar` test’s default icon import

## Validation

- `pnpm test:app -- src/frontend/hooks/__tests__/useAvatar.test.tsx --runInBand`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint` *(blocked locally by 9 pre-existing `@cherrystudio/ai-core` `import/no-unresolved` reports in untouched backend files; runtime and TypeScript package resolution succeed)*