### PR TITLE
fix(chat-input): restore model and reasoning controls

### DIFF
--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -86,8 +86,9 @@ clean cut. See [Branching](./agent-protocol.md#branching) for the rules.
 
 The Runtime contract, Fake Runtime, Pi Runtime, Protocol contract, and Mobile Agent Host are
 implemented. The Host binds `local` directly to Pi, consumes the message-centric
-`AgentSessionStore` port, owns the Turn projection, and forwards Agent inference settings into each
-execution. The durable `SqliteAgentSessionStore` is the production store binding over the
+`AgentSessionStore` port, owns the Turn projection, and merges immutable composer model/reasoning
+snapshots over the current Agent definition for each execution. These snapshots are not persisted
+by the Agent Protocol. The durable `SqliteAgentSessionStore` is the production store binding over the
 `agent`/`agent_session`/`agent_session_message` tables. Agent CRUD and static Session/transcript
 reads are exposed through the Data API, and the Host resolves definitions from the `agent` table.
 The table intentionally starts empty: retired Assistant data is not migrated or copied. See

--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -110,6 +110,9 @@ owns or reads it directly.
 second synonym set. Timestamps are integer epoch millis via `createUpdateDeleteTimestamps`; the
 store maps to the protocol's ISO strings at the boundary. `agent` uses UUID v4 (like `assistant`);
 `agent_session` and `agent_session_message` use time-ordered UUID v7 (`uuidPrimaryKeyOrdered`).
+Agent updates advance `updatedAt` with `max(previous + 1, wall clock)` inside the serialized write
+transaction. The composer can therefore use it as a strict row version when reconciling optimistic
+model selection with settings edits and inactive query caches.
 
 **Desktop divergence is documented.** Mobile shares the desktop table names and the
 `agent → agent_session → agent_session_message` shape but owns its columns, per the #568

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -202,6 +202,8 @@ interface AgentProtocol {
   submitMessage(input: {
     sessionId: string
     parts: AgentInputPart[]
+    modelId?: UniqueModelId
+    reasoningEffort?: ReasoningEffortOption
   }): Promise<{ turnId: string; userMessageId: string; assistantMessageId: string }>
 
   cancelTurn(input: { sessionId: string; turnId: string }): Promise<void>
@@ -224,6 +226,12 @@ type AgentSessionObservation = {
   unsubscribe(): void
 }
 ```
+
+`modelId` and `reasoningEffort` are immutable snapshots of the composer state for that submission.
+The model snapshot closes the gap while the same selection is persisted to the Agent. The reasoning
+snapshot is turn-local and is never written to Agent configuration. Omitting either field inherits
+the Agent definition loaded for that turn; an explicit reasoning `default` uses the selected model's
+default instead of the Agent's configured effort.
 
 `observeSession` registers the listener and captures the snapshot as one Host operation, so an
 event cannot fall into a snapshot/subscription gap. Calling it again replaces stale frontend state;

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -121,7 +121,7 @@ type RuntimeModel = {
 }
 
 type RuntimeOptions = {
-  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  reasoningEffort?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
   maxOutputTokens?: number
   temperature?: number
 }
@@ -133,6 +133,10 @@ type RuntimeInputPart =
 
 Runtime implementations receive model/provider dependencies from application composition. They do
 not query Cherry provider or model tables.
+
+The Host resolves protocol-level turn snapshots before this boundary. `default` and the current Pi
+`auto` fallback become an absent `reasoningEffort`, while `none` becomes `off`; Runtime
+implementations therefore receive only an executable effort level.
 
 File input is resolved by the Host before it reaches a Runtime: attachments enter the application's
 file storage first, and the Host converts stored `file://` references into a directly consumable

--- a/src/backend/ai/agent/types.ts
+++ b/src/backend/ai/agent/types.ts
@@ -61,7 +61,7 @@ export type RuntimeModel = {
 };
 
 export type RuntimeOptions = {
-  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
+  reasoningEffort?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   maxOutputTokens?: number;
   temperature?: number;
 };

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -70,9 +70,11 @@ import {
   type AgentProtocol,
   type AgentSessionObservation,
   type AgentSessionView,
+  type AgentSubmitMessageInput,
   type AgentTurnView,
 } from '@/shared/contracts/agent';
 import { loggerService } from '@/shared/core/logger/LoggerService';
+import { parseUniqueModelId } from '@/shared/data/types/model';
 
 import {
   createAgentTableDefinitionSource,
@@ -291,10 +293,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     }
   }
 
-  async submitMessage(input: {
-    sessionId: string;
-    parts: AgentInputPart[];
-  }): Promise<{ turnId: string; userMessageId: string; assistantMessageId: string }> {
+  async submitMessage(
+    input: AgentSubmitMessageInput,
+  ): Promise<{ turnId: string; userMessageId: string; assistantMessageId: string }> {
     const parsed = AgentSubmitMessageInputSchema.parse(input);
     const { sessionId } = parsed;
     this.assertIdle(sessionId);
@@ -307,7 +308,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       if (!session) {
         fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
       }
-      const agent = await this.requireAgent(session.agentId);
+      const configuredAgent = await this.requireAgent(session.agentId);
+      const agent = applyTurnOverrides(configuredAgent, parsed);
       const runtime = this.routeExecutionTarget(session.executionTarget);
       if (
         !runtime.descriptor.capabilities.attachments &&
@@ -780,4 +782,30 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         logger.warn('Agent Session auto-naming failed', error as Error);
       });
   }
+}
+
+function applyTurnOverrides(
+  agent: AgentDefinition,
+  input: Pick<AgentSubmitMessageInput, 'modelId' | 'reasoningEffort'>,
+): AgentDefinition {
+  if (input.modelId === undefined && input.reasoningEffort === undefined) {
+    return agent;
+  }
+
+  const options = { ...agent.options };
+  if (input.reasoningEffort !== undefined) {
+    if (input.reasoningEffort === 'default' || input.reasoningEffort === 'auto') {
+      // Pi resolves an absent effort to the selected model's default. Removing
+      // the Agent setting here makes an explicit composer "default" win.
+      delete options.reasoningEffort;
+    } else {
+      options.reasoningEffort = input.reasoningEffort === 'none' ? 'off' : input.reasoningEffort;
+    }
+  }
+
+  return {
+    ...agent,
+    ...(input.modelId ? { model: parseUniqueModelId(input.modelId) } : {}),
+    options,
+  };
 }

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -275,6 +275,54 @@ describe('MobileAgentHost', () => {
     expect(requests[1]?.history.map((message) => message.role)).toEqual(['user', 'assistant']);
   });
 
