### PR TITLE
fix(platform-ui): align native interaction behavior

### DIFF
--- a/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
+++ b/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
@@ -3,6 +3,10 @@
 package com.margelo.nitro.cherrystudio.ui
 
 import android.content.Context
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.util.TypedValue
 import android.view.GestureDetector
 import android.view.Menu
 import android.view.MotionEvent
@@ -12,10 +16,13 @@ import android.widget.PopupMenu
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.events.NativeGestureUtil
 
 private class MenuFrameLayout(context: Context) : FrameLayout(context) {
     var onLongPress: (() -> Unit)? = null
     var onTap: (() -> Unit)? = null
+    private var isMenuGestureActive = false
+    private var isNativeGestureActive = false
 
     private val gestureDetector = GestureDetector(
         context,
@@ -24,19 +31,75 @@ private class MenuFrameLayout(context: Context) : FrameLayout(context) {
 
             override fun onSingleTapUp(event: MotionEvent): Boolean {
                 val handler = onTap ?: return false
-                handler()
+                activateMenu(event, handler)
                 return true
             }
 
             override fun onLongPress(event: MotionEvent) {
-                onLongPress?.invoke()
+                onLongPress?.let { activateMenu(event, it) }
             }
         },
     )
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+            isMenuGestureActive = false
+            isNativeGestureActive = false
+            if (onTap != null) {
+                // RootView sees ACTION_UP before descendants do. Claim tap-trigger gestures on
+                // DOWN so a wrapped React Pressable cannot release before the menu takes over.
+                startNativeGesture(event)
+            }
+        }
+
         gestureDetector.onTouchEvent(event)
