### PR TITLE
feat(agent-chat): add live session client and transcript window

### DIFF
--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -1,0 +1,352 @@
+import type {
+  AgentApprovalView,
+  AgentEvent,
+  AgentInputPart,
+  AgentMessageDelta,
+  AgentMessageView,
+  AgentProtocol,
+  AgentSessionObservation,
+  AgentSessionSnapshot,
+  AgentSessionView,
+  AgentTurnView,
+} from '@/shared/contracts/agent';
+
+export type AgentSessionChatStatus = 'idle' | 'observing' | 'ready' | 'error';
+
+export type AgentSessionChatState = {
+  activeTurn: AgentTurnView | null;
+  enteringUserMessageId?: string;
+  error?: Error;
+  liveMessages: readonly AgentMessageView[];
+  pendingApprovals: readonly AgentApprovalView[];
+  sessionId: string;
+  snapshot?: AgentSessionSnapshot;
+  status: AgentSessionChatStatus;
+};
+
+type AgentSessionChatClientOptions = {
+  onSessionChanged?: (sessionId: string) => void;
+  onTranscriptChanged?: (sessionId: string) => void;
+};
+
+type SessionEntry = {
+  generation: number;
+  listeners: Set<() => void>;
+  liveMessages: Map<string, AgentMessageView>;
+  observation?: AgentSessionObservation;
+  observationPromise?: Promise<void>;
+  state: AgentSessionChatState;
+};
+
+const TERMINAL_TURN_STATUSES = new Set<AgentTurnView['status']>([
+  'completed',
+  'failed',
+  'cancelled',
+  'interrupted',
+]);
+
+function createSessionState(sessionId: string): AgentSessionChatState {
+  return {
+    activeTurn: null,
+    liveMessages: [],
+    pendingApprovals: [],
+    sessionId,
+    status: 'idle',
+  };
+}
+
+function applyMessageDelta(message: AgentMessageView, delta: AgentMessageDelta): AgentMessageView {
+  switch (delta.op) {
+    case 'part.add': {
+      const parts = [...message.parts];
+      parts.splice(Math.min(delta.index, parts.length), 0, delta.part);
+      return { ...message, parts };
+    }
+    case 'text.append': {
+      let changed = false;
+      const parts = message.parts.map((part) => {
+        if (part.id !== delta.partId || (part.type !== 'text' && part.type !== 'reasoning')) {
+          return part;
+        }
+
+        changed = true;
+        return { ...part, text: `${part.text}${delta.text}` };
+      });
+      return changed ? { ...message, parts } : message;
+    }
+    case 'part.replace': {
+      let changed = false;
+      const parts = message.parts.map((part) => {
+        if (part.id !== delta.part.id) {
+          return part;
+        }
+
+        changed = true;
+        return delta.part;
+      });
+      return changed ? { ...message, parts } : message;
+    }
+  }
+}
+
+export class AgentSessionChatClient {
+  private readonly sessions = new Map<string, SessionEntry>();
+
+  constructor(
+    private readonly protocol: AgentProtocol,
+    private readonly options: AgentSessionChatClientOptions = {},
+  ) {}
+
+  getState(sessionId: string): AgentSessionChatState {
+    return this.getEntry(sessionId).state;
+  }
+
+  subscribe(sessionId: string, listener: () => void): () => void {
+    const entry = this.getEntry(sessionId);
+    entry.listeners.add(listener);
+    void this.observe(sessionId).catch(() => undefined);
+
+    return () => {
+      entry.listeners.delete(listener);
+      if (entry.listeners.size === 0) {
+        this.stopObservation(entry);
+      }
+    };
+  }
+
+  async observe(sessionId: string, force = false): Promise<void> {
+    const entry = this.getEntry(sessionId);
+    if (entry.observationPromise) {
+      return entry.observationPromise;
+    }
+    if (entry.observation && !force) {
+      return;
+    }
+
+    this.stopObservation(entry);
+    const generation = entry.generation;
+    this.updateState(entry, {
+      ...entry.state,
+      error: undefined,
+      status: 'observing',
+    });
+
+    const queuedEvents: AgentEvent[] = [];
+    let isSnapshotInstalled = false;
+    const observationPromise = this.protocol
+      .observeSession(sessionId, (event) => {
+        if (entry.generation !== generation) {
+          return;
+        }
+        if (!isSnapshotInstalled) {
+          queuedEvents.push(event);
+          return;
+        }
+        this.applyEvent(entry, event);
+      })
+      .then((observation) => {
+        if (entry.generation !== generation) {
+          observation.unsubscribe();
+          return;
+        }
+
+        entry.observation = observation;
+        this.installSnapshot(entry, observation.snapshot);
+        isSnapshotInstalled = true;
+        for (const event of queuedEvents) {
+          this.applyEvent(entry, event);
+        }
+      })
+      .catch((error: unknown) => {
+        if (entry.generation !== generation) {
+          return;
+        }
+
+        const observationError = error instanceof Error ? error : new Error(String(error));
+        this.updateState(entry, {
+          ...createSessionState(sessionId),
+          error: observationError,
+          status: 'error',
+        });
+        throw observationError;
+      })
+      .finally(() => {
+        if (entry.observationPromise === observationPromise) {
+          entry.observationPromise = undefined;
+        }
+      });
+    entry.observationPromise = observationPromise;
+    return observationPromise;
+  }
+
+  async refresh(sessionId: string): Promise<void> {
+    await this.observe(sessionId, true);
+  }
+
+  async refreshObservedSessions(): Promise<void> {
+    await Promise.allSettled(
+      [...this.sessions.entries()]
+        .filter(([, entry]) => entry.listeners.size > 0)
+        .map(([sessionId]) => this.refresh(sessionId)),
+    );
+  }
+
+  createSession(agentId: string): Promise<AgentSessionView> {
+    return this.protocol.createSession({ agentId, executionTarget: { kind: 'local' } });
+  }
+
+  async submitMessage(sessionId: string, parts: AgentInputPart[]) {
+    await this.observe(sessionId);
+    return this.protocol.submitMessage({ parts, sessionId });
+  }
+
+  async cancelTurn(sessionId: string): Promise<void> {
+    const turn = this.getEntry(sessionId).state.activeTurn;
+    if (!turn || TERMINAL_TURN_STATUSES.has(turn.status)) {
+      return;
+    }
+
+    await this.protocol.cancelTurn({ sessionId, turnId: turn.id });
+  }
+
+  async respondApproval(
+    sessionId: string,
+    approvalId: string,
+    decision: 'approve' | 'deny',
+  ): Promise<void> {
+    const approval = this.getEntry(sessionId).state.pendingApprovals.find(
+      (candidate) => candidate.id === approvalId,
+    );
+    if (!approval) {
+      return;
+    }
+
+    await this.protocol.respondApproval({
+      approvalId,
+      decision,
+      sessionId,
+      turnId: approval.turnId,
+    });
+  }
+
+  dispose(): void {
+    for (const entry of this.sessions.values()) {
+      this.stopObservation(entry);
+      entry.listeners.clear();
+    }
+    this.sessions.clear();
+  }
+
+  private getEntry(sessionId: string): SessionEntry {
+    const existing = this.sessions.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    const entry: SessionEntry = {
+      generation: 0,
+      listeners: new Set(),
+      liveMessages: new Map(),
+      state: createSessionState(sessionId),
+    };
+    this.sessions.set(sessionId, entry);
+    return entry;
+  }
+
+  private stopObservation(entry: SessionEntry): void {
+    entry.generation += 1;
+    entry.observation?.unsubscribe();
+    entry.observation = undefined;
+    entry.observationPromise = undefined;
+  }
+
+  private installSnapshot(entry: SessionEntry, snapshot: AgentSessionSnapshot): void {
+    entry.liveMessages.clear();
+    if (snapshot.streamingMessage) {
+      entry.liveMessages.set(snapshot.streamingMessage.id, snapshot.streamingMessage);
+    }
+    this.updateState(entry, {
+      activeTurn: snapshot.activeTurn,
+      liveMessages: [...entry.liveMessages.values()],
+      pendingApprovals: snapshot.pendingApprovals,
+      sessionId: snapshot.session.id,
+      snapshot,
+      status: 'ready',
+    });
+  }
+
+  private applyEvent(entry: SessionEntry, event: AgentEvent): void {
+    switch (event.type) {
+      case 'turn.updated':
+        this.updateState(entry, {
+          ...entry.state,
+          activeTurn: event.turn,
+          pendingApprovals: TERMINAL_TURN_STATUSES.has(event.turn.status)
+            ? []
+            : entry.state.pendingApprovals,
+        });
+        if (TERMINAL_TURN_STATUSES.has(event.turn.status)) {
+          this.options.onSessionChanged?.(entry.state.sessionId);
+        }
+        return;
+      case 'message.created':
+        entry.liveMessages.set(event.message.id, event.message);
+        this.updateState(entry, {
+          ...entry.state,
+          ...(event.message.role === 'user' ? { enteringUserMessageId: event.message.id } : {}),
+          liveMessages: [...entry.liveMessages.values()],
+        });
+        this.options.onTranscriptChanged?.(entry.state.sessionId);
+        return;
+      case 'message.delta': {
+        const message = entry.liveMessages.get(event.messageId);
+        if (!message) {
+          return;
+        }
+        const nextMessage = applyMessageDelta(message, event.delta);
+        if (nextMessage === message) {
+          return;
+        }
+        entry.liveMessages.set(event.messageId, nextMessage);
+        this.updateState(entry, {
+          ...entry.state,
+          liveMessages: [...entry.liveMessages.values()],
+        });
+        return;
+      }
+      case 'message.finalized':
+        entry.liveMessages.set(event.message.id, event.message);
+        this.updateState(entry, {
+          ...entry.state,
+          liveMessages: [...entry.liveMessages.values()],
+        });
+        this.options.onTranscriptChanged?.(entry.state.sessionId);
+        return;
+      case 'approval.requested':
+        this.updateState(entry, {
+          ...entry.state,
+          pendingApprovals: [
+            ...entry.state.pendingApprovals.filter((approval) => approval.id !== event.approval.id),
+            event.approval,
+          ],
+        });
+        return;
+      case 'approval.resolved':
+        this.updateState(entry, {
+          ...entry.state,
+          pendingApprovals: entry.state.pendingApprovals.filter(
+            (approval) => approval.id !== event.approval.id,
+          ),
+        });
+    }
+  }
+
+  private updateState(entry: SessionEntry, state: AgentSessionChatState): void {
+    entry.state = state;
+    for (const listener of entry.listeners) {
+      listener();
+    }
+  }
+}
+
+export const __testing = { applyMessageDelta };

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -1,0 +1,151 @@
+import type {
+  AgentEvent,
+  AgentMessageView,
+  AgentProtocol,
+  AgentSessionObservation,
+  AgentSessionSnapshot,
+} from '@/shared/contracts/agent';
+
+import { AgentSessionChatClient } from '../AgentSessionChatClient';
+
+function deferred<TValue>() {
+  let resolve!: (value: TValue) => void;
+  const promise = new Promise<TValue>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function snapshot(): AgentSessionSnapshot {
+  return {
+    activeTurn: null,
+    agent: { id: 'agent-1', name: 'Agent' },
+    capabilities: { approvals: true, attachments: false, reasoning: true, tools: true },
+    pendingApprovals: [],
+    session: {
+      agentId: 'agent-1',
+      createdAt: '2026-08-25T00:00:00.000Z',
+      executionTarget: { kind: 'local' },
+      id: 'session-1',
+      title: '',
+      titleIsManual: false,
+      updatedAt: '2026-08-25T00:00:00.000Z',
+    },
+    streamingMessage: null,
+  };
+}
+
+function assistantMessage(): AgentMessageView {
+  return {
+    createdAt: '2026-08-25T00:00:00.000Z',
+    id: 'assistant-1',
+    parts: [{ id: 'text-1', state: 'streaming', text: '', type: 'text' }],
+    role: 'assistant',
+    sessionId: 'session-1',
+    status: 'streaming',
+    turnId: 'turn-1',
+    updatedAt: '2026-08-25T00:00:00.000Z',
+    usage: null,
+  };
+}
+
+function protocolWithObservation(
+  observeSession: AgentProtocol['observeSession'],
+): jest.Mocked<AgentProtocol> {
+  return {
+    cancelTurn: jest.fn(),
+    createSession: jest.fn(),
+    deleteSession: jest.fn(),
+    observeSession: jest.fn(observeSession),
+    renameSession: jest.fn(),
+    respondApproval: jest.fn(),
+    submitMessage: jest.fn(),
+  };
+}
+
+describe('AgentSessionChatClient', () => {
+  test('applies events emitted after subscription but before the snapshot promise resolves', async () => {
+    const observation = deferred<AgentSessionObservation>();
+    let listener: ((event: AgentEvent) => void) | undefined;
+    const protocol = protocolWithObservation(async (_sessionId, nextListener) => {
+      listener = nextListener;
+      return observation.promise;
+    });
+    const client = new AgentSessionChatClient(protocol);
+
+    const observing = client.observe('session-1');
+    listener?.({ type: 'message.created', message: assistantMessage() });
+    listener?.({
+      type: 'message.delta',
+      messageId: 'assistant-1',
+      delta: { op: 'text.append', partId: 'text-1', text: 'Hello' },
+    });
+    observation.resolve({ snapshot: snapshot(), unsubscribe: jest.fn() });
+    await observing;
+
+    expect(client.getState('session-1')).toMatchObject({
+      liveMessages: [
+        {
+          id: 'assistant-1',
+          parts: [{ id: 'text-1', state: 'streaming', text: 'Hello', type: 'text' }],
+        },
+      ],
+      status: 'ready',
+    });
+  });
+
+  test('cancels the active turn with the correlated session and turn ids', async () => {
+    let listener: ((event: AgentEvent) => void) | undefined;
+    const protocol = protocolWithObservation(async (_sessionId, nextListener) => {
+      listener = nextListener;
+      return { snapshot: snapshot(), unsubscribe: jest.fn() };
+    });
+    const client = new AgentSessionChatClient(protocol);
+    await client.observe('session-1');
+    listener?.({
+      type: 'turn.updated',
+      turn: {
+        assistantMessageId: 'assistant-1',
+        endedAt: null,
+        error: null,
+        id: 'turn-1',
+        sessionId: 'session-1',
+        startedAt: '2026-08-25T00:00:00.000Z',
+        status: 'running',
+      },
+    });
+
+    await client.cancelTurn('session-1');
+
+    expect(protocol.cancelTurn).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+    });
+  });
+
+  test('unsubscribes the Host observation when the final React subscriber leaves', async () => {
+    const unsubscribe = jest.fn();
+    const protocol = protocolWithObservation(async () => ({ snapshot: snapshot(), unsubscribe }));
+    const client = new AgentSessionChatClient(protocol);
+    const release = client.subscribe('session-1', jest.fn());
+    await client.observe('session-1');
+
+    release();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects an explicit observation after exposing its error state', async () => {
+    const protocol = protocolWithObservation(async () => {
+      throw new Error('observation failed');
+    });
+    const client = new AgentSessionChatClient(protocol);
+
+    await expect(client.observe('session-1')).rejects.toThrow('observation failed');
+
+    expect(client.getState('session-1')).toMatchObject({
+      error: new Error('observation failed'),
+      status: 'error',
+    });
+  });
+});

