### PR TITLE
feat(agent-data): add session history API

### DIFF
--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -90,17 +90,18 @@ The Runtime contract, Fake Runtime, AI SDK Runtime, Protocol contract, Mobile Ag
 Router exist as an earlier architecture slice. The Host consumes the message-centric
 `AgentSessionStore` port and owns the Turn projection. The durable `SqliteAgentSessionStore` is
 the production store binding over the `agent`/`agent_session`/`agent_session_message` tables.
-Agent CRUD is exposed through the Data API, and the Host resolves definitions from the `agent`
-table. The table intentionally starts empty: no assistant data is migrated or copied. See
+Agent CRUD and static Session/transcript reads are exposed through the Data API, and the Host
+resolves definitions from the `agent` table. The table intentionally starts empty: no assistant
+data is migrated or copied. See
 [Agent Persistence](./agent-persistence.md) for the schema, delete semantics, and remaining
 follow-ups, per the authority direction of
 [#568](https://github.com/CherryHQ/cherry-studio-app/issues/568).
 
-No frontend currently consumes the Agent Data API or `Backend.agent`. This Agent CRUD slice does not
-replace the current Topic or Chat Runtime surfaces. The current Topic Chat path has a transitional Pi
-adapter selected by `EXPO_PUBLIC_CHAT_RUNTIME`; development defaults to Pi and other builds default
-to AI SDK. That adapter currently handles text/reasoning only and rejects tool-bearing requests.
-It is not the final Pi Agent Runtime described here.
+No frontend currently consumes the Agent Data API or `Backend.agent`. These additive data slices do
+not replace the current Topic or Chat Runtime surfaces. The current Topic Chat path has a
+transitional Pi adapter selected by `EXPO_PUBLIC_CHAT_RUNTIME`; development defaults to Pi and other
+builds default to AI SDK. That adapter currently handles text/reasoning only and rejects
+tool-bearing requests. It is not the final Pi Agent Runtime described here.
 
 The next integration replaces the Host's AI SDK Runtime registration and Router with a directly
 composed Pi Runtime, resolves neutral `RuntimeTool` snapshots for each turn, maps Pi tool events into

--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -1,7 +1,8 @@
 # Agent Persistence
 
-Status: **schema, durable store, and Agent CRUD active in production** (`serviceRegistry` binds
-`SqliteAgentSessionStore`; step 5 follow-ups remain). Version 1 is local-only.
+Status: **schema, durable store, Agent CRUD, and static Session reads active in production**
+(`serviceRegistry` binds `SqliteAgentSessionStore`; step 6 follow-ups remain). Version 1 is
+local-only.
 
 This document defines the durable SQLite schema behind the Host-owned
 [`AgentSessionStore`](../../../src/backend/ai/agentHost/AgentSessionStore.ts) port and the rollout
@@ -19,9 +20,10 @@ record for mobile-originated Agent Sessions only.
   not change.
 - A `SqliteAgentSessionStore` adapter that is the production `AgentSessionStore` binding;
   `InMemoryAgentSessionStore` remains as the conformance-suite reference adapter.
-- Agent CRUD through the Data API and an Agent-table-backed `AgentDefinitionSource` used by the
-  production Host. The `agent` table intentionally starts empty; no assistant data is migrated or
-  copied.
+- Agent CRUD plus cursor-paginated Session and transcript reads through the Data API, and an
+  Agent-table-backed `AgentDefinitionSource` used by the production Host. Session renames and
+  deletes delegate to the Host so an active turn is cancelled and drained before rows disappear.
+  The `agent` table intentionally starts empty; no assistant data is migrated or copied.
 
 Out of scope: Agent UI, formal Pi Agent Runtime activation, chat-table
 (`assistant`/`topic`/`message`) migration or removal, branching columns, background turns, tool
@@ -36,8 +38,8 @@ surfaces:
 
 - Session observation currently resolves the live Agent definition first. Soft-deleting an Agent
   or clearing its model can therefore make its existing Sessions unavailable through the public
-  Host API even though their rows remain durable. Historical Session reads need a path that does
-  not require an executable Agent definition.
+  Host API even though their rows remain durable. The Data API's static Session and transcript
+  reads remain available without resolving an executable Agent definition.
 - Agent inference settings are persisted by CRUD, but the production Host currently sends empty
   Runtime options. `temperature`, `maxOutputTokens`, and `reasoningEffort` are stored configuration,
   not effective execution settings, until the definition and Runtime-option mapping is connected.
@@ -233,7 +235,10 @@ storage boundary moves.
    `AgentDefinitionSource` in the production Host (done). The table starts empty and assistant data
    is not copied; assistants remain authoritative only for the current Chat surface until its
    replacement lands.
-5. **Follow-ups (separate designs).** Agent UI consuming `Backend.agent`; avatar workflow
+5. **Session reads.** Expose recency-ordered Session lists and cursor-paginated linear transcript
+   history through the Data API. Keep these historical reads independent of executable Agent
+   lookup, and route Session rename/delete through the Host lifecycle boundary (done).
+6. **Follow-ups (separate designs).** Agent UI consuming `Backend.agent`; avatar workflow
    (generalizing `userAvatarStorage`); formal Pi Runtime activation and tool configuration; fork
    columns; the eventual chat-table decision.
 

--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -101,8 +101,10 @@ with the Agent.
 
 **Delete semantics.** `agent` soft-deletes (`deletedAt`), so Sessions never orphan; hard cleanup of
 an Agent is refused while Sessions exist (`RESTRICT`). `agent_session` hard-deletes and cascades
-messages — matching the store port's `deleteSession` contract. Messages are never deleted
-individually in V1.
+messages — matching the store port's `deleteSession` contract. Before deleting rows, the Host
+installs a per-Session barrier, waits any already-admitted submission to install its turn state,
+then cancels and drains that turn. New submissions fail closed until deletion finishes. Messages
+are never deleted individually in V1.
 
 **Deferred tool configuration.** The current foundation schema has no tool configuration and must
 not be described as tool-capable persistence. The direction is settled: tool references and

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -122,6 +122,14 @@ function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+function createCompletionSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 @Injectable('MobileAgentHost')
 @ServicePhase(Phase.PostReady)
 @DependsOn(['AgentSessionStore'])
@@ -129,7 +137,8 @@ function cloneJson<T>(value: T): T {
 export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
   private readonly activeTurns = new Map<string, ActiveTurnState>();
-  private readonly admittingSessions = new Set<string>();
+  private readonly admittingSessions = new Map<string, Promise<void>>();
+  private readonly deletingSessions = new Set<string>();
   private readonly runningTurnsBySession = new Map<string, Promise<void>>();
   private readonly runtimeSessions = new Map<
     string,
@@ -221,24 +230,40 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
 
   async deleteSession(input: { sessionId: string }): Promise<void> {
     const parsed = AgentDeleteSessionInputSchema.parse(input);
-    const active = this.activeTurns.get(parsed.sessionId);
-    if (active) {
-      await this.cancelTurn({ sessionId: parsed.sessionId, turnId: active.turn.id });
+    const { sessionId } = parsed;
+    if (this.deletingSessions.has(sessionId)) {
+      fail('SESSION_BUSY', 'The session is already being deleted.');
     }
-    const runningTurn = this.runningTurnsBySession.get(parsed.sessionId);
-    if (runningTurn) {
-      await runningTurn;
+    // Install the barrier before the first await: submissions that begin after
+    // this point fail closed, while an already-admitted submission may finish
+    // installing its active/running state for us to cancel and drain below.
+    this.deletingSessions.add(sessionId);
+    try {
+      const admission = this.admittingSessions.get(sessionId);
+      if (admission) {
+        await admission;
+      }
+      const active = this.activeTurns.get(sessionId);
+      if (active) {
+        await this.cancelTurn({ sessionId, turnId: active.turn.id });
+      }
+      const runningTurn = this.runningTurnsBySession.get(sessionId);
+      if (runningTurn) {
+        await runningTurn;
+      }
+      const cached = this.runtimeSessions.get(sessionId);
+      if (cached) {
+        this.runtimeSessions.delete(sessionId);
+        await cached.session.close();
+      }
+      const deleted = await this.store.deleteSession(sessionId);
+      if (!deleted) {
+        fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
+      }
+      this.listeners.delete(sessionId);
+    } finally {
+      this.deletingSessions.delete(sessionId);
     }
-    const cached = this.runtimeSessions.get(parsed.sessionId);
-    if (cached) {
-      this.runtimeSessions.delete(parsed.sessionId);
-      await cached.session.close();
-    }
-    const deleted = await this.store.deleteSession(parsed.sessionId);
-    if (!deleted) {
-      fail('SESSION_NOT_FOUND', `Session does not exist: ${parsed.sessionId}`);
-    }
-    this.listeners.delete(parsed.sessionId);
   }
 
   async submitMessage(input: {
@@ -250,7 +275,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     this.assertIdle(sessionId);
     // Synchronous admission guard: a second submit that interleaves at any
     // await below still fails SESSION_BUSY (invariant 1).
-    this.admittingSessions.add(sessionId);
+    const admission = createCompletionSignal();
+    this.admittingSessions.set(sessionId, admission.promise);
     try {
       const session = await this.store.getSession(sessionId);
       if (!session) {
@@ -330,6 +356,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       };
     } finally {
       this.admittingSessions.delete(sessionId);
+      admission.resolve();
     }
   }
 
@@ -577,6 +604,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   // ── Helpers ──
 
   private assertIdle(sessionId: string): void {
+    if (this.deletingSessions.has(sessionId)) {
+      fail('SESSION_BUSY', 'The session is being deleted.');
+    }
     if (this.activeTurns.has(sessionId) || this.admittingSessions.has(sessionId)) {
       fail('SESSION_BUSY', 'The session already has an active turn.');
     }

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -130,6 +130,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
   private readonly activeTurns = new Map<string, ActiveTurnState>();
   private readonly admittingSessions = new Set<string>();
+  private readonly runningTurnsBySession = new Map<string, Promise<void>>();
   private readonly runtimeSessions = new Map<
     string,
     { runtimeId: string; session: AgentRuntimeSession }
@@ -183,6 +184,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     }
     this.runtimeSessions.clear();
     await Promise.allSettled([...this.runningTurns]);
+    this.runningTurnsBySession.clear();
     this.listeners.clear();
   }
 
@@ -222,6 +224,10 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     const active = this.activeTurns.get(parsed.sessionId);
     if (active) {
       await this.cancelTurn({ sessionId: parsed.sessionId, turnId: active.turn.id });
+    }
+    const runningTurn = this.runningTurnsBySession.get(parsed.sessionId);
+    if (runningTurn) {
+      await runningTurn;
     }
     const cached = this.runtimeSessions.get(parsed.sessionId);
     if (cached) {
@@ -309,7 +315,13 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         parsed.parts,
       );
       this.runningTurns.add(run);
-      void run.finally(() => this.runningTurns.delete(run));
+      this.runningTurnsBySession.set(sessionId, run);
+      void run.finally(() => {
+        this.runningTurns.delete(run);
+        if (this.runningTurnsBySession.get(sessionId) === run) {
+          this.runningTurnsBySession.delete(sessionId);
+        }
+      });
 
       return {
         turnId: reserved.turnId,

--- a/src/backend/ai/agentHost/SqliteAgentSessionStore.ts
+++ b/src/backend/ai/agentHost/SqliteAgentSessionStore.ts
@@ -9,16 +9,13 @@ import {
   ServicePhase,
 } from '@/backend/core/lifecycle';
 import type { DbService, Database } from '@/backend/data/db/DbService';
-import {
-  agentSessionMessageTable,
-  agentSessionTable,
-  type AgentSessionMessageRow,
-  type AgentSessionRow,
-} from '@/backend/data/db/schemas';
+import { agentSessionMessageTable, agentSessionTable } from '@/backend/data/db/schemas';
 import { createOrderedUuid } from '@/backend/data/db/schemas/_columnHelpers';
 import {
-  AgentMessageViewSchema,
-  AgentSessionViewSchema,
+  toAgentMessageView,
+  toAgentSessionView,
+} from '@/backend/data/services/utils/agentSessionRows';
+import {
   type AgentErrorView,
   type AgentMessagePart,
   type AgentMessageView,
@@ -32,44 +29,6 @@ import type {
 } from './AgentSessionStore';
 
 const UNSETTLED_MESSAGE_STATUSES = ['pending', 'streaming'] as const;
-
-function toIso(epochMillis: number): string {
-  return new Date(epochMillis).toISOString();
-}
-
-/**
- * Rows leave the store as validated protocol views (invariant 9): epoch millis
- * become ISO strings and `data` re-validates against the protocol schema, so a
- * drifted or hand-edited row fails loudly instead of leaking a bad shape.
- */
-function toSessionView(row: AgentSessionRow): AgentSessionView {
-  return AgentSessionViewSchema.parse({
-    id: row.id,
-    agentId: row.agentId,
-    executionTarget: row.executionTarget,
-    title: row.title,
-    titleIsManual: row.titleIsManual,
-    createdAt: toIso(row.createdAt),
-    updatedAt: toIso(row.updatedAt),
-  } satisfies AgentSessionView);
-}
-
-function toMessageView(row: AgentSessionMessageRow): AgentMessageView {
-  if (row.data.version !== 1) {
-    throw new Error(`Unknown agent message data version: ${String(row.data.version)}`);
-  }
-  return AgentMessageViewSchema.parse({
-    id: row.id,
-    sessionId: row.sessionId,
-    turnId: row.turnId,
-    role: row.role,
-    status: row.status,
-    parts: row.data.parts,
-    usage: row.usage ?? null,
-    createdAt: toIso(row.createdAt),
-    updatedAt: toIso(row.updatedAt),
-  });
-}
 
 /**
  * Durable SQLite adapter for {@link AgentSessionStore}
@@ -99,7 +58,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
           titleIsManual: input.title !== undefined,
         })
         .returning();
-      return toSessionView(row);
+      return toAgentSessionView(row);
     });
   }
 
@@ -110,7 +69,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       .from(agentSessionTable)
       .where(eq(agentSessionTable.id, sessionId))
       .limit(1);
-    return row ? toSessionView(row) : null;
+    return row ? toAgentSessionView(row) : null;
   }
 
   async renameSession(sessionId: string, title: string): Promise<AgentSessionView | null> {
@@ -121,7 +80,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
         .set({ title, titleIsManual: true })
         .where(eq(agentSessionTable.id, sessionId))
         .returning();
-      return row ? toSessionView(row) : null;
+      return row ? toAgentSessionView(row) : null;
     });
   }
 
@@ -173,8 +132,8 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
         .returning();
       return {
         turnId,
-        userMessage: toMessageView(userRow),
-        assistantMessage: toMessageView(assistantRow),
+        userMessage: toAgentMessageView(userRow),
+        assistantMessage: toAgentMessageView(assistantRow),
       };
     });
   }
@@ -186,7 +145,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       .from(agentSessionMessageTable)
       .where(eq(agentSessionMessageTable.sessionId, sessionId))
       .orderBy(agentSessionMessageTable.createdAt, agentSessionMessageTable.id);
-    return rows.map(toMessageView);
+    return rows.map(toAgentMessageView);
   }
 
   async finalizeAssistantMessage(input: FinalizeAssistantMessageInput): Promise<AgentMessageView> {
@@ -208,7 +167,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
         .update(agentSessionTable)
         .set({ lastActivityAt: Date.now() })
         .where(eq(agentSessionTable.id, row.sessionId));
-      return toMessageView(row);
+      return toAgentMessageView(row);
     });
   }
 

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -270,6 +270,48 @@ describe('MobileAgentHost', () => {
     expect(observation.snapshot.activeTurn).toBeNull();
   });
 
+  test('settles an active turn before deleting its Session rows', async () => {
+    let executionStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      executionStarted = resolve;
+    });
+    const fake = new FakeRuntime({
+      descriptor: {
+        id: 'ai-sdk',
+        name: 'Scripted Runtime',
+        capabilities: { reasoning: true, tools: true, approvals: true, attachments: false },
+      },
+    }).script(async (controller) => {
+      executionStarted?.();
+      await new Promise<void>((resolve) => {
+        controller.signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+    const registry = new AgentRuntimeRegistry().register(fake);
+    const host = new MobileAgentHost(store, {
+      agents,
+      router: createAgentRuntimeRouter(registry),
+    });
+    const finalize = jest.spyOn(store, 'finalizeAssistantMessage');
+    const remove = jest.spyOn(store, 'deleteSession');
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Delete this Session.' }],
+    });
+    await started;
+    await host.deleteSession({ sessionId: session.id });
+
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(finalize.mock.invocationCallOrder[0]).toBeLessThan(remove.mock.invocationCallOrder[0]);
+    await expect(store.getSession(session.id)).resolves.toBeNull();
+  });
+
   test('maps runtime approvals onto protocol approvals and correlates responses', async () => {
     const fake = new FakeRuntime({
       descriptor: {

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -61,6 +61,14 @@ function hostWithModel(model: MockLanguageModelV3): MobileAgentHost {
   return new MobileAgentHost(store, { agents, router: createAgentRuntimeRouter(registry) });
 }
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 async function waitFor(predicate: () => boolean, what: string): Promise<void> {
   const deadline = Date.now() + 5000;
   while (!predicate()) {
@@ -310,6 +318,124 @@ describe('MobileAgentHost', () => {
     expect(remove).toHaveBeenCalledTimes(1);
     expect(finalize.mock.invocationCallOrder[0]).toBeLessThan(remove.mock.invocationCallOrder[0]);
     await expect(store.getSession(session.id)).resolves.toBeNull();
+  });
+
+  test('waits for an admitted submission before deleting its Session rows', async () => {
+    const admissionStarted = createDeferred();
+    const releaseAdmission = createDeferred();
+    const sequence: string[] = [];
+    const fake = new FakeRuntime({
+      descriptor: {
+        id: 'ai-sdk',
+        name: 'Scripted Runtime',
+        capabilities: { reasoning: true, tools: true, approvals: true, attachments: false },
+      },
+    }).scriptEvents([{ type: 'completed' }]);
+    const registry = new AgentRuntimeRegistry().register(fake);
+    const host = new MobileAgentHost(store, {
+      agents,
+      router: createAgentRuntimeRouter(registry),
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const getSession = store.getSession.bind(store);
+    jest.spyOn(store, 'getSession').mockImplementationOnce(async (sessionId) => {
+      const result = await getSession(sessionId);
+      sequence.push('admission.started');
+      admissionStarted.resolve();
+      await releaseAdmission.promise;
+      sequence.push('admission.resumed');
+      return result;
+    });
+    const removeSession = store.deleteSession.bind(store);
+    jest.spyOn(store, 'deleteSession').mockImplementation(async (sessionId) => {
+      sequence.push('delete.rows');
+      return removeSession(sessionId);
+    });
+
+    const submission = host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Admit before deleting.' }],
+    });
+    await admissionStarted.promise;
+    const deletion = host.deleteSession({ sessionId: session.id });
+    const deletedDuringAdmission = sequence.includes('delete.rows');
+
+    releaseAdmission.resolve();
+    const [submissionResult, deletionResult] = await Promise.allSettled([submission, deletion]);
+
+    expect(deletedDuringAdmission).toBe(false);
+    expect(sequence).toEqual(['admission.started', 'admission.resumed', 'delete.rows']);
+    expect(submissionResult.status).toBe('fulfilled');
+    expect(deletionResult.status).toBe('fulfilled');
+  });
+
+  test('rejects a new submission after an old turn drains while deletion is pending', async () => {
+    const firstExecutionStarted = createDeferred();
+    const deleteRowsStarted = createDeferred();
+    const releaseDeleteRows = createDeferred();
+    let executionCount = 0;
+    const fake = new FakeRuntime({
+      descriptor: {
+        id: 'ai-sdk',
+        name: 'Scripted Runtime',
+        capabilities: { reasoning: true, tools: true, approvals: true, attachments: false },
+      },
+    })
+      .script(async (controller) => {
+        executionCount += 1;
+        firstExecutionStarted.resolve();
+        await new Promise<void>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      })
+      .script((controller) => {
+        executionCount += 1;
+        controller.emit({ type: 'completed' });
+      });
+    const registry = new AgentRuntimeRegistry().register(fake);
+    const host = new MobileAgentHost(store, {
+      agents,
+      router: createAgentRuntimeRouter(registry),
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const removeSession = store.deleteSession.bind(store);
+    jest.spyOn(store, 'deleteSession').mockImplementationOnce(async (sessionId) => {
+      deleteRowsStarted.resolve();
+      await releaseDeleteRows.promise;
+      return removeSession(sessionId);
+    });
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Start the old turn.' }],
+    });
+    await firstExecutionStarted.promise;
+    const deletion = host.deleteSession({ sessionId: session.id });
+    await deleteRowsStarted.promise;
+
+    const resubmission = await host
+      .submitMessage({
+        sessionId: session.id,
+        parts: [{ type: 'text', text: 'Must not start during deletion.' }],
+      })
+      .then(
+        () => ({ status: 'accepted' as const }),
+        (error: unknown) => ({ status: 'rejected' as const, error }),
+      );
+    releaseDeleteRows.resolve();
+    await deletion;
+
+    expect(resubmission).toMatchObject({
+      status: 'rejected',
+      error: { view: { code: 'SESSION_BUSY' } },
+    });
+    expect(executionCount).toBe(1);
   });
 
   test('maps runtime approvals onto protocol approvals and correlates responses', async () => {

--- a/src/backend/data/api/handlers/__tests__/agentSessionMessages.test.ts
+++ b/src/backend/data/api/handlers/__tests__/agentSessionMessages.test.ts
@@ -1,0 +1,24 @@
+import type { AgentSessionMessageService } from '@/backend/data/services/AgentSessionMessageService';
+
+import { createAgentSessionMessageHandlers } from '../agentSessionMessages';
+
+describe('agent session message handlers', () => {
+  test('parses pagination and delegates the parent session id', async () => {
+    const service = {
+      listByCursor: jest.fn(async () => ({ items: [] })),
+    };
+    const handlers = createAgentSessionMessageHandlers(
+      service as unknown as AgentSessionMessageService,
+    );
+
+    await handlers['/agent-sessions/:sessionId/messages'].GET({
+      params: { sessionId: 'session-1' },
+      query: { cursor: '100:message-1', limit: '25' as never },
+    });
+
+    expect(service.listByCursor).toHaveBeenCalledWith('session-1', {
+      cursor: '100:message-1',
+      limit: 25,
+    });
+  });
+});

--- a/src/backend/data/api/handlers/__tests__/agentSessions.test.ts
+++ b/src/backend/data/api/handlers/__tests__/agentSessions.test.ts
@@ -1,0 +1,75 @@
+import type { AgentSessionService } from '@/backend/data/services/AgentSessionService';
+import { AgentProtocolError } from '@/shared/contracts/agent';
+
+import { type AgentSessionMutations, createAgentSessionHandlers } from '../agentSessions';
+
+function createService() {
+  return {
+    getById: jest.fn(async () => ({ id: 'session-1' })),
+    listByCursor: jest.fn(async () => ({ items: [] })),
+  };
+}
+
+function createMutations() {
+  return {
+    deleteSession: jest.fn(async () => undefined),
+    renameSession: jest.fn(async () => ({})),
+  };
+}
+
+describe('agent session handlers', () => {
+  test('parses list pagination before delegation', async () => {
+    const service = createService();
+    const mutations = createMutations();
+    const handlers = createAgentSessionHandlers(
+      service as unknown as AgentSessionService,
+      mutations as unknown as AgentSessionMutations,
+    );
+
+    await handlers['/agent-sessions'].GET({ query: { agentId: 'agent-1', limit: '25' as never } });
+
+    expect(service.listByCursor).toHaveBeenCalledWith({ agentId: 'agent-1', limit: 25 });
+  });
+
+  test('routes rename and delete through the Host mutation boundary', async () => {
+    const service = createService();
+    const mutations = createMutations();
+    const handlers = createAgentSessionHandlers(
+      service as unknown as AgentSessionService,
+      mutations as unknown as AgentSessionMutations,
+    );
+
+    await handlers['/agent-sessions/:id'].PATCH({
+      body: { title: '  Renamed  ' },
+      params: { id: 'session-1' },
+    });
+    await handlers['/agent-sessions/:id'].DELETE({ params: { id: 'session-1' } });
+
+    expect(mutations.renameSession).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      title: 'Renamed',
+    });
+    expect(service.getById).toHaveBeenCalledWith('session-1');
+    expect(mutations.deleteSession).toHaveBeenCalledWith({ sessionId: 'session-1' });
+  });
+
+  test('maps a missing Host session to the Data API not-found contract', async () => {
+    const service = createService();
+    const mutations = createMutations();
+    mutations.deleteSession.mockRejectedValueOnce(
+      new AgentProtocolError({
+        code: 'SESSION_NOT_FOUND',
+        message: 'missing',
+        retryable: false,
+      }),
+    );
+    const handlers = createAgentSessionHandlers(
+      service as unknown as AgentSessionService,
+      mutations as unknown as AgentSessionMutations,
+    );
+
+    await expect(
+      handlers['/agent-sessions/:id'].DELETE({ params: { id: 'missing' } }),
+    ).rejects.toMatchObject({ details: { id: 'missing', resource: 'AgentSession' } });
+  });
+});

--- a/src/backend/data/api/handlers/agentSessionMessages.ts
+++ b/src/backend/data/api/handlers/agentSessionMessages.ts
@@ -1,0 +1,20 @@
+import type { AgentSessionMessageService } from '@/backend/data/services/AgentSessionMessageService';
+import {
+  type AgentSessionMessageSchemas,
+  ListAgentSessionMessagesQuerySchema,
+} from '@/shared/data/api/schemas/agentSessionMessages';
+import type { HandlersFor } from '@/shared/data/api/types';
+
+export function createAgentSessionMessageHandlers(
+  service: AgentSessionMessageService,
+): HandlersFor<AgentSessionMessageSchemas> {
+  return {
+    '/agent-sessions/:sessionId/messages': {
+      GET: async ({ params, query }) =>
+        service.listByCursor(
+          params.sessionId,
+          ListAgentSessionMessagesQuerySchema.parse(query ?? {}),
+        ),
+    },
+  };
+}

--- a/src/backend/data/api/handlers/agentSessions.ts
+++ b/src/backend/data/api/handlers/agentSessions.ts
@@ -1,0 +1,52 @@
+import type { AgentSessionService } from '@/backend/data/services/AgentSessionService';
+import { AgentProtocolError, type AgentSessionView } from '@/shared/contracts/agent';
+import { DataApiErrorFactory, toDataApiError } from '@/shared/data/api/errors';
+import {
+  type AgentSessionSchemas,
+  ListAgentSessionsQuerySchema,
+  UpdateAgentSessionSchema,
+} from '@/shared/data/api/schemas/agentSessions';
+import type { HandlersFor } from '@/shared/data/api/types';
+
+export type AgentSessionMutations = {
+  deleteSession(input: { sessionId: string }): Promise<void>;
+  renameSession(input: { sessionId: string; title: string }): Promise<AgentSessionView>;
+};
+
+async function runSessionMutation<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof AgentProtocolError && error.view.code === 'SESSION_NOT_FOUND') {
+      throw DataApiErrorFactory.notFound('AgentSession', sessionId);
+    }
+    throw toDataApiError(error, 'Agent Session mutation');
+  }
+}
+
+export function createAgentSessionHandlers(
+  service: AgentSessionService,
+  mutations: AgentSessionMutations,
+): HandlersFor<AgentSessionSchemas> {
+  return {
+    '/agent-sessions': {
+      GET: async ({ query }) =>
+        service.listByCursor(ListAgentSessionsQuerySchema.parse(query ?? {})),
+    },
+    '/agent-sessions/:id': {
+      DELETE: async ({ params }) => {
+        await runSessionMutation(params.id, () =>
+          mutations.deleteSession({ sessionId: params.id }),
+        );
+      },
+      GET: async ({ params }) => service.getById(params.id),
+      PATCH: async ({ body, params }) => {
+        const { title } = UpdateAgentSessionSchema.parse(body);
+        await runSessionMutation(params.id, () =>
+          mutations.renameSession({ sessionId: params.id, title }),
+        );
+        return service.getById(params.id);
+      },
+    },
+  };
+}

--- a/src/backend/data/api/handlers/apiHandlers.ts
+++ b/src/backend/data/api/handlers/apiHandlers.ts
@@ -1,6 +1,8 @@
 import type { ApiImplementation } from '@/shared/data/api/types';
 
 import type { AgentService } from '../../services/AgentService';
+import type { AgentSessionMessageService } from '../../services/AgentSessionMessageService';
+import type { AgentSessionService } from '../../services/AgentSessionService';
 import type { AiUsageRecordService } from '../../services/AiUsageRecordService';
 import type { AssistantService } from '../../services/AssistantService';
 import type { ContentSearchService } from '../../services/ContentSearchService';
@@ -13,6 +15,8 @@ import type { PaintingService } from '../../services/PaintingService';
 import type { ProviderService } from '../../services/ProviderService';
 import type { TopicService } from '../../services/TopicService';
 import { createAgentHandlers } from './agents';
+import { createAgentSessionMessageHandlers } from './agentSessionMessages';
+import { createAgentSessionHandlers, type AgentSessionMutations } from './agentSessions';
 import { createAiUsageRecordHandlers } from './aiUsageRecords';
 import { createAssistantHandlers } from './assistants';
 import { createFileHandlers } from './files';
@@ -27,6 +31,9 @@ import { createTopicHandlers } from './topics';
 
 export type DataApiDependencies = {
   agents: AgentService;
+  agentSessionMessages: AgentSessionMessageService;
+  agentSessionMutations: AgentSessionMutations;
+  agentSessions: AgentSessionService;
   aiUsageRecords: AiUsageRecordService;
   assistants: AssistantService;
   contentSearch: ContentSearchService;
@@ -45,6 +52,8 @@ export type DataApiDependencies = {
 export function createDataApiHandlers(dependencies: DataApiDependencies): ApiImplementation {
   return {
     ...createAgentHandlers(dependencies.agents),
+    ...createAgentSessionHandlers(dependencies.agentSessions, dependencies.agentSessionMutations),
+    ...createAgentSessionMessageHandlers(dependencies.agentSessionMessages),
     ...createAiUsageRecordHandlers(dependencies.aiUsageRecords),
     ...createAssistantHandlers(dependencies.assistants),
     ...createFileHandlers(dependencies.files),

--- a/src/backend/data/services/AgentSessionMessageService.ts
+++ b/src/backend/data/services/AgentSessionMessageService.ts
@@ -1,0 +1,66 @@
+import { and, eq } from 'drizzle-orm';
+
+import { application } from '@/backend/core/application/Application';
+import { agentSessionMessageTable, agentSessionTable } from '@/backend/data/db/schemas';
+import type { AgentMessageView } from '@/shared/contracts/agent';
+import { DataApiErrorFactory } from '@/shared/data/api/errors';
+import {
+  AGENT_SESSION_MESSAGES_DEFAULT_LIMIT,
+  type ListAgentSessionMessagesQueryParams,
+  ListAgentSessionMessagesQuerySchema,
+} from '@/shared/data/api/schemas/agentSessionMessages';
+import type { CursorPaginationResponse } from '@/shared/data/api/types';
+
+import { toAgentMessageView } from './utils/agentSessionRows';
+import { asNumericKey, decodeListCursor, encodeCursor, keysetOrdering } from './utils/keysetCursor';
+
+/** SQL-only paginated reads for the durable linear transcript. */
+export class AgentSessionMessageService {
+  private get db() {
+    return application.get('DbService').getDb();
+  }
+
+  async listByCursor(
+    sessionId: string,
+    params: ListAgentSessionMessagesQueryParams = {},
+  ): Promise<CursorPaginationResponse<AgentMessageView>> {
+    const query = ListAgentSessionMessagesQuerySchema.parse(params);
+    const [session] = await this.db
+      .select({ id: agentSessionTable.id })
+      .from(agentSessionTable)
+      .where(eq(agentSessionTable.id, sessionId))
+      .limit(1);
+    if (!session) {
+      throw DataApiErrorFactory.notFound('AgentSession', sessionId);
+    }
+
+    const limit = query.limit ?? AGENT_SESSION_MESSAGES_DEFAULT_LIMIT;
+    const cursor = decodeListCursor(query.cursor, asNumericKey, 'agent-session-messages');
+    const ordering = keysetOrdering(
+      agentSessionMessageTable.createdAt,
+      agentSessionMessageTable.id,
+      { major: 'desc', tie: 'desc' },
+    );
+    const rows = await this.db
+      .select()
+      .from(agentSessionMessageTable)
+      .where(
+        and(
+          eq(agentSessionMessageTable.sessionId, sessionId),
+          cursor ? ordering.where(cursor) : undefined,
+        ),
+      )
+      .orderBy(...ordering.orderBy)
+      .limit(limit + 1);
+
+    const pageRows = rows.slice(0, limit);
+    const items = pageRows.map(toAgentMessageView);
+    const tail = pageRows.at(-1);
+    return {
+      items,
+      ...(rows.length > limit && tail ? { nextCursor: encodeCursor(tail.createdAt, tail.id) } : {}),
+    };
+  }
+}
+
+export const agentSessionMessageService = new AgentSessionMessageService();

--- a/src/backend/data/services/AgentSessionService.ts
+++ b/src/backend/data/services/AgentSessionService.ts
@@ -1,0 +1,70 @@
+import { and, eq } from 'drizzle-orm';
+
+import { application } from '@/backend/core/application/Application';
+import { agentSessionTable } from '@/backend/data/db/schemas';
+import { DataApiErrorFactory } from '@/shared/data/api/errors';
+import {
+  type AgentSessionEntity,
+  type ListAgentSessionsQueryParams,
+  ListAgentSessionsQuerySchema,
+} from '@/shared/data/api/schemas/agentSessions';
+import type { CursorPaginationResponse } from '@/shared/data/api/types';
+
+import { toAgentSessionEntity } from './utils/agentSessionRows';
+import { asNumericKey, decodeListCursor, encodeCursor, keysetOrdering } from './utils/keysetCursor';
+
+const DEFAULT_LIMIT = 50;
+
+/** SQL-only static reads for Agent Sessions. Live turn state stays in MobileAgentHost. */
+export class AgentSessionService {
+  private get db() {
+    return application.get('DbService').getDb();
+  }
+
+  async getById(id: string): Promise<AgentSessionEntity> {
+    const [row] = await this.db
+      .select()
+      .from(agentSessionTable)
+      .where(eq(agentSessionTable.id, id))
+      .limit(1);
+    if (!row) {
+      throw DataApiErrorFactory.notFound('AgentSession', id);
+    }
+    return toAgentSessionEntity(row);
+  }
+
+  async listByCursor(
+    params: ListAgentSessionsQueryParams = {},
+  ): Promise<CursorPaginationResponse<AgentSessionEntity>> {
+    const query = ListAgentSessionsQuerySchema.parse(params);
+    const limit = query.limit ?? DEFAULT_LIMIT;
+    const cursor = decodeListCursor(query.cursor, asNumericKey, 'agent-sessions');
+    const ordering = keysetOrdering(agentSessionTable.lastActivityAt, agentSessionTable.id, {
+      major: 'desc',
+      tie: 'desc',
+    });
+    const rows = await this.db
+      .select()
+      .from(agentSessionTable)
+      .where(
+        and(
+          query.agentId ? eq(agentSessionTable.agentId, query.agentId) : undefined,
+          cursor ? ordering.where(cursor) : undefined,
+        ),
+      )
+      .orderBy(...ordering.orderBy)
+      .limit(limit + 1);
+
+    const pageRows = rows.slice(0, limit);
+    const items = pageRows.map(toAgentSessionEntity);
+    const tail = pageRows.at(-1);
+    return {
+      items,
+      ...(rows.length > limit && tail
+        ? { nextCursor: encodeCursor(tail.lastActivityAt, tail.id) }
+        : {}),
+    };
+  }
+}
+
+export const agentSessionService = new AgentSessionService();

--- a/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
@@ -1,0 +1,92 @@
+import { DatabaseSync } from 'node:sqlite';
+
+import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
+
+import { agentSessionMessageService } from '../AgentSessionMessageService';
+import { createTestDb, type TestDb } from './_testDb';
+
+describe('AgentSessionMessageService persistence', () => {
+  let sqlite: DatabaseSync;
+  let testDb: TestDb;
+
+  beforeEach(async () => {
+    sqlite = new DatabaseSync(':memory:');
+    testDb = createTestDb(sqlite);
+    await installTestHost({ DbService: testDb.dbService });
+    sqlite
+      .prepare(
+        `INSERT INTO agent (id, name, settings, order_key, created_at, updated_at)
+         VALUES ('agent-1', 'Agent', '{}', 'a0', 1, 1)`,
+      )
+      .run();
+    insertSession(sqlite, 'session-1');
+  });
+
+  afterEach(async () => {
+    await uninstallTestHost();
+    sqlite.close();
+  });
+
+  test('pages the linear transcript newest-first with a stable tie-breaker', async () => {
+    insertMessage(sqlite, { createdAt: 100, id: 'message-a', text: 'A' });
+    insertMessage(sqlite, { createdAt: 300, id: 'message-b', text: 'B' });
+    insertMessage(sqlite, { createdAt: 300, id: 'message-c', text: 'C' });
+
+    const first = await agentSessionMessageService.listByCursor('session-1', { limit: 2 });
+    expect(first.items.map((message) => message.id)).toEqual(['message-c', 'message-b']);
+    expect(first.items[0]).toMatchObject({
+      parts: [{ state: 'done', text: 'C', type: 'text' }],
+      sessionId: 'session-1',
+      status: 'success',
+    });
+
+    const second = await agentSessionMessageService.listByCursor('session-1', {
+      cursor: first.nextCursor,
+      limit: 2,
+    });
+    expect(second.items.map((message) => message.id)).toEqual(['message-a']);
+    expect(second.nextCursor).toBeUndefined();
+  });
+
+  test('distinguishes an empty transcript from an unknown session', async () => {
+    await expect(agentSessionMessageService.listByCursor('session-1')).resolves.toEqual({
+      items: [],
+    });
+    await expect(agentSessionMessageService.listByCursor('missing')).rejects.toMatchObject({
+      details: { id: 'missing', resource: 'AgentSession' },
+    });
+  });
+});
+
+function insertSession(database: DatabaseSync, id: string): void {
+  database
+    .prepare(
+      `INSERT INTO agent_session (
+        id, agent_id, title, title_is_manual, execution_target,
+        last_activity_at, created_at, updated_at
+      ) VALUES (?, 'agent-1', '', 0, '{"kind":"local"}', 1, 1, 1)`,
+    )
+    .run(id);
+}
+
+function insertMessage(
+  database: DatabaseSync,
+  values: { createdAt: number; id: string; text: string },
+): void {
+  database
+    .prepare(
+      `INSERT INTO agent_session_message (
+        id, session_id, turn_id, role, data, status, created_at, updated_at
+      ) VALUES (?, 'session-1', ?, 'assistant', ?, 'success', ?, ?)`,
+    )
+    .run(
+      values.id,
+      `turn-${values.id}`,
+      JSON.stringify({
+        version: 1,
+        parts: [{ id: `part-${values.id}`, type: 'text', text: values.text, state: 'done' }],
+      }),
+      values.createdAt,
+      values.createdAt,
+    );
+}

--- a/src/backend/data/services/__tests__/AgentSessionService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionService.integration.test.ts
@@ -1,0 +1,92 @@
+import { DatabaseSync } from 'node:sqlite';
+
+import { installTestHost, uninstallTestHost } from '@/backend/core/application/testHost';
+
+import { agentSessionService } from '../AgentSessionService';
+import { createTestDb, type TestDb } from './_testDb';
+
+describe('AgentSessionService persistence', () => {
+  let sqlite: DatabaseSync;
+  let testDb: TestDb;
+
+  beforeEach(async () => {
+    sqlite = new DatabaseSync(':memory:');
+    testDb = createTestDb(sqlite);
+    await installTestHost({ DbService: testDb.dbService });
+    insertAgent(sqlite, 'agent-1');
+    insertAgent(sqlite, 'agent-2');
+  });
+
+  afterEach(async () => {
+    await uninstallTestHost();
+    sqlite.close();
+  });
+
+  test('lists by recency with stable cursor pagination and an optional agent filter', async () => {
+    insertSession(sqlite, { agentId: 'agent-1', id: 'session-a', lastActivityAt: 100 });
+    insertSession(sqlite, { agentId: 'agent-1', id: 'session-b', lastActivityAt: 300 });
+    insertSession(sqlite, { agentId: 'agent-2', id: 'session-c', lastActivityAt: 300 });
+
+    const first = await agentSessionService.listByCursor({ limit: 2 });
+    expect(first.items.map((session) => session.id)).toEqual(['session-c', 'session-b']);
+    expect(first.nextCursor).toBeDefined();
+
+    const second = await agentSessionService.listByCursor({ cursor: first.nextCursor, limit: 2 });
+    expect(second.items.map((session) => session.id)).toEqual(['session-a']);
+    expect(second.nextCursor).toBeUndefined();
+
+    await expect(agentSessionService.listByCursor({ agentId: 'agent-1' })).resolves.toMatchObject({
+      items: [{ id: 'session-b' }, { id: 'session-a' }],
+    });
+  });
+
+  test('keeps historical sessions readable after their Agent is soft-deleted', async () => {
+    insertSession(sqlite, { agentId: 'agent-1', id: 'session-a', lastActivityAt: 100 });
+    sqlite.prepare('UPDATE agent SET deleted_at = 200 WHERE id = ?').run('agent-1');
+
+    await expect(agentSessionService.getById('session-a')).resolves.toMatchObject({
+      agentId: 'agent-1',
+      id: 'session-a',
+      lastActivityAt: '1970-01-01T00:00:00.100Z',
+    });
+    await expect(agentSessionService.listByCursor({ agentId: 'agent-1' })).resolves.toMatchObject({
+      items: [{ id: 'session-a' }],
+    });
+  });
+
+  test('rejects an unknown session', async () => {
+    await expect(agentSessionService.getById('missing')).rejects.toMatchObject({
+      details: { id: 'missing', resource: 'AgentSession' },
+    });
+  });
+});
+
+function insertAgent(database: DatabaseSync, id: string): void {
+  database
+    .prepare(
+      `INSERT INTO agent (id, name, settings, order_key, created_at, updated_at)
+       VALUES (?, ?, '{}', ?, 1, 1)`,
+    )
+    .run(id, id, id);
+}
+
+function insertSession(
+  database: DatabaseSync,
+  values: { agentId: string; id: string; lastActivityAt: number },
+): void {
+  database
+    .prepare(
+      `INSERT INTO agent_session (
+        id, agent_id, title, title_is_manual, execution_target,
+        last_activity_at, created_at, updated_at
+      ) VALUES (?, ?, ?, 0, '{"kind":"local"}', ?, ?, ?)`,
+    )
+    .run(
+      values.id,
+      values.agentId,
+      values.id,
+      values.lastActivityAt,
+      values.lastActivityAt,
+      values.lastActivityAt,
+    );
+}

--- a/src/backend/data/services/utils/agentSessionRows.ts
+++ b/src/backend/data/services/utils/agentSessionRows.ts
@@ -1,0 +1,49 @@
+import type { AgentSessionMessageRow, AgentSessionRow } from '@/backend/data/db/schemas';
+import {
+  AgentMessageViewSchema,
+  AgentSessionViewSchema,
+  type AgentMessageView,
+  type AgentSessionView,
+} from '@/shared/contracts/agent';
+import {
+  type AgentSessionEntity,
+  AgentSessionEntitySchema,
+} from '@/shared/data/api/schemas/agentSessions';
+
+import { timestampToISO } from './rowMappers';
+
+export function toAgentSessionView(row: AgentSessionRow): AgentSessionView {
+  return AgentSessionViewSchema.parse({
+    id: row.id,
+    agentId: row.agentId,
+    executionTarget: row.executionTarget,
+    title: row.title,
+    titleIsManual: row.titleIsManual,
+    createdAt: timestampToISO(row.createdAt),
+    updatedAt: timestampToISO(row.updatedAt),
+  });
+}
+
+export function toAgentSessionEntity(row: AgentSessionRow): AgentSessionEntity {
+  return AgentSessionEntitySchema.parse({
+    ...toAgentSessionView(row),
+    lastActivityAt: timestampToISO(row.lastActivityAt),
+  });
+}
+
+export function toAgentMessageView(row: AgentSessionMessageRow): AgentMessageView {
+  if (row.data.version !== 1) {
+    throw new Error(`Unknown agent message data version: ${String(row.data.version)}`);
+  }
+  return AgentMessageViewSchema.parse({
+    id: row.id,
+    sessionId: row.sessionId,
+    turnId: row.turnId,
+    role: row.role,
+    status: row.status,
+    parts: row.data.parts,
+    usage: row.usage ?? null,
+    createdAt: timestampToISO(row.createdAt),
+    updatedAt: timestampToISO(row.updatedAt),
+  });
+}

--- a/src/bootstrap/composition/createDataServices.ts
+++ b/src/bootstrap/composition/createDataServices.ts
@@ -1,6 +1,8 @@
 import type { CacheService } from '@/backend/data/CacheService';
 import type { PreferenceService } from '@/backend/data/PreferenceService';
 import { agentService } from '@/backend/data/services/AgentService';
+import { agentSessionMessageService } from '@/backend/data/services/AgentSessionMessageService';
+import { agentSessionService } from '@/backend/data/services/AgentSessionService';
 import { aiUsageRecordService } from '@/backend/data/services/AiUsageRecordService';
 import { assistantService } from '@/backend/data/services/AssistantService';
 import { contentSearchService } from '@/backend/data/services/ContentSearchService';
@@ -35,6 +37,8 @@ export function createDataServices({
     // `agent` names the MobileAgentHost in the merged services object; the
     // CRUD data service gets the suffixed key.
     agentData: agentService,
+    agentSession: agentSessionService,
+    agentSessionMessage: agentSessionMessageService,
     aiUsageRecord: aiUsageRecordService,
     assistant: assistantService,
     cache,

--- a/src/bootstrap/runtime/createAppBootstrapRuntime.ts
+++ b/src/bootstrap/runtime/createAppBootstrapRuntime.ts
@@ -79,6 +79,9 @@ export function createAppBootstrapRuntime(
   const dataApi = new DataApiService(
     createDataApiHandlers({
       agents: services.agentData,
+      agentSessionMessages: services.agentSessionMessage,
+      agentSessionMutations: services.agent,
+      agentSessions: services.agentSession,
       aiUsageRecords: services.aiUsageRecord,
       assistants: services.assistant,
       contentSearch: services.contentSearch,

--- a/src/shared/data/api/schemas/__tests__/agentSessions.test.ts
+++ b/src/shared/data/api/schemas/__tests__/agentSessions.test.ts
@@ -1,0 +1,21 @@
+import { ListAgentSessionMessagesQuerySchema } from '../agentSessionMessages';
+import { ListAgentSessionsQuerySchema, UpdateAgentSessionSchema } from '../agentSessions';
+
+describe('agent session api schemas', () => {
+  test('coerces cursor page limits and enforces their shared maximum', () => {
+    expect(ListAgentSessionsQuerySchema.parse({ limit: '25' })).toEqual({ limit: 25 });
+    expect(ListAgentSessionMessagesQuerySchema.parse({ limit: '50' })).toEqual({ limit: 50 });
+    expect(ListAgentSessionsQuerySchema.safeParse({ limit: 201 }).success).toBe(false);
+    expect(ListAgentSessionMessagesQuerySchema.safeParse({ limit: 201 }).success).toBe(false);
+  });
+
+  test('normalizes a manual title and rejects empty or unknown fields', () => {
+    expect(UpdateAgentSessionSchema.parse({ title: '  Renamed  ' })).toEqual({
+      title: 'Renamed',
+    });
+    expect(UpdateAgentSessionSchema.safeParse({ title: '   ' }).success).toBe(false);
+    expect(UpdateAgentSessionSchema.safeParse({ title: 'Chat', unknown: true }).success).toBe(
+      false,
+    );
+  });
+});

--- a/src/shared/data/api/schemas/agentSessionMessages.ts
+++ b/src/shared/data/api/schemas/agentSessionMessages.ts
@@ -1,0 +1,30 @@
+import * as z from 'zod';
+
+import type { AgentMessageView } from '@/shared/contracts/agent';
+import type { CursorPaginationResponse } from '@/shared/data/api/types';
+
+export const AGENT_SESSION_MESSAGES_DEFAULT_LIMIT = 50;
+export const AGENT_SESSION_MESSAGES_MAX_LIMIT = 200;
+
+/**
+ * Walks the linear transcript newest-first. Each nextCursor continues toward
+ * older messages using the stable (createdAt, id) boundary.
+ */
+export const ListAgentSessionMessagesQuerySchema = z.strictObject({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(AGENT_SESSION_MESSAGES_MAX_LIMIT).optional(),
+});
+export type ListAgentSessionMessagesQueryParams = z.input<
+  typeof ListAgentSessionMessagesQuerySchema
+>;
+export type ListAgentSessionMessagesQuery = z.output<typeof ListAgentSessionMessagesQuerySchema>;
+
+export type AgentSessionMessageSchemas = {
+  '/agent-sessions/:sessionId/messages': {
+    GET: {
+      params: { sessionId: string };
+      query?: ListAgentSessionMessagesQueryParams;
+      response: CursorPaginationResponse<AgentMessageView>;
+    };
+  };
+};

--- a/src/shared/data/api/schemas/agentSessions.ts
+++ b/src/shared/data/api/schemas/agentSessions.ts
@@ -1,0 +1,47 @@
+import * as z from 'zod';
+
+import { AgentSessionViewSchema } from '@/shared/contracts/agent';
+import type { CursorPaginationResponse } from '@/shared/data/api/types';
+
+export const AgentSessionEntitySchema = AgentSessionViewSchema.extend({
+  /** Last real conversation activity, used for recency ordering. */
+  lastActivityAt: z.iso.datetime(),
+});
+export type AgentSessionEntity = z.infer<typeof AgentSessionEntitySchema>;
+
+export const ListAgentSessionsQuerySchema = z.strictObject({
+  agentId: z.string().min(1).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(200).optional(),
+});
+export type ListAgentSessionsQueryParams = z.input<typeof ListAgentSessionsQuerySchema>;
+export type ListAgentSessionsQuery = z.output<typeof ListAgentSessionsQuerySchema>;
+
+export const UpdateAgentSessionSchema = z.strictObject({
+  title: z.string().trim().min(1).max(255),
+});
+export type UpdateAgentSessionDto = z.infer<typeof UpdateAgentSessionSchema>;
+
+export type AgentSessionSchemas = {
+  '/agent-sessions': {
+    GET: {
+      query?: ListAgentSessionsQueryParams;
+      response: CursorPaginationResponse<AgentSessionEntity>;
+    };
+  };
+  '/agent-sessions/:id': {
+    DELETE: {
+      params: { id: string };
+      response: undefined;
+    };
+    GET: {
+      params: { id: string };
+      response: AgentSessionEntity;
+    };
+    PATCH: {
+      body: UpdateAgentSessionDto;
+      params: { id: string };
+      response: AgentSessionEntity;
+    };
+  };
+};

--- a/src/shared/data/api/schemas/apiSchemas.ts
+++ b/src/shared/data/api/schemas/apiSchemas.ts
@@ -1,4 +1,6 @@
 import type { AgentSchemas } from './agents';
+import type { AgentSessionMessageSchemas } from './agentSessionMessages';
+import type { AgentSessionSchemas } from './agentSessions';
 import type { AiUsageRecordSchemas } from './aiUsageRecords';
 import type { AssistantSchemas } from './assistants';
 import type { FileSchemas } from './files';
@@ -12,6 +14,8 @@ import type { SearchSchemas } from './search';
 import type { TopicSchemas } from './topics';
 
 export type ApiSchemas = AgentSchemas &
+  AgentSessionMessageSchemas &
+  AgentSessionSchemas &
   AiUsageRecordSchemas &
   AssistantSchemas &
   FileSchemas &


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - This is the second PR in stack #631.
> - It targets `zhangjiadi225/agent-crud` (#627), which targets `v0.2`.

### What this PR does

Before this PR:

- The Agent Host exposed live Session observation, but the Data API had no static Session or transcript reads for the upcoming frontend migration.
- Deleting a Session cancelled an active turn without waiting for its final persistence work to settle.

After this PR:

- Adds recency-ordered, cursor-paginated `GET /agent-sessions`, plus Session detail, rename, and delete endpoints.
- Adds newest-first cursor pagination for the linear transcript at `GET /agent-sessions/:sessionId/messages`.
- Keeps historical Session reads independent of executable Agent lookup, so soft-deleted Agents do not hide durable history.
- Routes rename/delete mutations through the Agent Host. Session deletion installs a per-Session barrier, waits any existing admission, then cancels and drains its turn before deleting rows; new submissions fail closed while deletion is pending.
- Consolidates Agent Session and message row-to-contract mapping in one shared data utility.
- Documents the completed B3 persistence rollout slice.

### Screenshots or videos

N/A — this is a backend-only Data API and lifecycle change with no frontend consumer yet.

### Why we need it and why it was done in this way

The frontend migration needs static Session list/history queries while `observeSession` remains responsible for active turn state. SQL-only read services keep historical browsing separate from runtime availability, while Host-owned mutations preserve cancellation and cleanup invariants.

The following tradeoffs were made:

- Transcript pages are returned newest-first to support efficient history loading with the existing keyset cursor utility.
- Session mutation handlers use a narrow structural Host port instead of importing the AI implementation into the data layer.
- No Agent UI, avatar workflow, Pi Runtime activation, or legacy Chat table removal is included in this layer.

The following alternatives were considered:

- Mutating Session rows directly in the Data service was rejected because it could delete rows while a runtime turn was still finalizing.
- Resolving the Agent before historical reads was rejected because a soft-deleted Agent must not make its durable Sessions unreadable.

### Breaking changes

None. These endpoints and services are additive, and no frontend consumes them yet.

### Special notes for your reviewer

- Review this PR as the delta above #627.
- The deletion regressions assert that an in-flight admission settles before row deletion, assistant finalization precedes deletion, and a new submission cannot start after the old turn drains while deletion is pending.

### Verification

- `pnpm test:app -- src/backend/ai/agentHost/__tests__/AgentSessionStore.test.ts src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts src/backend/data/api/handlers/__tests__/agentSessionMessages.test.ts src/backend/data/api/handlers/__tests__/agentSessions.test.ts src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts src/backend/data/services/__tests__/AgentSessionService.integration.test.ts src/shared/data/api/schemas/__tests__/agentSessions.test.ts --runInBand` (7 suites, 34 tests)
- `pnpm lint` (passes with pre-existing warnings)
- `pnpm format:check`
- `pnpm typecheck`

### Checklist

- [x] Branch: This stacked PR ultimately targets `v0.2` through #627
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: Not applicable; this PR has no visible UI effect
- [x] Code: The change follows existing Data API, keyset pagination, and lifecycle patterns
- [x] Refactor: Duplicate Session/message row mapping was consolidated
- [x] Upgrade: The change is additive and does not alter migrations or existing data
- [x] Documentation: Internal Agent persistence documentation is updated; no user-guide change is required
- [x] Self-review: The final stacked diff and local gates were reviewed

### Release note

```release-note
NONE
```
