### PR TITLE
feat(agent-session): migrate usage and background replies

### DIFF
--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -221,7 +221,12 @@ type RuntimeEvent =
   | { type: 'part.replace'; part: RuntimeOutputPart }
   | { type: 'approval.requested'; approval: RuntimeApproval }
   | { type: 'approval.resolved'; approval: RuntimeApproval }
-  | { type: 'usage'; usage: RuntimeUsage }
+  | {
+      type: 'usage'
+      usage: RuntimeUsage
+      context: RuntimeUsageContext
+      completedAt: number
+    }
   | { type: 'completed' }
   | { type: 'failed'; error: RuntimeError }
   | { type: 'cancelled' }
@@ -271,7 +276,13 @@ type RuntimeUsage = {
   inputTokens?: number
   outputTokens?: number
   totalTokens?: number
+  reasoningTokens?: number
+  noCacheTokens?: number
+  cacheReadTokens?: number
+  cacheWriteTokens?: number
 }
+
+type RuntimeUsageContext = Omit<AiUsageCaptureContext, 'source' | 'messageRef'>
 
 type RuntimeError = {
   code: string
@@ -284,8 +295,14 @@ Every execution emits exactly one terminal event: `completed`, `failed`, or `can
 may follow it. Runtime-native errors are normalized and must not expose credentials or stack traces.
 
 `usage` values are cumulative for the execution; the last report before the terminal event is
-authoritative. A Runtime that cannot report usage emits no `usage` event, and the assistant
-message's protocol `usage` stays `null`.
+authoritative. Detailed cache and reasoning counts remain available for pricing even though the
+Agent Protocol message projects only the input, output, and total counts. `context` is the immutable
+provider, served-model, pricing, and credential-attribution snapshot captured when the provider is
+resolved, before execution starts. `completedAt` is recorded at the Runtime provider boundary. The
+Host adds the Agent source and Session message reference without re-reading mutable provider/model
+configuration. It does not synthesize provider timing from the broader Host turn lifetime. A
+Runtime that cannot report usage emits no `usage` event, and the assistant message's protocol
+`usage` stays `null`.
 
 ## Host execution flow
 

--- a/src/backend/ai/agent/__tests__/FakeRuntime.test.ts
+++ b/src/backend/ai/agent/__tests__/FakeRuntime.test.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeExecutionRequest,
   RuntimeJsonValue,
   RuntimeTool,
+  RuntimeUsageContext,
 } from '../types';
 import {
   type ArrangedApprovalRequest,
@@ -18,6 +19,17 @@ import {
 } from './_runtimeConformance';
 
 const ERROR_SECRET = 'sk-live-super-secret-9f83b2';
+
+const USAGE_CONTEXT: RuntimeUsageContext = {
+  credentialReceipt: { attribution: 'unknown' },
+  modelId: 'fake-model',
+  modelName: 'Fake Model',
+  pricingSnapshot: null,
+  providerId: 'fake-provider',
+  providerName: 'Fake Provider',
+  reportedCostCurrency: null,
+  trustProviderReportedCost: false,
+};
 
 function baseRequest(
   turnId: string,
@@ -48,7 +60,12 @@ function successProgram(): FakeRuntimeProgram {
       type: 'part.replace',
       part: { id: 'text-0', type: 'text', text: 'Hi there', state: 'done' },
     });
-    controller.emit({ type: 'usage', usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 } });
+    controller.emit({
+      type: 'usage',
+      completedAt: 1_000,
+      context: USAGE_CONTEXT,
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+    });
     controller.emit({ type: 'completed' });
   };
 }

--- a/src/backend/ai/agent/index.ts
+++ b/src/backend/ai/agent/index.ts
@@ -16,6 +16,8 @@ export type {
   RuntimeOutputPart,
   RuntimeTool,
   RuntimeUsage,
+  RuntimeUsageContext,
+  RuntimeUsageReport,
 } from './types';
 
 export type {

--- a/src/backend/ai/agent/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/pi/PiRuntime.ts
@@ -25,6 +25,7 @@ import type {
   RuntimeOutputPart,
   RuntimeTool,
   RuntimeUsage,
+  RuntimeUsageContext,
 } from '../types';
 import { toPiConversation } from './modelMessages';
 
@@ -37,6 +38,7 @@ export type PiModelResolution = {
   model: PiModel<'openai-responses'>;
   supportsTools: boolean;
   timeoutMs: number;
+  usageContext: RuntimeUsageContext;
 };
 
 export interface PiRuntimeDependencies {
@@ -109,7 +111,7 @@ type ActiveTurn = {
   terminated: boolean;
   toolParts: Map<string, ToolPartBase>;
   turnId: string;
-  usage: Required<RuntimeUsage>;
+  usage: RuntimeUsage;
 };
 
 async function createDefaultAgent(options: AgentOptions): Promise<PiRuntimeAgent> {
@@ -173,10 +175,29 @@ function sensitiveValues(resolution: PiModelResolution): string[] {
 function toRuntimeUsage(usage: PiUsage): RuntimeUsage {
   const inputTokens = usage.input + usage.cacheRead + usage.cacheWrite;
   return {
+    cacheReadTokens: usage.cacheRead,
+    cacheWriteTokens: usage.cacheWrite,
     inputTokens,
+    noCacheTokens: usage.input,
     outputTokens: usage.output,
+    ...(usage.reasoning !== undefined ? { reasoningTokens: usage.reasoning } : {}),
     totalTokens: usage.totalTokens || inputTokens + usage.output,
   };
+}
+
+function mergeRuntimeUsage(current: RuntimeUsage, next: RuntimeUsage): RuntimeUsage {
+  const merged: RuntimeUsage = {
+    cacheReadTokens: (current.cacheReadTokens ?? 0) + (next.cacheReadTokens ?? 0),
+    cacheWriteTokens: (current.cacheWriteTokens ?? 0) + (next.cacheWriteTokens ?? 0),
+    inputTokens: (current.inputTokens ?? 0) + (next.inputTokens ?? 0),
+    noCacheTokens: (current.noCacheTokens ?? 0) + (next.noCacheTokens ?? 0),
+    outputTokens: (current.outputTokens ?? 0) + (next.outputTokens ?? 0),
+    totalTokens: (current.totalTokens ?? 0) + (next.totalTokens ?? 0),
+  };
+  if (current.reasoningTokens !== undefined || next.reasoningTokens !== undefined) {
+    merged.reasoningTokens = (current.reasoningTokens ?? 0) + (next.reasoningTokens ?? 0);
+  }
+  return merged;
 }
 
 function resolveThinkingLevel(
@@ -235,7 +256,14 @@ class PiRuntimeSession implements AgentRuntimeSession {
       terminated: false,
       toolParts: new Map(),
       turnId: request.turnId,
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      usage: {
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        inputTokens: 0,
+        noCacheTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      },
     };
     this.activeTurn = turn;
     void this.run(request, turn);
@@ -350,7 +378,12 @@ class PiRuntimeSession implements AgentRuntimeSession {
         return;
       }
 
-      this.emit(turn, { type: 'usage', usage: turn.usage });
+      this.emit(turn, {
+        type: 'usage',
+        completedAt: Date.now(),
+        context: resolution.usageContext,
+        usage: turn.usage,
+      });
       switch (terminal.stopReason) {
         case 'stop':
         case 'length':
@@ -409,10 +442,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       case 'turn_end':
         if (event.message.role === 'assistant') {
           turn.terminalMessage = event.message;
-          const usage = toRuntimeUsage(event.message.usage);
-          turn.usage.inputTokens += usage.inputTokens ?? 0;
-          turn.usage.outputTokens += usage.outputTokens ?? 0;
-          turn.usage.totalTokens += usage.totalTokens ?? 0;
+          turn.usage = mergeRuntimeUsage(turn.usage, toRuntimeUsage(event.message.usage));
         }
         this.settleUnmappedToolResults(turn, event.toolResults);
         break;

--- a/src/backend/ai/agent/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/pi/__tests__/PiRuntime.test.ts
@@ -6,6 +6,7 @@ import type {
   AssistantMessage,
   Message as PiMessage,
   ToolResultMessage,
+  Usage as PiUsage,
 } from '@earendil-works/pi-ai';
 
 import {
@@ -101,6 +102,20 @@ function createResolution(): PiModelResolution {
     },
     supportsTools: true,
     timeoutMs: 60_000,
+    usageContext: {
+      credentialReceipt: {
+        attribution: 'explicit',
+        id: 'credential-1',
+        masked: 'sk-…test',
+      },
+      modelId: 'mock-model',
+      modelName: 'Mock Model',
+      pricingSnapshot: null,
+      providerId: 'mock-provider',
+      providerName: 'Mock Provider',
+      reportedCostCurrency: null,
+      trustProviderReportedCost: false,
+    },
   };
 }
 
@@ -123,14 +138,21 @@ function arrange(runtime: AgentRuntime, program: TestAgentProgram): RuntimeHolde
   return holder;
 }
 
-function usage(input: number, output: number) {
+function usage(
+  input: number,
+  output: number,
+  details: { cacheRead?: number; cacheWrite?: number; reasoning?: number } = {},
+): PiUsage {
+  const cacheRead = details.cacheRead ?? 0;
+  const cacheWrite = details.cacheWrite ?? 0;
   return {
-    cacheRead: 0,
-    cacheWrite: 0,
+    cacheRead,
+    cacheWrite,
     cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0, total: 0 },
     input,
     output,
-    totalTokens: input + output,
+    ...(details.reasoning !== undefined ? { reasoning: details.reasoning } : {}),
+    totalTokens: input + cacheRead + cacheWrite + output,
   };
 }
 
@@ -378,7 +400,7 @@ describe('PiRuntime mapping', () => {
         message: assistantMessage({
           content: [],
           stopReason: 'toolUse',
-          usage: usage(2, 1),
+          usage: usage(2, 1, { cacheRead: 3, cacheWrite: 1, reasoning: 1 }),
         }),
         toolResults: [],
       });
@@ -423,7 +445,17 @@ describe('PiRuntime mapping', () => {
     ]);
     expect(events.at(-2)).toEqual({
       type: 'usage',
-      usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+      completedAt: expect.any(Number),
+      context: holder.resolution.usageContext,
+      usage: {
+        cacheReadTokens: 3,
+        cacheWriteTokens: 1,
+        inputTokens: 9,
+        noCacheTokens: 5,
+        outputTokens: 3,
+        reasoningTokens: 1,
+        totalTokens: 12,
+      },
     });
     expect(holder.lastOptions?.initialState).toMatchObject({
       messages: [

--- a/src/backend/ai/agent/types.ts
+++ b/src/backend/ai/agent/types.ts
@@ -15,6 +15,8 @@
  * fields without updating the spec first.
  */
 
+import type { AiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
+
 /** A JSON-safe value. Tool schemas, tool input/output, and history payloads use it. */
 export type RuntimeJsonValue =
   | null
@@ -155,6 +157,19 @@ export type RuntimeUsage = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  reasoningTokens?: number;
+  noCacheTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+};
+
+/** Provider-resolution snapshot captured before execution starts. */
+export type RuntimeUsageContext = Omit<AiUsageCaptureContext, 'source' | 'messageRef'>;
+
+export type RuntimeUsageReport = {
+  usage: RuntimeUsage;
+  context: RuntimeUsageContext;
+  completedAt: number;
 };
 
 export type RuntimeError = {
@@ -169,7 +184,7 @@ export type RuntimeEvent =
   | { type: 'part.replace'; part: RuntimeOutputPart }
   | { type: 'approval.requested'; approval: RuntimeApproval }
   | { type: 'approval.resolved'; approval: RuntimeApproval }
-  | { type: 'usage'; usage: RuntimeUsage }
+  | ({ type: 'usage' } & RuntimeUsageReport)
   | { type: 'completed' }
   | { type: 'failed'; error: RuntimeError }
   | { type: 'cancelled' };

--- a/src/backend/ai/agentHost/AgentSessionUsageRecorder.ts
+++ b/src/backend/ai/agentHost/AgentSessionUsageRecorder.ts
@@ -1,30 +1,21 @@
-import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
-
-import type { RuntimeUsage } from '@/backend/ai/agent';
+import type { RuntimeUsageReport } from '@/backend/ai/agent';
 import {
   aiUsageRecordService,
   type AiUsageRecordService,
 } from '@/backend/data/services/AiUsageRecordService';
-import { modelService, type ModelService } from '@/backend/data/services/ModelService';
-import { providerService, type ProviderService } from '@/backend/data/services/ProviderService';
 import { loggerService } from '@/shared/core/logger/LoggerService';
-import { createUniqueModelId } from '@/shared/data/types/model';
 
 import type { AgentDefinition } from './agentDefinitions';
 
 type UsageRecorderDependencies = {
-  model: Pick<ModelService, 'getById'>;
-  provider: Pick<ProviderService, 'getByProviderId'>;
   usage: Pick<AiUsageRecordService, 'recordInvocation'>;
 };
 
 type RecordAgentSessionUsageInput = {
   agent: AgentDefinition;
   assistantMessageId: string;
-  completedAt: number;
-  startedAt: number;
+  report: RuntimeUsageReport;
   turnId: string;
-  usage: RuntimeUsage;
 };
 
 const logger = loggerService.withContext('AgentSessionUsageRecorder');
@@ -35,8 +26,6 @@ export class AgentSessionUsageRecorder {
 
   constructor(
     private readonly dependencies: UsageRecorderDependencies = {
-      model: modelService,
-      provider: providerService,
       usage: aiUsageRecordService,
     },
   ) {}
@@ -56,33 +45,16 @@ export class AgentSessionUsageRecorder {
   }
 
   private async recordNow(input: RecordAgentSessionUsageInput): Promise<void> {
-    const uniqueModelId = createUniqueModelId(
-      input.agent.model.providerId,
-      input.agent.model.modelId,
-    );
-    const [model, provider] = await Promise.all([
-      this.dependencies.model.getById(uniqueModelId),
-      this.dependencies.provider.getByProviderId(input.agent.model.providerId),
-    ]);
-
     await this.dependencies.usage.recordInvocation({
-      completedAt: input.completedAt,
-      context: createAiUsageCaptureContext({
-        credentialReceipt: { attribution: 'unknown' },
+      completedAt: input.report.completedAt,
+      context: {
+        ...input.report.context,
         messageRef: { id: input.assistantMessageId, kind: 'agent-session' },
-        modelId: model?.apiModelId ?? input.agent.model.modelId,
-        modelName: model?.name ?? null,
-        pricing: model?.pricing,
-        providerId: provider.id,
-        providerName: provider.name,
-        reportedCostCurrency: provider.reportedCostCurrency,
         source: { icon: null, id: input.agent.id, name: input.agent.name, type: 'agent' },
-        trustProviderReportedCost: provider.apiFeatures.reportsActualCost,
-      }),
-      metrics: { timeCompletionMs: Math.max(0, input.completedAt - input.startedAt) },
+      },
       modality: 'language',
       requestId: `agent-session-turn:${input.turnId}`,
-      usage: input.usage,
+      usage: input.report.usage,
     });
   }
 }

--- a/src/backend/ai/agentHost/AgentSessionUsageRecorder.ts
+++ b/src/backend/ai/agentHost/AgentSessionUsageRecorder.ts
@@ -1,0 +1,88 @@
+import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
+
+import type { RuntimeUsage } from '@/backend/ai/agent';
+import {
+  aiUsageRecordService,
+  type AiUsageRecordService,
+} from '@/backend/data/services/AiUsageRecordService';
+import { modelService, type ModelService } from '@/backend/data/services/ModelService';
+import { providerService, type ProviderService } from '@/backend/data/services/ProviderService';
+import { loggerService } from '@/shared/core/logger/LoggerService';
+import { createUniqueModelId } from '@/shared/data/types/model';
+
+import type { AgentDefinition } from './agentDefinitions';
+
+type UsageRecorderDependencies = {
+  model: Pick<ModelService, 'getById'>;
+  provider: Pick<ProviderService, 'getByProviderId'>;
+  usage: Pick<AiUsageRecordService, 'recordInvocation'>;
+};
+
+type RecordAgentSessionUsageInput = {
+  agent: AgentDefinition;
+  assistantMessageId: string;
+  completedAt: number;
+  startedAt: number;
+  turnId: string;
+  usage: RuntimeUsage;
+};
+
+const logger = loggerService.withContext('AgentSessionUsageRecorder');
+
+/** Best-effort analytical projection for the single provider call in a V1 Agent turn. */
+export class AgentSessionUsageRecorder {
+  private readonly inFlight = new Set<Promise<void>>();
+
+  constructor(
+    private readonly dependencies: UsageRecorderDependencies = {
+      model: modelService,
+      provider: providerService,
+      usage: aiUsageRecordService,
+    },
+  ) {}
+
+  record(input: RecordAgentSessionUsageInput): void {
+    const operation = this.recordNow(input).catch((error: unknown) => {
+      logger.warn('Failed to record Agent Session usage', error as Error, {
+        turnId: input.turnId,
+      });
+    });
+    this.inFlight.add(operation);
+    void operation.finally(() => this.inFlight.delete(operation));
+  }
+
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.inFlight]);
+  }
+
+  private async recordNow(input: RecordAgentSessionUsageInput): Promise<void> {
+    const uniqueModelId = createUniqueModelId(
+      input.agent.model.providerId,
+      input.agent.model.modelId,
+    );
+    const [model, provider] = await Promise.all([
+      this.dependencies.model.getById(uniqueModelId),
+      this.dependencies.provider.getByProviderId(input.agent.model.providerId),
+    ]);
+
+    await this.dependencies.usage.recordInvocation({
+      completedAt: input.completedAt,
+      context: createAiUsageCaptureContext({
+        credentialReceipt: { attribution: 'unknown' },
+        messageRef: { id: input.assistantMessageId, kind: 'agent-session' },
+        modelId: model?.apiModelId ?? input.agent.model.modelId,
+        modelName: model?.name ?? null,
+        pricing: model?.pricing,
+        providerId: provider.id,
+        providerName: provider.name,
+        reportedCostCurrency: provider.reportedCostCurrency,
+        source: { icon: null, id: input.agent.id, name: input.agent.name, type: 'agent' },
+        trustProviderReportedCost: provider.apiFeatures.reportsActualCost,
+      }),
+      metrics: { timeCompletionMs: Math.max(0, input.completedAt - input.startedAt) },
+      modality: 'language',
+      requestId: `agent-session-turn:${input.turnId}`,
+      usage: input.usage,
+    });
+  }
+}

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -104,7 +104,6 @@ const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
   awaitApproval: () => {},
   finish: () => {},
   update: () => {},
-  updateConversationTitle: () => {},
 };
 
 type MobileAgentHostOverrides = {
@@ -248,7 +247,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     if (!session) {
       fail('SESSION_NOT_FOUND', `Session does not exist: ${parsed.sessionId}`);
     }
-    this.activeTurns.get(session.id)?.backgroundReply.updateConversationTitle(session.title);
+    this.updateBackgroundReplyTitle(session.id, session.title);
     this.publish(parsed.sessionId, { type: 'session.updated', session });
     return session;
   }
@@ -372,7 +371,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           sessionId,
           state.autoNameUserParts,
         );
-        this.publishSessionRename(state.autoNamePromise, state.backgroundReply);
+        this.publishSessionRename(state.autoNamePromise);
       }
 
       const run = this.runTurn(
@@ -666,7 +665,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         userParts: state.autoNameUserParts,
       });
       namingPromises.push(summaryNamePromise);
-      this.publishSessionRename(summaryNamePromise, state.backgroundReply);
+      this.publishSessionRename(summaryNamePromise);
     }
     state.backgroundReply.finish(
       outcome,
@@ -759,18 +758,21 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     }
   }
 
-  private publishSessionRename(
-    promise: Promise<AgentSessionView | null>,
-    originatingBackgroundReply?: BackgroundReplyTurn,
-  ): void {
+  private updateBackgroundReplyTitle(sessionId: string, title: string): void {
+    try {
+      this.backgroundReply.updateSessionTitle(sessionId, title);
+    } catch (error) {
+      logger.warn('Failed to update Agent Session background reply title', error as Error, {
+        sessionId,
+      });
+    }
+  }
+
+  private publishSessionRename(promise: Promise<AgentSessionView | null>): void {
     void promise
       .then((session) => {
         if (session) {
-          const activeBackgroundReply = this.activeTurns.get(session.id)?.backgroundReply;
-          activeBackgroundReply?.updateConversationTitle(session.title);
-          if (originatingBackgroundReply !== activeBackgroundReply) {
-            originatingBackgroundReply?.updateConversationTitle(session.title);
-          }
+          this.updateBackgroundReplyTitle(session.id, session.title);
           this.publish(session.id, { type: 'session.updated', session });
         }
       })

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -125,6 +125,7 @@ type ActiveTurnState = {
   agent: AgentDefinition;
   turn: AgentTurnView;
   assistantMessage: AgentMessageView;
+  autoNamePromise: Promise<AgentSessionView | null> | null;
   autoNameUserParts: AgentInputPart[] | null;
   backgroundReply: BackgroundReplyTurn;
   pendingApprovals: Map<string, AgentApprovalView>;
@@ -349,6 +350,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         agent,
         turn,
         assistantMessage: reserved.assistantMessage,
+        autoNamePromise: null,
         autoNameUserParts: priorMessages.length === 0 ? parsed.parts : null,
         backgroundReply: this.startBackgroundReply({
           agentId: agent.id,
@@ -366,9 +368,11 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       this.publish(sessionId, { type: 'message.created', message: reserved.assistantMessage });
       this.publish(sessionId, { type: 'turn.updated', turn });
       if (state.autoNameUserParts) {
-        this.publishSessionRename(
-          this.naming.maybeRenameFromFirstUserMessage(sessionId, state.autoNameUserParts),
+        state.autoNamePromise = this.naming.maybeRenameFromFirstUserMessage(
+          sessionId,
+          state.autoNameUserParts,
         );
+        this.publishSessionRename(state.autoNamePromise, state.backgroundReply);
       }
 
       const run = this.runTurn(
@@ -644,7 +648,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     if (this.activeTurns.get(sessionId) === state) {
       this.activeTurns.delete(sessionId);
     }
-    state.backgroundReply.finish(outcome);
     if (state.usage) {
       this.usage.record({
         agent: state.agent,
@@ -655,15 +658,20 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     }
     this.publish(sessionId, { type: 'message.finalized', message: finalized });
     this.publish(sessionId, { type: 'turn.updated', turn });
+    const namingPromises = state.autoNamePromise ? [state.autoNamePromise] : [];
     if (outcome === 'completed' && state.autoNameUserParts) {
-      this.publishSessionRename(
-        this.naming.maybeRenameFromConversationSummary({
-          assistantParts: finalized.parts,
-          sessionId,
-          userParts: state.autoNameUserParts,
-        }),
-      );
+      const summaryNamePromise = this.naming.maybeRenameFromConversationSummary({
+        assistantParts: finalized.parts,
+        sessionId,
+        userParts: state.autoNameUserParts,
+      });
+      namingPromises.push(summaryNamePromise);
+      this.publishSessionRename(summaryNamePromise, state.backgroundReply);
     }
+    state.backgroundReply.finish(
+      outcome,
+      namingPromises.length > 0 ? { waitFor: Promise.allSettled(namingPromises) } : undefined,
+    );
   }
 
   // ── Helpers ──
@@ -751,11 +759,18 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     }
   }
 
-  private publishSessionRename(promise: Promise<AgentSessionView | null>): void {
+  private publishSessionRename(
+    promise: Promise<AgentSessionView | null>,
+    originatingBackgroundReply?: BackgroundReplyTurn,
+  ): void {
     void promise
       .then((session) => {
         if (session) {
-          this.activeTurns.get(session.id)?.backgroundReply.updateConversationTitle(session.title);
+          const activeBackgroundReply = this.activeTurns.get(session.id)?.backgroundReply;
+          activeBackgroundReply?.updateConversationTitle(session.title);
+          if (originatingBackgroundReply !== activeBackgroundReply) {
+            originatingBackgroundReply?.updateConversationTitle(session.title);
+          }
           this.publish(session.id, { type: 'session.updated', session });
         }
       })

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -31,7 +31,7 @@ import type {
   AgentRuntime,
   AgentRuntimeSession,
   RuntimeEvent,
-  RuntimeUsage,
+  RuntimeUsageReport,
 } from '@/backend/ai/agent';
 import { PiRuntime } from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
@@ -104,6 +104,7 @@ const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
   awaitApproval: () => {},
   finish: () => {},
   update: () => {},
+  updateConversationTitle: () => {},
 };
 
 type MobileAgentHostOverrides = {
@@ -127,7 +128,7 @@ type ActiveTurnState = {
   autoNameUserParts: AgentInputPart[] | null;
   backgroundReply: BackgroundReplyTurn;
   pendingApprovals: Map<string, AgentApprovalView>;
-  usage: RuntimeUsage | null;
+  usage: RuntimeUsageReport | null;
   runtimeSession: AgentRuntimeSession;
 };
 
@@ -246,6 +247,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     if (!session) {
       fail('SESSION_NOT_FOUND', `Session does not exist: ${parsed.sessionId}`);
     }
+    this.activeTurns.get(session.id)?.backgroundReply.updateConversationTitle(session.title);
     this.publish(parsed.sessionId, { type: 'session.updated', session });
     return session;
   }
@@ -584,7 +586,11 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       }
       case 'usage': {
         // Cumulative; the last report before the terminal event is authoritative.
-        state.usage = event.usage;
+        state.usage = {
+          completedAt: event.completedAt,
+          context: event.context,
+          usage: event.usage,
+        };
         return false;
       }
       case 'completed':
@@ -625,7 +631,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       assistantMessageId: state.assistantMessage.id,
       status: messageStatus,
       parts,
-      usage: state.usage ? toAgentUsageView(state.usage) : null,
+      usage: state.usage ? toAgentUsageView(state.usage.usage) : null,
       error,
     });
     const turn: AgentTurnView = {
@@ -643,10 +649,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       this.usage.record({
         agent: state.agent,
         assistantMessageId: finalized.id,
-        completedAt: Date.parse(finalized.updatedAt),
-        startedAt: Date.parse(state.turn.startedAt),
+        report: state.usage,
         turnId: state.turn.id,
-        usage: state.usage,
       });
     }
     this.publish(sessionId, { type: 'message.finalized', message: finalized });
@@ -751,6 +755,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     void promise
       .then((session) => {
         if (session) {
+          this.activeTurns.get(session.id)?.backgroundReply.updateConversationTitle(session.title);
           this.publish(session.id, { type: 'session.updated', session });
         }
       })

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -46,6 +46,10 @@ import {
 import type { PreferenceService } from '@/backend/data/PreferenceService';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
+import type {
+  BackgroundReplyLifecycle,
+  BackgroundReplyTurn,
+} from '@/backend/services/backgroundReply';
 import {
   AgentCancelTurnInputSchema,
   AgentCreateSessionInputSchema,
@@ -77,6 +81,7 @@ import {
 } from './agentDefinitions';
 import { AgentSessionNaming } from './AgentSessionNaming';
 import type { AgentSessionStore } from './AgentSessionStore';
+import { AgentSessionUsageRecorder } from './AgentSessionUsageRecorder';
 import {
   toAgentApprovalView,
   toAgentErrorView,
@@ -95,12 +100,19 @@ const INTERRUPTED_ERROR: AgentErrorView = {
   retryable: true,
 };
 
+const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
+  awaitApproval: () => {},
+  finish: () => {},
+  update: () => {},
+};
+
 type MobileAgentHostOverrides = {
   agents: AgentDefinitionSource;
   naming: Pick<
     AgentSessionNaming,
     'drain' | 'maybeRenameFromConversationSummary' | 'maybeRenameFromFirstUserMessage'
   >;
+  usage: Pick<AgentSessionUsageRecorder, 'drain' | 'record'>;
 };
 
 /**
@@ -109,9 +121,11 @@ type MobileAgentHostOverrides = {
  * derived from the settled assistant message.
  */
 type ActiveTurnState = {
+  agent: AgentDefinition;
   turn: AgentTurnView;
   assistantMessage: AgentMessageView;
   autoNameUserParts: AgentInputPart[] | null;
+  backgroundReply: BackgroundReplyTurn;
   pendingApprovals: Map<string, AgentApprovalView>;
   usage: RuntimeUsage | null;
   runtimeSession: AgentRuntimeSession;
@@ -136,7 +150,7 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
 
 @Injectable('MobileAgentHost')
 @ServicePhase(Phase.PostReady)
-@DependsOn(['AgentSessionStore', 'AiService', 'PreferenceService'])
+@DependsOn(['AgentSessionStore', 'AiService', 'PreferenceService', 'BackgroundReplyRuntime'])
 @AppStatePolicy('continue')
 export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
@@ -150,6 +164,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   >();
   private readonly runningTurns = new Set<Promise<void>>();
   private readonly naming: MobileAgentHostOverrides['naming'];
+  private readonly usage: MobileAgentHostOverrides['usage'];
 
   /**
    * Lifecycle composition supplies the selected store adapter. Production
@@ -159,6 +174,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     private readonly store: AgentSessionStore,
     aiService: AiService,
     preferenceService: PreferenceService,
+    private readonly backgroundReply: BackgroundReplyLifecycle,
     private readonly runtime: AgentRuntime = new PiRuntime(createPiModelResolver()),
     private readonly overrides: Partial<MobileAgentHostOverrides> = {},
   ) {
@@ -172,6 +188,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         provider: providerService,
         store,
       });
+    this.usage = overrides.usage ?? new AgentSessionUsageRecorder();
   }
 
   private get agents(): AgentDefinitionSource {
@@ -196,6 +213,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     this.runtimeSessions.clear();
     await Promise.allSettled([...this.runningTurns]);
     await this.naming.drain();
+    await this.usage.drain();
     this.runningTurnsBySession.clear();
     this.listeners.clear();
   }
@@ -260,6 +278,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         this.runtimeSessions.delete(sessionId);
         await cached.session.close();
       }
+      this.backgroundReply.clearSession(sessionId);
       const deleted = await this.store.deleteSession(sessionId);
       if (!deleted) {
         fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
@@ -325,9 +344,16 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         endedAt: null,
       };
       const state: ActiveTurnState = {
+        agent,
         turn,
         assistantMessage: reserved.assistantMessage,
         autoNameUserParts: priorMessages.length === 0 ? parsed.parts : null,
+        backgroundReply: this.startBackgroundReply({
+          agentId: agent.id,
+          agentName: agent.name,
+          sessionId,
+          sessionTitle: session.title,
+        }),
         pendingApprovals: new Map(),
         usage: null,
         runtimeSession,
@@ -501,6 +527,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           messageId: state.assistantMessage.id,
           delta: { op: 'part.add', index: event.index, part },
         });
+        state.backgroundReply.update(state.assistantMessage);
         return false;
       }
       case 'text.delta': {
@@ -513,6 +540,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           messageId: state.assistantMessage.id,
           delta: { op: 'text.append', partId: event.partId, text: event.text },
         });
+        state.backgroundReply.update(state.assistantMessage);
         return false;
       }
       case 'part.replace': {
@@ -526,6 +554,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           messageId: state.assistantMessage.id,
           delta: { op: 'part.replace', part },
         });
+        state.backgroundReply.update(state.assistantMessage);
         return false;
       }
       case 'approval.requested': {
@@ -534,6 +563,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         const approval = toAgentApprovalView(event.approval, sessionId);
         state.pendingApprovals.set(approval.id, approval);
         state.turn = { ...state.turn, status: 'awaiting-approval' };
+        state.backgroundReply.awaitApproval(state.assistantMessage);
         this.publish(sessionId, { type: 'turn.updated', turn: state.turn });
         this.publish(sessionId, { type: 'approval.requested', approval });
         return false;
@@ -548,6 +578,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           state.turn = { ...state.turn, status: 'running' };
           this.publish(sessionId, { type: 'turn.updated', turn: state.turn });
         }
+        state.backgroundReply.update(state.assistantMessage);
         this.publish(sessionId, { type: 'approval.resolved', approval });
         return false;
       }
@@ -607,6 +638,17 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     if (this.activeTurns.get(sessionId) === state) {
       this.activeTurns.delete(sessionId);
     }
+    state.backgroundReply.finish(outcome);
+    if (state.usage) {
+      this.usage.record({
+        agent: state.agent,
+        assistantMessageId: finalized.id,
+        completedAt: Date.parse(finalized.updatedAt),
+        startedAt: Date.parse(state.turn.startedAt),
+        turnId: state.turn.id,
+        usage: state.usage,
+      });
+    }
     this.publish(sessionId, { type: 'message.finalized', message: finalized });
     this.publish(sessionId, { type: 'turn.updated', turn });
     if (outcome === 'completed' && state.autoNameUserParts) {
@@ -649,6 +691,23 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private projectCapabilities(target: AgentExecutionTarget): AgentCapabilities {
     const runtime = this.routeExecutionTarget(target);
     return { ...runtime.descriptor.capabilities };
+  }
+
+  private startBackgroundReply(input: {
+    agentId: string;
+    agentName: string;
+    sessionId: string;
+    sessionTitle: string;
+  }): BackgroundReplyTurn {
+    try {
+      return this.backgroundReply.startTurn(input);
+    } catch (error) {
+      logger.warn('Failed to start Agent Session background reply', error as Error, {
+        sessionId: input.sessionId,
+      });
+      this.backgroundReply.clearSession(input.sessionId);
+      return NOOP_BACKGROUND_REPLY_TURN;
+    }
   }
 
   /**

--- a/src/backend/ai/agentHost/__tests__/AgentSessionUsageRecorder.test.ts
+++ b/src/backend/ai/agentHost/__tests__/AgentSessionUsageRecorder.test.ts
@@ -1,0 +1,56 @@
+import { AgentSessionUsageRecorder } from '../AgentSessionUsageRecorder';
+
+describe('AgentSessionUsageRecorder', () => {
+  test('attributes a turn to its Agent and Agent Session message', async () => {
+    const recordInvocation = jest.fn(async () => undefined);
+    const recorder = new AgentSessionUsageRecorder({
+      model: {
+        getById: jest.fn(async () => ({
+          apiModelId: 'served-model',
+          modelId: 'configured-model',
+          name: 'Configured Model',
+          pricing: undefined,
+        })),
+      },
+      provider: {
+        getByProviderId: jest.fn(async () => ({
+          apiFeatures: { reportsActualCost: false },
+          id: 'provider-1',
+          name: 'Provider One',
+          reportedCostCurrency: undefined,
+        })),
+      },
+      usage: { recordInvocation },
+    } as never);
+
+    recorder.record({
+      agent: {
+        id: 'agent-1',
+        instructions: '',
+        model: { modelId: 'configured-model', providerId: 'provider-1' },
+        name: 'Agent One',
+        options: {},
+      },
+      assistantMessageId: 'message-1',
+      completedAt: 1_500,
+      startedAt: 1_000,
+      turnId: 'turn-1',
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+    await recorder.drain();
+
+    expect(recordInvocation).toHaveBeenCalledWith({
+      completedAt: 1_500,
+      context: expect.objectContaining({
+        messageRef: { id: 'message-1', kind: 'agent-session' },
+        modelId: 'served-model',
+        providerId: 'provider-1',
+        source: { icon: null, id: 'agent-1', name: 'Agent One', type: 'agent' },
+      }),
+      metrics: { timeCompletionMs: 500 },
+      modality: 'language',
+      requestId: 'agent-session-turn:turn-1',
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+  });
+});

--- a/src/backend/ai/agentHost/__tests__/AgentSessionUsageRecorder.test.ts
+++ b/src/backend/ai/agentHost/__tests__/AgentSessionUsageRecorder.test.ts
@@ -4,24 +4,8 @@ describe('AgentSessionUsageRecorder', () => {
   test('attributes a turn to its Agent and Agent Session message', async () => {
     const recordInvocation = jest.fn(async () => undefined);
     const recorder = new AgentSessionUsageRecorder({
-      model: {
-        getById: jest.fn(async () => ({
-          apiModelId: 'served-model',
-          modelId: 'configured-model',
-          name: 'Configured Model',
-          pricing: undefined,
-        })),
-      },
-      provider: {
-        getByProviderId: jest.fn(async () => ({
-          apiFeatures: { reportsActualCost: false },
-          id: 'provider-1',
-          name: 'Provider One',
-          reportedCostCurrency: undefined,
-        })),
-      },
       usage: { recordInvocation },
-    } as never);
+    });
 
     recorder.record({
       agent: {
@@ -32,10 +16,38 @@ describe('AgentSessionUsageRecorder', () => {
         options: {},
       },
       assistantMessageId: 'message-1',
-      completedAt: 1_500,
-      startedAt: 1_000,
+      report: {
+        completedAt: 1_500,
+        context: {
+          credentialReceipt: {
+            attribution: 'explicit',
+            id: 'credential-1',
+            label: 'Primary',
+            masked: 'sk-…1234',
+          },
+          modelId: 'served-model',
+          modelName: 'Configured Model',
+          pricingSnapshot: {
+            capturedAt: '2026-08-25T00:00:00.000Z',
+            currency: 'USD',
+            inputPerMillionTokens: 2,
+          },
+          providerId: 'provider-1',
+          providerName: 'Provider One',
+          reportedCostCurrency: 'USD',
+          trustProviderReportedCost: false,
+        },
+        usage: {
+          cacheReadTokens: 3,
+          cacheWriteTokens: 2,
+          inputTokens: 10,
+          noCacheTokens: 5,
+          outputTokens: 5,
+          reasoningTokens: 1,
+          totalTokens: 15,
+        },
+      },
       turnId: 'turn-1',
-      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
     });
     await recorder.drain();
 
@@ -45,12 +57,26 @@ describe('AgentSessionUsageRecorder', () => {
         messageRef: { id: 'message-1', kind: 'agent-session' },
         modelId: 'served-model',
         providerId: 'provider-1',
+        credentialReceipt: {
+          attribution: 'explicit',
+          id: 'credential-1',
+          label: 'Primary',
+          masked: 'sk-…1234',
+        },
+        pricingSnapshot: expect.objectContaining({ inputPerMillionTokens: 2 }),
         source: { icon: null, id: 'agent-1', name: 'Agent One', type: 'agent' },
       }),
-      metrics: { timeCompletionMs: 500 },
       modality: 'language',
       requestId: 'agent-session-turn:turn-1',
-      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      usage: {
+        cacheReadTokens: 3,
+        cacheWriteTokens: 2,
+        inputTokens: 10,
+        noCacheTokens: 5,
+        outputTokens: 5,
+        reasoningTokens: 1,
+        totalTokens: 15,
+      },
     });
   });
 });

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -43,12 +43,34 @@ const noOpNaming = {
   maybeRenameFromConversationSummary: async () => null,
   maybeRenameFromFirstUserMessage: async () => null,
 };
+const backgroundReplyTurn = {
+  awaitApproval: jest.fn(),
+  finish: jest.fn(),
+  update: jest.fn(),
+};
+const backgroundReply = {
+  clearSession: jest.fn(),
+  clearTopic: jest.fn(),
+  startTurn: jest.fn(() => backgroundReplyTurn),
+};
+const usage = {
+  drain: jest.fn(async () => undefined),
+  record: jest.fn(),
+};
 
 function createHost(runtime: FakeRuntime): MobileAgentHost {
-  return new MobileAgentHost(store, unusedAiService, unusedPreferenceService, runtime, {
-    agents,
-    naming: noOpNaming,
-  });
+  return new MobileAgentHost(
+    store,
+    unusedAiService,
+    unusedPreferenceService,
+    backgroundReply,
+    runtime,
+    {
+      agents,
+      naming: noOpNaming,
+      usage,
+    },
+  );
 }
 
 function hostWithText(texts: string[], requests: RuntimeExecutionRequest[] = []): MobileAgentHost {
@@ -117,6 +139,7 @@ let store: InMemoryAgentSessionStore;
 
 describe('MobileAgentHost', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     store = new InMemoryAgentSessionStore();
   });
 
@@ -169,6 +192,22 @@ describe('MobileAgentHost', () => {
       { id: 'text-1', type: 'text', text: 'Hi', state: 'done' },
     ]);
     expect(finalized.message.usage).toEqual({ inputTokens: 3, outputTokens: 2, totalTokens: 5 });
+    expect(backgroundReply.startTurn).toHaveBeenCalledWith({
+      agentId: AGENT_ID,
+      agentName: 'Test Agent',
+      sessionId: session.id,
+      sessionTitle: '',
+    });
+    expect(backgroundReplyTurn.update).toHaveBeenCalled();
+    expect(backgroundReplyTurn.finish).toHaveBeenCalledWith('completed');
+    expect(usage.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({ id: AGENT_ID }),
+        assistantMessageId: submitted.assistantMessageId,
+        turnId: submitted.turnId,
+        usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      }),
+    );
 
     const terminal = terminalTurnEvent(events);
     expect(terminal?.turn.status).toBe('completed');

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -11,9 +11,15 @@ import {
 } from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
 import type { PreferenceService } from '@/backend/data/PreferenceService';
-import { AgentEventSchema, AgentProtocolError, type AgentEvent } from '@/shared/contracts/agent';
+import {
+  AgentEventSchema,
+  AgentProtocolError,
+  type AgentEvent,
+  type AgentSessionView,
+} from '@/shared/contracts/agent';
 
 import type { AgentDefinitionSource } from '../agentDefinitions';
+import type { AgentSessionNaming } from '../AgentSessionNaming';
 import { InMemoryAgentSessionStore } from '../InMemoryAgentSessionStore';
 import { MobileAgentHost } from '../MobileAgentHost';
 
@@ -53,7 +59,12 @@ const FAKE_DESCRIPTOR = {
 
 const unusedAiService = {} as AiService;
 const unusedPreferenceService = {} as PreferenceService;
-const noOpNaming = {
+type NamingOverride = Pick<
+  AgentSessionNaming,
+  'drain' | 'maybeRenameFromConversationSummary' | 'maybeRenameFromFirstUserMessage'
+>;
+
+const noOpNaming: NamingOverride = {
   drain: async () => undefined,
   maybeRenameFromConversationSummary: async () => null,
   maybeRenameFromFirstUserMessage: async () => null,
@@ -74,7 +85,7 @@ const usage = {
   record: jest.fn(),
 };
 
-function createHost(runtime: FakeRuntime): MobileAgentHost {
+function createHost(runtime: FakeRuntime, naming: NamingOverride = noOpNaming): MobileAgentHost {
   return new MobileAgentHost(
     store,
     unusedAiService,
@@ -83,7 +94,7 @@ function createHost(runtime: FakeRuntime): MobileAgentHost {
     runtime,
     {
       agents,
-      naming: noOpNaming,
+      naming,
       usage,
     },
   );
@@ -217,7 +228,9 @@ describe('MobileAgentHost', () => {
       sessionTitle: '',
     });
     expect(backgroundReplyTurn.update).toHaveBeenCalled();
-    expect(backgroundReplyTurn.finish).toHaveBeenCalledWith('completed');
+    expect(backgroundReplyTurn.finish).toHaveBeenCalledWith('completed', {
+      waitFor: expect.any(Promise),
+    });
     expect(usage.record).toHaveBeenCalledWith(
       expect.objectContaining({
         agent: expect.objectContaining({ id: AGENT_ID }),
@@ -347,6 +360,39 @@ describe('MobileAgentHost', () => {
 
     expect(backgroundReplyTurn.updateConversationTitle).toHaveBeenCalledWith('Renamed Session');
     await host.cancelTurn({ sessionId: session.id, turnId: submitted.turnId });
+  });
+
+  test('applies summary naming after the turn leaves active Host state', async () => {
+    let resolveSummary!: (session: AgentSessionView | null) => void;
+    const summaryName = new Promise<AgentSessionView | null>((resolve) => {
+      resolveSummary = resolve;
+    });
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).scriptEvents([
+      { type: 'completed' },
+    ]);
+    const host = createHost(runtime, {
+      drain: async () => undefined,
+      maybeRenameFromConversationSummary: () => summaryName,
+      maybeRenameFromFirstUserMessage: async () => null,
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Hello.' }],
+    });
+    await waitFor(() => backgroundReplyTurn.finish.mock.calls.length > 0, 'the turn to finish');
+    const renamed = await store.autoRenameSession(session.id, '', 'Summary title');
+    resolveSummary(renamed);
+    await waitFor(
+      () => backgroundReplyTurn.updateConversationTitle.mock.calls.length > 0,
+      'the background title to update',
+    );
+
+    expect(backgroundReplyTurn.updateConversationTitle).toHaveBeenCalledWith('Summary title');
   });
 
   test('reconciliation marks preloaded unfinished messages interrupted', async () => {

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -73,12 +73,12 @@ const backgroundReplyTurn = {
   awaitApproval: jest.fn(),
   finish: jest.fn(),
   update: jest.fn(),
-  updateConversationTitle: jest.fn(),
 };
 const backgroundReply = {
   clearSession: jest.fn(),
   clearTopic: jest.fn(),
   startTurn: jest.fn(() => backgroundReplyTurn),
+  updateSessionTitle: jest.fn(),
 };
 const usage = {
   drain: jest.fn(async () => undefined),
@@ -358,7 +358,7 @@ describe('MobileAgentHost', () => {
 
     await host.renameSession({ sessionId: session.id, title: 'Renamed Session' });
 
-    expect(backgroundReplyTurn.updateConversationTitle).toHaveBeenCalledWith('Renamed Session');
+    expect(backgroundReply.updateSessionTitle).toHaveBeenCalledWith(session.id, 'Renamed Session');
     await host.cancelTurn({ sessionId: session.id, turnId: submitted.turnId });
   });
 
@@ -388,11 +388,40 @@ describe('MobileAgentHost', () => {
     const renamed = await store.autoRenameSession(session.id, '', 'Summary title');
     resolveSummary(renamed);
     await waitFor(
-      () => backgroundReplyTurn.updateConversationTitle.mock.calls.length > 0,
+      () => backgroundReply.updateSessionTitle.mock.calls.length > 0,
       'the background title to update',
     );
 
-    expect(backgroundReplyTurn.updateConversationTitle).toHaveBeenCalledWith('Summary title');
+    expect(backgroundReply.updateSessionTitle).toHaveBeenCalledWith(session.id, 'Summary title');
+  });
+
+  test('applies a manual rename while terminal background content awaits naming', async () => {
+    let resolveSummary!: (session: AgentSessionView | null) => void;
+    const summaryName = new Promise<AgentSessionView | null>((resolve) => {
+      resolveSummary = resolve;
+    });
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).scriptEvents([
+      { type: 'completed' },
+    ]);
+    const host = createHost(runtime, {
+      drain: async () => undefined,
+      maybeRenameFromConversationSummary: () => summaryName,
+      maybeRenameFromFirstUserMessage: async () => null,
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Hello.' }],
+    });
+    await waitFor(() => backgroundReplyTurn.finish.mock.calls.length > 0, 'the turn to finish');
+
+    await host.renameSession({ sessionId: session.id, title: 'Manual title' });
+
+    expect(backgroundReply.updateSessionTitle).toHaveBeenCalledWith(session.id, 'Manual title');
+    resolveSummary(null);
   });
 
   test('reconciliation marks preloaded unfinished messages interrupted', async () => {

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -4,7 +4,11 @@
  * conformance suite; durable-adapter behavior is outside this suite.
  */
 
-import { FakeRuntime, type RuntimeExecutionRequest } from '@/backend/ai/agent';
+import {
+  FakeRuntime,
+  type RuntimeExecutionRequest,
+  type RuntimeUsageContext,
+} from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
 import type { PreferenceService } from '@/backend/data/PreferenceService';
 import { AgentEventSchema, AgentProtocolError, type AgentEvent } from '@/shared/contracts/agent';
@@ -14,6 +18,17 @@ import { InMemoryAgentSessionStore } from '../InMemoryAgentSessionStore';
 import { MobileAgentHost } from '../MobileAgentHost';
 
 const AGENT_ID = 'agent-under-test';
+
+const USAGE_CONTEXT: RuntimeUsageContext = {
+  credentialReceipt: { attribution: 'unknown' },
+  modelId: 'mock-model',
+  modelName: 'Mock Model',
+  pricingSnapshot: null,
+  providerId: 'mock-provider',
+  providerName: 'Mock Provider',
+  reportedCostCurrency: null,
+  trustProviderReportedCost: false,
+};
 
 const agents: AgentDefinitionSource = {
   async getAgent(agentId) {
@@ -47,6 +62,7 @@ const backgroundReplyTurn = {
   awaitApproval: jest.fn(),
   finish: jest.fn(),
   update: jest.fn(),
+  updateConversationTitle: jest.fn(),
 };
 const backgroundReply = {
   clearSession: jest.fn(),
@@ -92,6 +108,8 @@ function hostWithText(texts: string[], requests: RuntimeExecutionRequest[] = [])
       });
       controller.emit({
         type: 'usage',
+        completedAt: 1_500,
+        context: USAGE_CONTEXT,
         usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
       });
       controller.emit({ type: 'completed' });
@@ -204,8 +222,12 @@ describe('MobileAgentHost', () => {
       expect.objectContaining({
         agent: expect.objectContaining({ id: AGENT_ID }),
         assistantMessageId: submitted.assistantMessageId,
+        report: {
+          completedAt: 1_500,
+          context: USAGE_CONTEXT,
+          usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+        },
         turnId: submitted.turnId,
-        usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
       }),
     );
 
@@ -300,6 +322,31 @@ describe('MobileAgentHost', () => {
     // The session is idle again.
     const observation = await host.observeSession(session.id, () => {});
     expect(observation.snapshot.activeTurn).toBeNull();
+  });
+
+  test('updates an active background reply when its Session is renamed', async () => {
+    const started = createDeferred();
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script(async (controller) => {
+      started.resolve();
+      await new Promise<void>((resolve) => {
+        controller.signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+    const host = createHost(runtime);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const submitted = await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Hello.' }],
+    });
+    await started.promise;
+
+    await host.renameSession({ sessionId: session.id, title: 'Renamed Session' });
+
+    expect(backgroundReplyTurn.updateConversationTitle).toHaveBeenCalledWith('Renamed Session');
+    await host.cancelTurn({ sessionId: session.id, turnId: submitted.turnId });
   });
 
   test('reconciliation marks preloaded unfinished messages interrupted', async () => {

--- a/src/backend/ai/agentHost/piModelResolver.ts
+++ b/src/backend/ai/agentHost/piModelResolver.ts
@@ -1,9 +1,14 @@
 import { resolveEffectiveEndpoint } from '@cherrystudio/ai-runtime/provider';
+import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
 import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import type { FetchFunction, ModelThinkingLevel } from '@earendil-works/pi-ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
-import type { PiModelResolution, PiRuntimeDependencies } from '@/backend/ai/agent';
+import type {
+  PiModelResolution,
+  PiRuntimeDependencies,
+  RuntimeUsageContext,
+} from '@/backend/ai/agent';
 import { resolveProviderAiSdkConfig } from '@/backend/ai/provider/config';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
@@ -34,7 +39,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       if (!model) throw new Error(`Model is not configured: ${uniqueModelId}`);
 
       assertPiModelSupported(provider, model);
-      const { config } = await resolveProviderAiSdkConfig(provider, model, {
+      const { config, credentialReceipt } = await resolveProviderAiSdkConfig(provider, model, {
         fetch: expoFetch as FetchFunction,
         getAuthConfig: (providerId) => providerService.getAuthConfig(providerId),
         resolveApiKey: (providerId, override) =>
@@ -44,6 +49,29 @@ export function createPiModelResolver(): PiRuntimeDependencies {
         throw new Error('Pi Runtime does not support a separate custom endpoint path.');
       }
       const settings = readPiProviderSettings(config.providerSettings);
+      const modelId = model.apiModelId ?? model.modelId;
+      const capturedContext = createAiUsageCaptureContext({
+        credentialReceipt,
+        messageRef: null,
+        modelId,
+        modelName: model.name,
+        pricing: model.pricing,
+        providerId: provider.id,
+        providerName: provider.name,
+        reportedCostCurrency: provider.reportedCostCurrency,
+        source: null,
+        trustProviderReportedCost: provider.apiFeatures.reportsActualCost,
+      });
+      const usageContext: RuntimeUsageContext = {
+        credentialReceipt: capturedContext.credentialReceipt,
+        modelId: capturedContext.modelId,
+        modelName: capturedContext.modelName,
+        pricingSnapshot: capturedContext.pricingSnapshot,
+        providerId: capturedContext.providerId,
+        providerName: capturedContext.providerName,
+        reportedCostCurrency: capturedContext.reportedCostCurrency,
+        trustProviderReportedCost: capturedContext.trustProviderReportedCost,
+      };
 
       return {
         apiKey: settings.apiKey,
@@ -57,7 +85,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
           contextWindow: model.contextWindow ?? DEFAULT_PI_CONTEXT_WINDOW,
           cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
           headers: mergeHeaders(settings),
-          id: model.apiModelId ?? model.modelId,
+          id: modelId,
           input: ['text'],
           maxTokens: model.maxOutputTokens ?? DEFAULT_PI_MAX_OUTPUT_TOKENS,
           name: model.name,
@@ -66,6 +94,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
         },
         supportsTools: model.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL),
         timeoutMs: DEFAULT_PI_TIMEOUT_MS,
+        usageContext,
       };
     },
   };

--- a/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
+++ b/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
@@ -157,6 +157,7 @@ describe('ChatRuntime', () => {
       startTurn: jest.fn(() => {
         throw new Error('native start failed');
       }),
+      updateSessionTitle: jest.fn(),
     };
     const throwingRuntime = createRuntime({
       backgroundReply: throwingLifecycle,
@@ -2616,6 +2617,7 @@ function createBackgroundReplyLifecycle(
     clearSession: jest.fn(),
     clearTopic: jest.fn(),
     startTurn: jest.fn(() => turn),
+    updateSessionTitle: jest.fn(),
   };
 }
 
@@ -2624,7 +2626,6 @@ function createBackgroundReplyTurn(): BackgroundReplyTurn {
     awaitApproval: jest.fn(),
     finish: jest.fn(),
     update: jest.fn(),
-    updateConversationTitle: jest.fn(),
   };
 }
 

--- a/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
+++ b/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
@@ -2624,6 +2624,7 @@ function createBackgroundReplyTurn(): BackgroundReplyTurn {
     awaitApproval: jest.fn(),
     finish: jest.fn(),
     update: jest.fn(),
+    updateConversationTitle: jest.fn(),
   };
 }
 

--- a/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
+++ b/src/backend/ai/streamManager/__tests__/ChatRuntime.test.ts
@@ -152,6 +152,7 @@ describe('ChatRuntime', () => {
   test('keeps streaming when the background reply lifecycle throws', async () => {
     const throwingServices = createServices();
     const throwingLifecycle: BackgroundReplyLifecycle = {
+      clearSession: jest.fn(),
       clearTopic: jest.fn(),
       startTurn: jest.fn(() => {
         throw new Error('native start failed');
@@ -2612,6 +2613,7 @@ function createBackgroundReplyLifecycle(
   turn: BackgroundReplyTurn = createBackgroundReplyTurn(),
 ): BackgroundReplyLifecycle {
   return {
+    clearSession: jest.fn(),
     clearTopic: jest.fn(),
     startTurn: jest.fn(() => turn),
   };

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -168,10 +168,15 @@ export class BackgroundReplyRuntime
             urgent: true,
           });
         }),
-      finish: (outcome) =>
-        this.runTurnCallback(record.key, 'finish turn', () => {
-          this.finishTurn(record.key, generation, outcome);
-        }),
+      finish: (outcome, options) => {
+        void this.finishTurn(record.key, generation, outcome, options?.waitFor).catch(
+          (error: unknown) => {
+            logger.error('Background reply failed to finish turn', error as Error, {
+              key: record.key,
+            });
+          },
+        );
+      },
       update: (message) =>
         this.runTurnCallback(record.key, 'update turn', () => {
           this.updateTurn(record.key, generation, message);
@@ -248,7 +253,12 @@ export class BackgroundReplyRuntime
     });
   }
 
-  private finishTurn(key: string, generation: number, outcome: BackgroundReplyOutcome): void {
+  private async finishTurn(
+    key: string,
+    generation: number,
+    outcome: BackgroundReplyOutcome,
+    waitFor?: Promise<unknown>,
+  ): Promise<void> {
     if (!this.isCurrent(key, generation)) return;
     const record = this.turns.get(key);
     if (!record) return;
@@ -258,10 +268,15 @@ export class BackgroundReplyRuntime
       record.content.preview,
       this.environment.translate,
     );
-    // Deferred so a continuation turn started in the same tick (approval
-    // resume, regenerate) inherits the live session instead of watching it
-    // end and restart.
-    void this.enqueue(async () => {
+    record.session?.update(this.toActivityProps(record), { keepAlive: false, urgent: true });
+    if (waitFor) {
+      await waitFor.catch((error: unknown) => {
+        logger.warn('Background reply finish dependency failed', error as Error, { key });
+      });
+    }
+    // Keep terminal content updateable until any final title projection settles.
+    // A continuation that supersedes this generation inherits the live session.
+    await this.enqueue(async () => {
       if (!this.isRecordCurrent(record)) return;
       record.session?.finish(this.toActivityProps(record));
       record.session = undefined;

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -41,13 +41,14 @@ const logger = loggerService.withContext('BackgroundReply');
 type ChatActivitySession = BackgroundActivitySession<BackgroundReplyActivityProps>;
 
 type TurnRecord = {
-  assistantName: string;
+  actorName: string;
   content: BackgroundReplyContent;
+  conversationTitle: string;
+  deepLinkUrl: string;
   generation: number;
+  key: string;
   session?: ChatActivitySession;
   startedAtEpochMs: number;
-  topicId: string;
-  topicTitle: string;
 };
 
 type BackgroundActivityPort = {
@@ -68,7 +69,7 @@ type EnvironmentPort = {
 
 /**
  * Chat's domain adapter over the background-activity mechanism: it owns the
- * per-topic turn state machine, derives presentable content from chat
+ * per-session turn state machine, derives presentable content from chat
  * messages, and maps generating phases onto the session's keepAlive bit.
  * Throttling, AppState handling, orphan sweeps, and keep-alive audio all live
  * behind the injected session manager.
@@ -131,28 +132,30 @@ export class BackgroundReplyRuntime
   startTurn = (input: BackgroundReplyTurnInput): BackgroundReplyTurn => {
     if (Platform.OS !== 'ios' || this.disposed) return noOpTurn;
 
-    const existing = this.turns.get(input.topicId);
+    const normalized = normalizeTurnInput(input);
+    const existing = this.turns.get(normalized.key);
     const generation = ++this.generation;
     const content = deriveBackgroundReplyContent(undefined, this.environment.translate);
-    const assistantName =
-      input.assistantName.trim() || this.environment.translate('chat.backgroundReply.assistant');
+    const actorName =
+      normalized.actorName.trim() || this.environment.translate('chat.backgroundReply.assistant');
     const record: TurnRecord = {
-      assistantName,
+      actorName,
       content,
+      conversationTitle: normalized.conversationTitle.trim(),
+      deepLinkUrl: normalized.deepLinkUrl,
       generation,
+      key: normalized.key,
       startedAtEpochMs: existing?.startedAtEpochMs ?? Date.now(),
-      topicId: input.topicId,
-      topicTitle: input.topicTitle.trim(),
       ...(existing?.session ? { session: existing.session } : {}),
     };
-    this.turns.set(input.topicId, record);
+    this.turns.set(record.key, record);
     this.ensureSession(record);
 
     return {
       awaitApproval: (message) =>
-        this.runTurnCallback(input.topicId, 'mark approval pending', () => {
-          if (!this.isCurrent(input.topicId, generation)) return;
-          const current = this.turns.get(input.topicId);
+        this.runTurnCallback(record.key, 'mark approval pending', () => {
+          if (!this.isCurrent(record.key, generation)) return;
+          const current = this.turns.get(record.key);
           if (!current) return;
           const latest = deriveBackgroundReplyContent(message, this.environment.translate);
           current.content = {
@@ -166,24 +169,33 @@ export class BackgroundReplyRuntime
           });
         }),
       finish: (outcome) =>
-        this.runTurnCallback(input.topicId, 'finish turn', () => {
-          this.finishTurn(input.topicId, generation, outcome);
+        this.runTurnCallback(record.key, 'finish turn', () => {
+          this.finishTurn(record.key, generation, outcome);
         }),
       update: (message) =>
-        this.runTurnCallback(input.topicId, 'update turn', () => {
-          this.updateTurn(input.topicId, generation, message);
+        this.runTurnCallback(record.key, 'update turn', () => {
+          this.updateTurn(record.key, generation, message);
         }),
     };
   };
 
+  clearSession = (sessionId: string): void => {
+    this.clearTurn(sessionId);
+  };
+
+  /** Transitional compatibility entry retained until D removes ChatRuntime. */
   clearTopic = (topicId: string): void => {
-    const record = this.turns.get(topicId);
+    this.clearTurn(legacyTopicKey(topicId));
+  };
+
+  private clearTurn(key: string): void {
+    const record = this.turns.get(key);
     if (!record) return;
 
-    this.turns.delete(topicId);
+    this.turns.delete(key);
     record.session?.cancel();
     record.session = undefined;
-  };
+  }
 
   protected async onStop(): Promise<void> {
     if (this.disposed) return;
@@ -208,12 +220,12 @@ export class BackgroundReplyRuntime
   }
 
   private updateTurn(
-    topicId: string,
+    key: string,
     generation: number,
     message: Parameters<BackgroundReplyTurn['update']>[0],
   ) {
-    if (!this.isCurrent(topicId, generation)) return;
-    const record = this.turns.get(topicId);
+    if (!this.isCurrent(key, generation)) return;
+    const record = this.turns.get(key);
     if (!record) return;
 
     const nextContent = deriveBackgroundReplyContent(message, this.environment.translate);
@@ -225,9 +237,9 @@ export class BackgroundReplyRuntime
     });
   }
 
-  private finishTurn(topicId: string, generation: number, outcome: BackgroundReplyOutcome): void {
-    if (!this.isCurrent(topicId, generation)) return;
-    const record = this.turns.get(topicId);
+  private finishTurn(key: string, generation: number, outcome: BackgroundReplyOutcome): void {
+    if (!this.isCurrent(key, generation)) return;
+    const record = this.turns.get(key);
     if (!record) return;
 
     record.content = getTerminalBackgroundReplyContent(
@@ -242,11 +254,11 @@ export class BackgroundReplyRuntime
       if (!this.isRecordCurrent(record)) return;
       record.session?.finish(this.toActivityProps(record));
       record.session = undefined;
-      if (this.turns.get(topicId) === record) this.turns.delete(topicId);
+      if (this.turns.get(key) === record) this.turns.delete(key);
     });
   }
 
-  /** Starts the topic's session, or re-syncs an inherited one, when enabled. */
+  /** Starts the conversation's activity, or re-syncs an inherited one, when enabled. */
   private ensureSession(record: TurnRecord, activating = false): void {
     // `onActivate` runs before BaseService flips `isActivated`; callers during
     // normal operation use the public state as the preference gate.
@@ -258,7 +270,7 @@ export class BackgroundReplyRuntime
       return;
     }
     record.session = this.activities.startSession({
-      deepLinkUrl: `cherrystudio://topics?topicId=${encodeURIComponent(record.topicId)}`,
+      deepLinkUrl: record.deepLinkUrl,
       keepAlive,
       presenter: this.environment.assistantPresenter,
       props: this.toActivityProps(record),
@@ -269,7 +281,7 @@ export class BackgroundReplyRuntime
   private toActivityProps(record: TurnRecord): BackgroundReplyActivityProps {
     return {
       ...record.content,
-      ...(record.topicTitle ? { attribution: record.assistantName } : {}),
+      ...(record.conversationTitle ? { attribution: record.actorName } : {}),
       compactIcon: 'bubble-ellipsis',
       ...(record.content.phase === 'awaiting-approval'
         ? { compactLabel: this.environment.translate('backgroundActivity.awaitingApproval') }
@@ -283,23 +295,23 @@ export class BackgroundReplyRuntime
       detail: record.content.detail,
       icon: backgroundReplyIcon(record.content.phase),
       startedAtEpochMs: record.startedAtEpochMs,
-      title: record.topicTitle || record.assistantName,
+      title: record.conversationTitle || record.actorName,
     };
   }
 
-  private isCurrent(topicId: string, generation: number): boolean {
-    return !this.disposed && this.turns.get(topicId)?.generation === generation;
+  private isCurrent(key: string, generation: number): boolean {
+    return !this.disposed && this.turns.get(key)?.generation === generation;
   }
 
   private isRecordCurrent(record: TurnRecord): boolean {
-    return !this.disposed && this.turns.get(record.topicId) === record;
+    return !this.disposed && this.turns.get(record.key) === record;
   }
 
-  private runTurnCallback(topicId: string, operation: string, callback: () => void): void {
+  private runTurnCallback(key: string, operation: string, callback: () => void): void {
     try {
       callback();
     } catch (error) {
-      logger.error(`Background reply failed to ${operation}`, error as Error, { topicId });
+      logger.error(`Background reply failed to ${operation}`, error as Error, { key });
     }
   }
 
@@ -308,6 +320,33 @@ export class BackgroundReplyRuntime
     this.operationTail = run.catch(() => {});
     return run;
   }
+}
+
+function normalizeTurnInput(input: BackgroundReplyTurnInput): {
+  actorName: string;
+  conversationTitle: string;
+  deepLinkUrl: string;
+  key: string;
+} {
+  if ('sessionId' in input) {
+    return {
+      actorName: input.agentName,
+      conversationTitle: input.sessionTitle,
+      deepLinkUrl: `cherrystudio:///?agentId=${encodeURIComponent(input.agentId)}&sessionId=${encodeURIComponent(input.sessionId)}`,
+      key: input.sessionId,
+    };
+  }
+
+  return {
+    actorName: input.assistantName,
+    conversationTitle: input.topicTitle,
+    deepLinkUrl: `cherrystudio://topics?topicId=${encodeURIComponent(input.topicId)}`,
+    key: legacyTopicKey(input.topicId),
+  };
+}
+
+function legacyTopicKey(topicId: string): string {
+  return `legacy-topic:${topicId}`;
 }
 
 const noOpTurn: BackgroundReplyTurn = {

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -181,17 +181,6 @@ export class BackgroundReplyRuntime
         this.runTurnCallback(record.key, 'update turn', () => {
           this.updateTurn(record.key, generation, message);
         }),
-      updateConversationTitle: (title) =>
-        this.runTurnCallback(record.key, 'update conversation title', () => {
-          if (!this.isCurrent(record.key, generation)) return;
-          const current = this.turns.get(record.key);
-          if (!current) return;
-          current.conversationTitle = title.trim();
-          current.session?.update(this.toActivityProps(current), {
-            keepAlive: isGeneratingPhase(current.content.phase),
-            urgent: true,
-          });
-        }),
     };
   };
 
@@ -202,6 +191,18 @@ export class BackgroundReplyRuntime
   /** Transitional compatibility entry retained until D removes ChatRuntime. */
   clearTopic = (topicId: string): void => {
     this.clearTurn(legacyTopicKey(topicId));
+  };
+
+  updateSessionTitle = (sessionId: string, title: string): void => {
+    this.runTurnCallback(sessionId, 'update Agent Session title', () => {
+      const record = this.turns.get(sessionId);
+      if (!record) return;
+      record.conversationTitle = title.trim();
+      record.session?.update(this.toActivityProps(record), {
+        keepAlive: isGeneratingPhase(record.content.phase),
+        urgent: true,
+      });
+    });
   };
 
   private clearTurn(key: string): void {
@@ -379,7 +380,6 @@ const noOpTurn: BackgroundReplyTurn = {
   awaitApproval: () => {},
   finish: () => {},
   update: () => {},
-  updateConversationTitle: () => {},
 };
 
 function isGeneratingPhase(phase: BackgroundReplyPhase): boolean {

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -176,6 +176,17 @@ export class BackgroundReplyRuntime
         this.runTurnCallback(record.key, 'update turn', () => {
           this.updateTurn(record.key, generation, message);
         }),
+      updateConversationTitle: (title) =>
+        this.runTurnCallback(record.key, 'update conversation title', () => {
+          if (!this.isCurrent(record.key, generation)) return;
+          const current = this.turns.get(record.key);
+          if (!current) return;
+          current.conversationTitle = title.trim();
+          current.session?.update(this.toActivityProps(current), {
+            keepAlive: isGeneratingPhase(current.content.phase),
+            urgent: true,
+          });
+        }),
     };
   };
 
@@ -353,6 +364,7 @@ const noOpTurn: BackgroundReplyTurn = {
   awaitApproval: () => {},
   finish: () => {},
   update: () => {},
+  updateConversationTitle: () => {},
 };
 
 function isGeneratingPhase(phase: BackgroundReplyPhase): boolean {

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -36,6 +36,7 @@ import {
 
 const PREFERENCE_KEY = 'chat.background_reply.enabled';
 const SESSION_TAG = 'chat.backgroundReply';
+const FINISH_TITLE_GRACE_MS = 5_000;
 const logger = loggerService.withContext('BackgroundReply');
 
 type ChatActivitySession = BackgroundActivitySession<BackgroundReplyActivityProps>;
@@ -271,9 +272,7 @@ export class BackgroundReplyRuntime
     );
     record.session?.update(this.toActivityProps(record), { keepAlive: false, urgent: true });
     if (waitFor) {
-      await waitFor.catch((error: unknown) => {
-        logger.warn('Background reply finish dependency failed', error as Error, { key });
-      });
+      await this.waitForFinishDependency(key, waitFor);
     }
     // Keep terminal content updateable until any final title projection settles.
     // A continuation that supersedes this generation inherits the live session.
@@ -283,6 +282,29 @@ export class BackgroundReplyRuntime
       record.session = undefined;
       if (this.turns.get(key) === record) this.turns.delete(key);
     });