--- a/src/frontend/features/chat/runtime/__tests__/agentMessageProjection.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/agentMessageProjection.test.ts
@@ -1,0 +1,72 @@
+import type { AgentMessageView } from '@/shared/contracts/agent';
+
+import { mergeAgentMessageViews, toAgentMessageListItem } from '../agentMessageProjection';
+
+function message(id: string, overrides: Partial<AgentMessageView> = {}): AgentMessageView {
+  return {
+    createdAt: '2026-08-25T00:00:00.000Z',
+    id,
+    parts: [],
+    role: 'assistant',
+    sessionId: 'session-1',
+    status: 'streaming',
+    turnId: 'turn-1',
+    updatedAt: '2026-08-25T00:00:00.000Z',
+    usage: null,
+    ...overrides,
+  };
+}
+
+describe('agentMessageProjection', () => {
+  test('maps protocol parts and streaming state onto the shared message renderer shape', () => {
+    const item = toAgentMessageListItem(
+      message('assistant-1', {
+        parts: [
+          { id: 'reasoning-1', state: 'streaming', text: 'Thinking', type: 'reasoning' },
+          {
+            approvalId: 'approval-1',
+            id: 'tool-1',
+            input: { path: '/tmp/a' },
+            state: 'awaiting-approval',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            type: 'tool',
+          },
+        ],
+      }),
+    );
+
+    expect(item).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      status: 'pending',
+      data: {
+        parts: [
+          { state: 'streaming', text: 'Thinking', type: 'reasoning' },
+          {
+            approval: { id: 'approval-1' },
+            state: 'approval-requested',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            type: 'dynamic-tool',
+          },
+        ],
+      },
+    });
+  });
+
+  test('replaces persisted rows by id and appends only new live rows', () => {
+    const persistedUser = message('user-1', { role: 'user', status: 'success' });
+    const persistedAssistant = message('assistant-1', { status: 'pending' });
+    const finalizedAssistant = message('assistant-1', { status: 'success' });
+    const nextUser = message('user-2', { role: 'user', status: 'success' });
+
+    expect(
+      mergeAgentMessageViews([persistedUser, persistedAssistant], [finalizedAssistant, nextUser]),
+    ).toEqual([persistedUser, finalizedAssistant, nextUser]);
+  });
+
+  test('omits system messages from the chat row projection', () => {
+    expect(toAgentMessageListItem(message('system-1', { role: 'system' }))).toBeUndefined();
+  });
+});

