### PR TITLE
feat(agent-hooks): add agent and agent-session data hooks and query keys

### DIFF
--- a/src/frontend/data/queryKeys/agentSessions.ts
+++ b/src/frontend/data/queryKeys/agentSessions.ts
@@ -1,0 +1,8 @@
+import type { ListAgentSessionsQueryParams } from '@/shared/data/api/schemas/agentSessions';
+
+export const agentSessionQueryKeys = {
+  all: () => ['/agent-sessions'] as const,
+  detail: (sessionId: string) => [`/agent-sessions/${sessionId}`] as const,
+  list: (params: ListAgentSessionsQueryParams = {}) => ['/agent-sessions', params] as const,
+  messages: (sessionId: string) => [`/agent-sessions/${sessionId}/messages`] as const,
+};

--- a/src/frontend/data/queryKeys/agents.ts
+++ b/src/frontend/data/queryKeys/agents.ts
@@ -1,0 +1,7 @@
+import type { ListAgentsQueryParams } from '@/shared/data/api/schemas/agents';
+
+export const agentQueryKeys = {
+  all: () => ['/agents'] as const,
+  detail: (agentId: string) => [`/agents/${agentId}`] as const,
+  list: (params: ListAgentsQueryParams = {}) => ['/agents', params] as const,
+};

--- a/src/frontend/data/queryKeys/index.ts
+++ b/src/frontend/data/queryKeys/index.ts
@@ -1,3 +1,5 @@
+import { agentQueryKeys } from './agents';
+import { agentSessionQueryKeys } from './agentSessions';
 import { aiUsageRecordQueryKeys } from './aiUsageRecords';
 import { assistantQueryKeys } from './assistants';
 import { fileQueryKeys } from './files';
