### PR TITLE
refactor(settings): extract shared scroll page shell

### DIFF
--- a/src/frontend/features/settings/AppearanceSettingsScreen.tsx
+++ b/src/frontend/features/settings/AppearanceSettingsScreen.tsx
@@ -5,13 +5,13 @@ import { Section } from '@cherrystudio/ui/components';
 import { normalizeFontSizeStep } from '@cherrystudio/ui/utils';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ScrollView, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
-import { RouteHeader } from '@/frontend/components/headers';
 import { usePreference } from '@/frontend/data/hooks';
 import { ThemeMode } from '@/shared/data/preference';
 
+import { SettingsScrollPage } from './components/SettingsScrollPage';
 import { ThemePreviewSelector } from './components/ThemePreviewSelector';
 import { useSettingPreferences } from './hooks/useSettingPreferences';
 import { FONT_SIZE_STEP_LABEL_KEYS } from './utils/fontSizeOptions';
@@ -38,53 +38,47 @@ export default function AppearanceSettingsScreen() {
   };
 
   return (
-    <>
-      <RouteHeader title={t('settings.appearance.title')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="gap-6 px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section title={t('settings.items.theme')}>
-          <Section.Item testID="theme-preview-section-item">
-            <ThemePreviewSelector
-              isAutomatic={isAutomaticTheme}
-              onAutomaticChange={handleAutomaticThemeChange}
-              onThemeChange={settingPreferences.theme.onValueChange}
-              selectedTheme={selectedTheme}
-            />
-          </Section.Item>
-        </Section>
+    <SettingsScrollPage
+      contentClassName="gap-6"
+      headerProps={{ title: t('settings.appearance.title') }}
+    >
+      <Section title={t('settings.items.theme')}>
+        <Section.Item testID="theme-preview-section-item">
+          <ThemePreviewSelector
+            isAutomatic={isAutomaticTheme}
+            onAutomaticChange={handleAutomaticThemeChange}
+            onThemeChange={settingPreferences.theme.onValueChange}
+            selectedTheme={selectedTheme}
+          />
+        </Section.Item>
+      </Section>
 
-        <Section>
-          <Section.Item
-            label={t('settings.items.appLanguage')}
-            leading={<GlobeIcon className="size-5 text-foreground" />}
-            onPress={() => router.push('/settings/language')}
-            trailing={
-              <View className="flex-row items-center gap-1">
-                <Text className="text-right text-base text-foreground">{languageLabel}</Text>
-                <ChevronRightIcon className="size-5 text-foreground" />
-              </View>
-            }
-          />
-          <Section.Item
-            label={t('settings.items.fontSize')}
-            leading={<ALargeSmallIcon className="size-5 text-foreground" />}
-            onPress={() => router.push('/settings/font-size')}
-            trailing={
-              <View className="flex-row items-center gap-1">
-                <Text className="text-right text-base text-foreground">
-                  {t(FONT_SIZE_STEP_LABEL_KEYS[normalizedFontSizeStep])}
-                </Text>
-                <ChevronRightIcon className="size-5 text-foreground" />
-              </View>
-            }
-          />
-        </Section>
-      </ScrollView>
-    </>
+      <Section>
+        <Section.Item
+          label={t('settings.items.appLanguage')}
+          leading={<GlobeIcon className="size-5 text-foreground" />}
+          onPress={() => router.push('/settings/language')}
+          trailing={
+            <View className="flex-row items-center gap-1">
+              <Text className="text-right text-base text-foreground">{languageLabel}</Text>
+              <ChevronRightIcon className="size-5 text-foreground" />
+            </View>
+          }
+        />
+        <Section.Item
+          label={t('settings.items.fontSize')}
+          leading={<ALargeSmallIcon className="size-5 text-foreground" />}
+          onPress={() => router.push('/settings/font-size')}
+          trailing={
+            <View className="flex-row items-center gap-1">
+              <Text className="text-right text-base text-foreground">
+                {t(FONT_SIZE_STEP_LABEL_KEYS[normalizedFontSizeStep])}
+              </Text>
+              <ChevronRightIcon className="size-5 text-foreground" />
+            </View>
+          }
+        />
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/FontSizeSettingsScreen.tsx
+++ b/src/frontend/features/settings/FontSizeSettingsScreen.tsx
@@ -2,13 +2,13 @@ import { Slider, useAlert } from '@cherrystudio/ui/components';
 import { normalizeFontSizeStep } from '@cherrystudio/ui/utils';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ScrollView, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
-import { RouteHeader } from '@/frontend/components/headers';
 import { MarkdownText } from '@/frontend/components/markdown';
 import { usePreference } from '@/frontend/data/hooks';
 import { applyFontSizeStepPreference } from '@/frontend/utils/theme';
 
+import { SettingsScrollPage } from './components/SettingsScrollPage';
 import { FONT_SIZE_STEP_LABEL_KEYS } from './utils/fontSizeOptions';
 
 export default function FontSizeSettingsScreen() {
@@ -38,48 +38,40 @@ export default function FontSizeSettingsScreen() {
   };
 
   return (
-    <>
-      <RouteHeader title={t('settings.fontSize.title')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="gap-6 px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <View className="gap-4 rounded-xl bg-grouped-surface px-4 py-5">
-          <View className="flex-row items-center justify-between gap-3">
-            <Text className="font-medium text-foreground text-base">
-              {t('settings.fontSize.title')}
-            </Text>
-            <Text className="text-foreground text-sm">
-              {t(FONT_SIZE_STEP_LABEL_KEYS[draftStep])}
-            </Text>
-          </View>
-          <Slider
-            accessibilityLabel={t('settings.fontSize.sliderLabel')}
-            max={2}
-            maximumValueLabel={t(FONT_SIZE_STEP_LABEL_KEYS[2])}
-            min={0}
-            minimumValueLabel={t(FONT_SIZE_STEP_LABEL_KEYS[0])}
-            onValueChange={handleChange}
-            step={1}
-            value={draftStep}
+    <SettingsScrollPage
+      contentClassName="gap-6"
+      headerProps={{ title: t('settings.fontSize.title') }}
+    >
+      <View className="gap-4 rounded-xl bg-grouped-surface px-4 py-5">
+        <View className="flex-row items-center justify-between gap-3">
+          <Text className="font-medium text-foreground text-base">
+            {t('settings.fontSize.title')}
+          </Text>
+          <Text className="text-foreground text-sm">{t(FONT_SIZE_STEP_LABEL_KEYS[draftStep])}</Text>
+        </View>
+        <Slider
+          accessibilityLabel={t('settings.fontSize.sliderLabel')}
+          max={2}
+          maximumValueLabel={t(FONT_SIZE_STEP_LABEL_KEYS[2])}
+          min={0}
+          minimumValueLabel={t(FONT_SIZE_STEP_LABEL_KEYS[0])}
+          onValueChange={handleChange}
+          step={1}
+          value={draftStep}
+        />
+      </View>
+
+      <View className="gap-2">
+        <Text className="px-1 font-medium text-foreground text-sm">
+          {t('settings.fontSize.previewTitle')}
+        </Text>
+        <View className="rounded-xl bg-grouped-surface px-4 py-5">
+          <MarkdownText
+            fontSizeStep={draftStep}
+            markdown={t('settings.fontSize.previewMarkdown')}
           />
         </View>
-
-        <View className="gap-2">
-          <Text className="px-1 font-medium text-foreground text-sm">
-            {t('settings.fontSize.previewTitle')}
-          </Text>
-          <View className="rounded-xl bg-grouped-surface px-4 py-5">
-            <MarkdownText
-              fontSizeStep={draftStep}
-              markdown={t('settings.fontSize.previewMarkdown')}
-            />
-          </View>
-        </View>
-      </ScrollView>
-    </>
+      </View>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/LanguageSettingsScreen.tsx
+++ b/src/frontend/features/settings/LanguageSettingsScreen.tsx
@@ -1,9 +1,7 @@
 import { Section } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
-import { ScrollView } from 'react-native';
 
-import { RouteHeader } from '@/frontend/components/headers';
-
+import { SettingsScrollPage } from './components/SettingsScrollPage';
 import { useSettingPreferences } from './hooks/useSettingPreferences';
 
 export default function LanguageSettingsScreen() {
@@ -11,34 +9,25 @@ export default function LanguageSettingsScreen() {
   const { language } = useSettingPreferences();
 
   return (
-    <>
-      <RouteHeader title={t('settings.items.appLanguage')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section>
-          {language.options.map((option) => {
-            const selected = option.value === language.value;
+    <SettingsScrollPage headerProps={{ title: t('settings.items.appLanguage') }}>
+      <Section>
+        {language.options.map((option) => {
+          const selected = option.value === language.value;
 
-            return (
-              <Section.RadioItem
-                key={option.value}
-                label={option.label}
-                onPress={() => {
-                  if (!selected) {
-                    language.onValueChange(option.value);
-                  }
-                }}
-                selected={selected}
-              />
-            );
-          })}
-        </Section>
-      </ScrollView>
-    </>
+          return (
+            <Section.RadioItem
+              key={option.value}
+              label={option.label}
+              onPress={() => {
+                if (!selected) {
+                  language.onValueChange(option.value);
+                }
+              }}
+              selected={selected}
+            />
+          );
+        })}
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/McpScreen/McpScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpScreen.tsx
@@ -3,13 +3,14 @@ import { Button } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, Text, View } from 'react-native';
 
-import { RouteHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
+import type { HeaderToolbarAction } from '@/frontend/components/headers';
 import { useMcpServerRuntimeSummaries, useMcpServersApi } from '@/frontend/hooks/mcp/useMcpServers';
 import type { McpServerRuntimeSummary } from '@/shared/contracts';
 import type { McpServer } from '@/shared/data/types/mcpServer';
 
+import { SettingsScrollPage } from '../components/SettingsScrollPage';
 import { SettingsServiceRow } from '../components/SettingsServiceRow';
 
 export function McpScreen() {
@@ -41,76 +42,70 @@ export function McpScreen() {
   );
 
   return (
-    <>
-      <RouteHeader rightActions={rightActions} title={t('settings.pages.mcp.title')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="flex-grow gap-6 px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        {isLoading ? (
-          <View className="items-center gap-2 px-1 py-8">
-            <ActivityIndicator size="small" />
-            <Text className="text-foreground text-sm">{t('settings.mcp.list.loading')}</Text>
-          </View>
-        ) : error ? (
-          <View className="items-center gap-3 px-1 py-8">
-            <Text className="text-destructive-foreground text-sm">
-              {t('settings.mcp.list.loadFailed')}
-            </Text>
-            <Text className="text-center text-foreground text-xs" selectable>
-              {error instanceof Error ? error.message : String(error)}
-            </Text>
-            <Button size="sm" variant="secondary" onPress={() => void refetch()}>
-              {t('settings.mcp.retry')}
-            </Button>
-          </View>
-        ) : servers.length === 0 ? (
-          <View className="flex-1 items-center justify-center gap-4 px-6 pb-20">
-            <Text className="text-center text-base text-foreground">{t('settings.mcp.empty')}</Text>
-            <Button onPress={openCreate} testID="mcp-empty-create" variant="default">
-              <Button.Label>{t('settings.mcp.emptyAction')}</Button.Label>
-            </Button>
-          </View>
-        ) : (
-          <View className="overflow-hidden rounded-2xl bg-grouped-surface">
-            {servers.map((server, index) => {
-              const previousServerId = servers[index - 1]?.id;
-              const summary = summaries[server.id];
-              const status = getServerStatus(server, summary);
+    <SettingsScrollPage
+      contentClassName="flex-grow gap-6"
+      headerProps={{ rightActions, title: t('settings.pages.mcp.title') }}
+    >
+      {isLoading ? (
+        <View className="items-center gap-2 px-1 py-8">
+          <ActivityIndicator size="small" />
+          <Text className="text-foreground text-sm">{t('settings.mcp.list.loading')}</Text>
+        </View>
+      ) : error ? (
+        <View className="items-center gap-3 px-1 py-8">
+          <Text className="text-destructive-foreground text-sm">
+            {t('settings.mcp.list.loadFailed')}
+          </Text>
+          <Text className="text-center text-foreground text-xs" selectable>
+            {error instanceof Error ? error.message : String(error)}
+          </Text>
+          <Button size="sm" variant="secondary" onPress={() => void refetch()}>
+            {t('settings.mcp.retry')}
+          </Button>
+        </View>
+      ) : servers.length === 0 ? (
+        <View className="flex-1 items-center justify-center gap-4 px-6 pb-20">
+          <Text className="text-center text-base text-foreground">{t('settings.mcp.empty')}</Text>
+          <Button onPress={openCreate} testID="mcp-empty-create" variant="default">
+            <Button.Label>{t('settings.mcp.emptyAction')}</Button.Label>
+          </Button>
+        </View>
+      ) : (
+        <View className="overflow-hidden rounded-2xl bg-grouped-surface">
+          {servers.map((server, index) => {
+            const previousServerId = servers[index - 1]?.id;
+            const summary = summaries[server.id];
+            const status = getServerStatus(server, summary);
 
-              return (
-                <SettingsServiceRow
-                  id={server.id}
-                  hideSeparator={
-                    pressedServerId === server.id || pressedServerId === previousServerId
-                  }
-                  key={server.id}
-                  name={server.name}
-                  showSeparator={index > 0}
-                  onPress={() =>
-                    router.push({
-                      pathname: './mcp/[serverId]',
-                      params: { serverId: server.id },
-                    })
-                  }
-                  onPressedChange={handleServerPressedChange}
-                  statusLabel={t(`settings.mcp.list.status.${status}`)}
-                  statusTone={
-                    status === 'connected' ? 'success' : status === 'error' ? 'danger' : 'default'
-                  }
-                  subtitle={getServerSubtitle(summary, (count) =>
-                    t('settings.mcp.list.toolCount', { count }),
-                  )}
-                />
-              );
-            })}
-          </View>
-        )}
-      </ScrollView>
-    </>
+            return (
+              <SettingsServiceRow
+                id={server.id}
+                hideSeparator={
+                  pressedServerId === server.id || pressedServerId === previousServerId
+                }
+                key={server.id}
+                name={server.name}
+                showSeparator={index > 0}
+                onPress={() =>
+                  router.push({
+                    pathname: './mcp/[serverId]',
+                    params: { serverId: server.id },
+                  })
+                }
+                onPressedChange={handleServerPressedChange}
+                statusLabel={t(`settings.mcp.list.status.${status}`)}
+                statusTone={
+                  status === 'connected' ? 'success' : status === 'error' ? 'danger' : 'default'
+                }
+                subtitle={getServerSubtitle(summary, (count) =>
+                  t('settings.mcp.list.toolCount', { count }),
+                )}
+              />
+            );
+          })}
+        </View>
+      )}
+    </SettingsScrollPage>
   );
 }
 

--- a/src/frontend/features/settings/NotificationSettingsScreen.tsx
+++ b/src/frontend/features/settings/NotificationSettingsScreen.tsx
@@ -1,10 +1,10 @@
 import RadioIcon from '@cherrystudio/app-icons/icons/radio';
 import { Section, Switch, useAlert } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
-import { ScrollView } from 'react-native';
 
-import { RouteHeader } from '@/frontend/components/headers';
 import { usePreference } from '@/frontend/data/hooks';
+
+import { SettingsScrollPage } from './components/SettingsScrollPage';
 
 export default function NotificationSettingsScreen() {
   const { t } = useTranslation();
@@ -20,32 +20,26 @@ export default function NotificationSettingsScreen() {
   };
 
   return (
-    <>
-      <RouteHeader title={t('settings.notifications.title')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="gap-6 px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section footer={t('settings.notifications.liveActivity.description')}>
-          <Section.Item
-            accessibilityRole="switch"
-            accessibilityState={{ checked: isLiveActivityEnabled }}
-            label={t('settings.notifications.liveActivity.title')}
-            leading={<RadioIcon className="size-5 text-foreground" />}
-            onPress={() => setLiveActivityPreference(!isLiveActivityEnabled)}
-            trailing={
-              <Switch
-                accessibilityLabel={t('settings.notifications.liveActivity.title')}
-                onValueChange={setLiveActivityPreference}
-                value={isLiveActivityEnabled}
-              />
-            }
-          />
-        </Section>
-      </ScrollView>
-    </>
+    <SettingsScrollPage
+      contentClassName="gap-6"
+      headerProps={{ title: t('settings.notifications.title') }}
+    >
+      <Section footer={t('settings.notifications.liveActivity.description')}>
+        <Section.Item
+          accessibilityRole="switch"
+          accessibilityState={{ checked: isLiveActivityEnabled }}
+          label={t('settings.notifications.liveActivity.title')}
+          leading={<RadioIcon className="size-5 text-foreground" />}
+          onPress={() => setLiveActivityPreference(!isLiveActivityEnabled)}
+          trailing={
+            <Switch
+              accessibilityLabel={t('settings.notifications.liveActivity.title')}
+              onValueChange={setLiveActivityPreference}
+              value={isLiveActivityEnabled}
+            />
+          }
+        />
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchAdvancedScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchAdvancedScreen.tsx
@@ -2,11 +2,10 @@ import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
 import { Section } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ScrollView, Text, View } from 'react-native';
-
-import { RouteHeader } from '@/frontend/components/headers';
+import { Text, View } from 'react-native';
 
 import { SettingNumberInput } from '../components/SettingNumberInput';
+import { SettingsScrollPage } from '../components/SettingsScrollPage';
 import { useWebSearchProviderPreferences } from '../hooks/useWebSearchProviderPreferences';
 
 export default function WebSearchAdvancedScreen() {
@@ -18,57 +17,50 @@ export default function WebSearchAdvancedScreen() {
   );
 
   return (
-    <>
-      <RouteHeader title={t('settings.websearch.advanced.title')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section>
+    <SettingsScrollPage
+      headerProps={{ title: t('settings.websearch.advanced.title') }}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Section>
+        <Section.Item
+          label={t('settings.websearch.maxResults')}
+          trailing={
+            <SettingNumberInput
+              accessibilityLabel={t('settings.websearch.maxResults')}
+              compact
+              value={webSearchProviders.maxResults.value}
+              onValueChange={webSearchProviders.maxResults.onValueChange}
+            />
+          }
+        />
+        <Section.Item
+          label={t('settings.websearch.compressionMethod')}
+          onPress={() => router.push('/settings/websearch/compression-method')}
+          trailing={
+            <View className="min-w-0 flex-row items-center justify-end gap-1">
+              <Text
+                className="min-w-0 shrink text-right text-base text-foreground"
+                numberOfLines={1}
+              >
+                {selectedCompressionMethod?.label ?? t('settings.select.placeholder')}
+              </Text>
+              <ChevronRightIcon className="size-5 shrink-0 text-muted-foreground" />
+            </View>
+          }
+        />
+        {webSearchProviders.compressionMethod.value === 'cutoff' ? (
           <Section.Item
-            label={t('settings.websearch.maxResults')}
+            label={t('settings.websearch.compressionCutoffLimit')}
             trailing={
               <SettingNumberInput
-                accessibilityLabel={t('settings.websearch.maxResults')}
-                compact
-                value={webSearchProviders.maxResults.value}
-                onValueChange={webSearchProviders.maxResults.onValueChange}
+                accessibilityLabel={t('settings.websearch.compressionCutoffLimit')}
+                value={webSearchProviders.compressionCutoffLimit.value}
+                onValueChange={webSearchProviders.compressionCutoffLimit.onValueChange}
               />
             }
           />
-          <Section.Item
-            label={t('settings.websearch.compressionMethod')}
-            onPress={() => router.push('/settings/websearch/compression-method')}
-            trailing={
-              <View className="min-w-0 flex-row items-center justify-end gap-1">
-                <Text
-                  className="min-w-0 shrink text-right text-base text-foreground"
-                  numberOfLines={1}
-                >
-                  {selectedCompressionMethod?.label ?? t('settings.select.placeholder')}
-                </Text>
-                <ChevronRightIcon className="size-5 shrink-0 text-muted-foreground" />
-              </View>
-            }
-          />
-          {webSearchProviders.compressionMethod.value === 'cutoff' ? (
-            <Section.Item
-              label={t('settings.websearch.compressionCutoffLimit')}
-              trailing={
-                <SettingNumberInput
-                  accessibilityLabel={t('settings.websearch.compressionCutoffLimit')}
-                  value={webSearchProviders.compressionCutoffLimit.value}
-                  onValueChange={webSearchProviders.compressionCutoffLimit.onValueChange}
-                />
-              }
-            />
-          ) : null}
-        </Section>
-      </ScrollView>
-    </>
+        ) : null}
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchCompressionMethodScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchCompressionMethodScreen.tsx
@@ -1,10 +1,8 @@
 import { Section } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ScrollView } from 'react-native';
 
-import { RouteHeader } from '@/frontend/components/headers';
-
+import { SettingsScrollPage } from '../components/SettingsScrollPage';
 import { useWebSearchProviderPreferences } from '../hooks/useWebSearchProviderPreferences';
 
 export default function WebSearchCompressionMethodScreen() {
@@ -13,35 +11,26 @@ export default function WebSearchCompressionMethodScreen() {
   const { compressionMethod } = useWebSearchProviderPreferences();
 
   return (
-    <>
-      <RouteHeader title={t('settings.websearch.compressionMethod')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section>
-          {compressionMethod.options.map((option) => {
-            const selected = option.value === compressionMethod.value;
+    <SettingsScrollPage headerProps={{ title: t('settings.websearch.compressionMethod') }}>
+      <Section>
+        {compressionMethod.options.map((option) => {
+          const selected = option.value === compressionMethod.value;
 
-            return (
-              <Section.RadioItem
-                key={option.value}
-                label={option.label}
-                onPress={() => {
-                  if (!selected) {
-                    compressionMethod.onValueChange(option.value);
-                    router.back();
-                  }
-                }}
-                selected={selected}
-              />
-            );
-          })}
-        </Section>
-      </ScrollView>
-    </>
+          return (
+            <Section.RadioItem
+              key={option.value}
+              label={option.label}
+              onPress={() => {
+                if (!selected) {
+                  compressionMethod.onValueChange(option.value);
+                  router.back();
+                }
+              }}
+              selected={selected}
+            />
+          );
+        })}
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchDefaultProviderScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchDefaultProviderScreen.tsx
@@ -1,11 +1,9 @@
 import { Image, Section } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ScrollView } from 'react-native';
 import { useUniwind } from 'uniwind';
 
-import { RouteHeader } from '@/frontend/components/headers';
-
+import { SettingsScrollPage } from '../components/SettingsScrollPage';
 import { useWebSearchProviderPreferences } from '../hooks/useWebSearchProviderPreferences';
 import { resolveWebSearchProviderIcon } from './utils/providerIcons';
 
@@ -17,47 +15,38 @@ export default function WebSearchDefaultProviderScreen() {
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
 
   return (
-    <>
-      <RouteHeader title={t('settings.websearch.provider.selection')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section>
-          {searchKeywords.options.map((option) => {
-            const selected = option.value === searchKeywords.value;
-            const imageSource = resolveWebSearchProviderIcon(option.value)?.[iconTheme];
+    <SettingsScrollPage headerProps={{ title: t('settings.websearch.provider.selection') }}>
+      <Section>
+        {searchKeywords.options.map((option) => {
+          const selected = option.value === searchKeywords.value;
+          const imageSource = resolveWebSearchProviderIcon(option.value)?.[iconTheme];
 
-            return (
-              <Section.RadioItem
-                key={option.value}
-                label={option.label}
-                leading={
-                  imageSource ? (
-                    <Image
-                      cachePolicy="memory-disk"
-                      className="size-5"
-                      contentFit="contain"
-                      recyclingKey={option.value}
-                      source={imageSource}
-                    />
-                  ) : null
+          return (
+            <Section.RadioItem
+              key={option.value}
+              label={option.label}
+              leading={
+                imageSource ? (
+                  <Image
+                    cachePolicy="memory-disk"
+                    className="size-5"
+                    contentFit="contain"
+                    recyclingKey={option.value}
+                    source={imageSource}
+                  />
+                ) : null
+              }
+              onPress={() => {
+                if (!selected) {
+                  searchKeywords.onValueChange(option.value);
+                  router.back();
                 }
-                onPress={() => {
-                  if (!selected) {
-                    searchKeywords.onValueChange(option.value);
-                    router.back();
-                  }
-                }}
-                selected={selected}
-              />
-            );
-          })}
-        </Section>
-      </ScrollView>
-    </>
+              }}
+              selected={selected}
+            />
+          );
+        })}
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchFetchProviderScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchFetchProviderScreen.tsx
@@ -1,11 +1,9 @@
 import { Image, Section } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ScrollView } from 'react-native';
 import { useUniwind } from 'uniwind';
 
-import { RouteHeader } from '@/frontend/components/headers';
-
+import { SettingsScrollPage } from '../components/SettingsScrollPage';
 import { useWebSearchProviderPreferences } from '../hooks/useWebSearchProviderPreferences';
 import { resolveWebSearchProviderIcon } from './utils/providerIcons';
 
@@ -17,47 +15,38 @@ export default function WebSearchFetchProviderScreen() {
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
 
   return (
-    <>
-      <RouteHeader title={t('settings.websearch.fetchUrlsProvider')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        <Section>
-          {fetchUrls.options.map((option) => {
-            const selected = option.value === fetchUrls.value;
-            const imageSource = resolveWebSearchProviderIcon(option.value)?.[iconTheme];
+    <SettingsScrollPage headerProps={{ title: t('settings.websearch.fetchUrlsProvider') }}>
+      <Section>
+        {fetchUrls.options.map((option) => {
+          const selected = option.value === fetchUrls.value;
+          const imageSource = resolveWebSearchProviderIcon(option.value)?.[iconTheme];
 
-            return (
-              <Section.RadioItem
-                key={option.value}
-                label={option.label}
-                leading={
-                  imageSource ? (
-                    <Image
-                      cachePolicy="memory-disk"
-                      className="size-5"
-                      contentFit="contain"
-                      recyclingKey={option.value}
-                      source={imageSource}
-                    />
-                  ) : null
+          return (
+            <Section.RadioItem
+              key={option.value}
+              label={option.label}
+              leading={
+                imageSource ? (
+                  <Image
+                    cachePolicy="memory-disk"
+                    className="size-5"
+                    contentFit="contain"
+                    recyclingKey={option.value}
+                    source={imageSource}
+                  />
+                ) : null
+              }
+              onPress={() => {
+                if (!selected) {
+                  fetchUrls.onValueChange(option.value);
+                  router.back();
                 }
-                onPress={() => {
-                  if (!selected) {
-                    fetchUrls.onValueChange(option.value);
-                    router.back();
-                  }
-                }}
-                selected={selected}
-              />
-            );
-          })}
-        </Section>
-      </ScrollView>
-    </>
+              }}
+              selected={selected}
+            />
+          );
+        })}
+      </Section>
+    </SettingsScrollPage>
   );
 }

--- a/src/frontend/features/settings/WebSearchScreen/WebSearchScreen.tsx
+++ b/src/frontend/features/settings/WebSearchScreen/WebSearchScreen.tsx
@@ -2,11 +2,10 @@ import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
 import { Image, Section } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ScrollView, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
-import { RouteHeader } from '@/frontend/components/headers';
-
+import { SettingsScrollPage } from '../components/SettingsScrollPage';
 import { useWebSearchProviderPreferences } from '../hooks/useWebSearchProviderPreferences';
 import { WebSearchApiManagementSection } from './components/WebSearchApiManagementSection';
 import { resolveWebSearchProviderIcon } from './utils/providerIcons';
@@ -22,49 +21,43 @@ export default function WebSearchSettingsScreen() {
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
 
   return (
-    <>
-      <RouteHeader title={t('settings.pages.websearch.title')} />
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerClassName="gap-6 px-4 py-5"
-        contentInsetAdjustmentBehavior="automatic"
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
+    <SettingsScrollPage
+      contentClassName="gap-6"
+      headerProps={{ title: t('settings.pages.websearch.title') }}
+      keyboardShouldPersistTaps="handled"
+    >
+      <WebSearchApiManagementSection
+        afterItems={
+          <Section.Item
+            label={t('settings.websearch.advanced.title')}
+            onPress={() => router.push('/settings/websearch/advanced')}
+          />
+        }
+        capability="searchKeywords"
+        provider={searchProvider}
+        providerOverrides={webSearchProviders.providerOverrides.value}
+        onProviderOverrideChange={webSearchProviders.providerOverrides.onProviderOverrideChange}
       >
-        <WebSearchApiManagementSection
-          afterItems={
-            <Section.Item
-              label={t('settings.websearch.advanced.title')}
-              onPress={() => router.push('/settings/websearch/advanced')}
-            />
-          }
-          capability="searchKeywords"
-          provider={searchProvider}
-          providerOverrides={webSearchProviders.providerOverrides.value}
-          onProviderOverrideChange={webSearchProviders.providerOverrides.onProviderOverrideChange}
-        >
-          <Section.Item
-            label={t('settings.websearch.provider.selection')}
-            onPress={() => router.push('/settings/websearch/default-provider')}
-            trailing={<ProviderSelectionValue iconTheme={iconTheme} provider={searchProvider} />}
-          />
-        </WebSearchApiManagementSection>
+        <Section.Item
+          label={t('settings.websearch.provider.selection')}
+          onPress={() => router.push('/settings/websearch/default-provider')}
+          trailing={<ProviderSelectionValue iconTheme={iconTheme} provider={searchProvider} />}
+        />
+      </WebSearchApiManagementSection>
 
-        <WebSearchApiManagementSection
-          capability="fetchUrls"
-          provider={fetchProvider}
-          providerOverrides={webSearchProviders.providerOverrides.value}
-          onProviderOverrideChange={webSearchProviders.providerOverrides.onProviderOverrideChange}
-        >
-          <Section.Item
-            label={t('settings.websearch.fetchUrlsProvider')}
-            onPress={() => router.push('/settings/websearch/fetch-provider')}
-            trailing={<ProviderSelectionValue iconTheme={iconTheme} provider={fetchProvider} />}
-          />
-        </WebSearchApiManagementSection>
-      </ScrollView>
-    </>
+      <WebSearchApiManagementSection
+        capability="fetchUrls"
+        provider={fetchProvider}
+        providerOverrides={webSearchProviders.providerOverrides.value}
+        onProviderOverrideChange={webSearchProviders.providerOverrides.onProviderOverrideChange}
+      >
+        <Section.Item
+          label={t('settings.websearch.fetchUrlsProvider')}
+          onPress={() => router.push('/settings/websearch/fetch-provider')}
+          trailing={<ProviderSelectionValue iconTheme={iconTheme} provider={fetchProvider} />}
+        />
+      </WebSearchApiManagementSection>
+    </SettingsScrollPage>
   );
 }
 

--- a/src/frontend/features/settings/components/SettingsScrollPage.tsx
+++ b/src/frontend/features/settings/components/SettingsScrollPage.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@cherrystudio/ui/utils';
+import type { PropsWithChildren } from 'react';
+import { ScrollView, type ScrollViewProps } from 'react-native';
+
+import { RouteHeader, type RouteHeaderProps } from '@/frontend/components/headers';
+
+type SettingsScrollPageProps = PropsWithChildren<
+  Pick<
+    ScrollViewProps,
+    'contentInsetAdjustmentBehavior' | 'keyboardDismissMode' | 'keyboardShouldPersistTaps'
+  > & {
+    contentClassName?: string;
+    headerProps: RouteHeaderProps;
+  }
+>;
+
+export function SettingsScrollPage({
+  children,
+  contentClassName,
+  contentInsetAdjustmentBehavior = 'automatic',
+  headerProps,
+  keyboardDismissMode,
+  keyboardShouldPersistTaps,
+}: SettingsScrollPageProps) {
+  return (
+    <>
+      <RouteHeader {...headerProps} />
+      <ScrollView
+        alwaysBounceVertical={false}
+        className="flex-1"
+        contentContainerClassName={cn('px-4 py-5', contentClassName)}
+        contentInsetAdjustmentBehavior={contentInsetAdjustmentBehavior}
+        keyboardDismissMode={keyboardDismissMode}
+        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+        showsVerticalScrollIndicator={false}
+      >
+        {children}
+      </ScrollView>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- add a feature-local `SettingsScrollPage` that composes the shared route header and standard settings scroll behavior
- centralize automatic content insets, hidden vertical indicators, and default settings content spacing
- migrate Language, Appearance, Notifications, Font Size, MCP, and five Web Search screens while preserving header actions, content gaps, and keyboard handling
- leave virtualized lists, keyboard-aware forms, animated screens, and special footer layouts unchanged

## Verification

- `pnpm format:check`
- targeted `pnpm exec oxlint` and `pnpm exec expo lint` for all changed files
- `pnpm lint` *(fails on unresolved `@cherrystudio/ai-core` imports in unchanged backend files; targeted lint passes)*
- not run per task scope: tests, typecheck, builds, or manual UI verification