--- a/src/frontend/features/chat/runtime/agentMessageProjection.ts
+++ b/src/frontend/features/chat/runtime/agentMessageProjection.ts
@@ -1,0 +1,131 @@
+import type { MessageListItem } from '@/frontend/components/messages';
+import type { AgentErrorView, AgentMessagePart, AgentMessageView } from '@/shared/contracts/agent';
+import type { CherryMessagePart, MessageStatus } from '@/shared/data/types/message';
+
+function toDisplayStatus(status: AgentMessageView['status']): MessageStatus {
+  switch (status) {
+    case 'pending':
+    case 'streaming':
+      return 'pending';
+    case 'error':
+      return 'error';
+    case 'cancelled':
+    case 'interrupted':
+      return 'paused';
+    case 'success':
+      return 'success';
+  }
+}
+
+function toErrorPart(error: AgentErrorView): CherryMessagePart {
+  return {
+    type: 'data-error',
+    data: {
+      code: error.code,
+      message: error.message,
+      name: error.code,
+    },
+  } as CherryMessagePart;
+}
+
+function toToolPart(part: Extract<AgentMessagePart, { type: 'tool' }>): CherryMessagePart {
+  const base = {
+    input: part.input,
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    type: 'dynamic-tool',
+  } as const;
+
+  switch (part.state) {
+    case 'input-available':
+    case 'running':
+      return { ...base, state: 'input-available' } as CherryMessagePart;
+    case 'awaiting-approval':
+      return part.approvalId
+        ? ({
+            ...base,
+            approval: { id: part.approvalId },
+            state: 'approval-requested',
+          } as CherryMessagePart)
+        : ({ ...base, state: 'input-available' } as CherryMessagePart);
+    case 'output-available':
+      return {
+        ...base,
+        output: part.output,
+        state: 'output-available',
+      } as CherryMessagePart;
+    case 'denied':
+      return {
+        ...base,
+        state: 'output-denied',
+      } as CherryMessagePart;
+    case 'error':
+      return {
+        ...base,
+        errorText: part.error?.message ?? 'Tool execution failed.',
+        state: 'output-error',
+      } as CherryMessagePart;
+  }
+}
+
+function toDisplayPart(part: AgentMessagePart): CherryMessagePart {
+  switch (part.type) {
+    case 'text':
+    case 'reasoning':
+      return { type: part.type, text: part.text, state: part.state } as CherryMessagePart;
+    case 'file':
+      return {
+        type: 'file',
+        filename: part.name ?? part.uri.split('/').at(-1) ?? 'File',
+        mediaType: part.mediaType,
+        url: part.uri,
+      } as CherryMessagePart;
+    case 'tool':
+      return toToolPart(part);
+    case 'error':
+      return toErrorPart(part.error);
+  }
+}
+
+export function toAgentMessageListItem(message: AgentMessageView): MessageListItem | undefined {
+  if (message.role !== 'user' && message.role !== 'assistant') {
+    return undefined;
+  }
+
+  return {
+    data: { parts: message.parts.map(toDisplayPart) },
+    id: message.id,
+    role: message.role,
+    status: toDisplayStatus(message.status),
+  };
+}
+
+export function mergeAgentMessageViews(
+  persisted: readonly AgentMessageView[],
+  live: readonly AgentMessageView[],
+): readonly AgentMessageView[] {
+  if (live.length === 0) {
+    return persisted;
+  }
+
+  const liveById = new Map(live.map((message) => [message.id, message]));
+  const merged = persisted.map((message) => liveById.get(message.id) ?? message);
+  const persistedIds = new Set(persisted.map((message) => message.id));
+
+  for (const message of live) {
+    if (!persistedIds.has(message.id)) {
+      merged.push(message);
+    }
+  }
+
+  return merged;
+}
+
+export function toAgentMessageListItems(
+  messages: readonly AgentMessageView[],
+): readonly MessageListItem[] {
+  return messages.flatMap((message) => {
+    const item = toAgentMessageListItem(message);
+    return item ? [item] : [];
+  });
+}

