### PR TITLE
feat(toast): unify global toast gateway

### DIFF
--- a/.rnstorybook/preview.tsx
+++ b/.rnstorybook/preview.tsx
@@ -1,4 +1,5 @@
 import '../src/frontend/styles/global.css';
+import { Toast } from '@cherrystudio/ui/components';
 import type { Preview } from '@storybook/react-native';
 import { BottomSheetProvider } from '@swmansion/react-native-bottom-sheet';
 import { HeroUINativeProvider } from 'heroui-native/provider';
@@ -7,12 +8,14 @@ import { View } from 'react-native';
 const preview: Preview = {
   decorators: [
     (Story) => (
-      <HeroUINativeProvider config={{ devInfo: { stylingPrinciples: false } }}>
-        <BottomSheetProvider>
-          <View className="flex-1 bg-background">
-            <Story />
-          </View>
-        </BottomSheetProvider>
+      <HeroUINativeProvider config={{ devInfo: { stylingPrinciples: false }, toast: 'disabled' }}>
+        <Toast.Provider>
+          <BottomSheetProvider>
+            <View className="flex-1 bg-background">
+              <Story />
+            </View>
+          </BottomSheetProvider>
+        </Toast.Provider>
       </HeroUINativeProvider>
     ),
   ],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,6 +120,10 @@ const tombstonePatterns = [
 
 const retiredImports = [
   {
+    name: 'heroui-native/toast',
+    message: 'Use Toast and useToast from @cherrystudio/ui/components.',
+  },
+  {
     name: '@/frontend/data',
     importNames: ['useDataModule'],
     message: 'Use the typed Data API hooks: useQuery, useMutation, or useInfiniteQuery.',

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -115,6 +115,23 @@ The provider presents queued dialogs in request order. Confirmation and prompt a
 without waiting for asynchronous business work, so failures can enqueue their own follow-up alert.
 The standalone `<Alert>` primitive remains available for controlled dialog composition.
 
+`Toast` is the shared gateway for temporary global notifications. Mount one provider at the
+application root; feature code then shows notifications through `useToast()` without importing the
+underlying toast library or mounting another host:
+
+```tsx
+<Toast.Provider>
+  <App />
+</Toast.Provider>
+
+const { toast } = useToast();
+toast.show({ label: 'Saved', variant: 'success' });
+```
+
+The gateway preserves the current four-second default duration and exposes `default`, `success`,
+`warning`, and `danger` variants. `DynamicToast` remains a separate animated visual component; it is
+not the global notification gateway.
+
 `Avatar` composes an image or fallback inside a clipped face while keeping badges outside that
 clipping boundary. It accepts numeric sizes so product avatars can follow their surrounding layout,
 and supports circular and rounded-square faces:

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -24,3 +24,4 @@ export * from './switch';
 export * from './tabs';
 export * from './text-animation';
 export * from './text-field';
+export * from './toast';

--- a/packages/ui/src/components/toast/index.ts
+++ b/packages/ui/src/components/toast/index.ts
@@ -1,0 +1,7 @@
+export { Toast, useToast } from './toast';
+export type {
+  ToastController,
+  ToastProviderProps,
+  ToastShowOptions,
+  ToastVariant,
+} from './toast.types';

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -1,0 +1,50 @@
+import { ToastProvider as HeroToastProvider, useToast as useHeroToast } from 'heroui-native/toast';
+import { createContext, use, useEffect, useMemo, useRef } from 'react';
+
+import type { ToastController, ToastProviderProps } from './toast.types';
+
+const DEFAULT_TOAST_DURATION = 4000;
+
+const ToastContext = createContext<ToastController | null>(null);
+
+function ToastControllerProvider({ children }: ToastProviderProps) {
+  const { toast: heroToast } = useHeroToast();
+  const heroToastRef = useRef(heroToast);
+
+  useEffect(() => {
+    heroToastRef.current = heroToast;
+  }, [heroToast]);
+
+  const controller = useMemo<ToastController>(
+    () => ({
+      show: ({ duration = DEFAULT_TOAST_DURATION, label, variant }) => {
+        void heroToastRef.current.show({ duration, label, variant });
+      },
+    }),
+    [],
+  );
+
+  return <ToastContext value={controller}>{children}</ToastContext>;
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  return (
+    <HeroToastProvider>
+      <ToastControllerProvider>{children}</ToastControllerProvider>
+    </HeroToastProvider>
+  );
+}
+
+export function useToast() {
+  const toast = use(ToastContext);
+
+  if (!toast) {
+    throw new Error('useToast must be used within Toast.Provider');
+  }
+
+  return { toast };
+}
+
+export const Toast = {
+  Provider: ToastProvider,
+};

--- a/packages/ui/src/components/toast/toast.types.ts
+++ b/packages/ui/src/components/toast/toast.types.ts
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from 'react';
+
+export type ToastVariant = 'danger' | 'default' | 'success' | 'warning';
+
+export type ToastShowOptions = {
+  duration?: number;
+  label: string;
+  variant?: ToastVariant;
+};
+
+export type ToastController = {
+  show: (options: ToastShowOptions) => void;
+};
+
+export type ToastProviderProps = PropsWithChildren;

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -2,7 +2,7 @@ import '../frontend/styles/global.css';
 import '@/bootstrap/preboot/abortSignal';
 import '@/bootstrap/preboot/blob';
 import '@/bootstrap/preboot/webCrypto';
-import { Alert } from '@cherrystudio/ui/components';
+import { Alert, Toast } from '@cherrystudio/ui/components';
 import { BottomSheetProvider } from '@swmansion/react-native-bottom-sheet';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
@@ -37,26 +37,28 @@ export default function RootLayout() {
   return (
     <RootGestureView className="flex-1">
       <KeyboardProvider>
-        <HeroUINativeProvider config={{ devInfo: { stylingPrinciples: false } }}>
-          <QueryProvider>
-            <AppBootstrapProvider>
-              <BootstrapStartupCoordinator>
-                <AppBootstrapGate>
-                  <StartupRouteReadyReporter>
-                    <NavigationThemeProvider>
-                      <AppAlertProvider>
-                        <BottomSheetProvider>
-                          <RouteHeaderProvider rootAction="back">
-                            <RootStack />
-                          </RouteHeaderProvider>
-                        </BottomSheetProvider>
-                      </AppAlertProvider>
-                    </NavigationThemeProvider>
-                  </StartupRouteReadyReporter>
-                </AppBootstrapGate>
-              </BootstrapStartupCoordinator>
-            </AppBootstrapProvider>
-          </QueryProvider>
+        <HeroUINativeProvider config={{ devInfo: { stylingPrinciples: false }, toast: 'disabled' }}>
+          <Toast.Provider>
+            <QueryProvider>
+              <AppBootstrapProvider>
+                <BootstrapStartupCoordinator>
+                  <AppBootstrapGate>
+                    <StartupRouteReadyReporter>
+                      <NavigationThemeProvider>
+                        <AppAlertProvider>
+                          <BottomSheetProvider>
+                            <RouteHeaderProvider rootAction="back">
+                              <RootStack />
+                            </RouteHeaderProvider>
+                          </BottomSheetProvider>
+                        </AppAlertProvider>
+                      </NavigationThemeProvider>
+                    </StartupRouteReadyReporter>
+                  </AppBootstrapGate>
+                </BootstrapStartupCoordinator>
+              </AppBootstrapProvider>
+            </QueryProvider>
+          </Toast.Provider>
         </HeroUINativeProvider>
       </KeyboardProvider>
     </RootGestureView>

--- a/src/frontend/components/composer/components/ComposerSurface.tsx
+++ b/src/frontend/components/composer/components/ComposerSurface.tsx
@@ -1,5 +1,4 @@
-import { Composer } from '@cherrystudio/ui/components';
-import { useToast } from 'heroui-native/toast';
+import { Composer, useToast } from '@cherrystudio/ui/components';
 import { type PropsWithChildren, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KeyboardController } from 'react-native-keyboard-controller';

--- a/src/frontend/components/composer/components/__tests__/ComposerSurface.test.tsx
+++ b/src/frontend/components/composer/components/__tests__/ComposerSurface.test.tsx
@@ -41,14 +41,13 @@ jest.mock('@cherrystudio/ui/components', () => {
     return React.createElement(View, { ...props, testID: 'mock-collapsible' }, children);
   }
 
-  return { Composer: Object.assign(MockComposer, { Collapsible: MockCollapsible }) };
+  return {
+    Composer: Object.assign(MockComposer, { Collapsible: MockCollapsible }),
+    useToast: () => ({ toast: { show: mockToastShow } }),
+  };
 });
 
 jest.mock('@/frontend/components/FileEntryPreview', () => ({ FileEntryPreview: () => null }));
-
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
-}));
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),

--- a/src/frontend/features/paintings/PaintingViewerScreen/hooks/__tests__/usePaintingViewerActions.test.tsx
+++ b/src/frontend/features/paintings/PaintingViewerScreen/hooks/__tests__/usePaintingViewerActions.test.tsx
@@ -36,12 +36,9 @@ jest.mock('expo-media-library', () => ({
   requestPermissionsAsync: (...args: unknown[]) => mockRequestPermissions(...args),
 }));
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
-}));
-
 jest.mock('@cherrystudio/ui/components', () => ({
   useAlert: () => ({ alert: { confirm: mockAlertConfirm, show: mockAlertShow } }),
+  useToast: () => ({ toast: { show: mockToastShow } }),
 }));
 
 jest.mock('react-i18next', () => ({

--- a/src/frontend/features/paintings/PaintingViewerScreen/hooks/usePaintingViewerActions.ts
+++ b/src/frontend/features/paintings/PaintingViewerScreen/hooks/usePaintingViewerActions.ts
@@ -1,7 +1,6 @@
-import { useAlert } from '@cherrystudio/ui/components';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import * as MediaLibrary from 'expo-media-library';
 import { useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Linking } from 'react-native';

--- a/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
@@ -1,6 +1,5 @@
-import { Button, Input, Label, TextField, useAlert } from '@cherrystudio/ui/components';
+import { Button, Input, Label, TextField, useAlert, useToast } from '@cherrystudio/ui/components';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';

--- a/src/frontend/features/settings/ProviderScreen/hooks/useProviderDeletion.ts
+++ b/src/frontend/features/settings/ProviderScreen/hooks/useProviderDeletion.ts
@@ -1,7 +1,6 @@
-import { useAlert } from '@cherrystudio/ui/components';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import { useToast } from 'heroui-native/toast';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelCheck.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/__tests__/useProviderModelCheck.test.tsx
@@ -16,16 +16,13 @@ jest.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: jest.fn() }),
 }));
 
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
-}));
-
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 jest.mock('@cherrystudio/ui/components', () => ({
   useAlert: () => ({ alert: { show: mockAlertShow } }),
+  useToast: () => ({ toast: { show: mockToastShow } }),
 }));
 
 jest.mock('@/frontend/data', () => ({

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelAdd.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelAdd.ts
@@ -1,5 +1,4 @@
-import { useAlert } from '@cherrystudio/ui/components';
-import { useToast } from 'heroui-native/toast';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelCheck.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelCheck.ts
@@ -1,6 +1,5 @@
-import { useAlert } from '@cherrystudio/ui/components';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useQueryClient } from '@tanstack/react-query';
-import { useToast } from 'heroui-native/toast';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPull.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelPull.ts
@@ -1,6 +1,5 @@
-import { useAlert } from '@cherrystudio/ui/components';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useQueryClient } from '@tanstack/react-query';
-import { useToast } from 'heroui-native/toast';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/frontend/features/settings/WebSearchScreen/apiService/hooks/__tests__/useWebSearchProviderCheck.test.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/apiService/hooks/__tests__/useWebSearchProviderCheck.test.tsx
@@ -12,11 +12,9 @@ const mockToastShow = jest.fn();
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
-jest.mock('heroui-native/toast', () => ({
-  useToast: () => ({ toast: { show: mockToastShow } }),
-}));
 jest.mock('@cherrystudio/ui/components', () => ({
   useAlert: () => ({ alert: { show: mockAlertShow } }),
+  useToast: () => ({ toast: { show: mockToastShow } }),
 }));
 jest.mock('@/frontend/data', () => ({
   useBackendModule: () => ({ checkProvider: mockCheckProvider }),

--- a/src/frontend/features/settings/WebSearchScreen/apiService/hooks/useWebSearchProviderCheck.ts
+++ b/src/frontend/features/settings/WebSearchScreen/apiService/hooks/useWebSearchProviderCheck.ts
@@ -1,5 +1,4 @@
-import { useAlert } from '@cherrystudio/ui/components';
-import { useToast } from 'heroui-native/toast';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 


### PR DESCRIPTION
## Summary

- add a CherryUI-owned `Toast.Provider` and `useToast` gateway with stable semantic types and the existing four-second default duration
- mount one global toast host in the app and Storybook while disabling HeroUI's implicit toast provider
- migrate Composer, Painting, MCP, Provider, and WebSearch callers without changing labels, variants, or user behavior
- update affected mocks, package documentation, and lint enforcement while keeping `DynamicToast` separate

## Risk

- the provider wiring has not been manually verified on a device; the underlying HeroUI toast renderer and styling remain unchanged

## Validation

- `pnpm format:check` (passed)
- targeted `oxlint` and Expo lint for all changed source files (passed)
- `git diff --check` (passed)
- `pnpm lint` (blocked by existing unresolved `@cherrystudio/ai-core` imports in unchanged backend files)
- tests, typecheck, builds, and manual UI verification were not run per task constraints
