### PR TITLE
refactor(content-state): unify loading, empty, and error states

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -200,6 +200,22 @@ whole chip is pressed, and `Chip.Tag` is non-interactive. Selection and removal 
 the caller. Removal labels are required so the icon-only action can be localized and announced by
 assistive technology.
 
+`ContentState` is the platform-neutral Loading, Empty, and Error family for content surfaces. Its
+explicit variants avoid boolean state combinations while sharing the content hierarchy, optional
+icon, and up to two actions. Loading uses CherryUI `Spinner`; actions use CherryUI `Button`.
+Product code keeps query state, retry behavior, list mounting, and localized copy:
+
+```tsx
+<ContentState.Error
+  description={error.message}
+  primaryAction={{ children: t('common.retry'), onPress: () => void refetch() }}
+  title={t('common.loadFailed')}
+/>;
+```
+
+Keep screen, list, composer, and card insets in the consuming feature and compose the state inside
+that layout. `ContentState` deliberately has no query, retry, inset, card, or compact-mode props.
+
 Shared components with text must be content-driven: avoid fixed width or height, keep React Native's
 system font scaling enabled, and allow constrained labels to wrap. `Button` follows this rule by
 using padding for its touch target and letting its label shrink and grow the container.

--- a/packages/ui/src/components/content-state/__tests__/content-state.test.tsx
+++ b/packages/ui/src/components/content-state/__tests__/content-state.test.tsx
@@ -1,0 +1,97 @@
+import { Text, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ContentState } from '..';
+
+jest.mock('../../loading/spinner', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    Spinner: (props: object) => <MockView {...props} testID="content-state-spinner" />,
+  };
+});
+
+jest.mock('heroui-native/utils', () => {
+  const { twMerge } = jest.requireActual('tailwind-merge');
+
+  return {
+    cn: (...values: unknown[]) => twMerge(values.filter(Boolean).join(' ')),
+  };
+});
+
+jest.mock('uniwind', () => ({
+  useResolveClassNames: () => ({ color: '#ffffff' }),
+}));
+
+describe('ContentState', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  function render(element: React.ReactElement) {
+    act(() => {
+      renderer = create(element);
+    });
+
+    if (!renderer) {
+      throw new Error('ContentState renderer was not created.');
+    }
+
+    return renderer;
+  }
+
+  test('renders loading with the shared spinner and busy semantics', () => {
+    const tree = render(<ContentState.Loading testID="state" title="Loading assistants" />);
+    const root = tree.root.findByProps({ testID: 'state' });
+    const spinner = tree.root.findByProps({ testID: 'content-state-spinner' });
+
+    expect(root.props.accessibilityState).toEqual({ busy: true });
+    expect(spinner.props.accessibilityLabel).toBe('Loading assistants');
+    expect(spinner.props.accessibilityRole).toBe('progressbar');
+    expect(tree.root.findByProps({ children: 'Loading assistants' })).toBeDefined();
+  });
+
+  test('renders optional empty content and both shared button actions', () => {
+    const onCreate = jest.fn();
+    const onImport = jest.fn();
+    const tree = render(
+      <ContentState.Empty
+        description="Create one or import an existing assistant."
+        icon={<View testID="empty-icon" />}
+        primaryAction={{ children: 'Create', onPress: onCreate }}
+        secondaryAction={{ children: 'Import', onPress: onImport }}
+        title="No assistants"
+      />,
+    );
+    const buttons = tree.root.findAll((node) => node.props.accessibilityRole === 'button');
+
+    expect(tree.root.findByProps({ testID: 'empty-icon' })).toBeDefined();
+    expect(tree.root.findByProps({ children: 'No assistants' })).toBeDefined();
+    expect(
+      tree.root.findByProps({ children: 'Create one or import an existing assistant.' }),
+    ).toBeDefined();
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]?.props.className).toContain('bg-foreground');
+    expect(buttons[1]?.props.className).toContain('bg-field');
+
+    act(() => buttons[0]?.props.onPress());
+    act(() => buttons[1]?.props.onPress());
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onImport).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses the error hierarchy without inventing retry behavior', () => {
+    const tree = render(<ContentState.Error description="Request timed out" title="Load failed" />);
+    const text = tree.root.findAllByType(Text);
+    const title = text.find((node) => node.props.children === 'Load failed');
+    const description = text.find((node) => node.props.children === 'Request timed out');
+
+    expect(title?.props.className).toContain('text-destructive-foreground');
+    expect(title?.props.selectable).toBe(true);
+    expect(description?.props.selectable).toBe(true);
+    expect(tree.root.findAll((node) => node.props.accessibilityRole === 'button')).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/content-state/content-state.tsx
+++ b/packages/ui/src/components/content-state/content-state.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from 'react';
+import { Text, View, type ViewProps } from 'react-native';
+
+import { cn } from '../../utils';
+import { Button, type ButtonProps } from '../button';
+import { Spinner } from '../loading/spinner';
+
+export type ContentStateAction = Omit<ButtonProps, 'children' | 'variant'> & {
+  children: ReactNode;
+};
+
+type ContentStateBaseProps = Omit<ViewProps, 'children'> & {
+  description?: string;
+  icon?: ReactNode;
+  primaryAction?: ContentStateAction;
+  secondaryAction?: ContentStateAction;
+  title?: string;
+};
+
+export type ContentStateEmptyProps = ContentStateBaseProps;
+export type ContentStateErrorProps = ContentStateBaseProps;
+export type ContentStateLoadingProps = ContentStateBaseProps;
+
+type ContentStateKind = 'empty' | 'error' | 'loading';
+
+type ContentStateFrameProps = ContentStateBaseProps & {
+  kind: ContentStateKind;
+};
+
+function ContentStateFrame({
+  accessibilityState,
+  className,
+  description,
+  icon,
+  kind,
+  primaryAction,
+  secondaryAction,
+  title,
+  ...props
+}: ContentStateFrameProps) {
+  const resolvedIcon =
+    icon ??
+    (kind === 'loading' ? (
+      <Spinner accessibilityLabel={title} accessibilityRole="progressbar" />
+    ) : null);
+
+  return (
+    <View
+      {...props}
+      accessibilityState={{
+        ...accessibilityState,
+        ...(kind === 'loading' ? { busy: true } : {}),
+      }}
+      className={cn('items-center justify-center gap-4', className)}
+    >
+      {resolvedIcon ? (
+        <View className="shrink-0 items-center justify-center">{resolvedIcon}</View>
+      ) : null}
+      {title || description ? (
+        <View className="max-w-full items-center gap-1.5">
+          {title ? (
+            <Text
+              className={cn(
+                'text-center font-semibold text-base',
+                kind === 'error' ? 'text-destructive-foreground' : 'text-foreground',
+              )}
+              selectable={kind === 'error'}
+            >
+              {title}
+            </Text>
+          ) : null}
+          {description ? (
+            <Text className="text-center text-muted-foreground text-sm" selectable>
+              {description}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+      {primaryAction || secondaryAction ? (
+        <View className="flex-row flex-wrap items-center justify-center gap-3">
+          {primaryAction ? (
+            <Button {...primaryAction} size={primaryAction.size ?? 'sm'} variant="default" />
+          ) : null}
+          {secondaryAction ? (
+            <Button {...secondaryAction} size={secondaryAction.size ?? 'sm'} variant="secondary" />
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function ContentStateEmpty(props: ContentStateEmptyProps) {
+  return <ContentStateFrame {...props} kind="empty" />;
+}
+
+ContentStateEmpty.displayName = 'ContentState.Empty';
+
+function ContentStateError(props: ContentStateErrorProps) {
+  return <ContentStateFrame {...props} kind="error" />;
+}
+
+ContentStateError.displayName = 'ContentState.Error';
+
+function ContentStateLoading(props: ContentStateLoadingProps) {
+  return <ContentStateFrame {...props} kind="loading" />;
+}
+
+ContentStateLoading.displayName = 'ContentState.Loading';
+
+export const ContentState = {
+  Empty: ContentStateEmpty,
+  Error: ContentStateError,
+  Loading: ContentStateLoading,
+};

--- a/packages/ui/src/components/content-state/index.ts
+++ b/packages/ui/src/components/content-state/index.ts
@@ -1,0 +1,7 @@
+export {
+  ContentState,
+  type ContentStateAction,
+  type ContentStateEmptyProps,
+  type ContentStateErrorProps,
+  type ContentStateLoadingProps,
+} from './content-state';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './bottom-sheet';
 export * from './button';
 export * from './chip';
 export * from './composer';
+export * from './content-state';
 export * from './file-preview';
 export * from './image';
 export * from './input';

--- a/packages/ui/stories/components/primitives/content-state.stories.tsx
+++ b/packages/ui/stories/components/primitives/content-state.stories.tsx
@@ -1,0 +1,65 @@
+import { BotIcon, RefreshCwIcon } from '@cherrystudio/app-icons';
+import { ContentState } from '@cherrystudio/ui/components';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import { ScrollView, Text, View } from 'react-native';
+import { fn } from 'storybook/test';
+import { ScopedTheme } from 'uniwind';
+
+const themes = ['light', 'dark'] as const;
+
+const meta = {
+  title: 'Components/Primitives/Content State',
+  component: ContentState.Empty,
+  decorators: [
+    (Story) => (
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="flex-grow gap-4 p-4"
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <Story />
+      </ScrollView>
+    ),
+  ],
+} satisfies Meta<typeof ContentState.Empty>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: () => (
+    <View className="gap-4">
+      {themes.map((theme) => (
+        <ScopedTheme key={theme} theme={theme}>
+          <View className="gap-8 bg-background p-6">
+            <Text className="font-semibold text-foreground text-lg">
+              {theme === 'light' ? 'Light' : 'Dark'}
+            </Text>
+            <ContentState.Loading title="Loading assistants" />
+            <ContentState.Empty
+              description="Create an assistant to get started."
+              icon={
+                <View className="size-14 items-center justify-center rounded-full bg-secondary">
+                  <BotIcon className="size-7 text-foreground" />
+                </View>
+              }
+              primaryAction={{ children: 'Create assistant', onPress: fn() }}
+              secondaryAction={{ children: 'Import', onPress: fn() }}
+              title="No assistants"
+            />
+            <ContentState.Error
+              description="The server did not respond."
+              primaryAction={{
+                children: 'Try again',
+                icon: <RefreshCwIcon />,
+                onPress: fn(),
+              }}
+              title="Could not load content"
+            />
+          </View>
+        </ScopedTheme>
+      ))}
+    </View>
+  ),
+};

--- a/packages/ui/stories/components/primitives/content-state.stories.tsx
+++ b/packages/ui/stories/components/primitives/content-state.stories.tsx
@@ -1,4 +1,5 @@
-import { BotIcon, RefreshCwIcon } from '@cherrystudio/app-icons';
+import BotIcon from '@cherrystudio/app-icons/icons/bot';
+import RefreshCwIcon from '@cherrystudio/app-icons/icons/refresh-cw';
 import { ContentState } from '@cherrystudio/ui/components';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { ScrollView, Text, View } from 'react-native';

--- a/src/frontend/features/assistants/AssistantDetailScreen.tsx
+++ b/src/frontend/features/assistants/AssistantDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@cherrystudio/ui/components';
+import { Button, ContentState } from '@cherrystudio/ui/components';
 import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -71,10 +71,10 @@ export default function AssistantDetailScreen() {
       >
         {assistant ? (
           <AssistantSummary assistant={assistant} />
+        ) : isLoading ? (
+          <ContentState.Loading title={t('assistant.form.loading')} />
         ) : (
-          <Text className="text-center text-foreground text-sm">
-            {isLoading ? t('assistant.form.loading') : t('assistant.list.emptyTitle')}
-          </Text>
+          <ContentState.Empty title={t('assistant.list.emptyTitle')} />
         )}
       </ScrollView>
       {assistant ? (

--- a/src/frontend/features/assistants/AssistantEditScreen.tsx
+++ b/src/frontend/features/assistants/AssistantEditScreen.tsx
@@ -2,6 +2,7 @@ import ChevronDownIcon from '@cherrystudio/app-icons/icons/chevron-down';
 import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
 import {
   BottomSheet,
+  ContentState,
   Description,
   Input,
   Label,
@@ -75,9 +76,7 @@ export default function AssistantEditScreen() {
     return (
       <>
         <RouteHeader title={t('assistant.edit.title')} />
-        <View className="p-4">
-          <Text className="text-center text-foreground text-sm">{t('assistant.form.loading')}</Text>
-        </View>
+        <ContentState.Loading className="p-4" title={t('assistant.form.loading')} />
       </>
     );
   }

--- a/src/frontend/features/assistants/AssistantListScreen.tsx
+++ b/src/frontend/features/assistants/AssistantListScreen.tsx
@@ -1,11 +1,11 @@
 import BotIcon from '@cherrystudio/app-icons/icons/bot';
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
 import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
-import { type MenuItem, useAlert } from '@cherrystudio/ui/components';
+import { ContentState, type MenuItem, useAlert } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type AccessibilityActionEvent, Pressable, ScrollView, Text, View } from 'react-native';
+import { type AccessibilityActionEvent, ScrollView, Text, View } from 'react-native';
 import { Pressable as GesturePressable } from 'react-native-gesture-handler';
 import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 
@@ -211,11 +211,29 @@ export default function AssistantListScreen() {
             ))}
           </View>
         ) : visibleAssistants.length === 0 ? (
-          <AssistantEmptyState isLoading={isLoading} onCreate={openCreateAssistant} />
+          isLoading ? (
+            <ContentState.Loading className="px-8 py-16" title={t('assistant.list.loading')} />
+          ) : (
+            <ContentState.Empty
+              className="px-8 py-16"
+              description={t('assistant.list.emptyDescription')}
+              icon={
+                <View className="size-14 items-center justify-center rounded-full bg-secondary">
+                  <BotIcon className="size-7 text-foreground" />
+                </View>
+              }
+              primaryAction={{
+                accessibilityLabel: t('assistant.actions.create'),
+                children: t('assistant.actions.create'),
+                className: 'rounded-full',
+                onPress: openCreateAssistant,
+                size: 'default',
+              }}
+              title={t('assistant.list.emptyTitle')}
+            />
+          )
         ) : (
-          <View className="items-center px-4 py-12">
-            <Text className="text-sm text-muted-foreground">{t('assistant.list.noResults')}</Text>
-          </View>
+          <ContentState.Empty className="px-4 py-12" description={t('assistant.list.noResults')} />
         )}
       </ScrollView>
       {isEditing ? (
@@ -354,45 +372,5 @@ function AssistantListRow({
     <ContextMenuLink href={href} items={menuItems} preview={false}>
       {row}
     </ContextMenuLink>
-  );
-}
-
-function AssistantEmptyState({
-  isLoading,
-  onCreate,
-}: {
-  isLoading: boolean;
-  onCreate: () => void;
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <View className="items-center justify-center gap-4 px-8 py-16">
-      <View className="size-14 items-center justify-center rounded-full bg-secondary">
-        <BotIcon className="size-7 text-foreground" />
-      </View>
-      <View className="items-center gap-1">
-        <Text className="text-center font-semibold text-foreground text-lg">
-          {isLoading ? t('assistant.list.loading') : t('assistant.list.emptyTitle')}
-        </Text>
-        {!isLoading ? (
-          <Text className="text-center text-foreground text-sm">
-            {t('assistant.list.emptyDescription')}
-          </Text>
-        ) : null}
-      </View>
-      {!isLoading ? (
-        <Pressable
-          accessibilityLabel={t('assistant.actions.create')}
-          accessibilityRole="button"
-          className="rounded-full bg-foreground px-5 py-2 active:opacity-80"
-          onPress={onCreate}
-        >
-          <Text className="font-semibold text-background text-base">
-            {t('assistant.actions.create')}
-          </Text>
-        </Pressable>
-      ) : null}
-    </View>
   );
 }

--- a/src/frontend/features/home/aiUsage/components/AiUsageRankingSection.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageRankingSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Section } from '@cherrystudio/ui/components';
+import { Button, ContentState, Section } from '@cherrystudio/ui/components';
 import { type ReactElement, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
@@ -81,11 +81,7 @@ export function AiUsageRankingSection({
   ) : isInitialLoading ? (
     <AiUsageRankingListSkeleton />
   ) : (
-    <View className="min-h-32 items-center justify-center px-6">
-      <Text selectable className="text-center text-muted-foreground text-sm">
-        {t('aiUsage.noUsageForDay')}
-      </Text>
-    </View>
+    <ContentState.Empty className="min-h-32 px-6" description={t('aiUsage.noUsageForDay')} />
   );
 
   return (

--- a/src/frontend/features/home/aiUsage/components/AiUsageSectionState.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSectionState.tsx
@@ -1,10 +1,11 @@
 import RefreshCwIcon from '@cherrystudio/app-icons/icons/refresh-cw';
+import { Button, ContentState, Spinner } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 type AiUsageSectionStatusProps = {
   isError: boolean;
   isRefreshing: boolean;
+  loadingTestID?: string;
   onRetry?: () => void;
   retryTestID?: string;
 };
@@ -12,28 +13,28 @@ type AiUsageSectionStatusProps = {
 export function AiUsageSectionStatus({
   isError,
   isRefreshing,
+  loadingTestID,
   onRetry,
   retryTestID,
 }: AiUsageSectionStatusProps) {
   const { t } = useTranslation();
 
   if (isRefreshing) {
-    return <ActivityIndicator accessibilityLabel={t('aiUsage.loading')} size="small" />;
+    return <Spinner accessibilityLabel={t('aiUsage.loading')} size="sm" testID={loadingTestID} />;
   }
   if (!isError || !onRetry) return null;
 
   return (
-    <Pressable
+    <Button
       accessibilityLabel={t('aiUsage.retry')}
-      accessibilityRole="button"
-      className="size-8 items-center justify-center rounded-full active:bg-secondary active:opacity-70"
+      className="rounded-full p-2 active:bg-secondary active:opacity-70"
       hitSlop={6}
-      style={styles.continuousCorners}
-      testID={retryTestID}
+      icon={<RefreshCwIcon className="text-destructive" />}
       onPress={onRetry}
-    >
-      <RefreshCwIcon className="size-4 text-destructive" />
-    </Pressable>
+      size="xs"
+      testID={retryTestID}
+      variant="ghost"
+    />
   );
 }
 
@@ -49,26 +50,15 @@ export function AiUsageSectionError({
   const { t } = useTranslation();
 
   return (
-    <View className="min-h-40 items-center justify-center gap-4 px-6">
-      <Text selectable className="text-center text-destructive-foreground text-sm">
-        {message}
-      </Text>
-      <Pressable
-        accessibilityRole="button"
-        className="flex-row items-center gap-2 rounded-lg bg-secondary px-4 py-2 active:opacity-70"
-        style={styles.continuousCorners}
-        testID={testID}
-        onPress={onRetry}
-      >
-        <RefreshCwIcon className="size-4 text-foreground" />
-        <Text className="font-medium text-foreground text-sm">{t('aiUsage.retry')}</Text>
-      </Pressable>
-    </View>
+    <ContentState.Error
+      className="min-h-40 px-6"
+      primaryAction={{
+        children: t('aiUsage.retry'),
+        icon: <RefreshCwIcon />,
+        onPress: onRetry,
+        testID,
+      }}
+      title={message}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  continuousCorners: {
-    borderCurve: 'continuous',
-  },
-});

--- a/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSummaryCard.tsx
@@ -1,10 +1,10 @@
 import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
 import RefreshCwIcon from '@cherrystudio/app-icons/icons/refresh-cw';
-import { Button, Section } from '@cherrystudio/ui/components';
+import { Button, ContentState, Section } from '@cherrystudio/ui/components';
 import { resolveProviderIcon } from '@cherrystudio/ui/icons';
 import { Link } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
 import { BrandAvatar, BrandAvatarIcon } from '@/frontend/components/avatar';
@@ -16,6 +16,7 @@ import type {
 import { useAiUsageOverview } from '../hooks/useAiUsageOverview';
 import { getFirstAiUsageDateKey } from '../utils/aiUsageOverview';
 import { AiUsageCalendar } from './AiUsageCalendar';
+import { AiUsageSectionStatus } from './AiUsageSectionState';
 
 const costSymbols = {
   CNY: '\u00a5',
@@ -48,25 +49,13 @@ export function AiUsageSummaryCard() {
             >
               {t('aiUsage.title')}
             </Text>
-            {isRefreshing ? (
-              <ActivityIndicator
-                accessibilityLabel={t('aiUsage.loading')}
-                size="small"
-                testID="ai-usage-summary-refreshing"
-              />
-            ) : isError && hasData ? (
-              <Pressable
-                accessibilityLabel={t('aiUsage.retry')}
-                accessibilityRole="button"
-                className="size-8 items-center justify-center rounded-full active:bg-secondary active:opacity-70"
-                hitSlop={6}
-                style={styles.continuousCorners}
-                testID="ai-usage-summary-refresh-retry"
-                onPress={() => void refetch()}
-              >
-                <RefreshCwIcon className="size-4 text-destructive" />
-              </Pressable>
-            ) : null}
+            <AiUsageSectionStatus
+              isError={isError && hasData}
+              isRefreshing={isRefreshing}
+              loadingTestID="ai-usage-summary-refreshing"
+              retryTestID="ai-usage-summary-refresh-retry"
+              onRetry={() => void refetch()}
+            />
           </View>
         }
       >
@@ -85,21 +74,16 @@ export function AiUsageSummaryCard() {
       </Section.Header>
 
       {showInitialError ? (
-        <View className="items-center justify-center gap-3" style={styles.stateContent}>
-          <Text selectable className="text-center text-destructive-foreground text-sm">
-            {t('aiUsage.loadError')}
-          </Text>
-          <Pressable
-            accessibilityRole="button"
-            className="flex-row items-center gap-2 rounded-lg bg-secondary px-4 py-2 active:opacity-70"
-            style={styles.continuousCorners}
-            testID="ai-usage-summary-retry"
-            onPress={() => void refetch()}
-          >
-            <RefreshCwIcon className="size-4 text-foreground" />
-            <Text className="font-medium text-foreground text-sm">{t('aiUsage.retry')}</Text>
-          </Pressable>
-        </View>
+        <ContentState.Error
+          primaryAction={{
+            children: t('aiUsage.retry'),
+            icon: <RefreshCwIcon />,
+            onPress: () => void refetch(),
+            testID: 'ai-usage-summary-retry',
+          }}
+          style={styles.stateContent}
+          title={t('aiUsage.loadError')}
+        />
       ) : (
         <View className="mt-4">
           <AiUsageCalendar

--- a/src/frontend/features/paintings/DrawingList.tsx
+++ b/src/frontend/features/paintings/DrawingList.tsx
@@ -3,6 +3,7 @@ import ImageIcon from '@cherrystudio/app-icons/icons/image';
 import RotateCcwIcon from '@cherrystudio/app-icons/icons/rotate-ccw';
 import {
   Button,
+  ContentState,
   Image,
   ImageGenerationLoader,
   Section,
@@ -199,26 +200,20 @@ export function DrawingList() {
   const listEmpty = useMemo(
     () =>
       paintings.isLoading || gallery.isLoading ? (
-        <View className="h-32 items-center justify-center">
-          <ActivityIndicator />
-        </View>
+        <ContentState.Loading className="h-32" />
       ) : (
-        <View
-          className="min-h-48 flex-1 items-center justify-center gap-4 px-6 pb-24"
+        <ContentState.Empty
+          className="min-h-48 flex-1 px-6 pb-24"
+          primaryAction={{
+            accessibilityLabel: t('painting.history.createNew'),
+            children: t('painting.history.createNew'),
+            onPress: handleCreatePainting,
+            size: 'default',
+            testID: 'painting-history-create',
+          }}
           testID="painting-history-empty"
-        >
-          <Text className="text-center text-base text-foreground">
-            {t('painting.history.empty')}
-          </Text>
-          <Button
-            accessibilityLabel={t('painting.history.createNew')}
-            onPress={handleCreatePainting}
-            testID="painting-history-create"
-            variant="default"
-          >
-            <Button.Label>{t('painting.history.createNew')}</Button.Label>
-          </Button>
-        </View>
+          title={t('painting.history.empty')}
+        />
       ),
     [gallery.isLoading, handleCreatePainting, paintings.isLoading, t],
   );

--- a/src/frontend/features/paintings/PaintingScreen.tsx
+++ b/src/frontend/features/paintings/PaintingScreen.tsx
@@ -1,6 +1,7 @@
+import { ContentState } from '@cherrystudio/ui/components';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useCallback, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { View } from 'react-native';
 
 import { RouteHeader } from '@/frontend/components/headers';
 
@@ -51,9 +52,7 @@ export function PaintingScreen() {
     <View className="flex-1 bg-background">
       <RouteHeader />
       {isLoading ? (
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator />
-        </View>
+        <ContentState.Loading className="flex-1" />
       ) : (
         <PaintingComposer
           initialAttachments={initialAttachments}

--- a/src/frontend/features/settings/McpScreen/McpScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpScreen.tsx
@@ -1,9 +1,9 @@
 import PlusIcon from '@cherrystudio/app-icons/icons/plus';
-import { Button } from '@cherrystudio/ui/components';
+import { ContentState } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActivityIndicator, Text, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { HeaderToolbarAction } from '@/frontend/components/headers';
 import { useMcpServerRuntimeSummaries, useMcpServersApi } from '@/frontend/hooks/mcp/useMcpServers';
@@ -47,29 +47,28 @@ export function McpScreen() {
       headerProps={{ rightActions, title: t('settings.pages.mcp.title') }}
     >
       {isLoading ? (
-        <View className="items-center gap-2 px-1 py-8">
-          <ActivityIndicator size="small" />
-          <Text className="text-foreground text-sm">{t('settings.mcp.list.loading')}</Text>
-        </View>
+        <ContentState.Loading className="px-1 py-8" title={t('settings.mcp.list.loading')} />
       ) : error ? (
-        <View className="items-center gap-3 px-1 py-8">
-          <Text className="text-destructive-foreground text-sm">
-            {t('settings.mcp.list.loadFailed')}
-          </Text>
-          <Text className="text-center text-foreground text-xs" selectable>
-            {error instanceof Error ? error.message : String(error)}
-          </Text>
-          <Button size="sm" variant="secondary" onPress={() => void refetch()}>
-            {t('settings.mcp.retry')}
-          </Button>
-        </View>
+        <ContentState.Error
+          className="px-1 py-8"
+          description={error instanceof Error ? error.message : String(error)}
+          primaryAction={{
+            children: t('settings.mcp.retry'),
+            onPress: () => void refetch(),
+          }}
+          title={t('settings.mcp.list.loadFailed')}
+        />
       ) : servers.length === 0 ? (
-        <View className="flex-1 items-center justify-center gap-4 px-6 pb-20">
-          <Text className="text-center text-base text-foreground">{t('settings.mcp.empty')}</Text>
-          <Button onPress={openCreate} testID="mcp-empty-create" variant="default">
-            <Button.Label>{t('settings.mcp.emptyAction')}</Button.Label>
-          </Button>
-        </View>
+        <ContentState.Empty
+          className="flex-1 px-6 pb-20"
+          primaryAction={{
+            children: t('settings.mcp.emptyAction'),
+            onPress: openCreate,
+            size: 'default',
+            testID: 'mcp-empty-create',
+          }}
+          title={t('settings.mcp.empty')}
+        />
       ) : (
         <View className="overflow-hidden rounded-2xl bg-grouped-surface">
           {servers.map((server, index) => {

--- a/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpServerScreen.tsx
@@ -1,6 +1,13 @@
-import { Button, Input, Label, TextField, useAlert, useToast } from '@cherrystudio/ui/components';
+import {
+  ContentState,
+  Input,
+  Label,
+  TextField,
+  useAlert,
+  useToast,
+} from '@cherrystudio/ui/components';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useCallback, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
@@ -36,22 +43,39 @@ export function McpServerScreen() {
   const { error, isLoading, refetch, server } = useMcpServerApiById(serverId);
 
   if (!isCreating && isLoading) {
-    return <McpServerLoadState isLoading message={t('settings.mcp.detail.loading')} />;
+    return (
+      <McpServerStateScreen>
+        <ContentState.Loading title={t('settings.mcp.detail.loading')} />
+      </McpServerStateScreen>
+    );
   }
 
   if (!isCreating && error) {
     const isNotFound = error instanceof DataApiError && error.code === ErrorCode.NOT_FOUND;
     return (
-      <McpServerLoadState
-        detail={isNotFound ? undefined : error instanceof Error ? error.message : String(error)}
-        message={t(isNotFound ? 'settings.mcp.detail.notFound' : 'settings.mcp.detail.loadFailed')}
-        onRetry={isNotFound ? undefined : () => void refetch()}
-      />
+      <McpServerStateScreen>
+        {isNotFound ? (
+          <ContentState.Empty title={t('settings.mcp.detail.notFound')} />
+        ) : (
+          <ContentState.Error
+            description={error instanceof Error ? error.message : String(error)}
+            primaryAction={{
+              children: t('settings.mcp.retry'),
+              onPress: () => void refetch(),
+            }}
+            title={t('settings.mcp.detail.loadFailed')}
+          />
+        )}
+      </McpServerStateScreen>
     );
   }
 
   if (!isCreating && !server) {
-    return <McpServerLoadState message={t('settings.mcp.detail.notFound')} />;
+    return (
+      <McpServerStateScreen>
+        <ContentState.Empty title={t('settings.mcp.detail.notFound')} />
+      </McpServerStateScreen>
+    );
   }
 
   return (
@@ -59,44 +83,13 @@ export function McpServerScreen() {
   );
 }
 
-function McpServerLoadState({
-  detail,
-  isLoading = false,
-  message,
-  onRetry,
-}: {
-  detail?: string;
-  isLoading?: boolean;
-  message: string;
-  onRetry?: () => void;
-}) {
+function McpServerStateScreen({ children }: { children: ReactNode }) {
   const { t } = useTranslation();
 
   return (
     <>
       <RouteHeader title={t('settings.mcp.tabs.configuration')} />
-      <View className="flex-1 items-center justify-center gap-3 px-6">
-        {isLoading ? <ActivityIndicator size="small" /> : null}
-        <Text
-          className={
-            onRetry
-              ? 'text-center text-destructive-foreground text-sm'
-              : 'text-center text-foreground text-sm'
-          }
-        >
-          {message}
-        </Text>
-        {detail ? (
-          <Text className="text-center text-foreground text-xs" selectable>
-            {detail}
-          </Text>
-        ) : null}
-        {onRetry ? (
-          <Button size="sm" variant="secondary" onPress={onRetry}>
-            {t('settings.mcp.retry')}
-          </Button>
-        ) : null}
-      </View>
+      <View className="flex-1 justify-center px-6">{children}</View>
     </>
   );
 }

--- a/src/frontend/features/settings/McpScreen/components/McpToolsSection.tsx
+++ b/src/frontend/features/settings/McpScreen/components/McpToolsSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner, Switch } from '@cherrystudio/ui/components';
+import { ContentState, Spinner, Switch } from '@cherrystudio/ui/components';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,34 +40,32 @@ export function McpToolsSection({
 
   if (toolsQuery.isLoading) {
     return (
-      <View className="flex-row items-center gap-2">
-        <Spinner size="sm" />
-        <Text className="text-foreground text-sm">{t('settings.mcp.tools.loading')}</Text>
-      </View>
+      <ContentState.Loading
+        className="flex-row items-center justify-start gap-2"
+        icon={<Spinner size="sm" />}
+        title={t('settings.mcp.tools.loading')}
+      />
     );
   }
 
   if (toolsQuery.isError) {
     return (
-      <View className="gap-2">
-        <Text className="text-destructive-foreground text-sm">
-          {t('settings.mcp.tools.loadFailed')}
-        </Text>
-        {/* The reason is the whole point here — an expired token and a typo'd
-            URL are the same generic failure without it. */}
-        <Text className="text-foreground text-xs" selectable>
-          {toolsQuery.error instanceof Error ? toolsQuery.error.message : String(toolsQuery.error)}
-        </Text>
-        <Button size="sm" variant="secondary" onPress={refetch}>
-          {t('settings.mcp.tools.retry')}
-        </Button>
-      </View>
+      <ContentState.Error
+        className="items-start"
+        // The reason is the whole point here — an expired token and a typo'd
+        // URL are the same generic failure without it.
+        description={
+          toolsQuery.error instanceof Error ? toolsQuery.error.message : String(toolsQuery.error)
+        }
+        primaryAction={{ children: t('settings.mcp.tools.retry'), onPress: refetch }}
+        title={t('settings.mcp.tools.loadFailed')}
+      />
     );
   }
 
   const tools = toolsQuery.data ?? [];
   if (tools.length === 0) {
-    return <Text className="text-foreground text-sm">{t('settings.mcp.tools.empty')}</Text>;
+    return <ContentState.Empty className="items-start" title={t('settings.mcp.tools.empty')} />;
   }
 
   return (

--- a/src/frontend/features/settings/ProviderScreen/components/ProviderModelList.tsx
+++ b/src/frontend/features/settings/ProviderScreen/components/ProviderModelList.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@cherrystudio/ui/components';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { ContentState } from '@cherrystudio/ui/components';
+import { type ReactNode, useDeferredValue, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Keyboard, Text, View } from 'react-native';
+import { Keyboard, View } from 'react-native';
 
 import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
@@ -54,17 +54,42 @@ export function ProviderModelList({
         isDefaultModel={isDefaultModel}
         ListEmptyComponent={
           hasNoModels && pullAction && addAction ? (
-            <ProviderModelEmptyActions addAction={addAction} pullAction={pullAction} />
-          ) : (
-            <ProviderModelEmptyState
-              title={
-                isLoading
-                  ? t('settings.provider.models.loading')
-                  : isSearching
-                    ? t('settings.provider.models.search.empty')
-                    : t('settings.provider.models.empty')
-              }
+            <ContentState.Empty
+              className="flex-1 px-6 pb-24"
+              primaryAction={{
+                children: t('settings.provider.models.emptyAction'),
+                disabled: pullAction.isDisabled,
+                loading: pullAction.isLoading,
+                onPress: pullAction.onPress,
+                size: 'default',
+              }}
+              secondaryAction={{
+                children: t('settings.provider.models.addSubmit'),
+                disabled: addAction.isDisabled,
+                loading: addAction.isLoading,
+                onPress: addAction.onPress,
+                size: 'default',
+              }}
+              title={t('settings.provider.models.empty')}
             />
+          ) : (
+            <ProviderModelStateCard>
+              {isLoading ? (
+                <ContentState.Loading
+                  className="flex-row justify-start gap-3"
+                  title={t('settings.provider.models.loading')}
+                />
+              ) : (
+                <ContentState.Empty
+                  className="items-start"
+                  title={
+                    isSearching
+                      ? t('settings.provider.models.search.empty')
+                      : t('settings.provider.models.empty')
+                  }
+                />
+              )}
+            </ProviderModelStateCard>
           )
         }
         models={displayedModels}
@@ -81,46 +106,10 @@ export function ProviderModelList({
   );
 }
 
-function ProviderModelEmptyActions({
-  addAction,
-  pullAction,
-}: {
-  addAction: ProviderModelAction;
-  pullAction: ProviderModelAction;
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <View className="flex-1 items-center justify-center gap-4 px-6 pb-24">
-      <Text className="text-center text-base text-foreground">
-        {t('settings.provider.models.empty')}
-      </Text>
-      <View className="flex-row gap-3">
-        <Button
-          disabled={pullAction.isDisabled}
-          loading={pullAction.isLoading}
-          onPress={pullAction.onPress}
-          variant="default"
-        >
-          <Button.Label>{t('settings.provider.models.emptyAction')}</Button.Label>
-        </Button>
-        <Button
-          disabled={addAction.isDisabled}
-          loading={addAction.isLoading}
-          onPress={addAction.onPress}
-          variant="secondary"
-        >
-          <Button.Label>{t('settings.provider.models.addSubmit')}</Button.Label>
-        </Button>
-      </View>
-    </View>
-  );
-}
-
-function ProviderModelEmptyState({ title }: { title: string }) {
+function ProviderModelStateCard({ children }: { children: ReactNode }) {
   return (
     <View className="mx-4 min-h-12 justify-center rounded-2xl bg-grouped-surface px-4 py-4">
-      <Text className="text-base text-foreground">{title}</Text>
+      {children}
     </View>
   );
 }

--- a/src/frontend/features/topics/TopicList.tsx
+++ b/src/frontend/features/topics/TopicList.tsx
@@ -1,8 +1,9 @@
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
+import { ContentState } from '@cherrystudio/ui/components';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActivityIndicator, type AccessibilityActionEvent, Text, View } from 'react-native';
+import { type AccessibilityActionEvent, Text, View } from 'react-native';
 import { Pressable } from 'react-native-gesture-handler';
 import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 
@@ -15,7 +16,6 @@ import {
   useSelectionState,
 } from '@/frontend/components/selection';
 import { useAssistantsApi } from '@/frontend/hooks/chat';
-import { useThemeColor } from '@/frontend/hooks/useThemeColor';
 import type { TopicListItem } from '@/shared/data/api/schemas/topics';
 import type { Assistant } from '@/shared/data/types/assistant';
 import type { Topic } from '@/shared/data/types/topic';
@@ -89,7 +89,6 @@ const TopicListView = memo(function TopicListView() {
     error: assistantsQueryError,
     isLoading: isAssistantsLoading,
   } = useAssistantsApi();
-  const primaryColor = useThemeColor('primary');
   const isInitialDataSettled = useTopicListInitialData({
     assistants: { error: assistantsQueryError, isLoading: isAssistantsLoading },
     topics: { error: topicQueryError, isLoading: isTopicListLoading },
@@ -142,17 +141,15 @@ const TopicListView = memo(function TopicListView() {
   const listEmptyComponent = useCallback(
     () =>
       isInitialDataSettled ? (
-        <View className="items-center justify-center px-6 py-8">
-          <Text className="text-center text-foreground text-sm">
-            {t(initialLoadError ? 'navigation.chatsLoadFailed' : 'navigation.noMatchingChats')}
-          </Text>
-        </View>
+        initialLoadError ? (
+          <ContentState.Error className="px-6 py-8" title={t('navigation.chatsLoadFailed')} />
+        ) : (
+          <ContentState.Empty className="px-6 py-8" description={t('navigation.noMatchingChats')} />
+        )
       ) : (
-        <View className="items-center justify-center px-6 py-8">
-          <ActivityIndicator color={primaryColor} />
-        </View>
+        <ContentState.Loading className="px-6 py-8" />
       ),
-    [initialLoadError, isInitialDataSettled, primaryColor, t],
+    [initialLoadError, isInitialDataSettled, t],
   );
 
   return (


### PR DESCRIPTION
### What this PR does

Before this PR:

- Loading, empty, and error states were assembled independently across screens from `ActivityIndicator`, `Spinner`, text, `Pressable`, and `Button`.
- Presentation hierarchy, actions, and accessibility semantics could drift between content surfaces.

After this PR:

- CherryUI exposes platform-neutral `ContentState.Loading`, `ContentState.Empty`, and `ContentState.Error` variants.
- The shared component owns presentation, CherryUI buttons/spinner, optional icons, up to two actions, and loading accessibility semantics.
- Product features continue to own query state, retry/create callbacks, localized copy, list mounting, and layout insets.
- Assistant, AI usage, painting, MCP, provider model, and topic surfaces use the shared presentation.
- CherryUI documentation, focused component tests, and a light/dark Storybook playground cover the new primitive.

### Screenshots or videos

Not captured yet. The PR includes `Components/Primitives/Content State/Playground` in native Storybook for deterministic light and dark inspection of all three variants.

### Why we need it and why it was done in this way

This removes repeated state markup and gives independent product areas one accessible presentation contract without coupling CherryUI to React Query or product workflows.

The following tradeoffs were made:

- `ContentState` deliberately owns no query, retry, inset, card, compact-mode, or list behavior.
- Primary and secondary actions use the shared CherryUI button variants, so adopting surfaces receive consistent interaction styling.

The following alternatives were considered:

- A query-aware state boundary was avoided because retry behavior, retained data, and mounting requirements differ by feature.
- Keeping feature-local copies was rejected because the same presentation hierarchy already appears across several independent areas.

### Breaking changes

None.

### Special notes for your reviewer

- Business state conditions and callbacks remain feature-owned; this PR changes their presentation composition.
- This single PR contains both the shared primitive and its migrations so the complete consistency change can be reviewed together.
- Validation performed:
  - `pnpm packages:build`
  - `pnpm lint` (passes with 26 existing warnings and 0 errors)
  - `pnpm format:check`
- Tests, typecheck, and device visual acceptance were not run.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: Device screenshots or video still need to be captured
- [x] Code: The shared component remains presentation-only and feature state stays local
- [x] Refactor: Repeated state markup was replaced with a focused CherryUI primitive
- [x] Upgrade: No data, schema, or upgrade flow changes are required
- [x] Documentation: CherryUI package documentation and Storybook coverage were added
- [x] Self-review: The final diff was reviewed against `origin/v0.2`

### Release note

```release-note
NONE
```