--- a/src/frontend/hooks/agent/__tests__/useAgentMessageHistoryWindow.test.ts
+++ b/src/frontend/hooks/agent/__tests__/useAgentMessageHistoryWindow.test.ts
@@ -1,0 +1,28 @@
+import type { AgentMessageView } from '@/shared/contracts/agent';
+
+import { __testing } from '../useAgentMessageHistoryWindow';
+
+function message(id: string): AgentMessageView {
+  return {
+    createdAt: '2026-08-25T00:00:00.000Z',
+    id,
+    parts: [],
+    role: 'assistant',
+    sessionId: 'session-1',
+    status: 'success',
+    turnId: 'turn-1',
+    updatedAt: '2026-08-25T00:00:00.000Z',
+    usage: null,
+  };
+}
+
+describe('Agent Session message history', () => {
+  test('reverses newest-first cursor pages into one chronological transcript', () => {
+    expect(
+      __testing.flattenMessagePages([
+        { items: [message('4'), message('3')], nextCursor: 'older' },
+        { items: [message('2'), message('1')] },
+      ]),
+    ).toEqual([message('1'), message('2'), message('3'), message('4')]);
+  });
+});

--- a/src/frontend/hooks/agent/index.ts
+++ b/src/frontend/hooks/agent/index.ts
@@ -6,3 +6,7 @@ export {
   useAgentSessionMutations,
   useAgentSessions,
 } from './useAgentSessions';
