### PR TITLE
fix(chat-input): preserve iOS focus on unmatched keyboard hide

### DIFF
--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -3,7 +3,6 @@ import { duration, easing } from '@cherrystudio/ui/motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type LayoutChangeEvent, View } from 'react-native';
-import { KeyboardEvents } from 'react-native-keyboard-controller';
 import Animated, {
   Extrapolation,
   interpolate,
@@ -51,6 +50,7 @@ import { isUniqueModelId } from '@/shared/data/types/model';
 import { useChatTopicControls } from '../runtime';
 import { ChatInputEffortOverlay } from './components/ChatInputEffortOverlay';
 import { ChatInputMenuItems } from './components/ChatInputMenuItems';
+import { useBlurComposerOnVisibleKeyboardHide } from './hooks/useBlurComposerOnVisibleKeyboardHide';
 import { useChatInputReasoningEfforts } from './hooks/useChatInputReasoningEfforts';
 import { useChatInputReasoningEffortSelection } from './hooks/useChatInputReasoningEffortSelection';
 import { useChatInputWebSearchToggle } from './hooks/useChatInputWebSearchToggle';
@@ -124,6 +124,7 @@ export function ChatInput({ assistantId, dismissKeyboardOnSend, topicId }: ChatI
   const [isInputActive, setIsInputActive] = useState(false);
   const isInputActiveRef = useRef(false);
   const { inputRef } = useComposerMeta();
+  useBlurComposerOnVisibleKeyboardHide(inputRef);
   const focusProgress = useSharedValue(0);
   const fieldFrameHeight = useSharedValue(restingInputHeight);
   const naturalFieldHeight = useRef(restingInputHeight);
@@ -204,15 +205,6 @@ export function ChatInput({ assistantId, dismissKeyboardOnSend, topicId }: ChatI
   }, [fieldFrameHeight, focusProgress]);
   const openModelPicker = useCallback(() => setIsModelPickerOpen(true), []);
   const { updateAssistant } = useAssistantMutations();
-
-  useEffect(() => {
-    const subscription = KeyboardEvents.addListener('keyboardWillHide', () => {
-      handleInputBlur();
-      inputRef.current?.blur();
-    });
-
-    return () => subscription.remove();
-  }, [handleInputBlur, inputRef]);
 
   const persistWebSearch = useCallback(
     (targetAssistantId: string, enabled: boolean) =>

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -49,9 +49,10 @@ Two consequences to take seriously:
       shared 250ms settle curve releases the field's horizontal inset, moves the same control row to
       its toolbar position, fades in the model/reasoning controls, and grows the surface. It reverses
       on blur and lands immediately when the system requests reduced motion.
-- [ ] As soon as the software keyboard begins hiding, the field gives up focus and the composer
-      returns to its resting presentation alongside it; a focused editor is never left behind in the
-      expanded UI.
+- [ ] Once a software keyboard that was actually visible begins hiding, the field gives up focus and
+      the composer returns to its resting presentation alongside it. An unmatched hide event is
+      ignored: iOS can emit one while the rich editor is becoming first responder, and hardware-
+      keyboard focus must not be cancelled just because no software keyboard appeared.
 - [ ] Attachments remain visible above either state. Collapsing the controls must never hide staged
       content that will be sent.
 - [ ] The field is `EnrichedMarkdownTextInput`, not RN's `TextInput`, and it is **uncontrolled**: it

--- a/src/frontend/features/chat/input/hooks/__tests__/useBlurComposerOnVisibleKeyboardHide.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useBlurComposerOnVisibleKeyboardHide.test.tsx
@@ -1,0 +1,71 @@
+import { KeyboardController, KeyboardEvents } from 'react-native-keyboard-controller';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { useBlurComposerOnVisibleKeyboardHide } from '../useBlurComposerOnVisibleKeyboardHide';
+
+const mockBlur = jest.fn();
+const mockRemove = jest.fn();
+const mockIsKeyboardVisible = KeyboardController.isVisible as jest.MockedFunction<
+  typeof KeyboardController.isVisible
+>;
+const mockAddKeyboardListener = KeyboardEvents.addListener as jest.MockedFunction<
+  typeof KeyboardEvents.addListener
+>;
+let handleKeyboardWillHide: (() => void) | undefined;
+let renderer: ReactTestRenderer | undefined;
+
+describe('useBlurComposerOnVisibleKeyboardHide', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handleKeyboardWillHide = undefined;
+    mockAddKeyboardListener.mockImplementation((event, listener) => {
+      if (event === 'keyboardWillHide') {
+        handleKeyboardWillHide = () => listener(KeyboardController.state());
+      }
+
+      return { remove: mockRemove } as ReturnType<typeof KeyboardEvents.addListener>;
+    });
+
+    act(() => {
+      renderer = create(<Harness />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  test('ignores an unmatched hide event while iOS focus is being established', () => {
+    mockIsKeyboardVisible.mockReturnValue(false);
+
+    act(() => handleKeyboardWillHide?.());
+
+    expect(mockBlur).not.toHaveBeenCalled();
+  });
+
+  test('blurs when a visible keyboard begins hiding', () => {
+    mockIsKeyboardVisible.mockReturnValue(true);
+
+    act(() => handleKeyboardWillHide?.());
+
+    expect(mockBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test('removes the keyboard listener on unmount', () => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+});
+
+function Harness() {
+  const inputRef = { current: { blur: mockBlur } } as Parameters<
+    typeof useBlurComposerOnVisibleKeyboardHide
+  >[0];
+
+  useBlurComposerOnVisibleKeyboardHide(inputRef);
+
+  return null;
+}

--- a/src/frontend/features/chat/input/hooks/__tests__/useBlurComposerOnVisibleKeyboardHide.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useBlurComposerOnVisibleKeyboardHide.test.tsx
@@ -23,7 +23,7 @@ describe('useBlurComposerOnVisibleKeyboardHide', () => {
         handleKeyboardWillHide = () => listener(KeyboardController.state());
       }
 
-      return { remove: mockRemove } as ReturnType<typeof KeyboardEvents.addListener>;
+      return { remove: mockRemove } as unknown as ReturnType<typeof KeyboardEvents.addListener>;
     });
 
     act(() => {
@@ -61,7 +61,7 @@ describe('useBlurComposerOnVisibleKeyboardHide', () => {
 });
 
 function Harness() {
-  const inputRef = { current: { blur: mockBlur } } as Parameters<
+  const inputRef = { current: { blur: mockBlur } } as unknown as Parameters<
     typeof useBlurComposerOnVisibleKeyboardHide
   >[0];
 

--- a/src/frontend/features/chat/input/hooks/useBlurComposerOnVisibleKeyboardHide.ts
+++ b/src/frontend/features/chat/input/hooks/useBlurComposerOnVisibleKeyboardHide.ts
@@ -1,0 +1,27 @@
+import type { ComposerInputHandle } from '@cherrystudio/ui/components';
+import { type RefObject, useEffect } from 'react';
+import { KeyboardController, KeyboardEvents } from 'react-native-keyboard-controller';
+
+/**
+ * Gives up editor focus when a keyboard that was actually visible starts to
+ * hide. iOS can emit an unmatched hide event while the rich editor is becoming
+ * first responder; treating that as a dismissal immediately cancels focus.
+ *
+ * The native field remains the source of truth for focus. Its `onBlur` owns the
+ * composer's resting presentation, so this hook only requests the blur.
+ */
+export function useBlurComposerOnVisibleKeyboardHide(
+  inputRef: RefObject<ComposerInputHandle | null>,
+) {
+  useEffect(() => {
+    const subscription = KeyboardEvents.addListener('keyboardWillHide', () => {
+      if (!KeyboardController.isVisible()) {
+        return;
+      }
+
+      inputRef.current?.blur();
+    });
+
+    return () => subscription.remove();
+  }, [inputRef]);
+}


### PR DESCRIPTION
## Summary

- Ignore unmatched keyboard hide events while the iOS rich editor is establishing focus.
- Keep native editor focus as the source of truth while preserving blur-on-visible-keyboard-dismissal behavior.
- Document the focus contract and add hook-level regression coverage.

## Validation

- `pnpm exec oxfmt --no-error-on-unmatched-pattern ...`
- `pnpm exec oxlint ...`
- `pnpm exec expo lint ...`
- Jest and post-change simulator verification were not run per the workspace verification policy; manual verification was deferred at the requester’s direction.