@@ -10,6 +12,8 @@ import { providerQueryKeys } from './providers';
 import { topicQueryKeys } from './topics';
 
 export const queryKeys = {
+  agentSessions: agentSessionQueryKeys,
+  agents: agentQueryKeys,
   aiUsageRecords: aiUsageRecordQueryKeys,
   assistants: assistantQueryKeys,
   files: fileQueryKeys,

--- a/src/frontend/hooks/agent/__tests__/useAgentSessions.test.tsx
+++ b/src/frontend/hooks/agent/__tests__/useAgentSessions.test.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { DataApiProvider } from '@/frontend/data/DataApiProvider';
+import type { AgentSessionEntity } from '@/shared/data/api/schemas/agentSessions';
+import type { ApiClient, CursorPaginationResponse } from '@/shared/data/api/types';
+
+import { useAgentSessionMutations, useAgentSessions } from '../useAgentSessions';
+
+let actions: ReturnType<typeof useAgentSessionMutations> | undefined;
+let queryClient: QueryClient;
+let renderer: ReactTestRenderer | undefined;
+
+const sessions = [makeSession('a'), makeSession('b'), makeSession('c')];
+const deleteA = deferred<void>();
+const deleteB = deferred<void>();
+let persistedSessions = sessions;
+
+const dataApi = {
+  delete: jest.fn((path: string) => {
+    if (path.endsWith('/a')) return deleteA.promise;
+    if (path.endsWith('/b')) return deleteB.promise;
+    return Promise.resolve(undefined);
+  }),
+  get: jest.fn(async () => ({ items: persistedSessions })),
+  patch: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+} as unknown as ApiClient;
+
+function Probe() {
+  useAgentSessions();
+  const mutations = useAgentSessionMutations();
+
+  useEffect(() => {
+    actions = mutations;
+  }, [mutations]);
+
+  return null;
+}
+
+describe('useAgentSessionMutations', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    actions = undefined;
+    persistedSessions = sessions;
+    queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { gcTime: Infinity, retry: false } },
+    });
+    await act(async () => {
+      renderer = create(
+        <QueryClientProvider client={queryClient}>
+          <DataApiProvider dataApi={dataApi}>
+            <Probe />
+          </DataApiProvider>
+        </QueryClientProvider>,
+      );
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+    queryClient.clear();
+  });
+
+  it('removes a batch once and reconciles partial failure with the server', async () => {
+    let deletion: Promise<unknown> | undefined;
+    await act(async () => {
+      deletion = actions?.deleteAgentSessions(['a', 'b', 'a']);
+      await Promise.resolve();
+    });
+
+    expect(readSessionIds()).toEqual(['c']);
+
+    persistedSessions = [sessions[1], sessions[2]];
+    deleteA.resolve();
+    deleteB.reject(new Error('delete b failed'));
+
+    await act(async () => {
+      await expect(deletion).rejects.toThrow('delete b failed');
+    });
+
+    expect(readSessionIds()).toEqual(['b', 'c']);
+    expect(dataApi.delete).toHaveBeenCalledTimes(2);
+  });
+});
+
+function readSessionIds() {
+  const data = queryClient.getQueryData<InfiniteData<CursorPaginationResponse<AgentSessionEntity>>>(
+    ['/agent-sessions', { limit: 50 }],
+  );
+  return (data?.pages ?? []).flatMap((page) => page.items.map((session) => session.id));
+}
+
+function makeSession(id: string): AgentSessionEntity {
+  return { id, title: id.toUpperCase() } as AgentSessionEntity;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/frontend/hooks/agent/__tests__/useAgents.test.tsx
+++ b/src/frontend/hooks/agent/__tests__/useAgents.test.tsx
@@ -1,0 +1,112 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { DataApiProvider } from '@/frontend/data/DataApiProvider';
+import type { ApiClient } from '@/shared/data/api/types';
+import type { Agent } from '@/shared/data/types/agent';
+
+import { useAgentMutations, useAgentsApi } from '../useAgents';
+
+let actions: ReturnType<typeof useAgentMutations> | undefined;
+let queryClient: QueryClient;
+let renderer: ReactTestRenderer | undefined;
+
+const agents = [makeAgent('a'), makeAgent('b'), makeAgent('c')];
+const deleteA = deferred<void>();
+const deleteB = deferred<void>();
+let persistedAgents = agents;
+
+const dataApi = {
+  delete: jest.fn((path: string) => {
+    if (path.endsWith('/a')) return deleteA.promise;
+    if (path.endsWith('/b')) return deleteB.promise;
+    return Promise.resolve({ deleted: true });
+  }),
+  get: jest.fn(async () => ({
+    items: persistedAgents,
+    page: 1,
+    total: persistedAgents.length,
+  })),
+  patch: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+} as unknown as ApiClient;
+
+function Probe() {
+  useAgentsApi();
+  const mutations = useAgentMutations();
+
+  useEffect(() => {
+    actions = mutations;
+  }, [mutations]);
+
+  return null;
+}
+
+describe('useAgentMutations', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    actions = undefined;
+    persistedAgents = agents;
+    queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { gcTime: Infinity, retry: false } },
+    });
+    await act(async () => {
+      renderer = create(
+        <QueryClientProvider client={queryClient}>
+          <DataApiProvider dataApi={dataApi}>
+            <Probe />
+          </DataApiProvider>
+        </QueryClientProvider>,
+      );
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+    queryClient.clear();
+  });
+
+  it('removes a batch once and reconciles partial failure with the server', async () => {
+    let deletion: Promise<unknown> | undefined;
+    await act(async () => {
+      deletion = actions?.deleteAgents(['a', 'b', 'a']);
+      await Promise.resolve();
+    });
+
+    expect(readAgentIds()).toEqual(['c']);
+
+    persistedAgents = [agents[1], agents[2]];
+    deleteA.resolve();
+    deleteB.reject(new Error('delete b failed'));
+
+    await act(async () => {
+      await expect(deletion).rejects.toThrow('delete b failed');
+    });
+
+    expect(readAgentIds()).toEqual(['b', 'c']);
+    expect(dataApi.delete).toHaveBeenCalledTimes(2);
+  });
+});
+
+function readAgentIds() {
+  return (
+    queryClient.getQueryData<{ items: Agent[] }>(['/agents', { limit: 500 }])?.items ?? []
+  ).map((agent) => agent.id);
+}
+
+function makeAgent(id: string): Agent {
+  return { id, name: id.toUpperCase() } as Agent;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/frontend/hooks/agent/index.ts
+++ b/src/frontend/hooks/agent/index.ts
@@ -1,0 +1,8 @@
+export { useAgentApiById, useAgentMutations, useAgentsApi } from './useAgents';
+export {
+  type AgentSessionsOptions,
+  type AgentSessionsViewModel,
+  useAgentSession,
+  useAgentSessionMutations,
+  useAgentSessions,
+} from './useAgentSessions';

--- a/src/frontend/hooks/agent/useAgentSessions.ts
+++ b/src/frontend/hooks/agent/useAgentSessions.ts
@@ -1,0 +1,133 @@
+import type { InfiniteData } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+
+import { useInfiniteQuery, useMutation, useQuery } from '@/frontend/data';
+import {
+  dataApiCollectionFilters,
+  removeItemsFromInfiniteData,
+  restoreQuerySnapshot,
+  updateQueriesOptimistically,
+} from '@/frontend/data/utils/optimisticQueryUpdate';
+import type {
+  AgentSessionEntity,
+  UpdateAgentSessionDto,
+} from '@/shared/data/api/schemas/agentSessions';
+import type { CursorPaginationResponse } from '@/shared/data/api/types';
+
+export type AgentSessionsOptions = {
+  agentId?: string;
+};
+
+export type AgentSessionsViewModel = {
+  error?: Error;
+  isLoadingInitial: boolean;
+  loadMore: () => Promise<void>;
+  sessions: readonly AgentSessionEntity[];
+};
+
+type AgentSessionListData = InfiniteData<CursorPaginationResponse<AgentSessionEntity>>;
+
+const defaultPageSize = 50;
+
+export function useAgentSessions(options: AgentSessionsOptions = {}): AgentSessionsViewModel {
+  const query = useInfiniteQuery('/agent-sessions', {
+    limit: defaultPageSize,
+    query: { agentId: options.agentId },
+  });
+
+  const sessions = useMemo(() => query.pages.flatMap((page) => page.items), [query.pages]);
+
+  return {
+    error: query.error,
+    isLoadingInitial: query.isLoading,
+    loadMore: query.loadNext,
+    sessions,
+  };
+}
+
+export function useAgentSession(sessionId: string | undefined) {
+  return useQuery('/agent-sessions/:id', {
+    enabled: Boolean(sessionId),
+    params: { id: sessionId ?? '' },
+  });
+}
+
+export function useAgentSessionMutations() {
+  const queryClient = useQueryClient();
+  const updateMutation = useMutation('PATCH', '/agent-sessions/:id', {
+    refresh: ({ args }) => [
+      '/agent-sessions',
+      ...(args ? [`/agent-sessions/${args.params.id}`] : []),
+    ],
+  });
+  const deleteMutation = useMutation('DELETE', '/agent-sessions/:id');
+  const updateSessionRequest = updateMutation.trigger;
+  const deleteSessionRequest = deleteMutation.trigger;
+
+  const updateAgentSession = useCallback(
+    (id: string, patch: UpdateAgentSessionDto) => {
+      if (!id) {
+        throw new Error('updateAgentSession called with empty id');
+      }
+      return updateSessionRequest({ body: patch, params: { id } });
+    },
+    [updateSessionRequest],
+  );
+
+  const deleteAgentSessions = useCallback(
+    async (ids: readonly string[]) => {
+      const uniqueIds = [...new Set(ids)];
+      if (uniqueIds.length === 0) {
+        return;
+      }
+
+      const idSet = new Set(uniqueIds);
+      const snapshot = await updateQueriesOptimistically<AgentSessionListData>(
+        queryClient,
+        dataApiCollectionFilters('/agent-sessions'),
+        (current) => removeItemsFromInfiniteData(current, idSet),
+      );
+      const results = await Promise.allSettled(
+        uniqueIds.map((id) => deleteSessionRequest({ params: { id } })),
+      );
+      const firstFailure = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+
+      for (const [index, result] of results.entries()) {
+        if (result.status === 'fulfilled') {
+          const id = uniqueIds[index];
+          queryClient.removeQueries({ queryKey: [`/agent-sessions/${id}`] });
+          queryClient.removeQueries({ queryKey: [`/agent-sessions/${id}/messages`] });
+        }
+      }
+
+      if (firstFailure) {
+        restoreQuerySnapshot(queryClient, snapshot);
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ['/agent-sessions'] });
+
+      if (firstFailure) {
+        throw firstFailure.reason;
+      }
+    },
+    [deleteSessionRequest, queryClient],
+  );
+
+  const deleteAgentSession = useCallback(
+    (id: string) => deleteAgentSessions([id]),
+    [deleteAgentSessions],
+  );
+
+  return {
+    updateAgentSession,
+    deleteAgentSession,
+    deleteAgentSessions,
+    isUpdating: updateMutation.isLoading,
+    isDeleting: deleteMutation.isLoading,
+    updateMutation,
+    deleteMutation,
+  };
+}

