### PR TITLE
fix(chat-errors): surface rename failures without LogBox noise

### DIFF
--- a/packages/design-tokens/scripts/check-app-theme.ts
+++ b/packages/design-tokens/scripts/check-app-theme.ts
@@ -44,8 +44,6 @@ const colorLiteralAllowlist: Record<string, string> = {
     'outside the theme runtime: paints before the CSS variable tree exists',
   'src/frontend/features/onboarding/logoDraw/utils/logoPalette.ts':
     'artwork: the logo colours encode relationships with each other, not roles',
-  'src/shared/core/logger/LoggerService.ts':
-    'outside the render tree: `%c` console styles never pass through uniwind',
 };
 
 const forbiddenPatterns = [

--- a/src/backend/ai/runtime/aiSdk/Agent.ts
+++ b/src/backend/ai/runtime/aiSdk/Agent.ts
@@ -145,7 +145,6 @@ export class Agent<Key extends AppProviderKey = AppProviderKey> {
         await safeCall('onAbort', hooks.onAbort);
         throw error;
       }
-      logger.error('agent generate error', error as Error);
       if (hooks.onError) {
         try {
           await hooks.onError({ error: toError(error) });
@@ -333,8 +332,6 @@ export class Agent<Key extends AppProviderKey = AppProviderKey> {
         const action = await invokeOnError(error);
         if (action === 'retry') {
           logger.warn('agentLoop onError returned retry; retry not implemented - aborting', error);
-        } else {
-          logger.error('agentLoop error', error as Error);
         }
         await settleWriter({ error });
       });

--- a/src/backend/ai/streamManager/ChatRuntime.ts
+++ b/src/backend/ai/streamManager/ChatRuntime.ts
@@ -1642,6 +1642,9 @@ export class ChatRuntime extends BaseService implements ChatModule {
     const renamed = await maybeRenameTopicFromConversationSummary({
       assistantId: input.assistantId,
       assistantText,
+      onFailure: () => {
+        this.emit({ topicId: input.topicId, type: 'topic-rename-failed' });
+      },
       services: this.dependencies.services,
       topicId: input.topicId,
       userText,

--- a/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
+++ b/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
@@ -8,7 +8,7 @@ import type {
   BackgroundReplyLifecycle,
   BackgroundReplyTurn,
 } from '@/backend/services/backgroundReply';
-import { NEW_TOPIC_SNAPSHOT_KEY } from '@/shared/contracts';
+import { type ChatEvent, NEW_TOPIC_SNAPSHOT_KEY } from '@/shared/contracts';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@/shared/data/types/assistant';
 import { type FileEntry, FileEntrySchema } from '@/shared/data/types/file';
@@ -1228,6 +1228,47 @@ describe('ChatRuntime', () => {
       name: 'Generated Topic Title',
     });
     expect(invalidateTopics).toHaveBeenCalled();
+  });
+
+  test('reports an automatic topic naming failure without failing the completed turn', async () => {
+    const services = createServices();
+    services.topic.getById = jest.fn(async () => createTopic({ name: 'hi' }));
+    const preferences: Record<string, unknown> = {
+      'app.language': 'en-US',
+      'topic.naming.enabled': true,
+      'topic.naming.model_id': null,
+      'topic.naming_prompt': '',
+    };
+    services.preference.get = jest.fn(
+      async (key: string) => preferences[key],
+    ) as typeof services.preference.get;
+    services.ai.generateText = jest.fn(async () => {
+      throw new Error('naming failed');
+    });
+    const runtime = createRuntime({ services });
+    const events: ChatEvent[] = [];
+    runtime.subscribe((event) => events.push(event));
+    mockReadUIMessageStream.mockReturnValue(
+      asyncIterable([createUiMessage('assistant-1', 'hello')]),
+    );
+
+    await runtime.sendText({
+      selectedModelId: 'provider::model' as UniqueModelId,
+      text: 'hi',
+      topicId: 'topic-1',
+    });
+
+    await waitUntil(() => events.some((event) => event.type === 'topic-rename-failed'));
+
+    expect(events).toContainEqual({
+      topicId: 'topic-1',
+      type: 'topic-rename-failed',
+    });
+    expect(services.message.finalizeAssistantMessage).toHaveBeenLastCalledWith(
+      'assistant-1',
+      expect.objectContaining({ status: 'success' }),
+    );
+    expect(services.topic.update).not.toHaveBeenCalled();
   });
 
   test('does not auto-name a topic that already has history', async () => {
@@ -2943,6 +2984,8 @@ function createRuntime(input: {
         break;
       case 'open-topic':
         input.openTopic?.(event.topicId);
+        break;
+      case 'topic-rename-failed':
         break;
       case 'snapshot-changed':
         break;

--- a/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
+++ b/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
@@ -1247,7 +1247,9 @@ describe('ChatRuntime', () => {
     });
     const runtime = createRuntime({ services });
     const events: ChatEvent[] = [];
-    runtime.subscribe((event) => events.push(event));
+    runtime.subscribe((event) => {
+      events.push(event);
+    });
     mockReadUIMessageStream.mockReturnValue(
       asyncIterable([createUiMessage('assistant-1', 'hello')]),
     );

--- a/src/backend/ai/streamManager/__tests__/topicNaming.test.ts
+++ b/src/backend/ai/streamManager/__tests__/topicNaming.test.ts
@@ -311,20 +311,23 @@ describe('maybeRenameTopicFromConversationSummary', () => {
     expect(services.topic.update).not.toHaveBeenCalled();
   });
 
-  it('returns false and logs instead of throwing when the LLM call fails', async () => {
+  it('reports the failure and returns false when the LLM call fails', async () => {
     const services = createServices({
       generateText: jest.fn(async () => {
         throw new Error('network error');
       }),
     });
+    const onFailure = jest.fn();
 
     const renamed = await maybeRenameTopicFromConversationSummary({
       assistantText: 'reply',
+      onFailure,
       services,
       topicId: 'topic-1',
       userText: 'question',
     });
 
     expect(renamed).toBe(false);
+    expect(onFailure).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/backend/ai/streamManager/topicNaming.ts
+++ b/src/backend/ai/streamManager/topicNaming.ts
@@ -66,12 +66,14 @@ export function inFlightTopicNamingWrites(): ReadonlyMap<string, Promise<boolean
 /**
  * Generates a topic title from the first user/assistant exchange and
  * applies it if the topic still has its auto-assigned name. Returns whether
- * the topic was renamed; never throws — naming is best-effort and must not
- * affect the chat turn it rides along with.
+ * the topic was renamed. Naming failures call `onFailure`, but skipped attempts
+ * do not. Never throws — naming is best-effort and must not affect the chat turn
+ * it rides along with.
  */
 export function maybeRenameTopicFromConversationSummary(input: {
   assistantId?: string;
   assistantText: string;
+  onFailure?: () => void;
   services: TopicNamingServices;
   topicId: string;
   userText: string;
@@ -86,6 +88,7 @@ export function maybeRenameTopicFromConversationSummary(input: {
 async function doMaybeRenameTopicFromConversationSummary(input: {
   assistantId?: string;
   assistantText: string;
+  onFailure?: () => void;
   services: TopicNamingServices;
   topicId: string;
   userText: string;
@@ -127,6 +130,11 @@ async function doMaybeRenameTopicFromConversationSummary(input: {
     return true;
   } catch (error) {
     logger.warn('Failed to auto-rename topic from conversation summary', error as Error);
+    try {
+      input.onFailure?.();
+    } catch (notificationError) {
+      logger.warn('Failed to report topic auto-rename failure', notificationError as Error);
+    }
     return false;
   } finally {
     summaryLocks.delete(topicId);

--- a/src/frontend/features/chat/README.md
+++ b/src/frontend/features/chat/README.md
@@ -19,5 +19,5 @@ behavior. Structured message rendering is shared with painting through
 - `workspace/` adapts visible Chat runtime messages into the shared `MessageList`, and owns loading
   indicators, initial-render gating, and tool approvals.
 - `runtime/` subscribes to the app-owned `ChatModule`, projects one Topic snapshot through
-  `useChatTopic()`, and owns frontend navigation and query invalidation effects. It does not create
-  or dispose `ChatRuntime`.
+  `useChatTopic()`, and owns frontend navigation, query invalidation, and the localized topic-rename
+  failure Toast. It does not create or dispose `ChatRuntime`.

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -1,3 +1,4 @@
+import { useToast } from '@cherrystudio/ui/components';
 import type { ComposerQueuedMessagePayload } from '@cherrystudio/universal/ai/transport';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'expo-router';
@@ -10,6 +11,7 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { queryKeys, useBackendModule } from '@/frontend/data';
 import { getMessagesQueryKey } from '@/frontend/hooks/chat/utils/messageQueryOptions';
@@ -40,6 +42,8 @@ type ChatTopicValue = ChatTopicSnapshot & {
 const ChatContext = createContext<ChatModule | null>(null);
 
 export function ChatProvider({ children }: PropsWithChildren) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
   const chat = useBackendModule('chat');
   const queryClient = useQueryClient();
   const pathname = usePathname();
@@ -53,6 +57,12 @@ export function ChatProvider({ children }: PropsWithChildren) {
     () =>
       chat.subscribe(async (event) => {
         switch (event.type) {
+          case 'topic-rename-failed':
+            toast.show({
+              label: t('topic.rename.failed'),
+              variant: 'danger',
+            });
+            break;
           case 'invalidate-topic-messages':
             await queryClient.invalidateQueries({ queryKey: getMessagesQueryKey(event.topicId) });
             break;
@@ -66,7 +76,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
             break;
         }
       }),
-    [chat, navigation, queryClient],
+    [chat, navigation, queryClient, t, toast],
   );
 
   return <ChatContext value={chat}>{children}</ChatContext>;

--- a/src/frontend/features/chat/runtime/__tests__/ChatProvider.test.tsx
+++ b/src/frontend/features/chat/runtime/__tests__/ChatProvider.test.tsx
@@ -1,0 +1,77 @@
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
+
+import { ChatProvider } from '../ChatProvider';
+
+const mockInvalidateQueries = jest.fn(async () => undefined);
+const mockReplace = jest.fn();
+const mockSetParams = jest.fn();
+const mockSubscribe = jest.fn();
+const mockToastShow = jest.fn();
+const mockUnsubscribe = jest.fn();
+let mockListener: ((event: unknown) => Promise<void> | void) | undefined;
+
+jest.mock('@cherrystudio/ui/components', () => ({
+  useToast: () => ({ toast: { show: mockToastShow } }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}));
+
+jest.mock('expo-router', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({ replace: mockReplace, setParams: mockSetParams }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/frontend/data', () => ({
+  queryKeys: { topics: { all: () => ['topics'] } },
+  useBackendModule: () => ({
+    subscribe: (listener: typeof mockListener) => {
+      mockListener = listener;
+      mockSubscribe(listener);
+      return mockUnsubscribe;
+    },
+  }),
+}));
+
+jest.mock('@/frontend/hooks/chat/utils/messageQueryOptions', () => ({
+  getMessagesQueryKey: (topicId: string) => ['messages', topicId],
+}));
+
+describe('ChatProvider', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListener = undefined;
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('turns a background topic rename failure into one localized danger Toast', async () => {
+    act(() => {
+      renderer = create(<ChatProvider />);
+    });
+
+    await act(async () => {
+      await mockListener?.({
+        topicId: 'topic-1',
+        type: 'topic-rename-failed',
+      });
+    });
+
+    expect(mockToastShow).toHaveBeenCalledTimes(1);
+    expect(mockToastShow).toHaveBeenCalledWith({
+      label: 'topic.rename.failed',
+      variant: 'danger',
+    });
+  });
+});

--- a/src/frontend/features/topics/components/__tests__/useTopicActionAlerts.test.tsx
+++ b/src/frontend/features/topics/components/__tests__/useTopicActionAlerts.test.tsx
@@ -1,4 +1,4 @@
-import { useAlert } from '@cherrystudio/ui/components';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
@@ -13,6 +13,7 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('@cherrystudio/ui/components', () => ({
   useAlert: jest.fn(),
+  useToast: jest.fn(),
 }));
 
 jest.mock('../../context/TopicListProvider', () => ({
@@ -22,9 +23,11 @@ jest.mock('../../context/TopicListProvider', () => ({
 const mockAlertConfirm = jest.fn();
 const mockAlertShow = jest.fn();
 const mockAlertPrompt = jest.fn();
+const mockToastShow = jest.fn();
 const mockDeleteTopic = jest.fn(async () => undefined);
 const mockRenameTopic = jest.fn(async () => undefined);
 const useAlertMock = useAlert as jest.MockedFunction<typeof useAlert>;
+const useToastMock = useToast as jest.MockedFunction<typeof useToast>;
 const useTopicListActionsMock = useTopicListActions as jest.MockedFunction<
   typeof useTopicListActions
 >;
@@ -58,6 +61,7 @@ describe('useTopicActionAlerts', () => {
         show: mockAlertShow,
       },
     });
+    useToastMock.mockReturnValue({ toast: { show: mockToastShow } });
     useTopicListActionsMock.mockReturnValue({
       deleteTopic: mockDeleteTopic,
       deleteTopics: jest.fn(),
@@ -98,7 +102,7 @@ describe('useTopicActionAlerts', () => {
     expect(mockRenameTopic).toHaveBeenCalledWith('topic-1', 'Renamed topic');
   });
 
-  test('shows an Alert after a failed optimistic rename', async () => {
+  test('shows a danger Toast after a failed optimistic rename', async () => {
     mockRenameTopic.mockRejectedValueOnce(new Error('rename failed'));
     act(() => actions?.requestRename(topic));
 
@@ -106,6 +110,10 @@ describe('useTopicActionAlerts', () => {
     act(() => prompt.onConfirm('Renamed topic'));
     await act(async () => Promise.resolve());
 
-    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'topic.rename.failed' });
+    expect(mockToastShow).toHaveBeenCalledWith({
+      label: 'topic.rename.failed',
+      variant: 'danger',
+    });
+    expect(mockAlertShow).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/features/topics/components/useTopicActionAlerts.ts
+++ b/src/frontend/features/topics/components/useTopicActionAlerts.ts
@@ -1,4 +1,4 @@
-import { useAlert } from '@cherrystudio/ui/components';
+import { useAlert, useToast } from '@cherrystudio/ui/components';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -15,6 +15,7 @@ export function useTopicActionAlerts(): TopicActionAlerts {
   const { t } = useTranslation();
   const { deleteTopic, renameTopic } = useTopicListActions();
   const { alert } = useAlert();
+  const { toast } = useToast();
 
   const requestRename = useCallback(
     (topic: Topic) => {
@@ -34,13 +35,13 @@ export function useTopicActionAlerts(): TopicActionAlerts {
           }
 
           void renameTopic(topic.id, trimmedName).catch(() => {
-            alert.show({ title: t('topic.rename.failed') });
+            toast.show({ label: t('topic.rename.failed'), variant: 'danger' });
           });
         },
         title: t('topic.renameTitle'),
       });
     },
-    [alert, renameTopic, t],
+    [alert, renameTopic, t, toast],
   );
 
   const requestDelete = useCallback(

--- a/src/shared/contracts/README.md
+++ b/src/shared/contracts/README.md
@@ -112,10 +112,12 @@ semantic rules that import restrictions cannot detect, especially shallow pass-t
   architecture decision.
 
 Chat's public state vocabulary is `ChatTopicStatus`, `ChatTopicSnapshot`, `ChatEvent`, and
-`ChatListener`; the temporary new-Topic projection uses `NEW_TOPIC_SNAPSHOT_KEY`. `ChatModule`
-exposes send, branch selection, regeneration, edit-and-resend, multi-model execution, steering,
-follow-up queuing, approval, cancellation, reconnectable streams, snapshots, and subscriptions
-directly. Do not reintroduce `createSession()` or a public Chat session object.
+`ChatListener`; auxiliary failures such as topic renaming use semantic `ChatEvent` variants so the
+frontend can localize them without exposing provider messages. The temporary new-Topic projection
+uses `NEW_TOPIC_SNAPSHOT_KEY`. `ChatModule` exposes send, branch selection, regeneration,
+edit-and-resend, multi-model execution, steering, follow-up queuing, approval, cancellation,
+reconnectable streams, snapshots, and subscriptions directly. Do not reintroduce `createSession()`
+or a public Chat session object.
 
 ## Current Modules
 

--- a/src/shared/contracts/chat.ts
+++ b/src/shared/contracts/chat.ts
@@ -86,7 +86,8 @@ export type ChatEvent =
   | { topicId: string; type: 'invalidate-topic-messages' }
   | { type: 'invalidate-topics' }
   | { topicId: string; type: 'open-topic' }
-  | { topicId: string; type: 'snapshot-changed' };
+  | { topicId: string; type: 'snapshot-changed' }
+  | { topicId: string; type: 'topic-rename-failed' };
 
 export type ChatListener = (event: ChatEvent) => Promise<void> | void;
 

--- a/src/shared/core/logger/LoggerService.ts
+++ b/src/shared/core/logger/LoggerService.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'verbose' | 'silly' | 'none';
 
 type LogContext = Record<string, unknown>;
@@ -25,6 +27,7 @@ const LEVEL_MAP: Record<LogLevel, number> = {
 };
 
 const isDevelopment = () => typeof __DEV__ !== 'undefined' && __DEV__;
+const isNativeDevelopment = () => isDevelopment() && Platform.OS !== 'web';
 const DEFAULT_LEVEL: LogLevel = isDevelopment() ? LEVEL.SILLY : LEVEL.INFO;
 
 export class LoggerService {
@@ -79,7 +82,7 @@ export class LoggerService {
   }
 
   private processLog(level: LogLevel, message: string, data: LogContextData): void {
-    if (LEVEL_MAP[level] < LEVEL_MAP[this.level]) {
+    if (!isDevelopment() || LEVEL_MAP[level] < LEVEL_MAP[this.level]) {
       return;
     }
 
@@ -90,11 +93,11 @@ export class LoggerService {
 
     switch (level) {
       case LEVEL.ERROR:
-        if (isDevelopment()) console.info(formattedMessage, ...logData);
+        if (isNativeDevelopment()) console.info(formattedMessage, ...logData);
         else console.error(formattedMessage, ...logData);
         break;
       case LEVEL.WARN:
-        if (isDevelopment()) console.info(formattedMessage, ...logData);
+        if (isNativeDevelopment()) console.info(formattedMessage, ...logData);
         else console.warn(formattedMessage, ...logData);
         break;
       case LEVEL.INFO:

--- a/src/shared/core/logger/LoggerService.ts
+++ b/src/shared/core/logger/LoggerService.ts
@@ -21,7 +21,7 @@ const LEVEL_MAP: Record<LogLevel, number> = {
   debug: 4,
   verbose: 2,
   silly: 0,
-  none: -1,
+  none: Number.POSITIVE_INFINITY,
 };
 
 const isDevelopment = () => typeof __DEV__ !== 'undefined' && __DEV__;
@@ -79,32 +79,35 @@ export class LoggerService {
   }
 
   private processLog(level: LogLevel, message: string, data: LogContextData): void {
-    if (!isDevelopment() || LEVEL_MAP[level] < LEVEL_MAP[this.level]) {
+    if (LEVEL_MAP[level] < LEVEL_MAP[this.level]) {
       return;
     }
 
     const logMessage = this.module ? `[${this.module}] ${message}` : message;
     const contextData = Object.keys(this.context).length > 0 ? [this.context] : [];
     const logData = [...contextData, ...data];
+    const formattedMessage = `<${level}> ${logMessage}`;
 
     switch (level) {
       case LEVEL.ERROR:
-        console.error('%c<error>', 'color: red; font-weight: bold', logMessage, ...logData);
+        if (isDevelopment()) console.info(formattedMessage, ...logData);
+        else console.error(formattedMessage, ...logData);
         break;
       case LEVEL.WARN:
-        console.warn('%c<warn>', 'color: #FFA500; font-weight: bold', logMessage, ...logData);
+        if (isDevelopment()) console.info(formattedMessage, ...logData);
+        else console.warn(formattedMessage, ...logData);
         break;
       case LEVEL.INFO:
-        console.info('%c<info>', 'color: #32CD32; font-weight: bold', logMessage, ...logData);
+        console.info(formattedMessage, ...logData);
         break;
       case LEVEL.DEBUG:
-        console.debug('%c<debug>', 'color: #7B68EE', logMessage, ...logData);
+        console.debug(formattedMessage, ...logData);
         break;
       case LEVEL.VERBOSE:
-        console.debug('%c<verbose>', 'color: #808080', logMessage, ...logData);
+        console.debug(formattedMessage, ...logData);
         break;
       case LEVEL.SILLY:
-        console.debug('%c<silly>', 'color: #808080', logMessage, ...logData);
+        console.debug(formattedMessage, ...logData);
         break;
     }
   }

--- a/src/shared/core/logger/__tests__/LoggerService.test.ts
+++ b/src/shared/core/logger/__tests__/LoggerService.test.ts
@@ -1,13 +1,17 @@
+import { Platform } from 'react-native';
+
 import { LoggerService } from '../LoggerService';
 
 describe('LoggerService', () => {
   const originalDevelopment = global.__DEV__;
+  const originalPlatform = Platform.OS;
   let debugSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
   let infoSpy: jest.SpyInstance;
   let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
     debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
@@ -16,6 +20,7 @@ describe('LoggerService', () => {
 
   afterEach(() => {
     global.__DEV__ = originalDevelopment;
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: originalPlatform });
     jest.restoreAllMocks();
   });
 
@@ -43,7 +48,20 @@ describe('LoggerService', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('preserves production logging at the configured level', () => {
+  it('preserves error and warning severity in web development', () => {
+    global.__DEV__ = true;
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'web' });
+    const logger = new LoggerService();
+
+    logger.error('Response failed');
+    logger.warn('Background task failed');
+
+    expect(errorSpy).toHaveBeenCalledWith('<error> Response failed');
+    expect(warnSpy).toHaveBeenCalledWith('<warn> Background task failed');
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses production logging', () => {
     global.__DEV__ = false;
     const logger = new LoggerService();
     logger.setLevel('info');
@@ -53,13 +71,14 @@ describe('LoggerService', () => {
     logger.info('Runtime ready');
     logger.debug('Hidden detail');
 
-    expect(errorSpy).toHaveBeenCalledWith('<error> Response failed');
-    expect(warnSpy).toHaveBeenCalledWith('<warn> Background task failed');
-    expect(infoSpy).toHaveBeenCalledWith('<info> Runtime ready');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
     expect(debugSpy).not.toHaveBeenCalled();
   });
 
   it('suppresses every log level when disabled', () => {
+    global.__DEV__ = true;
     const logger = new LoggerService();
     logger.setLevel('none');
 

--- a/src/shared/core/logger/__tests__/LoggerService.test.ts
+++ b/src/shared/core/logger/__tests__/LoggerService.test.ts
@@ -1,0 +1,74 @@
+import { LoggerService } from '../LoggerService';
+
+describe('LoggerService', () => {
+  const originalDevelopment = global.__DEV__;
+  let debugSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    global.__DEV__ = originalDevelopment;
+    jest.restoreAllMocks();
+  });
+
+  it('keeps handled development errors and warnings out of React Native LogBox', () => {
+    global.__DEV__ = true;
+    const error = new Error('provider failed');
+    const logger = new LoggerService().withContext('chat', { topicId: 'topic-1' });
+
+    logger.error('Response failed', error);
+    logger.warn('Background task failed', error);
+
+    expect(infoSpy).toHaveBeenNthCalledWith(
+      1,
+      '<error> [chat] Response failed',
+      { topicId: 'topic-1' },
+      error,
+    );
+    expect(infoSpy).toHaveBeenNthCalledWith(
+      2,
+      '<warn> [chat] Background task failed',
+      { topicId: 'topic-1' },
+      error,
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves production logging at the configured level', () => {
+    global.__DEV__ = false;
+    const logger = new LoggerService();
+    logger.setLevel('info');
+
+    logger.error('Response failed');
+    logger.warn('Background task failed');
+    logger.info('Runtime ready');
+    logger.debug('Hidden detail');
+
+    expect(errorSpy).toHaveBeenCalledWith('<error> Response failed');
+    expect(warnSpy).toHaveBeenCalledWith('<warn> Background task failed');
+    expect(infoSpy).toHaveBeenCalledWith('<info> Runtime ready');
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses every log level when disabled', () => {
+    const logger = new LoggerService();
+    logger.setLevel('none');
+
+    logger.error('Hidden error');
+    logger.warn('Hidden warning');
+    logger.info('Hidden info');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### What this PR does

Before this PR:

- React Native development builds routed handled logger errors and warnings through `console.error` / `console.warn` with browser-only `%c` formatting, which could surface unreadable LogBox UI.
- The AI agent logged failures before rethrowing them, duplicating the final boundary's diagnostic record.
- Automatic topic naming failures were only logged, while manual rename failures opened a blocking Alert.

After this PR:

- Handled development logs use plain native-compatible console output without triggering LogBox; production logging and the `none` threshold work as configured.
- Agent failures are recorded by their final handling boundary instead of being logged and rethrown.
- Automatic topic naming emits a semantic `topic-rename-failed` event, and both automatic and manual rename failures show the localized non-blocking danger Toast.
- Model response and streaming failures remain owned by the message list's existing `data-error` rendering; this PR does not add a response-failure Toast.

### Screenshots or videos

Not included in this draft. Device/manual UI verification was not run under the workspace verification policy.

### Why we need it and why it was done in this way

Logger diagnostics must not implicitly create application UI. User-facing feedback belongs to the feature that owns the failed operation: message failures stay inline with their message, while topic rename failures use the app's non-blocking Toast.

The following tradeoffs were made:

- Rename Toasts use a stable localized label instead of exposing raw provider or SDK error text.
- Automatic naming remains fire-and-forget and never changes the completed chat turn's outcome.

The following alternatives were considered:

- Disabling LogBox globally was rejected because genuine unhandled development errors should remain visible.
- Showing Toasts for model response failures was rejected because the message list already owns and renders those errors.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm format:check`: passed.
- `pnpm lint`: passed with existing repository warnings and no errors.
- Tests, typecheck, builds, and manual device verification were not run under the workspace verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: I have left the code cleaner than I found it
- [x] Upgrade: The impact of this change on upgrade flows was considered and no upgrade change is required
- [x] Documentation: Internal module documentation was updated; no user-guide update is required
- [x] Self-review: I reviewed the final diff before requesting review

### Release note

```release-note
Fixed topic rename failures showing developer LogBox output; rename failures now use a non-blocking Toast while message errors remain inline.
```
