### PR TITLE
feat(pi-runtime): support standard provider protocols

### DIFF
--- a/patches/@earendil-works__pi-ai@0.84.2.patch
+++ b/patches/@earendil-works__pi-ai@0.84.2.patch
@@ -1,3 +1,33 @@
+diff --git a/dist/api/anthropic-messages.js b/dist/api/anthropic-messages.js
+--- a/dist/api/anthropic-messages.js
++++ b/dist/api/anthropic-messages.js
+@@ -1,5 +1,5 @@
+ import Anthropic from "@anthropic-ai/sdk";
+-import { calculateCost } from "../models.js";
++import { calculateCost } from "../utils/model-runtime.js";
+ import { splitDeferredTools } from "../utils/deferred-tools.js";
+ import { AssistantMessageEventStream } from "../utils/event-stream.js";
+ import { headersToRecord } from "../utils/headers.js";
+diff --git a/dist/api/google-generative-ai.js b/dist/api/google-generative-ai.js
+--- a/dist/api/google-generative-ai.js
++++ b/dist/api/google-generative-ai.js
+@@ -1,5 +1,5 @@
+ import { GoogleGenAI, } from "@google/genai";
+-import { calculateCost, clampThinkingLevel } from "../models.js";
++import { calculateCost, clampThinkingLevel } from "../utils/model-runtime.js";
+ import { formatProviderError, normalizeProviderError } from "../utils/error-body.js";
+ import { AssistantMessageEventStream } from "../utils/event-stream.js";
+ import { providerHeadersToRecord } from "../utils/headers.js";
+diff --git a/dist/api/openai-completions.js b/dist/api/openai-completions.js
+--- a/dist/api/openai-completions.js
++++ b/dist/api/openai-completions.js
+@@ -1,5 +1,5 @@
+ import OpenAI from "openai";
+-import { calculateCost, clampThinkingLevel } from "../models.js";
++import { calculateCost, clampThinkingLevel } from "../utils/model-runtime.js";
+ import { formatProviderError, normalizeProviderError } from "../utils/error-body.js";
+ import { AssistantMessageEventStream } from "../utils/event-stream.js";
+ import { shortHash } from "../utils/hash.js";
 diff --git a/dist/api/openai-responses-shared.js b/dist/api/openai-responses-shared.js
 index c35771dcc9b2173d0b459d13c6d86e622de45e9a..8e03a85b7fd678240b31bc62f1f1825a89c2b788 100644
 --- a/dist/api/openai-responses-shared.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ patchedDependencies:
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
   '@bottom-tabs/react-navigation@1.4.0': 3b020e5c2082d73190742b6c8fbdf6712b3db373d93c237c4ee935a92118a61e
   '@earendil-works/pi-agent-core@0.84.2': 31f00c04fc94f65d0ebf9d19d9f16d7ca51a4e65a3ce68ad46477a713ef729f1
-  '@earendil-works/pi-ai@0.84.2': e62145d4f31b18be3f6226984e3d8cb7481e9386234bfdb8e6d1fadcfc54d30d
+  '@earendil-works/pi-ai@0.84.2': 747662d8c61ec7f524e0aac679382e63b41bd2fffa99db9d595bb0e04281d43e
   '@magrinj/expo-quick-look@0.3.1': 2b97fda8470c046179cf3e97282b6984fd1b926d2f54df9056a5cc455f073f2f
   '@openrouter/ai-sdk-provider@2.10.0': fe61d9ff590828fc0fd3f8b3b8b88a4a1b736a99b595a276c8df9e12c9498009
   '@opeoginni/github-copilot-openai-compatible@1.0.0': 4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25
@@ -139,7 +139,7 @@ importers:
         version: 0.84.2(patch_hash=31f00c04fc94f65d0ebf9d19d9f16d7ca51a4e65a3ce68ad46477a713ef729f1)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=e62145d4f31b18be3f6226984e3d8cb7481e9386234bfdb8e6d1fadcfc54d30d)(ws@8.21.1)(zod@4.4.3)