+export {
+  type AgentMessageHistoryWindow,
+  useAgentMessageHistoryWindow,
+} from './useAgentMessageHistoryWindow';

--- a/src/frontend/hooks/agent/useAgentMessageHistoryWindow.ts
+++ b/src/frontend/hooks/agent/useAgentMessageHistoryWindow.ts
@@ -1,0 +1,105 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { useInfiniteQuery } from '@/frontend/data';
+import { useMessageRenderWindow } from '@/frontend/hooks/chat/useMessageRenderWindow';
+import { getOlderLoadAction } from '@/frontend/hooks/chat/utils/messageHistoryWindowStrategy';
+import { messageWindowPolicy } from '@/frontend/hooks/chat/utils/messageWindowPolicy';
+import type { AgentMessageView } from '@/shared/contracts/agent';
+import type { CursorPaginationResponse } from '@/shared/data/api/types';
+
+export type AgentMessageHistoryWindow = {
+  error?: Error;
+  isLoadingInitial: boolean;
+  isLoadingOlder: boolean;
+  loadOlder: () => Promise<void>;
+  messages: readonly AgentMessageView[];
+};
+
+type OlderFetchOptions = {
+  showLoading: boolean;
+};
+
+function flattenMessagePages(
+  pages: readonly CursorPaginationResponse<AgentMessageView>[],
+): AgentMessageView[] {
+  const messages: AgentMessageView[] = [];
+
+  for (let pageIndex = pages.length - 1; pageIndex >= 0; pageIndex -= 1) {
+    const page = pages[pageIndex];
+    for (let itemIndex = page.items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      messages.push(page.items[itemIndex]);
+    }
+  }
+
+  return messages;
+}
+
+export function useAgentMessageHistoryWindow(
+  sessionId: string | undefined,
+): AgentMessageHistoryWindow {
+  const enabled = Boolean(sessionId);
+  const query = useInfiniteQuery('/agent-sessions/:sessionId/messages', {
+    enabled,
+    limit: messageWindowPolicy.initialFetchCount,
+    params: { sessionId: sessionId ?? '__missing_session__' },
+    staleTime: messageWindowPolicy.staleTimeMs,
+  });
+  const { error, hasNext, isLoading, isLoadingMore, loadNext, pages } = query;
+  const allMessages = useMemo(() => flattenMessagePages(pages), [pages]);
+  const { hasHiddenMessages, hiddenMessageCount, revealMore, visibleMessages } =
+    useMessageRenderWindow(allMessages);
+  const activeOlderFetchRef = useRef<Promise<void> | null>(null);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+
+  const fetchOlderIfNeeded = useCallback(
+    async (fetchOptions: OlderFetchOptions) => {
+      const activeFetch = activeOlderFetchRef.current;
+      if (activeFetch) {
+        if (fetchOptions.showLoading) {
+          setIsLoadingOlder(true);
+          await activeFetch.finally(() => setIsLoadingOlder(false));
+        }
+        return;
+      }
+
+      if (!hasNext || isLoadingMore) {
+        return;
+      }
+
+      const fetchPromise = loadNext();
+      activeOlderFetchRef.current = fetchPromise;
+      if (fetchOptions.showLoading) {
+        setIsLoadingOlder(true);
+      }
+
+      await fetchPromise.finally(() => {
+        if (activeOlderFetchRef.current === fetchPromise) {
+          activeOlderFetchRef.current = null;
+        }
+        if (fetchOptions.showLoading) {
+          setIsLoadingOlder(false);
+        }
+      });
+    },
+    [hasNext, isLoadingMore, loadNext],
+  );
+
+  const loadOlder = useCallback(async () => {
+    const action = getOlderLoadAction({ hasHiddenMessages, hiddenMessageCount });
+    if (action === 'reveal') {
+      revealMore();
+      return;
+    }
+    await fetchOlderIfNeeded({ showLoading: true });
+  }, [fetchOlderIfNeeded, hasHiddenMessages, hiddenMessageCount, revealMore]);
+
+  return {
+    error,
+    isLoadingInitial: isLoading,
+    isLoadingOlder,
+    loadOlder,
+    messages: visibleMessages,
+  };
+}
+
+export const __testing = { flattenMessagePages };