+  }
+
+  private async waitForFinishDependency(key: string, dependency: Promise<unknown>): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const settled = dependency.then(
+      () => undefined,
+      (error: unknown) => {
+        logger.warn('Background reply finish dependency failed', error as Error, { key });
+      },
+    );
+    const graceExpired = new Promise<void>((resolve) => {
+      timeout = setTimeout(() => {
+        timeout = undefined;
+        logger.warn('Background reply finish dependency timed out', {
+          graceMs: FINISH_TITLE_GRACE_MS,
+          key,
+        });
+        resolve();
+      }, FINISH_TITLE_GRACE_MS);
+    });
+
+    await Promise.race([settled, graceExpired]);
+    if (timeout !== undefined) clearTimeout(timeout);
   }
 
   /** Starts the conversation's activity, or re-syncs an inherited one, when enabled. */

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -100,14 +100,14 @@ describe('BackgroundReplyRuntime', () => {
 
   test('updates the visible title while an Agent Session turn is active', async () => {
     const runtime = await createRuntime();
-    const turn = runtime.startTurn({
+    runtime.startTurn({
       agentId: 'agent-1',
       agentName: 'Alpha',
       sessionId: 'session-1',
       sessionTitle: '',
     });
 
-    turn.updateConversationTitle('  Renamed session  ');
+    runtime.updateSessionTitle('session-1', '  Renamed session  ');
 
     expect(mockSessions[0]?.update).toHaveBeenLastCalledWith(
       expect.objectContaining({ attribution: 'Alpha', title: 'Renamed session' }),
@@ -136,7 +136,7 @@ describe('BackgroundReplyRuntime', () => {
     await flushOperations();
     expect(session?.finish).not.toHaveBeenCalled();
 
-    turn.updateConversationTitle('Summary title');
+    runtime.updateSessionTitle('session-1', 'Summary title');
     finishDependency.resolve();
     await flushOperations();
     expect(session?.finish).toHaveBeenCalledWith(

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -178,7 +178,7 @@ describe('BackgroundReplyRuntime', () => {
     });
     const session = mockSessions[0];
 
-    turn.update({ id: 'assistant-1', parts: [{ type: 'text', text: 'hello' }], role: 'assistant' });
+    turn.update({ parts: [{ type: 'text', text: 'hello' }] });
     expect(session?.update).toHaveBeenLastCalledWith(
       expect.objectContaining({
         icon: 'bubble-ellipsis',
@@ -190,16 +190,14 @@ describe('BackgroundReplyRuntime', () => {
     expect(session?.update.mock.calls.at(-1)?.[0]).not.toHaveProperty('compactLabel');
 
     turn.update({
-      id: 'assistant-1',
       parts: [{ type: 'text', text: 'hello more' }],
-      role: 'assistant',
     });
     expect(session?.update).toHaveBeenLastCalledWith(
       expect.objectContaining({ phase: 'responding' }),
       { keepAlive: true, urgent: false },
     );
 
-    turn.awaitApproval({ id: 'assistant-1', parts: [], role: 'assistant' });
+    turn.awaitApproval({ parts: [] });
     expect(session?.update).toHaveBeenLastCalledWith(
       expect.objectContaining({
         compactLabel: '等待审批',
@@ -210,9 +208,7 @@ describe('BackgroundReplyRuntime', () => {
     );
 
     turn.update({
-      id: 'assistant-1',
       parts: [{ type: 'text', text: 'approved and continuing' }],
-      role: 'assistant',
     });
     expect(session?.update).toHaveBeenLastCalledWith(
       expect.objectContaining({ phase: 'responding' }),
@@ -297,7 +293,7 @@ describe('BackgroundReplyRuntime', () => {
     runtime.clearSession('session-1');
     expect(mockSessions[0]?.cancel).toHaveBeenCalledTimes(1);
 
-    turn.update({ id: 'assistant-1', parts: [{ type: 'text', text: 'late' }], role: 'assistant' });
+    turn.update({ parts: [{ type: 'text', text: 'late' }] });
     expect(mockStartSession).toHaveBeenCalledTimes(1);
     await runtime._doStop();
   });
@@ -315,7 +311,7 @@ describe('BackgroundReplyRuntime', () => {
     expect(runtime.isActivated).toBe(false);
     expect(mockSessions[0]?.cancel).toHaveBeenCalledTimes(1);
 
-    turn.update({ id: 'assistant-1', parts: [{ type: 'text', text: 'hi' }], role: 'assistant' });
+    turn.update({ parts: [{ type: 'text', text: 'hi' }] });
     expect(mockStartSession).toHaveBeenCalledTimes(1);
 
     enabled = true;
@@ -403,9 +399,7 @@ describe('BackgroundReplyRuntime', () => {
     });
     expect(() =>
       turn.update({
-        id: 'assistant-1',
         parts: [{ type: 'text', text: 'hello' }],
-        role: 'assistant',
       }),
     ).not.toThrow();
     expect(() => turn.awaitApproval()).not.toThrow();

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -43,23 +43,25 @@ describe('BackgroundReplyRuntime', () => {
     jest.restoreAllMocks();
   });
 
-  test('opens one keep-alive session per topic with derived initial content', async () => {
+  test('opens one keep-alive activity per Agent Session with a chat deeplink', async () => {
     const runtime = await createRuntime();
     expect(runtime.isActivated).toBe(true);
     const first = runtime.startTurn({
-      assistantName: 'Alpha',
-      topicId: 'topic-1',
-      topicTitle: 'First topic',
+      agentId: 'agent-1',
+      agentName: 'Alpha',
+      sessionId: 'session-1',
+      sessionTitle: 'First session',
     });
     const second = runtime.startTurn({
-      assistantName: 'Beta',
-      topicId: 'topic-2',
-      topicTitle: 'Second topic',
+      agentId: 'agent-2',
+      agentName: 'Beta',
+      sessionId: 'session-2',
+      sessionTitle: 'Second session',
     });
     expect(first).not.toBe(second);
     expect(mockStartSession).toHaveBeenCalledTimes(2);
     expect(mockSessions[0]?.input).toMatchObject({
-      deepLinkUrl: 'cherrystudio://topics?topicId=topic-1',
+      deepLinkUrl: 'cherrystudio:///?agentId=agent-1&sessionId=session-1',
       keepAlive: true,
       props: expect.objectContaining({
         attribution: 'Alpha',
@@ -67,16 +69,16 @@ describe('BackgroundReplyRuntime', () => {
         detail: 'chat.backgroundReply.preparing',
         icon: 'hourglass',
         phase: 'preparing',
-        title: 'First topic',
+        title: 'First session',
       }),
       tag: 'chat.backgroundReply',
     });
     expect(mockSessions[1]?.input).toMatchObject({
-      deepLinkUrl: 'cherrystudio://topics?topicId=topic-2',
+      deepLinkUrl: 'cherrystudio:///?agentId=agent-2&sessionId=session-2',
       props: expect.objectContaining({
         attribution: 'Beta',
         detail: 'chat.backgroundReply.preparing',
-        title: 'Second topic',
+        title: 'Second session',
       }),
     });
 
@@ -85,7 +87,12 @@ describe('BackgroundReplyRuntime', () => {
 
   test('uses the localized assistant fallback when no assistant or model name is available', async () => {
     const runtime = await createRuntime();
-    runtime.startTurn({ assistantName: ' ', topicId: 'topic-1', topicTitle: ' ' });
+    runtime.startTurn({
+      agentId: 'agent-1',
+      agentName: ' ',
+      sessionId: 'session-1',
+      sessionTitle: ' ',
+    });
     expect(mockSessions[0]?.input.props).toMatchObject({ title: 'Localized assistant' });
 
     await runtime._doStop();
@@ -207,15 +214,16 @@ describe('BackgroundReplyRuntime', () => {
     await runtime._doStop();
   });
 
-  test('clearTopic cancels the session so approval records cannot recreate it later', async () => {
+  test('clearSession cancels the activity so approval records cannot recreate it later', async () => {
     const runtime = await createRuntime();
     const turn = runtime.startTurn({
-      assistantName: 'Alpha',
-      topicId: 'topic-1',
-      topicTitle: 'First topic',
+      agentId: 'agent-1',
+      agentName: 'Alpha',
+      sessionId: 'session-1',
+      sessionTitle: 'First session',
     });
     turn.awaitApproval();
-    runtime.clearTopic('topic-1');
+    runtime.clearSession('session-1');
     expect(mockSessions[0]?.cancel).toHaveBeenCalledTimes(1);
 
     turn.update({ id: 'assistant-1', parts: [{ type: 'text', text: 'late' }], role: 'assistant' });

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -145,6 +145,30 @@ describe('BackgroundReplyRuntime', () => {
     await runtime._doStop();
   });
 
+  test('bounds the final-title grace period when its dependency does not settle', async () => {
+    const runtime = await createRuntime();
+    jest.useFakeTimers();
+    try {
+      const turn = runtime.startTurn({
+        agentId: 'agent-1',
+        agentName: 'Alpha',
+        sessionId: 'session-1',
+        sessionTitle: '',
+      });
+      const session = mockSessions[0];
+
+      turn.finish('completed', { waitFor: new Promise(() => {}) });
+      await jest.advanceTimersByTimeAsync(4_999);
+      expect(session?.finish).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(session?.finish).toHaveBeenCalledWith(expect.objectContaining({ phase: 'completed' }));
+    } finally {
+      jest.useRealTimers();
+      await runtime._doStop();
+    }
+  });
+
   test('marks phase changes urgent and drops keep-alive while approval is pending', async () => {
     const runtime = await createRuntime();
     const turn = runtime.startTurn({

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -116,6 +116,35 @@ describe('BackgroundReplyRuntime', () => {
     await runtime._doStop();
   });
 
+  test('keeps terminal content updateable until a finish dependency settles', async () => {
+    const runtime = await createRuntime();
+    const finishDependency = createDeferred();
+    const turn = runtime.startTurn({
+      agentId: 'agent-1',
+      agentName: 'Alpha',
+      sessionId: 'session-1',
+      sessionTitle: '',
+    });
+    const session = mockSessions[0];
+
+    turn.finish('completed', { waitFor: finishDependency.promise });
+
+    expect(session?.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({ phase: 'completed' }),
+      { keepAlive: false, urgent: true },
+    );
+    await flushOperations();
+    expect(session?.finish).not.toHaveBeenCalled();
+
+    turn.updateConversationTitle('Summary title');
+    finishDependency.resolve();
+    await flushOperations();
+    expect(session?.finish).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'completed', title: 'Summary title' }),
+    );
+    await runtime._doStop();
+  });
+
   test('marks phase changes urgent and drops keep-alive while approval is pending', async () => {
     const runtime = await createRuntime();
     const turn = runtime.startTurn({
@@ -397,4 +426,12 @@ describe('BackgroundReplyRuntime', () => {
 async function flushOperations() {
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
 }

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -98,6 +98,24 @@ describe('BackgroundReplyRuntime', () => {
     await runtime._doStop();
   });
 
+  test('updates the visible title while an Agent Session turn is active', async () => {
+    const runtime = await createRuntime();
+    const turn = runtime.startTurn({
+      agentId: 'agent-1',
+      agentName: 'Alpha',
+      sessionId: 'session-1',
+      sessionTitle: '',
+    });
+
+    turn.updateConversationTitle('  Renamed session  ');
+
+    expect(mockSessions[0]?.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attribution: 'Alpha', title: 'Renamed session' }),
+      { keepAlive: true, urgent: true },
+    );
+    await runtime._doStop();
+  });
+
   test('marks phase changes urgent and drops keep-alive while approval is pending', async () => {
     const runtime = await createRuntime();
     const turn = runtime.startTurn({

--- a/src/backend/services/backgroundReply/__tests__/deriveBackgroundReplyContent.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/deriveBackgroundReplyContent.test.ts
@@ -1,3 +1,4 @@
+import type { AgentMessagePart } from '@/shared/contracts/agent';
 import type { CherryMessagePart, CherryUIMessage } from '@/shared/data/types/message';
 
 import {
@@ -86,6 +87,27 @@ describe('deriveBackgroundReplyContent', () => {
       phase: 'awaiting-approval',
       preview: 'Partial answer',
     });
+  });
+
+  test('derives tool and approval phases from Agent message parts', () => {
+    const tool = {
+      id: 'tool-1',
+      input: {},
+      state: 'running',
+      toolCallId: 'call-1',
+      toolName: 'web_search',
+      type: 'tool',
+    } as const satisfies AgentMessagePart;
+    expect(deriveBackgroundReplyContent({ parts: [tool] }, t)).toEqual({
+      detail: 'Searching the web',
+      phase: 'using-tool',
+    });
+    expect(
+      deriveBackgroundReplyContent(
+        { parts: [{ ...tool, approvalId: 'approval-1', state: 'awaiting-approval' }] },
+        t,
+      ),
+    ).toEqual({ detail: 'Awaiting approval', phase: 'awaiting-approval' });
   });
 
   test('truncates from the end without splitting unicode characters', () => {

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -29,7 +29,6 @@ export type BackgroundReplyTurn = {
   /** Shows terminal content immediately; `waitFor` delays only final surface dismissal. */
   finish: (outcome: BackgroundReplyOutcome, options?: { waitFor?: Promise<unknown> }) => void;
   update: (message: BackgroundReplyMessage) => void;
-  updateConversationTitle: (title: string) => void;
 };
 
 export type AgentSessionBackgroundReplyTurnInput = {
@@ -55,4 +54,5 @@ export type BackgroundReplyLifecycle = {
   /** Transitional compatibility entry retained until D removes ChatRuntime. */
   clearTopic: (topicId: string) => void;
   startTurn: (input: BackgroundReplyTurnInput) => BackgroundReplyTurn;
+  updateSessionTitle: (sessionId: string, title: string) => void;
 };

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -26,7 +26,8 @@ export type BackgroundReplyMessage =
  */
 export type BackgroundReplyTurn = {
   awaitApproval: (message?: BackgroundReplyMessage) => void;
-  finish: (outcome: BackgroundReplyOutcome) => void;
+  /** Shows terminal content immediately; `waitFor` delays only final surface dismissal. */
+  finish: (outcome: BackgroundReplyOutcome, options?: { waitFor?: Promise<unknown> }) => void;
   update: (message: BackgroundReplyMessage) => void;
   updateConversationTitle: (title: string) => void;
 };

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -1,4 +1,5 @@
 import type { BackgroundReplyPhase } from '@/shared/backgroundActivity/chatReply';
+import type { AgentMessageView } from '@/shared/contracts/agent';
 import type { CherryUIMessage } from '@/shared/data/types/message';
 
 // The feature contract lives in shared so the service and activity
@@ -15,23 +16,41 @@ export type BackgroundReplyOutcome = Extract<
   'cancelled' | 'completed' | 'failed'
 >;
 
+export type BackgroundReplyMessage =
+  | Pick<AgentMessageView, 'parts'>
+  | Pick<CherryUIMessage, 'parts'>;
+
 /**
  * Capability handle for one reply generation. Calls never throw, and handles
  * superseded by a newer generation become no-ops.
  */
 export type BackgroundReplyTurn = {
-  awaitApproval: (message?: CherryUIMessage) => void;
+  awaitApproval: (message?: BackgroundReplyMessage) => void;
   finish: (outcome: BackgroundReplyOutcome) => void;
-  update: (message: CherryUIMessage) => void;
+  update: (message: BackgroundReplyMessage) => void;
 };
 
-export type BackgroundReplyTurnInput = {
+export type AgentSessionBackgroundReplyTurnInput = {
+  agentId: string;
+  agentName: string;
+  sessionId: string;
+  sessionTitle: string;
+};
+
+/** Transitional input retained only until the old ChatRuntime is deleted in D. */
+export type LegacyChatBackgroundReplyTurnInput = {
   assistantName: string;
   topicId: string;
   topicTitle: string;
 };
 
+export type BackgroundReplyTurnInput =
+  | AgentSessionBackgroundReplyTurnInput
+  | LegacyChatBackgroundReplyTurnInput;
+
 export type BackgroundReplyLifecycle = {
+  clearSession: (sessionId: string) => void;
+  /** Transitional compatibility entry retained until D removes ChatRuntime. */
   clearTopic: (topicId: string) => void;
   startTurn: (input: BackgroundReplyTurnInput) => BackgroundReplyTurn;
 };

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -28,6 +28,7 @@ export type BackgroundReplyTurn = {
   awaitApproval: (message?: BackgroundReplyMessage) => void;
   finish: (outcome: BackgroundReplyOutcome) => void;
   update: (message: BackgroundReplyMessage) => void;
+  updateConversationTitle: (title: string) => void;
 };
 
 export type AgentSessionBackgroundReplyTurnInput = {

--- a/src/backend/services/backgroundReply/deriveBackgroundReplyContent.ts
+++ b/src/backend/services/backgroundReply/deriveBackgroundReplyContent.ts
@@ -2,9 +2,10 @@ import type {
   BackgroundReplyContent,
   BackgroundReplyPhase,
 } from '@/shared/backgroundActivity/chatReply';
-import type { CherryMessagePart, CherryUIMessage } from '@/shared/data/types/message';
+import type { AgentMessagePart } from '@/shared/contracts/agent';
+import type { CherryMessagePart } from '@/shared/data/types/message';
 
-import type { BackgroundReplyOutcome } from './backgroundReplyTypes';
+import type { BackgroundReplyMessage, BackgroundReplyOutcome } from './backgroundReplyTypes';
 
 const PREVIEW_CHARACTER_LIMIT = 160;
 const PREVIEW_MIN_COMPLETE_SUFFIX_LENGTH = 24;
@@ -31,16 +32,22 @@ const BUILT_IN_TOOL_TITLE_KEYS: Record<string, string> = {
   reminder_update_item: 'chat.builtinTool.reminders.update',
 };
 
-type ToolPart = Extract<CherryMessagePart, { type: 'dynamic-tool' | `tool-${string}` }>;
+type BackgroundReplyPart = AgentMessagePart | CherryMessagePart;
+type LegacyToolPart = Extract<CherryMessagePart, { type: 'dynamic-tool' | `tool-${string}` }>;
+type AgentToolPart = Extract<AgentMessagePart, { type: 'tool' }>;
+type ToolPart = AgentToolPart | LegacyToolPart;
 export type BackgroundReplyTranslate = (key: string) => string;
 
 export function deriveBackgroundReplyContent(
-  message: CherryUIMessage | undefined,
+  message: BackgroundReplyMessage | undefined,
   t: BackgroundReplyTranslate,
 ): BackgroundReplyContent {
   const parts = message?.parts ?? [];
   const preview = extractReplyPreview(parts);
-  const approval = findLastToolPart(parts, (part) => part.state === 'approval-requested');
+  const approval = findLastToolPart(
+    parts,
+    (part) => part.state === 'approval-requested' || part.state === 'awaiting-approval',
+  );
 
   if (approval) {
     return createContent('awaiting-approval', t('chat.backgroundReply.awaitingApproval'), preview);
@@ -71,9 +78,9 @@ export function getTerminalBackgroundReplyContent(
   return createContent(outcome, t(key), outcome === 'completed' ? preview : undefined);
 }
 
-export function extractReplyPreview(parts: readonly CherryMessagePart[]): string | undefined {
+export function extractReplyPreview(parts: readonly BackgroundReplyPart[]): string | undefined {
   const text = parts
-    .filter((part): part is Extract<CherryMessagePart, { type: 'text' }> => part.type === 'text')
+    .filter((part): part is Extract<BackgroundReplyPart, { type: 'text' }> => part.type === 'text')
     .map((part) => part.text)
     .join('\n');
   const plainText = stripMarkdown(text);
@@ -106,7 +113,7 @@ function createContent(
 }
 
 function findLastToolPart(
-  parts: readonly CherryMessagePart[],
+  parts: readonly BackgroundReplyPart[],
   predicate: (part: ToolPart) => boolean,
 ): ToolPart | undefined {
   return parts.findLast((part): part is ToolPart => isToolPart(part) && predicate(part));
@@ -123,19 +130,21 @@ function getToolActivityLabel(part: ToolPart, t: BackgroundReplyTranslate): stri
 }
 
 function getToolName(part: ToolPart): string {
-  return part.type === 'dynamic-tool' ? part.toolName : part.type.slice('tool-'.length);
+  if (part.type === 'dynamic-tool' || part.type === 'tool') return part.toolName;
+  return part.type.slice('tool-'.length);
 }
 
 function isActiveToolPart(part: ToolPart): boolean {
   return (
     part.state === 'input-streaming' ||
     part.state === 'input-available' ||
+    part.state === 'running' ||
     (part.state === 'approval-responded' && part.approval?.approved === true)
   );
 }
 
-function isToolPart(part: CherryMessagePart): part is ToolPart {
-  return part.type === 'dynamic-tool' || part.type.startsWith('tool-');
+function isToolPart(part: BackgroundReplyPart): part is ToolPart {
+  return part.type === 'tool' || part.type === 'dynamic-tool' || part.type.startsWith('tool-');
 }
 
 function stripMarkdown(value: string): string {

--- a/src/backend/services/backgroundReply/index.ts
+++ b/src/backend/services/backgroundReply/index.ts
@@ -1,6 +1,7 @@
 export { BackgroundReplyRuntime } from './BackgroundReplyRuntime';
 export type {
   BackgroundReplyLifecycle,
+  BackgroundReplyMessage,
   BackgroundReplyOutcome,
   BackgroundReplyPhase,
   BackgroundReplyTurn,


### PR DESCRIPTION
### What this PR does

Before this PR, Agent Session turns did not create analytical usage records or participate in background reply activities.

After this PR:

- settled turns project detailed token usage into `ai_usage_record` with Agent, Agent Session, and
  serving-credential attribution;
- provider, served-model, pricing, and credential context is snapshotted during request-time model
  resolution instead of being re-read after the turn;
- background reply activities are keyed by Session and open the Agent Session deep link;
- streaming, approval, Session rename, terminal, deletion, and lifecycle cleanup update or finish
  the activity;
- terminal activities release keep-alive immediately, then allow up to five seconds for a final
  title projection before finishing;
- the legacy Topic input remains explicitly isolated until the D cleanup removes `ChatRuntime`.

### Screenshots or videos

N/A — background activity UI was not manually exercised in this workspace.

### Why we need it and why it was done in this way

Both projections are best-effort side effects around the durable Agent turn lifecycle. Failures cannot fail a turn, request IDs are stable per turn, and lifecycle drains prevent pending usage work from being abandoned during host teardown.

The final-title grace period is deliberately bounded so a slow naming provider cannot leave a
completed background activity open indefinitely.

The Runtime usage event carries its immutable request-time accounting context and cumulative
no-cache, cache-read, cache-write, output, and reasoning token counts. The Host adds only the Agent
and message attribution; it deliberately omits a completion-duration metric until provider-boundary
timing is available.

### Breaking changes

None. The legacy Topic background-reply adapter remains until the old Chat runtime is removed.

### Special notes for your reviewer

This is the third layer of C3 stack #647 and targets PR #644.

Local formatting and lint passed. Per the workspace verification policy, tests, typecheck, builds, and manual UI verification were not run locally; remote CI is the complete-suite gate.

### Checklist

- [x] Branch: This PR targets the preceding stack layer
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: N/A is explained above
- [x] Code: Usage and background-reply changes follow the same Agent turn lifecycle
- [x] Refactor: Legacy compatibility is isolated and explicitly temporary
- [x] Upgrade: Existing Topic background replies remain compatible until D
- [x] Documentation: No user-guide update is required
- [x] Self-review: The branch diff and stack integration were reviewed

### Release note

```release-note
Keep Agent replies visible in background activities and include them in AI usage statistics.
```