+        version: 0.84.2(patch_hash=747662d8c61ec7f524e0aac679382e63b41bd2fffa99db9d595bb0e04281d43e)(ws@8.21.1)(zod@4.4.3)
       '@expo/dom-webview':
         specifier: ^57.0.1
         version: 57.0.1(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -10941,7 +10941,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.84.2(patch_hash=31f00c04fc94f65d0ebf9d19d9f16d7ca51a4e65a3ce68ad46477a713ef729f1)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.2(patch_hash=e62145d4f31b18be3f6226984e3d8cb7481e9386234bfdb8e6d1fadcfc54d30d)(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.2(patch_hash=747662d8c61ec7f524e0aac679382e63b41bd2fffa99db9d595bb0e04281d43e)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-telemetry': 0.84.2
       diff: 8.0.4
       ignore: 7.0.5
@@ -10955,7 +10955,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.2(patch_hash=e62145d4f31b18be3f6226984e3d8cb7481e9386234bfdb8e6d1fadcfc54d30d)(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.2(patch_hash=747662d8c61ec7f524e0aac679382e63b41bd2fffa99db9d595bb0e04281d43e)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0

--- a/src/backend/ai/agent/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/pi/PiRuntime.ts
@@ -4,8 +4,8 @@ import type {
 } from '@earendil-works/pi-agent-core';
 import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type {
+  Api as PiApi,
   AssistantMessage,
-  FetchFunction,
   Message as PiMessage,
   Model as PiModel,
   ModelThinkingLevel,
@@ -30,14 +30,11 @@ import type {
 import { toPiConversation } from './modelMessages';
 
 export type PiModelResolution = {
-  apiKey: string;
   defaultThinkingLevel: ModelThinkingLevel;
-  fetch?: FetchFunction;
-  headers?: Record<string, string>;
-  maxRetries: number;
-  model: PiModel<'openai-responses'>;
+  model: PiModel<PiApi>;
+  redactionValues: readonly string[];
+  streamFn: AgentOptions['streamFn'];
   supportsTools: boolean;
-  timeoutMs: number;
   usageContext: RuntimeUsageContext;
 };
 
@@ -165,11 +162,7 @@ function normalizeExecutionError(error: unknown, secrets: readonly string[] = []
 }
 
 function sensitiveValues(resolution: PiModelResolution): string[] {
-  const values = [resolution.apiKey];
-  for (const [name, value] of Object.entries(resolution.headers ?? {})) {
-    if (/authorization|api[-_]key|token|secret/i.test(name)) values.push(value);
-  }
-  return values;
+  return [...resolution.redactionValues];
 }
 
 function toRuntimeUsage(usage: PiUsage): RuntimeUsage {
@@ -327,22 +320,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       }
 
       const conversation = toPiConversation(request, resolution.model);
-      const streamFn: AgentOptions['streamFn'] = async (model, context, options) => {
-        const { streamSimple } = await import('@earendil-works/pi-ai/api/openai-responses');
-        return streamSimple(model as PiModel<'openai-responses'>, context, {
-          ...options,
-          apiKey: resolution.apiKey,
-          fetch: resolution.fetch,
-          headers: resolution.headers,
-          maxRetries: resolution.maxRetries,
-          maxTokens: request.options.maxOutputTokens ?? resolution.model.maxTokens,
-          signal: options?.signal,
-          temperature: request.options.temperature,
-          timeoutMs: resolution.timeoutMs,
-        });
-      };
       const agentOptions: AgentOptions = {
-        getApiKey: () => resolution.apiKey,
         initialState: {
           messages: conversation.history,
           model: resolution.model,
@@ -350,7 +328,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
           thinkingLevel: resolveThinkingLevel(request, resolution),
           tools: this.toPiTools(request.tools, turn),
         },
-        streamFn,
+        streamFn: resolution.streamFn,
       };
       const agent = this.createAgent
         ? this.createAgent(agentOptions)

--- a/src/backend/ai/agent/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/pi/__tests__/PiRuntime.test.ts
@@ -85,9 +85,7 @@ const holders = new WeakMap<AgentRuntime, RuntimeHolder>();
 
 function createResolution(): PiModelResolution {
   return {
-    apiKey: 'test-key',
     defaultThinkingLevel: 'medium',
-    maxRetries: 0,
     model: {
       api: 'openai-responses',
       baseUrl: 'https://provider.example/v1',
@@ -100,8 +98,11 @@ function createResolution(): PiModelResolution {
       provider: 'mock-provider',
       reasoning: true,
     },
+    redactionValues: [ERROR_SECRET],
+    streamFn: () => {
+      throw new Error('The fake Pi agent must not call the provider stream.');
+    },
     supportsTools: true,
-    timeoutMs: 60_000,
     usageContext: {
       credentialReceipt: {
         attribution: 'explicit',
@@ -483,6 +484,8 @@ describe('PiRuntime mapping', () => {
       systemPrompt: 'Be helpful.\n\nPrior system note.',
       thinkingLevel: 'high',
     });
+    expect(holder.lastOptions?.streamFn).toBe(holder.resolution.streamFn);
+    expect(holder.lastOptions?.getApiKey).toBeUndefined();
     await session.close();
   });
 

--- a/src/backend/ai/agent/pi/modelMessages.ts
+++ b/src/backend/ai/agent/pi/modelMessages.ts
@@ -1,4 +1,5 @@
 import type {
+  Api as PiApi,
   AssistantMessage,
   Message as PiMessage,
   Model as PiModel,
@@ -26,7 +27,7 @@ export type PiConversation = {
 /** Convert the complete normalized Runtime context into one fresh Pi conversation. */
 export function toPiConversation(
   request: RuntimeExecutionRequest,
-  model: PiModel<'openai-responses'>,
+  model: PiModel<PiApi>,
 ): PiConversation {
   const history: PiMessage[] = [];
   const systemParts = request.instructions.length > 0 ? [request.instructions] : [];
@@ -76,7 +77,7 @@ function appendAssistantHistory(
   history: PiMessage[],
   parts: RuntimeMessagePart[],
   toolNamesByCallId: Map<string, string>,
-  model: PiModel<'openai-responses'>,
+  model: PiModel<PiApi>,
 ): void {
   let content: AssistantMessage['content'] = [];
   const flushAssistant = () => {

--- a/src/backend/ai/agentHost/__tests__/piApiAdapters.test.ts
+++ b/src/backend/ai/agentHost/__tests__/piApiAdapters.test.ts
@@ -1,0 +1,113 @@
+import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
+import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
+import type { Context, FetchFunction, Model as PiModel } from '@earendil-works/pi-ai';
+
+import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from '../piApiAdapters';
+
+const mockAnthropicStreamSimple = jest.fn();
+const mockGoogleStreamSimple = jest.fn();
+const mockOpenAiCompletionsStreamSimple = jest.fn();
+const mockOpenAiResponsesStreamSimple = jest.fn();
+
+const mockStreamResult = { id: 'stream' };
+const mockFetch = jest.fn() as unknown as FetchFunction;
+const context: Context = { messages: [] };
+
+const CASES: {
+  api: SupportedPiApi;
+  baseUrl: string;
+  endpointType: EndpointType;
+  expectedBaseUrl: string;
+  expectedFetch: FetchFunction | undefined;
+  streamSimple: jest.Mock;
+}[] = [
+  {
+    api: 'openai-responses',
+    baseUrl: 'https://api.openai.test',
+    endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES,
+    expectedBaseUrl: 'https://api.openai.test/v1',
+    expectedFetch: mockFetch,
+    streamSimple: mockOpenAiResponsesStreamSimple,
+  },
+  {
+    api: 'openai-completions',
+    baseUrl: 'https://api.compat.test',
+    endpointType: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    expectedBaseUrl: 'https://api.compat.test/v1',
+    expectedFetch: mockFetch,
+    streamSimple: mockOpenAiCompletionsStreamSimple,
+  },
+  {
+    api: 'anthropic-messages',
+    baseUrl: 'https://api.anthropic.test/v1',
+    endpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+    expectedBaseUrl: 'https://api.anthropic.test',
+    expectedFetch: mockFetch,
+    streamSimple: mockAnthropicStreamSimple,
+  },
+  {
+    api: 'google-generative-ai',
+    baseUrl: 'https://api.google.test',
+    endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+    expectedBaseUrl: 'https://api.google.test/v1beta',
+    expectedFetch: undefined,
+    streamSimple: mockGoogleStreamSimple,
+  },
+];
+
+describe('Pi API adapters', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    for (const testCase of CASES) testCase.streamSimple.mockReturnValue(mockStreamResult);
+  });
+
+  test.each(CASES)('binds $endpointType to $api', async (testCase) => {
+    const adapter = resolvePiApiAdapter(testCase.endpointType);
+    expect(adapter).toBeDefined();
+    if (!adapter) throw new Error('Expected a supported Pi API adapter.');
+
+    expect(adapter.api).toBe(testCase.api);
+    expect(adapter.formatBaseUrl(testCase.baseUrl)).toBe(testCase.expectedBaseUrl);
+    jest
+      .spyOn(adapter, 'loadStreamSimple')
+      .mockResolvedValue(testCase.streamSimple as unknown as AgentOptions['streamFn']);
+
+    const streamFn = await bindPiStream(adapter, {
+      apiKey: 'secret-key',
+      fetch: mockFetch,
+      headers: { 'X-App': 'Cherry' },
+      maxRetries: 0,
+      maxTokens: 2048,
+      temperature: 0.2,
+      timeoutMs: 60_000,
+    });
+    const model = { api: testCase.api } as PiModel<SupportedPiApi>;
+    const result = streamFn(model, context, {
+      fetch: jest.fn() as unknown as FetchFunction,
+      headers: { 'X-Request': 'request' },
+      maxTokens: 32,
+      reasoning: 'high',
+    });
+
+    expect(result).toBe(mockStreamResult);
+    expect(testCase.streamSimple).toHaveBeenCalledWith(
+      model,
+      context,
+      expect.objectContaining({
+        apiKey: 'secret-key',
+        fetch: testCase.expectedFetch,
+        headers: { 'X-App': 'Cherry', 'X-Request': 'request' },
+        maxRetries: 0,
+        maxTokens: 2048,
+        reasoning: 'high',
+        temperature: 0.2,
+        timeoutMs: 60_000,
+      }),
+    );
+  });
+
+  test('fails closed for endpoints outside the four supported protocols', () => {
+    expect(resolvePiApiAdapter(ENDPOINT_TYPE.OLLAMA_CHAT)).toBeUndefined();
+    expect(resolvePiApiAdapter(undefined)).toBeUndefined();
+  });
+});

--- a/src/backend/ai/agentHost/__tests__/piModelResolver.test.ts
+++ b/src/backend/ai/agentHost/__tests__/piModelResolver.test.ts
@@ -1,0 +1,274 @@
+import {
+  ENDPOINT_TYPE,
+  MODEL_CAPABILITY,
+  type EndpointType,
+} from '@cherrystudio/provider-registry';
+
+import type { PiRuntimeDependencies } from '@/backend/ai/agent';
+import type { Model } from '@/shared/data/types/model';
+import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
+
+import { createPiModelResolver } from '../piModelResolver';
+
+type BindPiStream = typeof import('../piApiAdapters').bindPiStream;
+
+const mockGetModelById = jest.fn();
+const mockGetProviderById = jest.fn();
+const mockResolveApiKey = jest.fn();
+const mockBoundStreamFn = jest.fn();
+const mockBindPiStream = jest.fn<ReturnType<BindPiStream>, Parameters<BindPiStream>>();
+
+jest.mock('@/backend/data/services/ModelService', () => ({
+  modelService: { getById: (...args: unknown[]) => mockGetModelById(...args) },
+}));
+jest.mock('@/backend/data/services/ProviderService', () => ({
+  providerService: {
+    getByProviderId: (...args: unknown[]) => mockGetProviderById(...args),
+    resolveApiKey: (...args: unknown[]) => mockResolveApiKey(...args),
+  },
+}));
+jest.mock('../piApiAdapters', () => {
+  const actual = jest.requireActual('../piApiAdapters');
+  return {
+    ...actual,
+    bindPiStream: (...args: Parameters<BindPiStream>) => mockBindPiStream(...args),
+  };
+});
+
+const CREDENTIAL_RECEIPT = {
+  attribution: 'explicit' as const,
+  id: 'key-1',
+  masked: 'secr****-key',
+};
+
+const CASES = [
+  {
+    adapterFamily: 'openai',
+    api: 'openai-responses',
+    baseUrl: 'https://responses.test',
+    endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES,
+    expectedBaseUrl: 'https://responses.test/v1',
+    expectedModelId: 'models/test-model',
+  },
+  {
+    adapterFamily: 'openai-compatible',
+    api: 'openai-completions',
+    baseUrl: 'https://chat.test/v1',
+    endpointType: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    expectedBaseUrl: 'https://chat.test/v1',
+    expectedModelId: 'models/test-model',
+  },
+  {
+    adapterFamily: 'anthropic',
+    api: 'anthropic-messages',
+    baseUrl: 'https://anthropic.test/v1',
+    endpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+    expectedBaseUrl: 'https://anthropic.test',
+    expectedModelId: 'models/test-model',
+  },
+  {
+    adapterFamily: 'google',
+    api: 'google-generative-ai',
+    baseUrl: 'https://google.test',
+    endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+    expectedBaseUrl: 'https://google.test/v1beta',
+    expectedModelId: 'test-model',
+  },
+] as const;
+
+describe('Pi model resolver', () => {
+  let resolver: PiRuntimeDependencies;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveApiKey.mockResolvedValue({
+      apiKeySelection: CREDENTIAL_RECEIPT,
+      value: 'secret-key',
+    });
+    mockBindPiStream.mockResolvedValue(mockBoundStreamFn);
+    resolver = createPiModelResolver();
+  });
+
+  test.each(CASES)('resolves $endpointType through $api', async (testCase) => {
+    const provider = makeProvider(testCase.endpointType, testCase.baseUrl, testCase.adapterFamily);
+    const model = makeModel(testCase.endpointType);
+    mockGetProviderById.mockResolvedValue(provider);
+    mockGetModelById.mockResolvedValue(model);
+
+    const resolution = await resolve(resolver, { maxOutputTokens: 1024, temperature: 0.25 });
+
+    expect(resolution.model).toMatchObject({
+      api: testCase.api,
+      baseUrl: testCase.expectedBaseUrl,
+      contextWindow: 128_000,
+      id: testCase.expectedModelId,
+      maxTokens: 4096,
+      provider: 'test-provider',
+      reasoning: true,
+    });
+    expect(resolution.streamFn).toBe(mockBoundStreamFn);
+    expect(resolution.supportsTools).toBe(true);
+    expect(resolution.defaultThinkingLevel).toBe('high');
+    expect(resolution.redactionValues).toEqual(['secret-key', 'Bearer header-secret']);
+    expect(resolution.usageContext).toMatchObject({
+      credentialReceipt: CREDENTIAL_RECEIPT,
+      modelId: testCase.expectedModelId,
+      providerId: 'test-provider',
+    });
+    expect(mockBindPiStream).toHaveBeenCalledWith(
+      expect.objectContaining({ api: testCase.api }),
+      expect.objectContaining({
+        apiKey: 'secret-key',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer header-secret',
+          'X-App-Name': 'CherryStudioMobile',
+          'X-Custom': 'custom',
+        }),
+        maxRetries: 0,
+        maxTokens: 1024,
+        temperature: 0.25,
+        timeoutMs: 600_000,
+      }),
+    );
+  });
+
+  test('uses the existing per-model gateway route', async () => {
+    const provider = makeProvider(
+      ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      'https://aihubmix.test/v1',
+      'aihubmix',
+    );
+    provider.id = 'aihubmix';
+    provider.presetProviderId = 'aihubmix';
+    provider.endpointConfigs = {
+      ...provider.endpointConfigs,
+      [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: {
+        adapterFamily: 'aihubmix',
+        baseUrl: 'https://aihubmix.test',
+      },
+    };
+    const model = makeModel(undefined, {
+      apiModelId: 'claude-sonnet-4-5',
+      endpointTypes: undefined,
+      id: 'aihubmix::claude-sonnet-4-5',
+      modelId: 'claude-sonnet-4-5',
+      providerId: 'aihubmix',
+    });
+    mockGetProviderById.mockResolvedValue(provider);
+    mockGetModelById.mockResolvedValue(model);
+
+    const resolution = await resolver.resolveModel(
+      { modelId: 'claude-sonnet-4-5', providerId: 'aihubmix' },
+      {},
+    );
+
+    expect(resolution.model).toMatchObject({
+      api: 'anthropic-messages',
+      baseUrl: 'https://aihubmix.test',
+    });
+  });
+
+  test.each([
+    {
+      name: 'an unsupported endpoint',
+      provider: makeProvider(ENDPOINT_TYPE.OLLAMA_CHAT, 'http://localhost:11434', 'ollama'),
+      error: 'does not support the selected endpoint: ollama-chat',
+    },
+    {
+      name: 'a non-standard adapter family',
+      provider: makeProvider(
+        ENDPOINT_TYPE.OPENAI_RESPONSES,
+        'https://azure.test',
+        'azure-responses',
+      ),
+      error: 'does not support provider adapter family: azure-responses',
+    },
+    {
+      name: 'a non-API-key auth type',
+      provider: {
+        ...makeProvider(ENDPOINT_TYPE.ANTHROPIC_MESSAGES, 'https://bedrock.test', 'anthropic'),
+        authType: 'iam-aws' as const,
+      },
+      error: 'does not support provider authentication type: iam-aws',
+    },
+    {
+      name: 'a custom endpoint path',
+      provider: makeProvider(
+        ENDPOINT_TYPE.OPENAI_RESPONSES,
+        'https://responses.test/responses#',
+        'openai',
+      ),
+      error: 'does not support a separate custom endpoint path',
+    },
+  ])('fails before credential selection for $name', async ({ provider, error }) => {
+    mockGetProviderById.mockResolvedValue(provider);
+    mockGetModelById.mockResolvedValue(makeModel(provider.defaultChatEndpoint));
+
+    await expect(resolve(resolver)).rejects.toThrow(error);
+    expect(mockResolveApiKey).not.toHaveBeenCalled();
+    expect(mockBindPiStream).not.toHaveBeenCalled();
+  });
+
+  test('rejects a missing API key before binding the provider stream', async () => {
+    mockGetProviderById.mockResolvedValue(
+      makeProvider(ENDPOINT_TYPE.OPENAI_RESPONSES, 'https://responses.test', 'openai'),
+    );
+    mockGetModelById.mockResolvedValue(makeModel(ENDPOINT_TYPE.OPENAI_RESPONSES));
+    mockResolveApiKey.mockResolvedValue({
+      apiKeySelection: { attribution: 'unknown' },
+      value: '',
+    });
+
+    await expect(resolve(resolver)).rejects.toThrow('requires an API key');
+    expect(mockBindPiStream).not.toHaveBeenCalled();
+  });
+});
+
+function makeProvider(
+  endpointType: EndpointType,
+  baseUrl: string,
+  adapterFamily: string,
+): Provider {
+  return {
+    apiFeatures: { ...DEFAULT_API_FEATURES },
+    apiKeys: [],
+    authMethods: ['api-key'],
+    authType: 'api-key',
+    defaultChatEndpoint: endpointType,
+    endpointConfigs: { [endpointType]: { adapterFamily, baseUrl } },
+    id: 'test-provider',
+    isEnabled: true,
+    name: 'Test Provider',
+    settings: {
+      extraHeaders: {
+        Authorization: 'Bearer header-secret',
+        'X-Custom': 'custom',
+      },
+    },
+  };
+}
+
+function makeModel(endpointType: EndpointType | undefined, overrides: Partial<Model> = {}): Model {
+  return {
+    apiModelId: 'models/test-model',
+    capabilities: [MODEL_CAPABILITY.FUNCTION_CALL, MODEL_CAPABILITY.REASONING],
+    endpointTypes: endpointType ? [endpointType] : undefined,
+    id: 'test-provider::test-model',
+    isEnabled: true,
+    isHidden: false,
+    maxOutputTokens: 4096,
+    modelId: 'test-model',
+    name: 'Test Model',
+    providerId: 'test-provider',
+    reasoning: { defaultEffort: 'high', selectableEfforts: ['high'] },
+    supportsStreaming: true,
+    ...overrides,
+  };
+}
+
+function resolve(
+  resolver: PiRuntimeDependencies,
+  options: Parameters<PiRuntimeDependencies['resolveModel']>[1] = {},
+) {
+  return resolver.resolveModel({ modelId: 'test-model', providerId: 'test-provider' }, options);
+}

--- a/src/backend/ai/agentHost/piApiAdapters.ts
+++ b/src/backend/ai/agentHost/piApiAdapters.ts
@@ -1,0 +1,89 @@
+import { formatApiHost, withoutTrailingApiVersion } from '@cherrystudio/ai-runtime/provider';
+import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
+import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
+import type { FetchFunction } from '@earendil-works/pi-ai';
+
+export type SupportedPiApi =
+  | 'anthropic-messages'
+  | 'google-generative-ai'
+  | 'openai-completions'
+  | 'openai-responses';
+
+type PiStreamFn = AgentOptions['streamFn'];
+
+type PiApiAdapter = {
+  api: SupportedPiApi;
+  formatBaseUrl(baseUrl: string): string;
+  loadStreamSimple(): Promise<PiStreamFn>;
+  supportsCustomFetch: boolean;
+};
+
+const PI_API_ADAPTERS: Partial<Record<EndpointType, PiApiAdapter>> = {
+  [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: {
+    api: 'anthropic-messages',
+    formatBaseUrl: (baseUrl) => withoutTrailingApiVersion(formatApiHost(baseUrl, false)),
+    loadStreamSimple: async () =>
+      (await import('@earendil-works/pi-ai/api/anthropic-messages'))
+        .streamSimple as unknown as PiStreamFn,
+    supportsCustomFetch: true,
+  },
+  [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]: {
+    api: 'google-generative-ai',
+    formatBaseUrl: (baseUrl) => formatApiHost(baseUrl, true, 'v1beta'),
+    loadStreamSimple: async () =>
+      (await import('@earendil-works/pi-ai/api/google-generative-ai'))
+        .streamSimple as unknown as PiStreamFn,
+    supportsCustomFetch: false,
+  },
+  [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+    api: 'openai-completions',
+    formatBaseUrl: (baseUrl) => formatApiHost(baseUrl),
+    loadStreamSimple: async () =>
+      (await import('@earendil-works/pi-ai/api/openai-completions'))
+        .streamSimple as unknown as PiStreamFn,
+    supportsCustomFetch: true,
+  },
+  [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+    api: 'openai-responses',
+    formatBaseUrl: (baseUrl) => formatApiHost(baseUrl),
+    loadStreamSimple: async () =>
+      (await import('@earendil-works/pi-ai/api/openai-responses'))
+        .streamSimple as unknown as PiStreamFn,
+    supportsCustomFetch: true,
+  },
+};
+
+export function resolvePiApiAdapter(
+  endpointType: EndpointType | undefined,
+): PiApiAdapter | undefined {
+  return endpointType ? PI_API_ADAPTERS[endpointType] : undefined;
+}
+
+type PiStreamBinding = {
+  apiKey: string;
+  fetch: FetchFunction;
+  headers: Record<string, string>;
+  maxRetries: number;
+  maxTokens: number;
+  temperature?: number;
+  timeoutMs: number;
+};
+
+export async function bindPiStream(
+  adapter: PiApiAdapter,
+  binding: PiStreamBinding,
+): Promise<PiStreamFn> {
+  const streamSimple = await adapter.loadStreamSimple();
+
+  return (model, context, options) =>
+    streamSimple(model, context, {
+      ...options,
+      apiKey: binding.apiKey,
+      fetch: adapter.supportsCustomFetch ? binding.fetch : undefined,
+      headers: { ...options?.headers, ...binding.headers },
+      maxRetries: binding.maxRetries,
+      maxTokens: binding.maxTokens,
+      temperature: binding.temperature,
+      timeoutMs: binding.timeoutMs,
+    });
+}

--- a/src/backend/ai/agentHost/piModelResolver.ts
+++ b/src/backend/ai/agentHost/piModelResolver.ts
@@ -1,7 +1,11 @@
-import { resolveEffectiveEndpoint } from '@cherrystudio/ai-runtime/provider';
+import {
+  getExtraHeaders,
+  resolveEffectiveEndpoint,
+  resolveWireModelId,
+} from '@cherrystudio/ai-runtime/provider';
 import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
-import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-import type { FetchFunction, ModelThinkingLevel } from '@earendil-works/pi-ai';
+import { MODEL_CAPABILITY, type EndpointType } from '@cherrystudio/provider-registry';
+import type { FetchFunction, Model as PiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
 import type {
@@ -9,28 +13,29 @@ import type {
   PiRuntimeDependencies,
   RuntimeUsageContext,
 } from '@/backend/ai/agent';
-import { resolveProviderAiSdkConfig } from '@/backend/ai/provider/config';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
+import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
+
+import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from './piApiAdapters';
 
 const DEFAULT_PI_CONTEXT_WINDOW = 128_000;
 const DEFAULT_PI_MAX_OUTPUT_TOKENS = 8_192;
 const DEFAULT_PI_TIMEOUT_MS = 10 * 60_000;
 
-type PiProviderSettings = {
-  apiKey: string;
-  baseURL: string;
-  fetch?: FetchFunction;
-  headers?: Record<string, string | undefined>;
-  organization?: string;
-  project?: string;
-};
+const NON_STANDARD_ADAPTER_FAMILIES = new Set([
+  'azure',
+  'azure-responses',
+  'bedrock',
+  'google-vertex',
+  'google-vertex-anthropic',
+]);
 
 export function createPiModelResolver(): PiRuntimeDependencies {
   return {
-    async resolveModel(runtimeModel): Promise<PiModelResolution> {
+    async resolveModel(runtimeModel, runtimeOptions): Promise<PiModelResolution> {
       const uniqueModelId = createUniqueModelId(runtimeModel.providerId, runtimeModel.modelId);
       const [provider, model] = await Promise.all([
         providerService.getByProviderId(runtimeModel.providerId),
@@ -38,20 +43,47 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       ]);
       if (!model) throw new Error(`Model is not configured: ${uniqueModelId}`);
 
-      assertPiModelSupported(provider, model);
-      const { config, credentialReceipt } = await resolveProviderAiSdkConfig(provider, model, {
-        fetch: expoFetch as FetchFunction,
-        getAuthConfig: (providerId) => providerService.getAuthConfig(providerId),
-        resolveApiKey: (providerId, override) =>
-          providerService.resolveApiKey(providerId, override),
-      });
-      if (config.endpoint) {
+      const resolvedEndpoint = resolveEffectiveEndpoint(provider, model);
+      const adapter = resolveSupportedAdapter(provider, resolvedEndpoint.endpointType);
+      const configuredBaseUrl = resolvedEndpoint.baseUrl.trim();
+      if (!configuredBaseUrl) {
+        throw new Error('Pi Runtime requires a base URL from the selected provider.');
+      }
+      if (configuredBaseUrl.endsWith('#')) {
         throw new Error('Pi Runtime does not support a separate custom endpoint path.');
       }
-      const settings = readPiProviderSettings(config.providerSettings);
-      const modelId = model.apiModelId ?? model.modelId;
+
+      const selectedApiKey = await providerService.resolveApiKey(provider.id);
+      if (!selectedApiKey.value.trim()) {
+        throw new Error('Pi Runtime requires an API key from the selected provider.');
+      }
+
+      const modelId = resolveWireModelId(model, resolvedEndpoint.endpointType);
+      const headers = { ...defaultAppHeaders(), ...getExtraHeaders(provider) };
+      const piModel: PiModel<SupportedPiApi> = {
+        api: adapter.api,
+        baseUrl: adapter.formatBaseUrl(configuredBaseUrl),
+        contextWindow: model.contextWindow ?? DEFAULT_PI_CONTEXT_WINDOW,
+        cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
+        headers,
+        id: modelId,
+        input: ['text'],
+        maxTokens: model.maxOutputTokens ?? DEFAULT_PI_MAX_OUTPUT_TOKENS,
+        name: model.name,
+        provider: provider.id,
+        reasoning: model.reasoning !== undefined,
+      };
+      const streamFn = await bindPiStream(adapter, {
+        apiKey: selectedApiKey.value,
+        fetch: expoFetch as FetchFunction,
+        headers,
+        maxRetries: 0,
+        maxTokens: runtimeOptions.maxOutputTokens ?? piModel.maxTokens,
+        temperature: runtimeOptions.temperature,
+        timeoutMs: DEFAULT_PI_TIMEOUT_MS,
+      });
       const capturedContext = createAiUsageCaptureContext({
-        credentialReceipt,
+        credentialReceipt: selectedApiKey.apiKeySelection,
         messageRef: null,
         modelId,
         modelName: model.name,
@@ -74,89 +106,49 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       };
 
       return {
-        apiKey: settings.apiKey,
         defaultThinkingLevel: resolveDefaultThinkingLevel(model),
-        fetch: settings.fetch ?? (expoFetch as FetchFunction),
-        headers: mergeHeaders(settings),
-        maxRetries: 0,
-        model: {
-          api: 'openai-responses',
-          baseUrl: settings.baseURL,
-          contextWindow: model.contextWindow ?? DEFAULT_PI_CONTEXT_WINDOW,
-          cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
-          headers: mergeHeaders(settings),
-          id: modelId,
-          input: ['text'],
-          maxTokens: model.maxOutputTokens ?? DEFAULT_PI_MAX_OUTPUT_TOKENS,
-          name: model.name,
-          provider: provider.id,
-          reasoning: model.reasoning !== undefined,
-        },
+        model: piModel,
+        redactionValues: collectRedactionValues(selectedApiKey.value, headers),
+        streamFn,
         supportsTools: model.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL),
-        timeoutMs: DEFAULT_PI_TIMEOUT_MS,
         usageContext,
       };
     },
   };
 }
 
-function assertPiModelSupported(provider: Provider, model: Model): void {
-  const endpointType = resolveEffectiveEndpoint(provider, model).endpointType;
-  if (endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES) {
+function resolveSupportedAdapter(provider: Provider, endpointType: EndpointType | undefined) {
+  const adapterFamily = endpointType
+    ? provider.endpointConfigs?.[endpointType]?.adapterFamily
+    : undefined;
+  if (adapterFamily && NON_STANDARD_ADAPTER_FAMILIES.has(adapterFamily)) {
+    throw new Error(`Pi Runtime does not support provider adapter family: ${adapterFamily}.`);
+  }
+
+  const adapter = resolvePiApiAdapter(endpointType);
+  if (!adapter) {
     throw new Error(
-      `Pi Runtime currently supports the OpenAI Responses endpoint; received ${endpointType ?? 'unknown'}.`,
+      `Pi Runtime does not support the selected endpoint: ${endpointType ?? 'unknown'}.`,
     );
   }
   if (provider.authType !== 'api-key') {
     throw new Error(
-      `Pi Runtime does not support provider authentication type: ${provider.authType}`,
+      `Pi Runtime does not support provider authentication type: ${provider.authType}.`,
     );
   }
   if (provider.authMethods?.length && !provider.authMethods.includes('api-key')) {
     throw new Error('Pi Runtime does not support this provider authentication flow.');
   }
+  return adapter;
 }
 
-function readPiProviderSettings(value: unknown): PiProviderSettings {
-  if (!isRecord(value)) throw new Error('Pi Runtime requires plain provider settings.');
-  if (typeof value.apiKey !== 'string' || value.apiKey.length === 0) {
-    throw new Error('Pi Runtime requires an API key from the selected provider.');
-  }
-  if (typeof value.baseURL !== 'string' || value.baseURL.trim().length === 0) {
-    throw new Error('Pi Runtime requires a base URL from the selected provider.');
-  }
-  if (value.headers !== undefined && !isStringRecord(value.headers)) {
-    throw new Error('Pi Runtime requires plain string provider headers.');
-  }
-  if (value.organization !== undefined && typeof value.organization !== 'string') {
-    throw new Error('Pi Runtime requires a string OpenAI organization.');
-  }
-  if (value.project !== undefined && typeof value.project !== 'string') {
-    throw new Error('Pi Runtime requires a string OpenAI project.');
-  }
-  if (value.fetch !== undefined && typeof value.fetch !== 'function') {
-    throw new Error('Pi Runtime requires a callable provider transport.');
-  }
-
-  return {
-    apiKey: value.apiKey,
-    baseURL: value.baseURL,
-    ...(typeof value.fetch === 'function' ? { fetch: value.fetch as FetchFunction } : {}),
-    ...(value.headers ? { headers: value.headers } : {}),
-    ...(value.organization ? { organization: value.organization } : {}),
-    ...(value.project ? { project: value.project } : {}),
-  };
-}
-
-function mergeHeaders(settings: PiProviderSettings): Record<string, string> | undefined {
-  const headers = Object.fromEntries(
-    Object.entries({
-      ...settings.headers,
-      ...(settings.organization ? { 'OpenAI-Organization': settings.organization } : {}),
-      ...(settings.project ? { 'OpenAI-Project': settings.project } : {}),
-    }).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
-  );
-  return Object.keys(headers).length > 0 ? headers : undefined;
+function collectRedactionValues(apiKey: string, headers: Record<string, string>): string[] {
+  return [
+    apiKey,
+    ...Object.entries(headers).flatMap(([name, value]) =>
+      /authorization|api[-_]key|token|secret/i.test(name) ? [value] : [],
+    ),
+  ];
 }
 
 function resolveDefaultThinkingLevel(model: Model): ModelThinkingLevel {
@@ -165,12 +157,4 @@ function resolveDefaultThinkingLevel(model: Model): ModelThinkingLevel {
   if (effort === 'none') return 'off';
   if (effort === 'auto') return 'medium';
   return effort;
-}
-
-function isStringRecord(value: unknown): value is Record<string, string | undefined> {
-  return isRecord(value) && Object.values(value).every((entry) => typeof entry === 'string');
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/src/backend/ai/runtime/pi/__tests__/piReactNativePatches.test.ts
+++ b/src/backend/ai/runtime/pi/__tests__/piReactNativePatches.test.ts
@@ -33,7 +33,7 @@ describe('Pi React Native patches', () => {
     expect(providerEnv).toContain('function getBunSandboxEnvValue(_name)');
   });
 
-  test('keeps the OpenAI Responses runtime out of the Pi model and auth graph', () => {
+  test('keeps supported Pi adapters out of the Pi model and auth graph', () => {
     const packageJson = JSON.parse(
       readFileSync(`${process.cwd()}/node_modules/@earendil-works/pi-ai/package.json`, 'utf8'),
     ) as { exports?: Record<string, unknown> };
@@ -44,6 +44,16 @@ describe('Pi React Native patches', () => {
     const responsesShared = readFileSync(
       `${process.cwd()}/node_modules/@earendil-works/pi-ai/dist/api/openai-responses-shared.js`,
       'utf8',
+    );
+    const additionalAdapters = [
+      'anthropic-messages',
+      'google-generative-ai',
+      'openai-completions',
+    ].map((api) =>
+      readFileSync(
+        `${process.cwd()}/node_modules/@earendil-works/pi-ai/dist/api/${api}.js`,
+        'utf8',
+      ),
     );
 
     expect(packageJson.exports).toMatchObject({
@@ -60,5 +70,9 @@ describe('Pi React Native patches', () => {
     expect(responsesShared).not.toContain('from "../models.js"');
     expect(responses).toContain('from "../utils/model-runtime.js"');
     expect(responsesShared).toContain('from "../utils/model-runtime.js"');
+    for (const adapter of additionalAdapters) {
+      expect(adapter).not.toContain('from "../models.js"');
+      expect(adapter).toContain('from "../utils/model-runtime.js"');
+    }
   });
 });


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: Pi Runtime only supported OpenAI Responses and assembled transport details itself.

After this PR: the model resolver selects OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, or Google Generate Content and returns a bound stream function, keeping Pi Runtime provider agnostic.

### Screenshots or videos

N/A; this is a backend runtime change with no direct UI surface.

### Why we need it and why it was done in this way

The following tradeoffs were made: mobile supports API keys, standard protocols, custom base URLs, and existing gateway routing, while intentionally failing closed for OAuth/IAM, Azure, Bedrock, Vertex, Ollama, and custom payload/path rewrites.

The following alternatives were considered: desktop-style provider registry injection was rejected because its provider-specific complexity is unnecessary on mobile.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The Pi React Native patch now covers all four adapters; verification includes `pnpm typecheck`, 32 focused Pi tests, 1,087 package tests, 2,663 app tests, and successful iOS and Android Metro exports.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Expanded Pi agent compatibility across OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, and Google Generate Content providers.
```