+  test('applies composer model and reasoning snapshots to only the submitted turn', async () => {
+    const requests: RuntimeExecutionRequest[] = [];
+    const host = hostWithText(['One', 'Two', 'Three'], requests);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const events: AgentEvent[] = [];
+    await host.observeSession(session.id, (event) => events.push(event));
+    const completedTurnCount = () =>
+      events.filter((event) => event.type === 'turn.updated' && event.turn.status === 'completed')
+        .length;
+
+    await host.submitMessage({
+      modelId: 'override-provider::override-model',
+      parts: [{ type: 'text', text: 'Override both.' }],
+      reasoningEffort: 'max',
+      sessionId: session.id,
+    });
+    await waitFor(() => completedTurnCount() === 1, 'the override turn');
+    expect(requests[0]).toMatchObject({
+      model: { modelId: 'override-model', providerId: 'override-provider' },
+      options: { maxOutputTokens: 512, reasoningEffort: 'max', temperature: 0.2 },
+    });
+
+    await host.submitMessage({
+      parts: [{ type: 'text', text: 'Use the model default.' }],
+      reasoningEffort: 'default',
+      sessionId: session.id,
+    });
+    await waitFor(() => completedTurnCount() === 2, 'the default-effort turn');
+    expect(requests[1]).toMatchObject({
+      model: { modelId: 'mock-model', providerId: 'mock-provider' },
+      options: { maxOutputTokens: 512, temperature: 0.2 },
+    });
+    expect(requests[1]?.options).not.toHaveProperty('reasoningEffort');
+
+    await host.submitMessage({
+      parts: [{ type: 'text', text: 'Use the Agent configuration again.' }],
+      sessionId: session.id,
+    });
+    await waitFor(() => completedTurnCount() === 3, 'the inherited Agent turn');
+    expect(requests[2]).toMatchObject({
+      model: { modelId: 'mock-model', providerId: 'mock-provider' },
+      options: { maxOutputTokens: 512, reasoningEffort: 'low', temperature: 0.2 },
+    });
+  });
+
   test('cancel settles the turn as cancelled and is idempotent', async () => {
     const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script(async (controller) => {
       controller.emit({

--- a/src/backend/data/db/schemas/_columnHelpers.ts
+++ b/src/backend/data/db/schemas/_columnHelpers.ts
@@ -2,7 +2,8 @@
  * Column helper utilities for Drizzle schemas
  *
  * USAGE RULES:
- * - DO NOT manually set id, createdAt, or updatedAt - they are auto-generated
+ * - DO NOT manually set id, createdAt, or updatedAt. State with a documented row-version
+ *   contract may set `updatedAt` only through `monotonicUpdateTimestamp`.
  * - Use .returning() to get inserted/updated rows instead of re-querying
  * - See db/README.md for detailed field generation rules
  *
@@ -15,6 +16,7 @@
  *   soft-deleted.
  */
 
+import { type AnyColumn, type SQL, sql } from 'drizzle-orm';
 import { type AnySQLiteColumn, index, integer, text } from 'drizzle-orm/sqlite-core';
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid';
 
@@ -42,6 +44,15 @@ export const uuidPrimaryKeyOrdered = () =>
 const createTimestamp = () => {
   return Date.now();
 };
+
+/**
+ * Produces a row-relative timestamp version for state that must reconcile concurrent writers.
+ * The expression runs inside the serialized write transaction, so it advances even when two
+ * updates share one wall-clock millisecond.
+ */
+export function monotonicUpdateTimestamp(column: AnyColumn): SQL<number> {
+  return sql<number>`max(${column} + 1, ${Date.now()})`;
+}
 
 export const createUpdateTimestamps = {
   createdAt: integer().notNull().$defaultFn(createTimestamp),

--- a/src/backend/data/db/schemas/index.ts
+++ b/src/backend/data/db/schemas/index.ts
@@ -15,6 +15,7 @@ export * from './agent';
 export * from './agentSession';
 export * from './agentSessionMessage';
 export * from './aiUsageRecord';
+export { monotonicUpdateTimestamp } from './_columnHelpers';
 export * from './job';
 export * from './mcpServer';
 export * from './painting';

--- a/src/backend/data/services/AgentService.ts
+++ b/src/backend/data/services/AgentService.ts
@@ -1,7 +1,12 @@
 import { and, asc, desc, eq, inArray, isNull, or, type SQL, sql } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
-import { type AgentRow, agentTable, userModelTable } from '@/backend/data/db/schemas';
+import {
+  type AgentRow,
+  agentTable,
+  monotonicUpdateTimestamp,
+  userModelTable,
+} from '@/backend/data/db/schemas';
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
 import {
   type CreateAgentDto,
@@ -188,7 +193,10 @@ export class AgentService {
 
       const [updated] = await tx
         .update(agentTable)
-        .set(updates)
+        .set({
+          ...updates,
+          updatedAt: monotonicUpdateTimestamp(agentTable.updatedAt),
+        })
         .where(and(eq(agentTable.id, id), isNull(agentTable.deletedAt)))
         .returning();
       if (!updated) {
@@ -214,7 +222,10 @@ export class AgentService {
     const deleted = await this.dbService.withWriteTx(async (tx) => {
       const [row] = await tx
         .update(agentTable)
-        .set({ deletedAt: Date.now() })
+        .set({
+          deletedAt: Date.now(),
+          updatedAt: monotonicUpdateTimestamp(agentTable.updatedAt),
+        })
         .where(and(eq(agentTable.id, id), isNull(agentTable.deletedAt)))
         .returning({ id: agentTable.id });
       return Boolean(row);
@@ -240,6 +251,7 @@ export class AgentService {
       }
 
       await applyMoves(tx, agentTable, [{ anchor, id }], {
+        monotonicUpdatedAtColumn: agentTable.updatedAt,
         pkColumn: agentTable.id,
         scope: isNull(agentTable.deletedAt),
       });
@@ -265,6 +277,7 @@ export class AgentService {
       }
 
       await applyMoves(tx, agentTable, moves, {
+        monotonicUpdatedAtColumn: agentTable.updatedAt,
         pkColumn: agentTable.id,
         scope: isNull(agentTable.deletedAt),
       });

--- a/src/backend/data/services/ModelService.ts
+++ b/src/backend/data/services/ModelService.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, inArray, type SQL } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
+import { agentTable, monotonicUpdateTimestamp } from '@/backend/data/db/schemas';
 import type { InsertUserModelRow, UserModelRow } from '@/backend/data/db/schemas/userModel';
 import { userModelTable } from '@/backend/data/db/schemas/userModel';
 import { DataApiErrorFactory, ErrorCode } from '@/shared/data/api/errors';
@@ -470,6 +471,10 @@ export class ModelService {
     await this.assertNotUsedAsDefault(id, `delete model ${id}`);
 
     await this.dbService.withWriteTx(async (tx) => {
+      await tx
+        .update(agentTable)
+        .set({ updatedAt: monotonicUpdateTimestamp(agentTable.updatedAt) })
+        .where(eq(agentTable.modelId, id));
       const rows = await tx
         .delete(userModelTable)
         .where(and(eq(userModelTable.providerId, providerId), eq(userModelTable.modelId, modelId)))
@@ -512,6 +517,12 @@ export class ModelService {
       }
 
       for (const idChunk of chunks(ids, sqliteBatchSize)) {
+        // Keep Agent row versions ahead of the FK's modelId -> null cascade.
+        // react-doctor-disable-next-line async-await-in-loop -- chunks avoid SQLite's variable limit
+        await tx
+          .update(agentTable)
+          .set({ updatedAt: monotonicUpdateTimestamp(agentTable.updatedAt) })
+          .where(inArray(agentTable.modelId, idChunk));
         // react-doctor-disable-next-line async-await-in-loop -- chunks avoid SQLite's variable limit
         await tx.delete(userModelTable).where(inArray(userModelTable.id, idChunk));
       }
@@ -672,6 +683,12 @@ export class ModelService {
       );
       const removedIds: string[] = [];
       for (const idChunk of chunks(removableIds, sqliteBatchSize)) {
+        // Keep Agent row versions ahead of the FK's modelId -> null cascade.
+        // react-doctor-disable-next-line async-await-in-loop -- chunks avoid SQLite's variable limit
+        await tx
+          .update(agentTable)
+          .set({ updatedAt: monotonicUpdateTimestamp(agentTable.updatedAt) })
+          .where(inArray(agentTable.modelId, idChunk));
         // react-doctor-disable-next-line async-await-in-loop -- chunks avoid SQLite's variable limit
         const rows = await tx
           .delete(userModelTable)

--- a/src/backend/data/services/ProviderService.ts
+++ b/src/backend/data/services/ProviderService.ts
@@ -3,6 +3,7 @@ import { asc, eq, inArray } from 'drizzle-orm';
 import * as Crypto from 'expo-crypto';
 
 import { application } from '@/backend/core/application/Application';
+import { agentTable, monotonicUpdateTimestamp, userModelTable } from '@/backend/data/db/schemas';
 import type {
   InsertUserProviderRow,
   UserProviderRow,
@@ -537,6 +538,15 @@ export class ProviderService {
       ) {
         throw DataApiErrorFactory.invalidOperation(`Cannot delete preset provider '${providerId}'`);
       }
+
+      const providerModelIds = tx
+        .select({ id: userModelTable.id })
+        .from(userModelTable)
+        .where(eq(userModelTable.providerId, providerId));
+      await tx
+        .update(agentTable)
+        .set({ updatedAt: monotonicUpdateTimestamp(agentTable.updatedAt) })
+        .where(inArray(agentTable.modelId, providerModelIds));
 
       const deletedProviders = await tx
         .delete(userProviderTable)

--- a/src/backend/data/services/__tests__/AgentService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentService.integration.test.ts
@@ -120,6 +120,17 @@ describe('AgentService persistence', () => {
     });
   });
 
+  it('advances the Agent version when updates share one wall-clock millisecond', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const agent = await agentService.create({ name: 'Researcher' });
+
+    const firstUpdate = await agentService.update(agent.id, { description: 'First' });
+    const secondUpdate = await agentService.update(agent.id, { description: 'Second' });
+
+    expect(Date.parse(firstUpdate.updatedAt)).toBeGreaterThan(Date.parse(agent.updatedAt));
+    expect(Date.parse(secondUpdate.updatedAt)).toBeGreaterThan(Date.parse(firstUpdate.updatedAt));
+  });
+
   it('clears a stored setting when the patch carries the key as explicit undefined', async () => {
     const agent = await agentService.create({
       name: 'Researcher',

--- a/src/backend/data/services/__tests__/ModelService.test.ts
+++ b/src/backend/data/services/__tests__/ModelService.test.ts
@@ -101,6 +101,7 @@ describe('ModelService', () => {
           where: jest.fn(async () => [{ id: 'openai::old-model', presetModelId: 'old-model' }]),
         })),
       })),
+      update: createUpdateMock(),
     };
     const dbService = {
       withWriteTx: jest.fn(async (callback) => callback(tx)),
@@ -113,7 +114,11 @@ describe('ModelService', () => {
     });
 
     expect(dbService.withWriteTx).toHaveBeenCalledTimes(1);
+    expect(tx.update).toHaveBeenCalledTimes(1);
     expect(tx.delete).toHaveBeenCalledWith(userModelTable);
+    expect(tx.update.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.delete.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(deletedWhereClauses).toHaveLength(1);
     expect(result.added).toEqual([
       expect.objectContaining({
@@ -146,6 +151,7 @@ describe('ModelService', () => {
           ]),
         })),
       })),
+      update: createUpdateMock(),
     };
     const dbService = {
       withWriteTx: jest.fn(async (callback) => callback(tx)),
@@ -176,6 +182,7 @@ describe('ModelService', () => {
     });
 
     expect(result.removedIds).toEqual(['openai::replace', 'openai::stale']);
+    expect(tx.update).toHaveBeenCalledTimes(1);
     expect(tx.delete.mock.invocationCallOrder[0]).toBeLessThan(
       jest.mocked(insertManyWithOrderKey).mock.invocationCallOrder.at(-1) ??
         Number.POSITIVE_INFINITY,
@@ -202,6 +209,7 @@ describe('ModelService', () => {
       select: jest.fn(() => ({
         from: jest.fn(() => ({ where: selectWhere })),
       })),
+      update: createUpdateMock(),
     };
     const service = await createService({
       withWriteTx: jest.fn(async (callback) => callback(tx)),
@@ -216,6 +224,7 @@ describe('ModelService', () => {
     });
 
     expect(selectWhere).toHaveBeenCalledTimes(3);
+    expect(tx.update).toHaveBeenCalledTimes(3);
     expect(returning).toHaveBeenCalledTimes(3);
     const insertCalls = jest.mocked(insertManyWithOrderKey).mock.calls;
     expect(insertCalls.length).toBeGreaterThan(3);
@@ -303,12 +312,14 @@ describe('ModelService', () => {
       delete: jest.fn(() => ({
         where: jest.fn(() => ({ returning: jest.fn(async () => [{ id: 'openai::custom' }]) })),
       })),
+      update: createUpdateMock(),
     };
     const service = await createService({
       withWriteTx: jest.fn(async (callback) => callback(tx)),
     } as unknown as DbService);
 
     await expect(service.delete('openai::custom')).resolves.toBe(true);
+    expect(tx.update).toHaveBeenCalledTimes(1);
   });
 
   test('refuses to delete the chat default and never opens a transaction for it', async () => {
@@ -326,6 +337,7 @@ describe('ModelService', () => {
       delete: jest.fn(() => ({
         where: jest.fn(() => ({ returning: jest.fn(async () => []) })),
       })),
+      update: createUpdateMock(),
     };
     const service = await createService({
       withWriteTx: jest.fn(async (callback) => callback(tx)),
@@ -343,4 +355,10 @@ async function createService(
 ): Promise<ModelService> {
   await installTestHost({ DbService: dbService, PreferenceService: preferenceService });
   return new ModelService();
+}
+
+function createUpdateMock() {
+  return jest.fn(() => ({
+    set: jest.fn(() => ({ where: jest.fn(async () => undefined) })),
+  }));
 }

--- a/src/backend/data/services/__tests__/ProviderService.test.ts
+++ b/src/backend/data/services/__tests__/ProviderService.test.ts
@@ -177,7 +177,11 @@ describe('ProviderService', () => {
 
     await service.delete('custom-provider');
 
+    expect(tx.update).toHaveBeenCalledTimes(1);
     expect(tx.delete).toHaveBeenCalledTimes(1);
+    expect(tx.update.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.delete.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   test('allows deleting a user clone of a registry provider', async () => {
@@ -420,6 +424,9 @@ function createDeleteTransaction(input: { presetProviderId: string | null; provi
           limit: jest.fn(async () => [{ presetProviderId: input.presetProviderId }]),
         })),
       })),
+    })),
+    update: jest.fn(() => ({
+      set: jest.fn(() => ({ where: jest.fn(async () => undefined) })),
     })),
   };
 }

--- a/src/backend/data/services/utils/orderKey.ts
+++ b/src/backend/data/services/utils/orderKey.ts
@@ -13,6 +13,7 @@ import {
 import type { SQLiteTable } from 'drizzle-orm/sqlite-core';
 import { generateKeyBetween, generateNKeysBetween } from 'fractional-indexing';
 
+import { monotonicUpdateTimestamp } from '@/backend/data/db/schemas';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
 import type { OrderRequest } from '@/shared/data/api/schemas/endpointHelpers';
@@ -36,6 +37,7 @@ interface InsertManyWithOrderKeyOptions {
 }
 
 interface ApplyMovesOptions {
+  monotonicUpdatedAtColumn?: AnyColumn;
   pkColumn: AnyColumn;
   scope?: SQL;
 }
@@ -163,7 +165,14 @@ export async function applyMoves(
 
     await tx
       .update(table)
-      .set({ orderKey: newKey })
+      .set({
+        orderKey: newKey,
+        ...(options.monotonicUpdatedAtColumn
+          ? {
+              updatedAt: monotonicUpdateTimestamp(options.monotonicUpdatedAtColumn),
+            }
+          : {}),
+      })
       .where(scope ? and(eq(pkColumn, move.id), scope) : eq(pkColumn, move.id));
   }
 }

--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -1,15 +1,41 @@
 import { Composer } from '@cherrystudio/ui/components';
-import { useCallback } from 'react';
+import { duration, easing } from '@cherrystudio/ui/motion';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { type LayoutChangeEvent, View } from 'react-native';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import {
   ComposerAttachments,
   ComposerField,
+  ComposerModelPill,
   type ComposerSendPayload,
   ComposerSurface,
+  useComposerMeta,
 } from '@/frontend/components/composer';
+import {
+  ModelPickerDrawer,
+  ModelPickerIcon,
+  type ModelPickerModelItem,
+  useModelPickerData,
+} from '@/frontend/components/modelPicker';
+import { useAgentApiById, useAgentMutations } from '@/frontend/hooks/agent';
+import { loggerService } from '@/shared/core/logger/LoggerService';
 
 import { useAgentChatControls } from '../runtime';
+import { ChatInputEffortOverlay } from './components/ChatInputEffortOverlay';
+import { useBlurComposerOnVisibleKeyboardHide } from './hooks/useBlurComposerOnVisibleKeyboardHide';
+import { useChatInputAgentModelSelection } from './hooks/useChatInputAgentModelSelection';
+import { useChatInputReasoningEfforts } from './hooks/useChatInputReasoningEfforts';
+import { useChatInputReasoningEffortSelection } from './hooks/useChatInputReasoningEffortSelection';
+import { getChatInputReasoningEffortSnapshot } from './utils/chatInputReasoning';
 
 type ChatInputProps = {
   agentId?: string;
@@ -19,17 +45,163 @@ type ChatInputProps = {
 
 class AgentAttachmentsUnsupportedError extends Error {}
 
+const logger = loggerService.withContext('ChatInput');
+const restingInputHeight = 32;
+const restingSendSlotWidth = restingInputHeight + 8;
+const activeToolbarGap = 12;
+const focusTransitionMotion = {
+  duration: duration.base,
+  easing: easing.settle,
+  reduceMotion: ReduceMotion.System,
+} as const;
+
 export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInputProps) {
   const { t } = useTranslation();
   const { cancel, isBusy, sendText } = useAgentChatControls({ agentId, sessionId });
+  const { agent } = useAgentApiById(agentId);
+  const { updateAgent } = useAgentMutations();
+  const modelPickerData = useModelPickerData();
+  const persistModel = useCallback(
+    (targetAgentId: string, modelId: ModelPickerModelItem['modelId']) =>
+      updateAgent(targetAgentId, { modelId }),
+    [updateAgent],
+  );
+  const handleModelPersistenceError = useCallback(
+    (error: unknown, { agentId: targetAgentId, modelId }: { agentId: string; modelId: string }) => {
+      logger.warn('Failed to persist Agent model selection', error as Error, {
+        agentId: targetAgentId,
+        modelId,
+      });
+    },
+    [],
+  );
+  const { selectModel, selectedModelId } = useChatInputAgentModelSelection(
+    agentId,
+    agent,
+    persistModel,
+    handleModelPersistenceError,
+  );
+  const selectedModelItem = modelPickerData.getModelItem(selectedModelId);
+  const selectedModel = selectedModelItem?.model;
+  const selectedModelLabel = selectedModel?.name;
+  const reasoningEfforts = useChatInputReasoningEfforts(selectedModel);
+  const { isReasoningEffortSelected, reasoningEffort, selectReasoningEffort } =
+    useChatInputReasoningEffortSelection(
+      reasoningEfforts,
+      agent?.settings.reasoningEffort,
+      agentId,
+    );
+  const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
+  const [isInputActive, setIsInputActive] = useState(false);
+  const isInputActiveRef = useRef(false);
+  const naturalFieldHeight = useRef(restingInputHeight);
+  const { inputRef } = useComposerMeta();
+  useBlurComposerOnVisibleKeyboardHide(inputRef);
+  const focusProgress = useSharedValue(0);
+  const fieldFrameHeight = useSharedValue(restingInputHeight);
+  const morphFrameStyle = useAnimatedStyle(() => ({
+    height: fieldFrameHeight.value + focusProgress.value * (activeToolbarGap + restingInputHeight),
+  }));
+  const fieldFrameStyle = useAnimatedStyle(() => ({
+    height: fieldFrameHeight.value,
+    left: 0,
+    right: interpolate(focusProgress.value, [0, 1], [restingSendSlotWidth, 0], Extrapolation.CLAMP),
+  }));
+  const controlsRowStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateY: focusProgress.value * (fieldFrameHeight.value + activeToolbarGap),
+      },
+    ],
+  }));
+  const modelControlStyle = useAnimatedStyle(() => ({
+    opacity: focusProgress.value,
+    transform: [
+      {
+        scale: interpolate(focusProgress.value, [0, 1], [0.92, 1], Extrapolation.CLAMP),
+      },
+    ],
+  }));
+  const effortControlStyle = useAnimatedStyle(() => ({
+    opacity: focusProgress.value,
+    transform: [
+      {
+        scale: interpolate(focusProgress.value, [0, 1], [0.92, 1], Extrapolation.CLAMP),
+      },
+    ],
+  }));
+  const closeModelPicker = useCallback(() => setIsModelPickerOpen(false), []);
+  const openModelPicker = useCallback(() => setIsModelPickerOpen(true), []);
+  const handleFieldLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = Math.max(restingInputHeight, Math.ceil(event.nativeEvent.layout.height));
+      if (naturalFieldHeight.current === nextHeight) {
+        return;
+      }
+
+      naturalFieldHeight.current = nextHeight;
+      if (isInputActive) {
+        fieldFrameHeight.set(nextHeight);
+      }
+    },
+    [fieldFrameHeight, isInputActive],
+  );
+  const handleInputBlur = useCallback(() => {
+    if (!isInputActiveRef.current) {
+      return;
+    }
+
+    isInputActiveRef.current = false;
+    setIsInputActive(false);
+    focusProgress.set(withTiming(0, focusTransitionMotion));
+    fieldFrameHeight.set(withTiming(restingInputHeight, focusTransitionMotion));
+  }, [fieldFrameHeight, focusProgress]);
+  const handleInputFocus = useCallback(() => {
+    isInputActiveRef.current = true;
+    setIsInputActive(true);
+    focusProgress.set(withTiming(1, focusTransitionMotion));
+    fieldFrameHeight.set(withTiming(naturalFieldHeight.current, focusTransitionMotion));
+  }, [fieldFrameHeight, focusProgress]);
+  const handleModelSelect = useCallback(
+    (item: ModelPickerModelItem) => {
+      setIsModelPickerOpen(false);
+      if (!agentId || selectedModelId === item.modelId) {
+        return;
+      }
+
+      selectModel(item.modelId);
+    },
+    [agentId, selectModel, selectedModelId],
+  );
   const handleSendPress = useCallback(
     ({ attachments, text }: ComposerSendPayload) => {
       if (attachments.length > 0) {
         throw new AgentAttachmentsUnsupportedError();
       }
-      return sendText(text);
+
+      return sendText({
+        text,
+        ...(selectedModelId ? { modelId: selectedModelId } : {}),
+        ...(reasoningEfforts.length > 0
+          ? {
+              reasoningEffort: getChatInputReasoningEffortSnapshot(
+                reasoningEffort,
+                isReasoningEffortSelected,
+                agent?.settings.reasoningEffort,
+                reasoningEfforts,
+              ),
+            }
+          : {}),
+      });
     },
-    [sendText],
+    [
+      agent?.settings.reasoningEffort,
+      isReasoningEffortSelected,
+      reasoningEffort,
+      reasoningEfforts,
+      selectedModelId,
+      sendText,
+    ],
   );
   const getSendErrorLabel = useCallback(
     (error: unknown) =>
@@ -40,20 +212,83 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
   );
 
   return (
-    <ComposerSurface
-      dismissKeyboardOnSend={dismissKeyboardOnSend}
-      getSendErrorLabel={getSendErrorLabel}
-      onSend={handleSendPress}
-      onStop={() => void cancel()}
-      streaming={isBusy}
-    >
-      {/* Pasted attachments remain visible and removable, but sending fails closed until
-          the Host-side file resolver enables the protocol capability. */}
-      <ComposerAttachments />
-      <ComposerField />
-      <Composer.Toolbar>
-        <Composer.Send />
-      </Composer.Toolbar>
-    </ComposerSurface>
+    <>
+      <ChatInputEffortOverlay
+        modelLabel={selectedModelLabel}
+        onChange={selectReasoningEffort}
+        reasoningEffort={reasoningEffort}
+        reasoningEfforts={reasoningEfforts}
+      >
+        {(effortGauge) => (
+          <ComposerSurface
+            dismissKeyboardOnSend={dismissKeyboardOnSend}
+            getSendErrorLabel={getSendErrorLabel}
+            onSend={handleSendPress}
+            onStop={() => void cancel()}
+            streaming={isBusy}
+          >
+            {/* Pasted attachments remain visible and removable, but sending fails closed until
+                the Host-side file resolver enables the protocol capability. */}
+            <ComposerAttachments />
+            <Animated.View className="relative overflow-hidden" style={morphFrameStyle}>
+              <Animated.View className="absolute top-0 overflow-hidden" style={fieldFrameStyle}>
+                <View className="absolute top-0 right-0 left-0" onLayout={handleFieldLayout}>
+                  <ComposerField onBlur={handleInputBlur} onFocus={handleInputFocus} />
+                </View>
+              </Animated.View>
+              <Animated.View
+                className="absolute top-0 right-0 left-0 flex-row items-center gap-2"
+                pointerEvents="box-none"
+                style={controlsRowStyle}
+              >
+                <Animated.View
+                  accessibilityElementsHidden={!isInputActive}
+                  className="min-w-0 shrink"
+                  importantForAccessibility={isInputActive ? 'auto' : 'no-hide-descendants'}
+                  pointerEvents={isInputActive ? 'auto' : 'none'}
+                  style={modelControlStyle}
+                >
+                  <ComposerModelPill
+                    icon={
+                      selectedModelItem ? (
+                        <ModelPickerIcon
+                          model={selectedModelItem.model}
+                          provider={selectedModelItem.provider}
+                          providerIconSize={18}
+                          size={20}
+                        />
+                      ) : undefined
+                    }
+                    label={selectedModelLabel}
+                    onPress={openModelPicker}
+                  />
+                </Animated.View>
+                <View className="ml-auto flex-row items-center gap-2" pointerEvents="box-none">
+                  {effortGauge ? (
+                    <Animated.View
+                      accessibilityElementsHidden={!isInputActive}
+                      importantForAccessibility={isInputActive ? 'auto' : 'no-hide-descendants'}
+                      pointerEvents={isInputActive ? 'auto' : 'none'}
+                      style={effortControlStyle}
+                    >
+                      {effortGauge}
+                    </Animated.View>
+                  ) : null}
+                  <Composer.Send />
+                </View>
+              </Animated.View>
+            </Animated.View>
+          </ComposerSurface>
+        )}
+      </ChatInputEffortOverlay>
+      {isModelPickerOpen ? (
+        <ModelPickerDrawer
+          open
+          onClose={closeModelPicker}
+          onSelect={handleModelSelect}
+          selectedModelId={selectedModelId}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -12,6 +12,14 @@ exported through `index.ts` and receives the current `agentId` and optional `ses
 - The Agent Host currently reports `attachments: false`. Chat exposes no attachment picker; pasted
   attachments remain removable but sending them fails with an explicit unsupported message.
 - While a turn is active, the send control becomes stop and calls `cancelTurn` for that Session.
-- Agent model and inference settings are edited on the Agent screen, not inside the composer.
+- The resting composer is one row. Focusing it reveals the model pill and reasoning-effort gauge on
+  the toolbar below without remounting the field, draft, or send control.
+- Picking a model updates the current Agent's `modelId`. Submission also snapshots the visible
+  model so an immediate send cannot race the Agent mutation or query refresh. Rapid picks are
+  persisted serially and coalesced to the latest visible selection.
+- The reasoning gauge inherits the Agent setting until the user picks a value. A pick is local to
+  the current Agent composer and is snapshotted into each submission; it never updates Agent
+  configuration. An explicit `default` selection bypasses the Agent effort for that turn and uses
+  the selected model's default.
 - Web search, tool mentions, follow-up queues, and steering are not part of the Version 1 Agent
   Session composer.

--- a/src/frontend/features/chat/input/hooks/__tests__/useChatInputAgentModelSelection.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useChatInputAgentModelSelection.test.tsx
@@ -1,0 +1,500 @@
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { Agent } from '@/shared/data/types/agent';
+import type { UniqueModelId } from '@/shared/data/types/model';
+
+import { useChatInputAgentModelSelection } from '../useChatInputAgentModelSelection';
+
+type Snapshot = ReturnType<typeof useChatInputAgentModelSelection>;
+type AgentModelSnapshot = Pick<Agent, 'modelId' | 'updatedAt'>;
+
+describe('useChatInputAgentModelSelection', () => {
+  test('keeps a local selection until the Agent query catches up', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const persistModel = jest.fn(async (_agentId: string, selectedModelId: UniqueModelId) =>
+      agentModel(selectedModelId, 2),
+    );
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+
+    await act(async () => {
+      renderer?.update(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-b')}
+          persistedUpdatedAt={updatedAt(2)}
+        />,
+      );
+    });
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+  });
+
+  test('serializes rapid selections so the last selection wins', async () => {
+    let snapshot: Snapshot | undefined;
+    const firstUpdate = deferred<AgentModelSnapshot>();
+    const secondUpdate = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(firstUpdate.promise)
+      .mockReturnValueOnce(secondUpdate.promise);
+
+    await act(async () => {
+      create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => snapshot?.selectModel(modelId('model-c')));
+
+    expect(persistModel).toHaveBeenCalledTimes(1);
+    expect(persistModel).toHaveBeenLastCalledWith('agent-a', modelId('model-b'));
+    expect(snapshot?.selectedModelId).toBe(modelId('model-c'));
+
+    await act(async () => firstUpdate.resolve(agentModel(modelId('model-b'), 2)));
+    expect(persistModel).toHaveBeenCalledTimes(2);
+    expect(persistModel).toHaveBeenLastCalledWith('agent-a', modelId('model-c'));
+    expect(snapshot?.selectedModelId).toBe(modelId('model-c'));
+
+    await act(async () => secondUpdate.resolve(agentModel(modelId('model-c'), 3)));
+    expect(snapshot?.selectedModelId).toBe(modelId('model-c'));
+  });
+
+  test('does not let an old failed ABA selection reject the latest selection', async () => {
+    let snapshot: Snapshot | undefined;
+    const firstUpdate = deferred<AgentModelSnapshot>();
+    const retry = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(firstUpdate.promise)
+      .mockReturnValueOnce(retry.promise);
+
+    await act(async () => {
+      create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => snapshot?.selectModel(modelId('model-c')));
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => firstUpdate.reject(new Error('old request failed')));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+    expect(persistModel).toHaveBeenCalledTimes(2);
+    expect(persistModel).toHaveBeenLastCalledWith('agent-a', modelId('model-b'));
+
+    await act(async () => retry.resolve(agentModel(modelId('model-b'), 2)));
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+  });
+
+  test('finishes the latest selection for an Agent after switching Agents', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const firstAgentFirstUpdate = deferred<AgentModelSnapshot>();
+    const firstAgentLatestUpdate = deferred<AgentModelSnapshot>();
+    const secondAgentUpdate = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(firstAgentFirstUpdate.promise)
+      .mockReturnValueOnce(firstAgentLatestUpdate.promise)
+      .mockReturnValueOnce(secondAgentUpdate.promise);
+    const renderHarness = (
+      agentId: string,
+      persistedModelId: UniqueModelId | null,
+      persistedUpdatedAt = updatedAt(1),
+    ) => (
+      <Harness
+        agentId={agentId}
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+        persistModel={persistModel}
+        persistedModelId={persistedModelId}
+        persistedUpdatedAt={persistedUpdatedAt}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness('agent-a', modelId('model-a')));
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => snapshot?.selectModel(modelId('model-c')));
+    await act(async () => renderer?.update(renderHarness('agent-x', modelId('model-x'))));
+    await act(async () => snapshot?.selectModel(modelId('model-d')));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-d'));
+    expect(persistModel).toHaveBeenCalledTimes(1);
+
+    await act(async () => firstAgentFirstUpdate.resolve(agentModel(modelId('model-b'), 2)));
+    expect(persistModel).toHaveBeenCalledTimes(2);
+    expect(persistModel).toHaveBeenLastCalledWith('agent-a', modelId('model-c'));
+
+    await act(async () => firstAgentLatestUpdate.resolve(agentModel(modelId('model-c'), 3)));
+    expect(persistModel).toHaveBeenCalledTimes(3);
+    expect(persistModel).toHaveBeenLastCalledWith('agent-x', modelId('model-d'));
+
+    await act(async () => secondAgentUpdate.resolve(agentModel(modelId('model-d'), 2)));
+    await act(async () =>
+      renderer?.update(renderHarness('agent-a', modelId('model-c'), updatedAt(3))),
+    );
+    expect(snapshot?.selectedModelId).toBe(modelId('model-c'));
+  });
+
+  test('keeps the last confirmed model when a later selection fails offscreen', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const firstUpdate = deferred<AgentModelSnapshot>();
+    const latestUpdate = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(firstUpdate.promise)
+      .mockReturnValueOnce(latestUpdate.promise);
+    const renderHarness = (
+      agentId: string,
+      persistedModelId: UniqueModelId | null,
+      persistedUpdatedAt = updatedAt(1),
+    ) => (
+      <Harness
+        agentId={agentId}
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+        persistModel={persistModel}
+        persistedModelId={persistedModelId}
+        persistedUpdatedAt={persistedUpdatedAt}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness('agent-a', modelId('model-a')));
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => snapshot?.selectModel(modelId('model-c')));
+    await act(async () => renderer?.update(renderHarness('agent-x', modelId('model-x'))));
+    await act(async () => firstUpdate.resolve(agentModel(modelId('model-b'), 2)));
+    await act(async () => latestUpdate.reject(new Error('latest request failed')));
+    await act(async () => renderer?.update(renderHarness('agent-a', modelId('model-a'))));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+  });
+
+  test('uses a newer external model when a pending selection fails', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const update = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(update.promise);
+    const renderHarness = (
+      persistedModelId: UniqueModelId | null,
+      persistedUpdatedAt = updatedAt(1),
+    ) => (
+      <Harness
+        agentId="agent-a"
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+        persistModel={persistModel}
+        persistedModelId={persistedModelId}
+        persistedUpdatedAt={persistedUpdatedAt}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness(null));
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => renderer?.update(renderHarness(modelId('model-d'), updatedAt(2))));
+    await act(async () => update.reject(new Error('selection failed')));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-d'));
+  });
+
+  test('releases a confirmed selection when a newer external model arrives', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const update = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(update.promise);
+    const renderHarness = (
+      persistedModelId: UniqueModelId | null,
+      persistedUpdatedAt = updatedAt(1),
+    ) => (
+      <Harness
+        agentId="agent-a"
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+        persistModel={persistModel}
+        persistedModelId={persistedModelId}
+        persistedUpdatedAt={persistedUpdatedAt}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness(null));
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => update.resolve(agentModel(modelId('model-b'), 2)));
+    await act(async () => renderer?.update(renderHarness(modelId('model-d'), updatedAt(3))));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-d'));
+  });
+
+  test('keeps a confirmed selection over an older cached model', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const update = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(update.promise);
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () =>
+      renderer?.update(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-d')}
+          persistedUpdatedAt={updatedAt(2)}
+        />,
+      ),
+    );
+    await act(async () => update.resolve(agentModel(modelId('model-b'), 3)));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+  });
+
+  test('releases a confirmed selection after an external ABA update', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const update = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(update.promise);
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => update.resolve(agentModel(modelId('model-b'), 2)));
+    await act(async () =>
+      renderer?.update(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+          persistedUpdatedAt={updatedAt(3)}
+        />,
+      ),
+    );
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-a'));
+  });
+
+  test('preserves loaded null when a selection fails', async () => {
+    let snapshot: Snapshot | undefined;
+    const update = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(update.promise);
+
+    await act(async () => {
+      create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={null}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => update.reject(new Error('selection failed')));
+
+    expect(snapshot?.selectedModelId).toBeNull();
+  });
+
+  test('accepts an external clear after a confirmed selection', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const update = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(update.promise);
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={modelId('model-a')}
+        />,
+      );
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => update.resolve(agentModel(modelId('model-b'), 2)));
+    await act(async () =>
+      renderer?.update(
+        <Harness
+          agentId="agent-a"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          persistModel={persistModel}
+          persistedModelId={null}
+          persistedUpdatedAt={updatedAt(3)}
+        />,
+      ),
+    );
+
+    expect(snapshot?.selectedModelId).toBeNull();
+  });
+
+  test('rolls the latest failed selection back to the last confirmed model', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const firstUpdate = deferred<AgentModelSnapshot>();
+    const secondUpdate = deferred<AgentModelSnapshot>();
+    const persistModel = jest
+      .fn<Promise<AgentModelSnapshot>, [string, UniqueModelId]>()
+      .mockReturnValueOnce(firstUpdate.promise)
+      .mockReturnValueOnce(secondUpdate.promise);
+    const renderHarness = (
+      persistedModelId: UniqueModelId | null,
+      persistedUpdatedAt = updatedAt(1),
+    ) => (
+      <Harness
+        agentId="agent-a"
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+        persistModel={persistModel}
+        persistedModelId={persistedModelId}
+        persistedUpdatedAt={persistedUpdatedAt}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness(modelId('model-a')));
+    });
+    await act(async () => snapshot?.selectModel(modelId('model-b')));
+    await act(async () => firstUpdate.resolve(agentModel(modelId('model-b'), 2)));
+    await act(async () => renderer?.update(renderHarness(modelId('model-b'), updatedAt(2))));
+    await act(async () => snapshot?.selectModel(modelId('model-c')));
+    await act(async () => secondUpdate.reject(new Error('latest request failed')));
+
+    expect(snapshot?.selectedModelId).toBe(modelId('model-b'));
+  });
+});
+
+function Harness({
+  agentId,
+  onSnapshot,
+  persistModel,
+  persistedModelId,
+  persistedUpdatedAt = updatedAt(1),
+}: {
+  agentId: string;
+  onSnapshot: (snapshot: Snapshot) => void;
+  persistModel: (agentId: string, modelId: UniqueModelId) => Promise<AgentModelSnapshot>;
+  persistedModelId: UniqueModelId | null;
+  persistedUpdatedAt?: string;
+}) {
+  const snapshot = useChatInputAgentModelSelection(
+    agentId,
+    { modelId: persistedModelId, updatedAt: persistedUpdatedAt },
+    persistModel,
+  );
+
+  useEffect(() => onSnapshot(snapshot), [onSnapshot, snapshot]);
+  return null;
+}
+
+function modelId(value: string): UniqueModelId {
+  return `provider::${value}` as UniqueModelId;
+}
+
+function agentModel(modelId: UniqueModelId | null, version: number): AgentModelSnapshot {
+  return { modelId, updatedAt: updatedAt(version) };
+}
+
+function updatedAt(version: number): string {
+  return `2026-08-26T00:00:00.${version.toString().padStart(3, '0')}Z`;
+}
+
+function deferred<TValue>() {
+  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: TValue | PromiseLike<TValue>) => void;
+  const promise = new Promise<TValue>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}

--- a/src/frontend/features/chat/input/hooks/__tests__/useChatInputReasoningEffortSelection.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useChatInputReasoningEffortSelection.test.tsx
@@ -1,0 +1,99 @@
+import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { ChatInputReasoningEffort } from '../../utils/chatInputReasoning';
+import { useChatInputReasoningEffortSelection } from '../useChatInputReasoningEffortSelection';
+
+type Snapshot = ReturnType<typeof useChatInputReasoningEffortSelection>;
+
+describe('useChatInputReasoningEffortSelection', () => {
+  test('shows the Agent effort without turning it into a local override', async () => {
+    let snapshot: Snapshot | undefined;
+
+    await act(async () => {
+      create(
+        <Harness
+          agentEffort="high"
+          availableEfforts={['default', 'low', 'high']}
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+        />,
+      );
+    });
+
+    expect(snapshot).toMatchObject({
+      isReasoningEffortSelected: false,
+      reasoningEffort: 'high',
+    });
+  });
+
+  test('keeps a composer selection when the Agent value refreshes', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const renderHarness = (agentEffort: ReasoningEffortOption) => (
+      <Harness
+        agentEffort={agentEffort}
+        availableEfforts={['default', 'low', 'high']}
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness('low'));
+    });
+    await act(async () => snapshot?.selectReasoningEffort('high'));
+    await act(async () => renderer?.update(renderHarness('low')));
+
+    expect(snapshot).toMatchObject({
+      isReasoningEffortSelected: true,
+      reasoningEffort: 'high',
+    });
+  });
+
+  test('clears a composer selection when the Agent changes', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+    const renderHarness = (agentId: string, agentEffort: ReasoningEffortOption) => (
+      <Harness
+        agentEffort={agentEffort}
+        agentId={agentId}
+        availableEfforts={['default', 'low', 'high']}
+        onSnapshot={(value) => {
+          snapshot = value;
+        }}
+      />
+    );
+
+    await act(async () => {
+      renderer = create(renderHarness('agent-a', 'low'));
+    });
+    await act(async () => snapshot?.selectReasoningEffort('high'));
+    await act(async () => renderer?.update(renderHarness('agent-b', 'low')));
+
+    expect(snapshot).toMatchObject({
+      isReasoningEffortSelected: false,
+      reasoningEffort: 'low',
+    });
+  });
+});
+
+function Harness({
+  agentEffort,
+  agentId,
+  availableEfforts,
+  onSnapshot,
+}: {
+  agentEffort: ReasoningEffortOption;
+  agentId?: string;
+  availableEfforts: readonly ChatInputReasoningEffort[];
+  onSnapshot: (snapshot: Snapshot) => void;
+}) {
+  const snapshot = useChatInputReasoningEffortSelection(availableEfforts, agentEffort, agentId);
+
+  useEffect(() => onSnapshot(snapshot), [onSnapshot, snapshot]);
+  return null;
+}

--- a/src/frontend/features/chat/input/hooks/useChatInputAgentModelSelection.ts
+++ b/src/frontend/features/chat/input/hooks/useChatInputAgentModelSelection.ts
@@ -1,0 +1,182 @@
+import { useCallback, useRef, useState } from 'react';
+
+import type { Agent } from '@/shared/data/types/agent';
+import type { UniqueModelId } from '@/shared/data/types/model';
+
+type AgentModelSnapshot = Pick<Agent, 'modelId' | 'updatedAt'>;
+
+type ModelSelectionOverride = {
+  agentId: string;
+  confirmedUpdatedAt: string | null;
+  fallback: AgentModelSnapshot | undefined;
+  modelId: UniqueModelId | null;
+  selectionId: number;
+};
+
+type DesiredModelSelection = Omit<ModelSelectionOverride, 'modelId'> & {
+  modelId: UniqueModelId;
+};
+
+type PersistModelSelection = (
+  agentId: string,
+  modelId: UniqueModelId,
+) => Promise<AgentModelSnapshot>;
+
+type ModelPersistenceErrorHandler = (
+  error: unknown,
+  selection: Pick<DesiredModelSelection, 'agentId' | 'modelId'>,
+) => void;
+
+/**
+ * Keeps a picked model visible while the Agent mutation and query refresh
+ * settle. The persisted Agent remains authoritative once it catches up.
+ */
+export function useChatInputAgentModelSelection(
+  agentId: string | undefined,
+  persistedModel: AgentModelSnapshot | undefined,
+  persistModel: PersistModelSelection,
+  onPersistenceError?: ModelPersistenceErrorHandler,
+) {
+  const [overrides, setOverrides] = useState<ReadonlyMap<string, ModelSelectionOverride>>(
+    () => new Map(),
+  );
+  const desiredSelectionsRef = useRef(new Map<string, DesiredModelSelection>());
+  const pendingAgentIdsRef = useRef<string[]>([]);
+  const isPersistingRef = useRef(false);
+  const nextSelectionIdRef = useRef(0);
+
+  let activeOverride = agentId ? overrides.get(agentId) : undefined;
+  if (
+    agentId &&
+    activeOverride?.confirmedUpdatedAt &&
+    persistedModel &&
+    persistedModel.updatedAt >= activeOverride.confirmedUpdatedAt
+  ) {
+    const confirmedSelectionId = activeOverride.selectionId;
+    activeOverride = undefined;
+
+    setOverrides((current) => {
+      if (current.get(agentId)?.selectionId !== confirmedSelectionId) {
+        return current;
+      }
+
+      const next = new Map(current);
+      next.delete(agentId);
+      return next;
+    });
+  }
+
+  const flushSelections = useCallback(() => {
+    if (isPersistingRef.current) {
+      return;
+    }
+
+    isPersistingRef.current = true;
+    void (async () => {
+      try {
+        while (pendingAgentIdsRef.current.length > 0) {
+          const targetAgentId = pendingAgentIdsRef.current[0];
+          const target = desiredSelectionsRef.current.get(targetAgentId);
+          if (!target) {
+            pendingAgentIdsRef.current.shift();
+            continue;
+          }
+
+          try {
+            const confirmedModel = await persistModel(target.agentId, target.modelId);
+            const latest = desiredSelectionsRef.current.get(targetAgentId);
+            if (latest?.modelId === target.modelId) {
+              desiredSelectionsRef.current.delete(targetAgentId);
+              pendingAgentIdsRef.current.shift();
+              setOverrides((current) => {
+                if (current.get(targetAgentId)?.selectionId !== latest.selectionId) {
+                  return current;
+                }
+
+                const next = new Map(current);
+                next.set(targetAgentId, {
+                  ...latest,
+                  confirmedUpdatedAt: confirmedModel.updatedAt,
+                  modelId: confirmedModel.modelId,
+                });
+                return next;
+              });
+            } else if (latest) {
+              desiredSelectionsRef.current.set(targetAgentId, {
+                ...latest,
+                fallback: confirmedModel,
+              });
+            }
+          } catch (error) {
+            if (
+              desiredSelectionsRef.current.get(targetAgentId)?.selectionId === target.selectionId
+            ) {
+              desiredSelectionsRef.current.delete(targetAgentId);
+              pendingAgentIdsRef.current.shift();
+              setOverrides((current) => {
+                if (current.get(targetAgentId)?.selectionId !== target.selectionId) {
+                  return current;
+                }
+
+                const next = new Map(current);
+                if (target.fallback) {
+                  next.set(targetAgentId, {
+                    agentId: targetAgentId,
+                    confirmedUpdatedAt: target.fallback.updatedAt,
+                    fallback: target.fallback,
+                    modelId: target.fallback.modelId,
+                    selectionId: target.selectionId,
+                  });
+                } else {
+                  next.delete(targetAgentId);
+                }
+                return next;
+              });
+            }
+            onPersistenceError?.(error, target);
+            continue;
+          }
+        }
+      } finally {
+        isPersistingRef.current = false;
+      }
+    })();
+  }, [onPersistenceError, persistModel]);
+
+  const selectModel = useCallback(
+    (modelId: UniqueModelId) => {
+      if (!agentId) {
+        return;
+      }
+
+      const pendingSelection = desiredSelectionsRef.current.get(agentId);
+      const selection = {
+        agentId,
+        confirmedUpdatedAt: null,
+        fallback:
+          pendingSelection?.fallback ??
+          (activeOverride?.confirmedUpdatedAt
+            ? { modelId: activeOverride.modelId, updatedAt: activeOverride.confirmedUpdatedAt }
+            : persistedModel),
+        modelId,
+        selectionId: ++nextSelectionIdRef.current,
+      };
+      if (!desiredSelectionsRef.current.has(agentId)) {
+        pendingAgentIdsRef.current.push(agentId);
+      }
+      desiredSelectionsRef.current.set(agentId, selection);
+      setOverrides((current) => {
+        const next = new Map(current);
+        next.set(agentId, selection);
+        return next;
+      });
+      flushSelections();
+    },
+    [activeOverride, agentId, flushSelections, persistedModel],
+  );
+
+  return {
+    selectModel,
+    selectedModelId: activeOverride ? activeOverride.modelId : (persistedModel?.modelId ?? null),
+  };
+}

--- a/src/frontend/features/chat/input/hooks/useChatInputReasoningEffortSelection.ts
+++ b/src/frontend/features/chat/input/hooks/useChatInputReasoningEffortSelection.ts
@@ -1,0 +1,50 @@
+import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
+import { useCallback, useState } from 'react';
+
+import {
+  CHAT_INPUT_DEFAULT_REASONING_EFFORT,
+  type ChatInputReasoningEffort,
+  resolveAvailableChatInputReasoningEffort,
+} from '../utils/chatInputReasoning';
+
+type ReasoningEffortOverride = {
+  agentId: string | null;
+  reasoningEffort: ChatInputReasoningEffort;
+};
+
+/**
+ * Owns the composer's per-turn reasoning selection. Agent configuration is an
+ * inherited fallback only and is never mutated by this state.
+ */
+export function useChatInputReasoningEffortSelection(
+  reasoningEfforts: readonly ChatInputReasoningEffort[],
+  agentReasoningEffort: ReasoningEffortOption = CHAT_INPUT_DEFAULT_REASONING_EFFORT,
+  agentId?: string | null,
+) {
+  const [override, setOverride] = useState<ReasoningEffortOverride | null>(null);
+
+  let activeOverride = override;
+  if (
+    activeOverride &&
+    (activeOverride.agentId !== (agentId ?? null) || reasoningEfforts.length === 0)
+  ) {
+    activeOverride = null;
+    setOverride(null);
+  }
+
+  const selectReasoningEffort = useCallback(
+    (reasoningEffort: ChatInputReasoningEffort) => {
+      setOverride({ agentId: agentId ?? null, reasoningEffort });
+    },
+    [agentId],
+  );
+
+  return {
+    isReasoningEffortSelected: activeOverride !== null,
+    reasoningEffort: resolveAvailableChatInputReasoningEffort(
+      activeOverride?.reasoningEffort ?? agentReasoningEffort,
+      reasoningEfforts,
+    ),
+    selectReasoningEffort,
+  };
+}

--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -8,6 +8,7 @@ import type {
   AgentSessionObservation,
   AgentSessionSnapshot,
   AgentSessionView,
+  AgentSubmitMessageInput,
   AgentTurnView,
 } from '@/shared/contracts/agent';
 
@@ -195,9 +196,13 @@ export class AgentSessionChatClient {
     return this.protocol.createSession({ agentId, executionTarget: { kind: 'local' } });
   }
 
-  async submitMessage(sessionId: string, parts: AgentInputPart[]) {
+  async submitMessage(
+    sessionId: string,
+    parts: AgentInputPart[],
+    overrides: Pick<AgentSubmitMessageInput, 'modelId' | 'reasoningEffort'> = {},
+  ) {
     await this.observe(sessionId);
-    return this.protocol.submitMessage({ parts, sessionId });
+    return this.protocol.submitMessage({ parts, sessionId, ...overrides });
   }
 
   async cancelTurn(sessionId: string): Promise<void> {

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -13,12 +13,14 @@ import {
 import { AppState } from 'react-native';
 
 import { queryKeys, useBackendModule } from '@/frontend/data';
-import type { AgentInputPart } from '@/shared/contracts/agent';
+import type { AgentInputPart, AgentSubmitMessageInput } from '@/shared/contracts/agent';
 
 import { AgentSessionChatClient, type AgentSessionChatState } from './AgentSessionChatClient';
 
 type AgentChatSendInput = {
   agentId?: string;
+  modelId?: AgentSubmitMessageInput['modelId'];
+  reasoningEffort?: AgentSubmitMessageInput['reasoningEffort'];
   sessionId?: string;
   text: string;
 };
@@ -78,7 +80,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
   useEffect(() => () => client.dispose(), [client]);
 
   const sendText = useCallback(
-    async ({ agentId, sessionId, text }: AgentChatSendInput) => {
+    async ({ agentId, modelId, reasoningEffort, sessionId, text }: AgentChatSendInput) => {
       let targetSessionId = sessionId;
       if (!targetSessionId) {
         if (!agentId) {
@@ -93,7 +95,10 @@ export function ChatProvider({ children }: PropsWithChildren) {
       }
 
       const parts: AgentInputPart[] = [{ text, type: 'text' }];
-      await client.submitMessage(targetSessionId, parts);
+      await client.submitMessage(targetSessionId, parts, {
+        ...(modelId !== undefined ? { modelId } : {}),
+        ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+      });
     },
     [client, navigation, queryClient],
   );
@@ -148,7 +153,8 @@ export function useAgentChatControls(input: { agentId?: string; sessionId?: stri
     return client.cancelTurn(sessionId);
   }, [client, sessionId]);
   const send = useCallback(
-    (text: string) => sendText({ agentId, sessionId, text }),
+    (message: Omit<AgentChatSendInput, 'agentId' | 'sessionId'>) =>
+      sendText({ agentId, sessionId, ...message }),
     [agentId, sendText, sessionId],
   );
 

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -64,6 +64,26 @@ function protocolWithObservation(
 }
 
 describe('AgentSessionChatClient', () => {
+  test('forwards composer model and reasoning snapshots with the submitted message', async () => {
+    const protocol = protocolWithObservation(async () => ({
+      snapshot: snapshot(),
+      unsubscribe: jest.fn(),
+    }));
+    const client = new AgentSessionChatClient(protocol);
+
+    await client.submitMessage('session-1', [{ text: 'Hello', type: 'text' }], {
+      modelId: 'provider::model-b',
+      reasoningEffort: 'high',
+    });
+
+    expect(protocol.submitMessage).toHaveBeenCalledWith({
+      modelId: 'provider::model-b',
+      parts: [{ text: 'Hello', type: 'text' }],
+      reasoningEffort: 'high',
+      sessionId: 'session-1',
+    });
+  });
+
   test('applies events emitted after subscription but before the snapshot promise resolves', async () => {
     const observation = deferred<AgentSessionObservation>();
     let listener: ((event: AgentEvent) => void) | undefined;

--- a/src/frontend/features/settings/ProviderScreen/hooks/useProviderDeletion.ts
+++ b/src/frontend/features/settings/ProviderScreen/hooks/useProviderDeletion.ts
@@ -12,6 +12,8 @@ import {
 } from '@/frontend/data/utils/optimisticQueryUpdate';
 import type { Provider } from '@/shared/data/types/provider';
 
+import { refreshProviderModelQueries } from '../models/utils/refreshProviderModelQueries';
+
 /**
  * Deleting the provider, from wherever the action is offered — currently the
  * provider settings screen, which is two pushes deep, hence `dismissTo` rather
@@ -38,9 +40,10 @@ export function useProviderDeletion() {
     onError: (_error, _variables, context) => {
       restoreQuerySnapshot(queryClient, context?.providers);
     },
-    onSuccess: (_result, variables) => {
+    onSuccess: async (_result, variables) => {
       if (variables) {
         queryClient.removeQueries({ queryKey: [`/providers/${variables.params.id}`] });
+        await refreshProviderModelQueries(queryClient, variables.params.id);
       }
     },
     refresh: ['/providers'],

--- a/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelRemove.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/hooks/useProviderModelRemove.ts
@@ -1,10 +1,13 @@
 import { useAlert } from '@cherrystudio/ui/components';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMutation } from '@/frontend/data';
 import { usePreference } from '@/frontend/data/hooks';
 import type { Model } from '@/shared/data/types/model';
+
+import { refreshAgentQueriesAfterModelRemoval } from '../utils/refreshProviderModelQueries';
 
 /**
  * Removing models from their provider. The list removes by selection rather
@@ -18,7 +21,9 @@ import type { Model } from '@/shared/data/types/model';
 export function useProviderModelRemove() {
   const { t } = useTranslation();
   const { alert } = useAlert();
+  const queryClient = useQueryClient();
   const removeModelsMutation = useMutation('DELETE', '/models', {
+    onSuccess: () => refreshAgentQueriesAfterModelRemoval(queryClient),
     refresh: ['/models'],
   });
   const deleteModels = removeModelsMutation.trigger;

--- a/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/refreshProviderModelQueries.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/refreshProviderModelQueries.test.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/frontend/data';
+
+import { refreshAgentQueriesAfterModelRemoval } from '../refreshProviderModelQueries';
+
+describe('refreshAgentQueriesAfterModelRemoval', () => {
+  test('refetches inactive Agent details before returning', async () => {
+    const queryClient = new QueryClient();
+    const detailKey = queryKeys.agents.detail('agent-a');
+    let persistedModelId: string | null = 'provider::model-b';
+    await queryClient.fetchQuery({
+      queryFn: async () => ({ modelId: persistedModelId }),
+      queryKey: detailKey,
+    });
+    persistedModelId = null;
+
+    await refreshAgentQueriesAfterModelRemoval(queryClient);
+
+    expect(queryClient.getQueryData(detailKey)).toEqual({ modelId: null });
+  });
+});

--- a/src/frontend/features/settings/ProviderScreen/models/utils/refreshProviderModelQueries.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/refreshProviderModelQueries.ts
@@ -14,5 +14,22 @@ export async function refreshProviderModelQueries(queryClient: QueryClient, prov
       queryKey: queryKeys.models.list({ enabled: true, providerId }),
     }),
     queryClient.invalidateQueries({ queryKey: queryKeys.models.list() }),
+    refreshAgentQueriesAfterModelRemoval(queryClient),
+  ]);
+}
+
+/**
+ * A model removal may clear any Agent's model through the database FK. Refetch detail queries,
+ * including inactive caches, before the mutation settles so chat cannot briefly submit a deleted
+ * model snapshot when that Agent is opened again.
+ */
+export async function refreshAgentQueriesAfterModelRemoval(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.agents.all() }),
+    queryClient.refetchQueries({
+      predicate: ({ queryKey }) =>
+        typeof queryKey[0] === 'string' && queryKey[0].startsWith('/agents/'),
+      type: 'all',
+    }),
   ]);
 }

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -13,7 +13,10 @@
  * static shape cannot drift.
  */
 
+import { ReasoningEffortOptionSchema } from '@cherrystudio/universal/types/aiSdk';
 import * as z from 'zod';
+
+import { UniqueModelIdSchema } from '@/shared/data/types/model';
 
 export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
@@ -256,7 +259,12 @@ export const AgentDeleteSessionInputSchema = z.strictObject({
 export const AgentSubmitMessageInputSchema = z.strictObject({
   sessionId: z.string().min(1),
   parts: z.array(AgentInputPartSchema).min(1),
+  /** Snapshots the composer's selected model while its Agent mutation settles. */
+  modelId: UniqueModelIdSchema.optional(),
+  /** Per-turn only; this value is never persisted back to the Agent. */
+  reasoningEffort: ReasoningEffortOptionSchema.optional(),
 });
+export type AgentSubmitMessageInput = z.infer<typeof AgentSubmitMessageInputSchema>;
 export const AgentCancelTurnInputSchema = z.strictObject({
   sessionId: z.string().min(1),
   turnId: z.string().min(1),
@@ -293,10 +301,9 @@ export interface AgentProtocol {
   renameSession(input: { sessionId: string; title: string }): Promise<AgentSessionView>;
   deleteSession(input: { sessionId: string }): Promise<void>;
 
-  submitMessage(input: {
-    sessionId: string;
-    parts: AgentInputPart[];
-  }): Promise<{ turnId: string; userMessageId: string; assistantMessageId: string }>;
+  submitMessage(
+    input: AgentSubmitMessageInput,
+  ): Promise<{ turnId: string; userMessageId: string; assistantMessageId: string }>;
 
   cancelTurn(input: { sessionId: string; turnId: string }): Promise<void>;
 


### PR DESCRIPTION
## Summary

- restore the composer model selector and reasoning-effort control without remounting the input or send control
- persist model changes to the Agent with serialized last-selection-wins reconciliation while keeping reasoning effort turn-local
- carry model and reasoning snapshots through the Agent protocol and refresh Agent caches when models are removed
- make Agent update timestamps monotonic so optimistic selections reconcile safely across inactive caches and concurrent edits

## Validation

- `pnpm format`
- `pnpm packages:build`
- scoped `oxlint` and `expo lint` for every changed TypeScript file: 0 errors
- `git diff --check`
- independent static review: 94/100 confidence, no P0/P1 findings

## Known repository gate

- full `pnpm lint` was run; Oxlint completed, while Expo lint reported seven existing `import/no-unresolved` errors for `@cherrystudio/ai-core` imports in untouched files
- tests, typecheck, builds beyond the required workspace package build, and manual UI verification were not run per workspace instructions