--- a/src/frontend/hooks/agent/useAgents.ts
+++ b/src/frontend/hooks/agent/useAgents.ts
@@ -1,0 +1,143 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useMutation, useQuery } from '@/frontend/data';
+import {
+  dataApiCollectionFilters,
+  removeItemsFromCountedList,
+  restoreQuerySnapshot,
+  updateQueriesOptimistically,
+} from '@/frontend/data/utils/optimisticQueryUpdate';
+import type {
+  CreateAgentDto,
+  DeleteAgentResult,
+  UpdateAgentDto,
+} from '@/shared/data/api/schemas/agents';
+import { AGENTS_MAX_LIMIT } from '@/shared/data/api/schemas/agents';
+import type { OffsetPaginationResponse } from '@/shared/data/api/types';
+import type { Agent } from '@/shared/data/types/agent';
+
+const EMPTY_AGENTS: readonly Agent[] = Object.freeze([]);
+type AgentListData = OffsetPaginationResponse<Agent>;
+
+export function useAgentsApi() {
+  const query = useQuery('/agents', {
+    query: { limit: AGENTS_MAX_LIMIT },
+  });
+
+  return {
+    agents: query.data?.items ?? EMPTY_AGENTS,
+    total: query.data?.total ?? 0,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+    query,
+  };
+}
+
+export function useAgentApiById(id: string | undefined) {
+  const enabled = Boolean(id);
+  const query = useQuery('/agents/:id', {
+    enabled,
+    params: { id: id ?? '' },
+  });
+
+  return {
+    agent: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+    query,
+  };
+}
+
+export function useAgentMutations() {
+  const queryClient = useQueryClient();
+  const createMutation = useMutation('POST', '/agents', {
+    refresh: ['/agents'],
+  });
+  const updateMutation = useMutation('PATCH', '/agents/:id', {
+    refresh: ({ args }) => ['/agents', ...(args ? [`/agents/${args.params.id}`] : [])],
+  });
+  const deleteMutation = useMutation('DELETE', '/agents/:id');
+  const createAgentRequest = createMutation.trigger;
+  const updateAgentRequest = updateMutation.trigger;
+  const deleteAgentRequest = deleteMutation.trigger;
+
+  const createAgent = useCallback(
+    (dto: CreateAgentDto) => createAgentRequest({ body: dto }),
+    [createAgentRequest],
+  );
+
+  const updateAgent = useCallback(
+    (id: string, patch: UpdateAgentDto) => {
+      if (!id) {
+        throw new Error('updateAgent called with empty id');
+      }
+      return updateAgentRequest({ body: patch, params: { id } });
+    },
+    [updateAgentRequest],
+  );
+
+  const deleteAgents = useCallback(
+    async (ids: readonly string[]) => {
+      const uniqueIds = [...new Set(ids)];
+      if (uniqueIds.length === 0) {
+        return [];
+      }
+
+      const idSet = new Set(uniqueIds);
+      const snapshot = await updateQueriesOptimistically<AgentListData>(
+        queryClient,
+        dataApiCollectionFilters('/agents'),
+        (current) => removeItemsFromCountedList(current, idSet),
+      );
+      const results = await Promise.allSettled(
+        uniqueIds.map((id) => deleteAgentRequest({ params: { id } })),
+      );
+      const firstFailure = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+
+      for (const [index, result] of results.entries()) {
+        if (result.status === 'fulfilled') {
+          queryClient.removeQueries({ queryKey: [`/agents/${uniqueIds[index]}`] });
+        }
+      }
+
+      if (firstFailure) {
+        restoreQuerySnapshot(queryClient, snapshot);
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ['/agents'] });
+
+      if (firstFailure) {
+        throw firstFailure.reason;
+      }
+
+      return results.map((result) => (result as PromiseFulfilledResult<DeleteAgentResult>).value);
+    },
+    [deleteAgentRequest, queryClient],
+  );
+
+  const deleteAgent = useCallback(
+    async (id: string): Promise<DeleteAgentResult> => {
+      const [result] = await deleteAgents([id]);
+      return result;
+    },
+    [deleteAgents],
+  );
+
+  return {
+    createAgent,
+    updateAgent,
+    deleteAgent,
+    deleteAgents,
+    isCreating: createMutation.isLoading,
+    isUpdating: updateMutation.isLoading,
+    isDeleting: deleteMutation.isLoading,
+    createMutation,
+    updateMutation,
+    deleteMutation,
+  };
+}


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.
> - This PR is submitted through `gh stack` and must not be merged outside the stack workflow.

