### PR TITLE
feat(agent-data): activate SqliteAgentSessionStore in production

### DIFF
--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -87,13 +87,12 @@ clean cut. See [Branching](./agent-protocol.md#branching) for the rules.
 
 The Runtime contract, Fake Runtime, AI SDK Runtime, Protocol contract, Mobile Agent Host, and V1
 Router are implemented as an architecture slice. The Host consumes the message-centric
-`AgentSessionStore` port and owns the Turn projection. The durable `SqliteAgentSessionStore`,
-`agent`/`agent_session`/`agent_session_message` tables, and agent-table definition source are
-implemented as inactive foundation code. The `agent` table intentionally starts empty: this phase
-does not migrate or copy assistant data. Production composition deliberately continues to use the
-process-local store and assistant-backed definition source until Agent/Pi integration. See
-[Agent Persistence](./agent-persistence.md) for the schema, delete semantics, and remaining
-follow-ups, per the authority direction of
+`AgentSessionStore` port and owns the Turn projection. The durable `SqliteAgentSessionStore` is
+the production store binding over the `agent`/`agent_session`/`agent_session_message` tables. The
+`agent` table intentionally starts empty: no assistant data is migrated or copied. Production
+composition deliberately keeps the assistant-backed definition source until Agent business
+integration lands Agent CRUD. See [Agent Persistence](./agent-persistence.md) for the schema,
+delete semantics, and remaining follow-ups, per the authority direction of
 [#568](https://github.com/CherryHQ/cherry-studio-app/issues/568).
 
 No frontend currently consumes `Backend.agent`. This slice does not replace the current Topic,

--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -1,7 +1,7 @@
 # Agent Persistence
 
-Status: **implemented as inactive foundation code** (production activation and step 5 follow-ups
-remain). Version 1 is local-only.
+Status: **schema and durable store active in production** (`serviceRegistry` binds
+`SqliteAgentSessionStore`; step 5 follow-ups remain). Version 1 is local-only.
 
 This document defines the durable SQLite schema behind the Host-owned
 [`AgentSessionStore`](../../../src/backend/ai/agentHost/AgentSessionStore.ts) port and the rollout
@@ -18,8 +18,8 @@ record for mobile-originated Agent Sessions only.
   projection over the assistant message plus Host-held live state. The Agent Protocol itself does
   not change. Nothing consumes `Backend.agent` yet, so this reshape is contained in
   `src/backend/ai/agentHost` and its tests.
-- A `SqliteAgentSessionStore` adapter ready to replace `InMemoryAgentSessionStore` when Agent/Pi
-  business integration begins. Production composition deliberately remains in-memory for now.
+- A `SqliteAgentSessionStore` adapter that is the production `AgentSessionStore` binding;
+  `InMemoryAgentSessionStore` remains as the conformance-suite reference adapter.
 - An Agent-table-backed `AgentDefinitionSource` ready for later integration. The `agent` table
   intentionally starts empty; this phase does not migrate or copy assistant data, and the
   production Host deliberately remains assistant-backed for now.
@@ -210,9 +210,9 @@ storage boundary moves.
    lands first so the schema implements the settled port.
 2. **Schema + migration.** Add the three schema modules, run `pnpm db:generate`, register the SQL
    in `migrations.ts`, add the agent FTS statements to `customSql.ts`.
-3. **`SqliteAgentSessionStore`.** Implement against the port and pass the shared conformance suite.
-   Keep the production `serviceRegistry` binding on the in-memory adapter until Agent/Pi business
-   integration begins.
+3. **`SqliteAgentSessionStore`.** Implement against the port, pass the shared conformance suite,
+   and bind it as the production `AgentSessionStore` in `serviceRegistry` (done — the in-memory
+   adapter remains the conformance reference).
 4. **Agent rows.** Add an `agent`-table-backed `AgentDefinitionSource`, but leave `agent` empty in
    this foundation phase. Agent/Pi business integration owns the later Agent creation or import
    rules. Keep the production Host on the assistant-backed source until then; assistants remain

--- a/src/backend/core/application/serviceRegistry.ts
+++ b/src/backend/core/application/serviceRegistry.ts
@@ -1,5 +1,5 @@
-import { InMemoryAgentSessionStore } from '@/backend/ai/agentHost/InMemoryAgentSessionStore';
 import { MobileAgentHost } from '@/backend/ai/agentHost/MobileAgentHost';
+import { SqliteAgentSessionStore } from '@/backend/ai/agentHost/SqliteAgentSessionStore';
 import { AiService } from '@/backend/ai/AiService';
 import { McpRuntimeService } from '@/backend/ai/mcp';
 import { ChatRuntime } from '@/backend/ai/streamManager/ChatRuntime';
@@ -45,9 +45,7 @@ export const services = {
   McpRuntimeService,
   AiService,
   ChatRuntime,
-  // Keep Agent persistence inactive until the Agent/Pi business integration.
-  // The SQLite adapter and schema remain available as foundation code.
-  AgentSessionStore: InMemoryAgentSessionStore,
+  AgentSessionStore: SqliteAgentSessionStore,
   MobileAgentHost,
   JobHandlerRegistry,
   JobRuntime,


### PR DESCRIPTION
## Summary

Rollout step 3 follow-up from agent-persistence.md (#621): switch the production `AgentSessionStore` binding in `serviceRegistry` from `InMemoryAgentSessionStore` to `SqliteAgentSessionStore`. Agent Session reservations, finalization, and boot reconciliation now persist to the `agent_session`/`agent_session_message` tables.

- `InMemoryAgentSessionStore` remains as the conformance-suite reference adapter
- Docs (`agent-persistence.md` status/scope/rollout, agent `README.md` current-implementation) updated to match
- No behavior change for chat: nothing consumes `Backend.agent` in the UI yet

## Validation

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm docs:check-links`
- `pnpm test:app -- src/backend/ai/agentHost src/backend/core/application --runInBand` (4 suites, 62 tests — includes the store conformance suite running against both adapters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)