-        return super.dispatchTouchEvent(event)
+
+        if (isMenuGestureActive) {
+            if (
+                event.actionMasked == MotionEvent.ACTION_UP ||
+                    event.actionMasked == MotionEvent.ACTION_CANCEL
+            ) {
+                isMenuGestureActive = false
+                endNativeGesture(event)
+            }
+            return true
+        }
+
+        val handled = super.dispatchTouchEvent(event)
+        if (
+            event.actionMasked == MotionEvent.ACTION_UP ||
+                event.actionMasked == MotionEvent.ACTION_CANCEL
+        ) {
+            endNativeGesture(event)
+        }
+        return handled
+    }
+
+    private fun activateMenu(event: MotionEvent, handler: () -> Unit) {
+        isMenuGestureActive = true
+        // Long-press claims RN's root responder here; tap already claimed it on DOWN. Both still
+        // cancel the native child that received the gesture stream.
+        startNativeGesture(event)
+        MotionEvent.obtain(event).also { cancelEvent ->
+            cancelEvent.action = MotionEvent.ACTION_CANCEL
+            super.dispatchTouchEvent(cancelEvent)
+            cancelEvent.recycle()
+        }
+        handler()
+    }
+
+    private fun startNativeGesture(event: MotionEvent) {
+        if (isNativeGestureActive) return
+
+        isNativeGestureActive = true
+        NativeGestureUtil.notifyNativeGestureStarted(this, event)
+    }
+
+    private fun endNativeGesture(event: MotionEvent) {
+        if (!isNativeGestureActive) return
+
+        isNativeGestureActive = false
+        NativeGestureUtil.notifyNativeGestureEnded(this, event)
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
@@ -92,7 +155,9 @@ class HybridCherryMenuView(
         val itemIds = mutableMapOf<Int, String>()
 
         items.forEachIndexed { index, item ->
-            val menuItem = popup.menu.add(Menu.NONE, index, Menu.NONE, item.label)
+            val title =
+                if (item.destructive && !item.disabled) destructiveTitle(item.label) else item.label
+            val menuItem = popup.menu.add(Menu.NONE, index, Menu.NONE, title)
             menuItem.isEnabled = !item.disabled
             if (item.checked != NativeMenuCheckedState.NONE) {
                 menuItem.isCheckable = true
@@ -113,5 +178,25 @@ class HybridCherryMenuView(
 
         currentPopup = popup
         popup.show()
+    }
+
+    private fun destructiveTitle(label: String): CharSequence =
+        SpannableString(label).apply {
+            setSpan(
+                ForegroundColorSpan(resolveDestructiveColor()),
+                0,
+                length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
+
+    private fun resolveDestructiveColor(): Int {
+        val color = TypedValue()
+        val context = containerView.context
+        if (!context.theme.resolveAttribute(android.R.attr.colorError, color, true)) {
+            return context.getColor(android.R.color.holo_red_dark)
+        }
+
+        return if (color.resourceId == 0) color.data else context.getColor(color.resourceId)
     }
 }

--- a/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
+++ b/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { BackHandler, StyleSheet, Text } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { BottomSheet } from '..';
 
 let mockBottomSheetProps: Record<string, unknown> = {};
+let mockHardwareBackPress: (() => boolean | null | undefined) | undefined;
 
 jest.mock('@cherrystudio/app-icons/icons/arrow-left', () => {
   const { View } = jest.requireActual('react-native');
@@ -31,15 +32,24 @@ jest.mock('uniwind', () => ({
 }));
 
 describe('BottomSheet', () => {
+  let backHandlerSpy: jest.SpyInstance;
   let renderer: ReactTestRenderer | undefined;
 
   beforeEach(() => {
     mockBottomSheetProps = {};
+    mockHardwareBackPress = undefined;
+    backHandlerSpy = jest
+      .spyOn(BackHandler, 'addEventListener')
+      .mockImplementation((_event, handler) => {
+        mockHardwareBackPress = () => handler({ type: 'hardwareBackPress', timeStamp: Date.now() });
+        return { remove: jest.fn() };
+      });
   });
 
   afterEach(() => {
     act(() => renderer?.unmount());
     renderer = undefined;
+    backHandlerSpy.mockRestore();
   });
 
   test('reports one user dismissal after the close motion settles', () => {
@@ -130,6 +140,31 @@ describe('BottomSheet', () => {
 
     act(() => renderer?.root.findByProps({ accessibilityLabel: 'Back' }).props.onPress());
     expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test('routes Android hardware back through the optional second-level action', () => {
+    const onBack = jest.fn();
+
+    act(() => {
+      renderer = create(
+        <BottomSheet
+          backAction={{ accessibilityLabel: 'Back', onPress: onBack }}
+          onClose={jest.fn()}
+          open
+          size="medium"
+          title="Size"
+        >
+          <Text>Content</Text>
+        </BottomSheet>,
+      );
+    });
+
+    act(() => {
+      expect(mockHardwareBackPress?.()).toBe(true);
+    });
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(mockBottomSheetProps.index).toBe(1);
   });
 
   test('updates the native height when the semantic size changes', () => {

--- a/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
@@ -113,18 +113,25 @@ export function BottomSheet(props: BottomSheetProps) {
     setIndex(CLOSED_INDEX);
   }, [dismissible]);
 
+  const handleHardwareBackPress = useCallback(() => {
+    if (backAction) {
+      backAction.onPress();
+    } else {
+      requestClose();
+    }
+
+    return true;
+  }, [backAction, requestClose]);
+
   useEffect(() => {
     if (!open) {
       return;
     }
 
-    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
-      requestClose();
-      return true;
-    });
+    const subscription = BackHandler.addEventListener('hardwareBackPress', handleHardwareBackPress);
 
     return () => subscription.remove();
-  }, [open, requestClose]);
+  }, [handleHardwareBackPress, open]);
 
   const handleIndexChange = useCallback(
     (nextIndex: number) => {

--- a/packages/ui/src/components/slider/__tests__/slider.android.test.tsx
+++ b/packages/ui/src/components/slider/__tests__/slider.android.test.tsx
@@ -47,15 +47,28 @@ describe('Slider (Android)', () => {
     expect(root.props.minValue).toBe(0);
     expect(root.props.maxValue).toBe(100);
     expect(root.props.step).toBe(1);
+    expect(root.props.accessibilityLabel).toBeUndefined();
     expect(renderer!.root.findByProps({ testID: 'track' })).toBeDefined();
     expect(renderer!.root.findByProps({ testID: 'fill' })).toBeDefined();
-    expect(renderer!.root.findByProps({ testID: 'thumb' })).toBeDefined();
+    const thumb = renderer!.root.findByProps({ testID: 'thumb' });
+    expect(thumb.props.accessibilityLabel).toBe('Volume');
+    expect(thumb.props.accessibilityActions).toEqual([
+      { name: 'decrement' },
+      { name: 'increment' },
+    ]);
 
     act(() => root.props.onChange(45));
     expect(onValueChange).toHaveBeenCalledWith(45);
+
+    act(() => thumb.props.onAccessibilityAction({ nativeEvent: { actionName: 'increment' } }));
+    act(() => thumb.props.onAccessibilityAction({ nativeEvent: { actionName: 'decrement' } }));
+    expect(onValueChange).toHaveBeenNthCalledWith(2, 41);
+    expect(onValueChange).toHaveBeenNthCalledWith(3, 39);
   });
 
   test('maps custom bounds and disabled state to HeroUI', () => {
+    const onValueChange = jest.fn();
+
     act(() => {
       renderer = create(
         <Slider
@@ -63,7 +76,7 @@ describe('Slider (Android)', () => {
           disabled
           max={1}
           min={0.1}
-          onValueChange={jest.fn()}
+          onValueChange={onValueChange}
           step={0.1}
           value={0.5}
         />,
@@ -76,6 +89,11 @@ describe('Slider (Android)', () => {
     expect(root.props.minValue).toBe(0.1);
     expect(root.props.maxValue).toBe(1);
     expect(root.props.step).toBe(0.1);
+
+    const thumb = renderer!.root.findByProps({ testID: 'thumb' });
+    expect(thumb.props.accessibilityActions).toBeUndefined();
+    expect(thumb.props.onAccessibilityAction).toBeUndefined();
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 
   test('renders endpoint labels around a flexible slider', () => {

--- a/packages/ui/src/components/slider/slider.android.tsx
+++ b/packages/ui/src/components/slider/slider.android.tsx
@@ -1,7 +1,9 @@
 import { Slider as HeroSlider } from 'heroui-native';
-import { Text, View } from 'react-native';
+import { type AccessibilityActionEvent, Text, View } from 'react-native';
 
 import type { SliderProps } from './slider.types';
+
+const ACCESSIBILITY_ACTIONS = [{ name: 'decrement' }, { name: 'increment' }] as const;
 
 export function Slider({
   accessibilityLabel,
@@ -17,9 +19,27 @@ export function Slider({
   value,
 }: SliderProps) {
   const hasValueLabels = Boolean(minimumValueLabel || maximumValueLabel);
+  const handleAccessibilityAction = (event: AccessibilityActionEvent) => {
+    if (disabled) {
+      return;
+    }
+
+    const { actionName } = event.nativeEvent;
+    if (actionName !== 'decrement' && actionName !== 'increment') {
+      return;
+    }
+
+    const direction = actionName === 'increment' ? 1 : -1;
+    const nextValue = Math.min(
+      max,
+      Math.max(min, Number((value + direction * step).toPrecision(12))),
+    );
+    if (nextValue !== value) {
+      onValueChange(nextValue);
+    }
+  };
   const slider = (
     <HeroSlider
-      accessibilityLabel={accessibilityLabel}
       className={hasValueLabels ? 'min-w-0 flex-1' : undefined}
       isDisabled={disabled}
       maxValue={max}
@@ -32,7 +52,11 @@ export function Slider({
     >
       <HeroSlider.Track>
         <HeroSlider.Fill />
-        <HeroSlider.Thumb />
+        <HeroSlider.Thumb
+          accessibilityActions={disabled ? undefined : ACCESSIBILITY_ACTIONS}
+          accessibilityLabel={accessibilityLabel}
+          onAccessibilityAction={disabled ? undefined : handleAccessibilityAction}
+        />
       </HeroSlider.Track>
     </HeroSlider>
   );

--- a/src/frontend/components/avatar/components/AvatarImagePicker.tsx
+++ b/src/frontend/components/avatar/components/AvatarImagePicker.tsx
@@ -38,13 +38,12 @@ export function AvatarImagePicker({
 
       isSelectingRef.current = true;
       try {
-        const permission =
-          source === 'camera'
-            ? await ImagePicker.requestCameraPermissionsAsync()
-            : await ImagePicker.requestMediaLibraryPermissionsAsync(false);
+        if (source === 'camera') {
+          const permission = await ImagePicker.requestCameraPermissionsAsync();
 
-        if (!permission.granted) {
-          return;
+          if (!permission.granted) {
+            return;
+          }
         }
 
         const commonOptions = {

--- a/src/frontend/components/composer/components/ComposerMenu.tsx
+++ b/src/frontend/components/composer/components/ComposerMenu.tsx
@@ -64,15 +64,6 @@ export function ComposerMenu({ children }: PropsWithChildren) {
   }, [addAttachments, dismissField]);
   const openPhotoLibrary = useCallback(async () => {
     await dismissField();
-    // `false` means "don't ask for write access". Limited access needs no
-    // special handling here: the picker runs out of process and returns what
-    // was chosen in it, whether or not the app can see the rest of the library.
-    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
-
-    if (!permission.granted) {
-      return;
-    }
-
     const result = await ImagePicker.launchImageLibraryAsync({
       allowsMultipleSelection: true,
       mediaTypes: ['images'],

--- a/src/frontend/components/composer/components/__tests__/ComposerMenu.test.tsx
+++ b/src/frontend/components/composer/components/__tests__/ComposerMenu.test.tsx
@@ -22,7 +22,6 @@ const mockLaunchCamera = jest.fn();
 const mockLaunchImageLibrary = jest.fn();
 const mockPickDocument = jest.fn();
 const mockRequestCameraPermission = jest.fn();
-const mockRequestMediaLibraryPermission = jest.fn();
 const mockKeyboardDismiss = KeyboardController.dismiss as jest.MockedFunction<
   typeof KeyboardController.dismiss
 >;
@@ -55,8 +54,6 @@ jest.mock('expo-image-picker', () => ({
   launchCameraAsync: (...args: unknown[]) => mockLaunchCamera(...args),
   launchImageLibraryAsync: (...args: unknown[]) => mockLaunchImageLibrary(...args),
   requestCameraPermissionsAsync: (...args: unknown[]) => mockRequestCameraPermission(...args),
-  requestMediaLibraryPermissionsAsync: (...args: unknown[]) =>
-    mockRequestMediaLibraryPermission(...args),
 }));
 
 jest.mock('expo-document-picker', () => ({
@@ -81,7 +78,6 @@ describe('ComposerMenu', () => {
     mockComposerState = undefined;
     mockKeyboardDismiss.mockResolvedValue(undefined);
     mockRequestCameraPermission.mockResolvedValue({ granted: true });
-    mockRequestMediaLibraryPermission.mockResolvedValue({ granted: true });
     mockLaunchCamera.mockResolvedValue({ canceled: true });
     mockLaunchImageLibrary.mockResolvedValue({ canceled: true });
     mockPickDocument.mockResolvedValue({ canceled: true });
@@ -101,7 +97,6 @@ describe('ComposerMenu', () => {
 
     expect(mockKeyboardDismiss).toHaveBeenCalledTimes(1);
     expect(mockBlur).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaLibraryPermission).not.toHaveBeenCalled();
     expect(mockLaunchImageLibrary).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -110,7 +105,6 @@ describe('ComposerMenu', () => {
       await flushPromises();
     });
 
-    expect(mockRequestMediaLibraryPermission).toHaveBeenCalledWith(false);
     expect(mockLaunchImageLibrary).toHaveBeenCalledTimes(1);
     expect(mockComposerState?.attachments).toEqual([]);
     expect(mockFocus).not.toHaveBeenCalled();

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -4,7 +4,7 @@ import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type LayoutChangeEvent, useWindowDimensions, View } from 'react-native';
+import { type LayoutChangeEvent, Platform, useWindowDimensions, View } from 'react-native';
 import { runOnJS, useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
 
 import { usePreference } from '@/frontend/data/hooks';
@@ -222,7 +222,7 @@ export function MessageList({
             freeze={freeze}
             getItemType={getMessageRowType}
             keyExtractor={messageKeyExtractor}
-            keyboardDismissMode="interactive"
+            keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
             // 贴底时才让键盘抬起内容——在历史里翻看时点输入框，内容不该跟着动。
             // 别改成 persistent：它的收起分支确实不产生位移（那正是 patches/ 里给
             // whenAtEnd 补上的语义），但它的抬起分支恒抬、且收起时把抬起量保住，

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -1,6 +1,6 @@
 import type { LegendListRef } from '@legendapp/list/react-native';
 import type { ReactNode, Ref } from 'react';
-import type { LayoutChangeEvent } from 'react-native';
+import { Platform, type LayoutChangeEvent } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
@@ -30,6 +30,7 @@ type MockLegendListProps = {
   extraData?: unknown;
   freeze?: unknown;
   getItemType?: (item: MessageListItem) => string;
+  keyboardDismissMode?: string;
   keyboardLiftBehavior?: string;
   keyboardOffset?: number;
   maintainVisibleContentPosition?: unknown;
@@ -465,6 +466,21 @@ describe('MessageList anchoring and manual scrolling', () => {
       paddingBottom: 80,
       paddingTop: 12,
     });
+  });
+
+  test('uses a keyboard dismissal mode supported by Android', () => {
+    const originalPlatformOS = Platform.OS;
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'android' });
+
+    try {
+      act(() => {
+        renderer = create(<MessageList {...listProps([createMessage('user-1', 'user')])} />);
+      });
+
+      expect(mockLatestListProps?.keyboardDismissMode).toBe('on-drag');
+    } finally {
+      Object.defineProperty(Platform, 'OS', { configurable: true, value: originalPlatformOS });
+    }
   });
 
   test('never lets the reveal gate scroll away from a finger on the list', () => {

--- a/src/frontend/features/settings/ProviderScreen/providerForm/components/ProviderFormAvatar.tsx
+++ b/src/frontend/features/settings/ProviderScreen/providerForm/components/ProviderFormAvatar.tsx
@@ -43,11 +43,6 @@ export function ProviderFormAvatar({ children }: { children?: ReactNode }) {
   }, [setAvatarUri]);
 
   const selectAvatarFromPhotoLibrary = useCallback(async () => {
-    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync(false);
-    if (!permission.granted) {
-      return;
-    }
-
     const result = await ImagePicker.launchImageLibraryAsync({
       allowsEditing: true,
       aspect: [1, 1],


### PR DESCRIPTION
### What this PR does

Before this PR:

- Android native menus could release the wrapped React Native press target after opening, destructive actions lacked a reliable system error treatment, and disabled destructive actions could retain an enabled-looking color.
- Android hardware back always requested sheet dismissal instead of returning from a nested sheet page.
- The Android slider label and adjustment actions were attached to the wrong accessibility node, including no-op actions while disabled.
- Photo-library flows requested broad media permissions before opening the system picker.
- The message list used the iOS-only interactive keyboard dismissal mode on Android.

After this PR:

- Native menu gestures cancel and finish the React Native responder stream correctly, preserve normal child taps for long-press menus, and use state-aware destructive styling.
- Nested bottom-sheet pages handle Android hardware back through their back action.
- Android sliders expose their label and increment/decrement actions on the adjustable thumb, and disabled sliders expose no actions.
- Photo-library flows open the system picker without unnecessary permission prompts while camera flows retain camera permission handling.
- Android message lists use `on-drag` keyboard dismissal while iOS keeps `interactive`.

### Screenshots or videos

N/A for this draft. These changes affect system menus, hardware back, accessibility actions, system picker permissions, and keyboard gestures; no device capture was produced in this workspace.

### Why we need it and why it was done in this way

The shared product contracts stay unchanged while the smallest native or platform-value boundary handles behavior imposed by Android and iOS. The Android menu uses React Native's native-gesture notifications because sending `ACTION_CANCEL` only to the child view does not cancel the RootView responder stream.

The following tradeoffs were made:

- Tap-trigger menus claim the React Native gesture on `ACTION_DOWN` so RootView cancellation happens before release; long-press menus claim it only after the long press activates, preserving their child's normal tap.
- Disabled destructive menu rows keep the system disabled text treatment instead of forcing the error color span.

The following alternatives were considered:

- Recreating native menus or pickers in JavaScript was rejected because these surfaces should retain system presentation, permissions, gestures, and accessibility behavior.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm typecheck`: passed.
- `pnpm format:check`: passed.
- `pnpm lint`: blocked in the existing Expo ESLint baseline by nine unresolved `@cherrystudio/ai-core` imports in unmodified backend files; the preceding Oxlint stage completed without errors.
- Tests, Android builds, and device acceptance were not run under the workspace verification policy. The riskiest acceptance path is long-pressing a navigation row on Android and confirming that opening the menu does not navigate.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and is not applicable
- [x] Documentation: A user-guide update was considered and is not required for these platform bug fixes
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Improves Android menus, bottom-sheet back navigation, slider accessibility, photo picking, and keyboard dismissal behavior.
```