### What this PR does

Before this PR, no frontend code consumed the Agent Data API landed in #627/#630.

After this PR:

- `queryKeys.agents` and `queryKeys.agentSessions` join the frontend query-key registry.
- `useAgentsApi` / `useAgentApiById` / `useAgentMutations` wrap the offset-paginated `/agents`
  CRUD surface, including an optimistic batch delete that reconciles partial failure with the
  server.
- `useAgentSessions` / `useAgentSession` / `useAgentSessionMutations` wrap the cursor-paginated
  `/agent-sessions` surface with rename and an optimistic batch delete over infinite data that
  also drops per-session detail and message caches.

No UI consumes these hooks yet; the two stacked PRs above add the screens.

### Screenshots or videos

N/A — data plumbing only, no visible UI.

### Why we need it and why it was done in this way

The hooks mirror `useAssistant.ts` / `useTopics.ts` so the agent surfaces stay reviewable as a
mechanical transplant. Batch deletion lives in the hooks rather than a screen so both the list
screens and the shared selection toolbar reuse one optimistic implementation.

### Breaking changes

None.

### Special notes for your reviewer

The session batch delete issues per-id `DELETE`s because the API has no batch endpoint; the
backend cancels and drains an active turn per delete.

### Verification

- 2 new Jest suites (optimistic batch-delete reconciliation for both hooks) pass
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` pass on the stack head

### Checklist

- [x] Branch: This PR targets `v0.2` through stack #638
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: N/A; this PR has no visible UI effect
- [x] Code: Hooks mirror the existing assistant/topic data-hook patterns
- [x] Refactor: No existing behavior changed
- [x] Upgrade: No persisted schema or migration changes are introduced
- [x] Documentation: N/A; feature READMEs land with the screens above
- [x] Self-review: The final diff and focused behavior were reviewed locally

### Release note

```release-note
NONE
```
