### PR TITLE
feat(cherryui): export HeroUI Skeleton

### DIFF
--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -19,6 +19,7 @@ export * from './scroll-shadow';
 export * from './scroll-to-bottom-button';
 export * from './section';
 export * from './shimmer-text';
+export * from './skeleton';
 export * from './slider';
 export * from './switch';
 export * from './tabs';

--- a/packages/ui/src/components/skeleton/index.ts
+++ b/packages/ui/src/components/skeleton/index.ts
@@ -1,0 +1,6 @@
+export { Skeleton } from 'heroui-native/skeleton';
+export type {
+  SkeletonAnimation,
+  SkeletonAnimationContextValue,
+  SkeletonProps,
+} from 'heroui-native/skeleton';


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: CherryUI consumers could not import HeroUI's `Skeleton` through the package's public component entry point.

After this PR: `Skeleton` and its public types are available from `@cherrystudio/ui/components`.

### Screenshots or videos

N/A because this changes only the package export surface and has no visible effect.

### Why we need it and why it was done in this way

The direct re-export uses HeroUI's stable `heroui-native/skeleton` subpath and matches CherryUI's existing thin gateway modules.

The following tradeoffs were made: CherryUI intentionally preserves the upstream component API without adding product-specific behavior

The following alternatives were considered: wrapping the component, which would add an unnecessary abstraction

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

Local lint, format check, and typecheck passed

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