--- a/src/frontend/hooks/chat/useMessageRenderWindow.ts
+++ b/src/frontend/hooks/chat/useMessageRenderWindow.ts
@@ -1,8 +1,10 @@
 import { startTransition, useCallback, useMemo, useState } from 'react';
 
-import type { Message } from '@/shared/data/types/message';
-
 import { messageWindowPolicy } from './utils/messageWindowPolicy';
+
+type MessageWindowItem = {
+  id: string;
+};
 
 type MessageWindowSignature = {
   firstId: string | undefined;
@@ -15,7 +17,7 @@ type MessageRenderWindowState = {
   visibleCount: number;
 };
 
-function getMessageWindowSignature(messages: readonly Message[]): MessageWindowSignature {
+function getMessageWindowSignature(messages: readonly MessageWindowItem[]): MessageWindowSignature {
   return {
     firstId: messages[0]?.id,
     lastId: messages[messages.length - 1]?.id,
@@ -53,7 +55,9 @@ export function getVisibleCountForWindow(
   return Math.min(messageWindowPolicy.initialRenderCount, current.length);
 }
 
-export function useMessageRenderWindow(messages: readonly Message[]) {
+export function useMessageRenderWindow<TMessage extends MessageWindowItem>(
+  messages: readonly TMessage[],
+) {
   const signature = useMemo(() => getMessageWindowSignature(messages), [messages]);
   const [renderWindow, setRenderWindow] = useState<MessageRenderWindowState>(() => ({
     signature,


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - This is the first PR in a two-PR stack targeting `v0.2`.

### What this PR does

Before this PR:

- The frontend had no client for composing Agent Session snapshots and protocol events into live chat state.
- Agent Session transcript pagination was exposed by the Data API but had no chat-oriented chronological window.

After this PR:

- Adds a ref-counted `AgentSessionChatClient` that observes Sessions, installs atomic snapshots before queued events, applies normalized message deltas, and exposes cancellation and approval actions.
- Rejects explicit observation and submission flows when live observation cannot be established, while React subscriptions record the error without producing unhandled rejections.
- Adds Agent message-to-`MessageList` projection for text, reasoning, files, tools, approvals, errors, and terminal statuses.
- Adds a linear Agent transcript window that reverses newest-first cursor pages into chronological display order and reuses the existing bounded render window.
- Generalizes the render-window hook to stable `{ id: string }` items without changing existing Message callers.

### Screenshots or videos

N/A — this foundation PR has no production UI consumer until the next stack layer.

### Why we need it and why it was done in this way

Agent Session chat has two intentionally separate state sources: durable transcript pages from the Data API and ephemeral active-turn state from `AgentProtocol`. A small external-store client keeps token deltas out of React Query while stable message ids let the presentation layer replace persisted rows with newer live projections.

The following tradeoffs were made:

- The client observes only Sessions with React subscribers and refreshes them from snapshots after foreground transitions.
- Live finalized rows remain in the observation projection and are deduplicated against refreshed transcript rows by id.
- This layer does not switch the current chat UI or remove the legacy Chat runtime.

The following alternatives were considered:

- Writing every token delta into React Query was rejected because it would turn the static transcript cache into a streaming store.
- Fetching the complete transcript through the protocol snapshot was rejected because persisted pagination is already a normal resource read.

### Breaking changes

None. The new client, projection, and hook are additive in this layer.

### Special notes for your reviewer

- Review this PR as the foundation below `zhangjiadi225/agent-session-chat-ui`.
- The observation-race test covers events emitted after listener registration but before the snapshot Promise resolves.

### Verification

- `pnpm lint` (passes with pre-existing warnings)
- `pnpm format:check`
- `git diff --check`
- Tests, typecheck, build, and manual UI verification were not run under the current task's verification constraints.

### Checklist

- [x] Branch: This stacked PR ultimately targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: Not applicable; this PR has no visible effect
- [x] Code: The change follows the Agent Protocol and existing history-window patterns
- [x] Refactor: The generic render-window constraint removes duplicate Agent-specific window logic
- [x] Upgrade: No schema, migration, or persisted-data change is included
- [x] Documentation: The UI integration layer updates the as-built Agent chat references
- [x] Self-review: The final stacked diff and allowed local gates were reviewed

### Release note

```release-note
NONE
```
