### PR TITLE
feat(agent-tools): write files from chat into the file library

### DIFF
--- a/.rnstorybook/stories/messages/MessagesStoryProviders.tsx
+++ b/.rnstorybook/stories/messages/MessagesStoryProviders.tsx
@@ -23,17 +23,19 @@ import { FileEntrySchema } from '@/shared/data/types/file';
 
 import { STORY_FILE_ENTRY_ID } from './messageFixtures';
 
-const storyFileEntry = FileEntrySchema.parse({
-  cleanupPolicy: 'manual',
-  contentHash: null,
-  createdAt: 1,
-  ext: 'png',
-  id: STORY_FILE_ENTRY_ID,
-  name: 'cherry-studio',
-  origin: 'internal',
-  size: 1,
-  updatedAt: 1,
-});
+const storyFileEntries = new Map(
+  [
+    {
+      createdAt: 1,
+      filename: 'cherry-studio.png',
+      id: STORY_FILE_ENTRY_ID,
+      mediaType: 'image/png',
+      size: 1,
+      updatedAt: 1,
+    },
+  ].map((entry) => [entry.id, FileEntrySchema.parse(entry)]),
+);
+// Every entry resolves to the same asset: a card renders from the row, not the bytes.
 const storyFileUri = Image.resolveAssetSource(require('../../../assets/icon.png')).uri;
 const storyQueryClient = new QueryClient({
   defaultOptions: { queries: { gcTime: Infinity, retry: false, staleTime: Infinity } },
@@ -50,8 +52,9 @@ void storyI18n.use(initReactI18next).init({
 
 const storyDataApi = {
   get: async (path: string) => {
-    if (path === `/files/entries/${STORY_FILE_ENTRY_ID}`) {
-      return storyFileEntry;
+    const entry = storyFileEntries.get(path.replace('/files/entries/', ''));
+    if (entry) {
+      return entry;
     }
     throw new Error(`Story Data API received an unsupported GET: ${path}`);
   },
@@ -62,8 +65,8 @@ const storyBackend = {
     createInternalEntry: async () => {
       throw new Error('Story file creation is not supported');
     },
-    deleteIfUnreferenced: async () => false,
-    getUri: async (id: string) => (id === STORY_FILE_ENTRY_ID ? storyFileUri : undefined),
+    delete: async () => false,
+    getUri: async (id: string) => (storyFileEntries.has(id) ? storyFileUri : undefined),
   },
 } as unknown as Backend;
 

--- a/.rnstorybook/stories/messages/MessagesStoryProviders.tsx
+++ b/.rnstorybook/stories/messages/MessagesStoryProviders.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/shared/data/preference';
 import { FileEntrySchema } from '@/shared/data/types/file';
 
-import { STORY_FILE_ENTRY_ID } from './messageFixtures';
+import { STORY_FILE_ENTRY_ID, STORY_WRITTEN_FILE_ENTRY_ID } from './messageFixtures';
 
 const storyFileEntries = new Map(
   [
@@ -33,9 +33,17 @@ const storyFileEntries = new Map(
       size: 1,
       updatedAt: 1,
     },
+    {
+      createdAt: 1,
+      filename: 'release-notes.md',
+      id: STORY_WRITTEN_FILE_ENTRY_ID,
+      mediaType: 'text/markdown',
+      size: 128,
+      updatedAt: 1,
+    },
   ].map((entry) => [entry.id, FileEntrySchema.parse(entry)]),
 );
-// Every entry resolves to the same asset: a card renders from the row, not the bytes.
+// Both entries resolve to the same asset: a card renders from the row, not the bytes.
 const storyFileUri = Image.resolveAssetSource(require('../../../assets/icon.png')).uri;
 const storyQueryClient = new QueryClient({
   defaultOptions: { queries: { gcTime: Infinity, retry: false, staleTime: Infinity } },

--- a/.rnstorybook/stories/messages/__tests__/messageFixtures.test.ts
+++ b/.rnstorybook/stories/messages/__tests__/messageFixtures.test.ts
@@ -1,6 +1,10 @@
 import { readCherryMeta } from '@cherrystudio/universal/data/types/uiParts';
 
-import { messageExamples, STORY_FILE_ENTRY_ID } from '../messageFixtures';
+import {
+  messageExamples,
+  STORY_FILE_ENTRY_ID,
+  STORY_WRITTEN_FILE_ENTRY_ID,
+} from '../messageFixtures';
 
 describe('messages Storybook fixtures', () => {
   it('covers every message adapter family in the playground', () => {
@@ -42,11 +46,23 @@ describe('messages Storybook fixtures', () => {
         'tool_invoke',
         'tool_search',
         'web_search',
+        'write_file',
       ]),
     );
     expect(
       parts.some(
         (part) => part.type === 'file' && readCherryMeta(part)?.fileEntryId === STORY_FILE_ENTRY_ID,
+      ),
+    ).toBe(true);
+    // A written file renders as a card, so its id must be one the story providers resolve.
+    expect(
+      parts.some(
+        (part) =>
+          part.type === 'dynamic-tool' &&
+          part.toolName === 'write_file' &&
+          part.state === 'output-available' &&
+          (part.output as { fileEntryId?: string } | undefined)?.fileEntryId ===
+            STORY_WRITTEN_FILE_ENTRY_ID,
       ),
     ).toBe(true);
   });

--- a/.rnstorybook/stories/messages/messageFixtures.ts
+++ b/.rnstorybook/stories/messages/messageFixtures.ts
@@ -3,6 +3,7 @@ import type { CherryMessagePart } from '@cherrystudio/universal/data/types/messa
 import type { MessageListItem } from '@/frontend/components/messages';
 
 export const STORY_FILE_ENTRY_ID = '00000000-0000-7000-8000-000000000101';
+export const STORY_WRITTEN_FILE_ENTRY_ID = '00000000-0000-7000-8000-000000000102';
 
 export type MessageExample = {
   label: string;
@@ -87,6 +88,40 @@ const toolParts: CherryMessagePart[] = [
     toolCallId: 'mcp-complete',
     toolMetadata: { cherry: { tool: { serverName: 'Filesystem', type: 'mcp' } } },
     toolName: 'read_file',
+    type: 'dynamic-tool',
+  },
+];
+
+const writeFileParts: CherryMessagePart[] = [
+  {
+    input: { content: '# Release Notes\n', filename: 'release-notes.md' },
+    state: 'input-available',
+    toolCallId: 'write-file-running',
+    toolName: 'write_file',
+    type: 'dynamic-tool',
+  },
+  {
+    input: { content: '# Release Notes\n', filename: 'release-notes.md' },
+    output: {
+      fileEntryId: STORY_WRITTEN_FILE_ENTRY_ID,
+      filename: 'release-notes.md',
+      size: 128,
+      status: 'created',
+    },
+    state: 'output-available',
+    toolCallId: 'write-file-complete',
+    toolName: 'write_file',
+    type: 'dynamic-tool',
+  },
+  {
+    input: { content: '...', filename: 'notes/report.md' },
+    output: {
+      message: 'Invalid filename: give a plain name with an extension, such as `report.md`.',
+      status: 'error',
+    },
+    state: 'output-available',
+    toolCallId: 'write-file-rejected',
+    toolName: 'write_file',
     type: 'dynamic-tool',
   },
 ];
@@ -225,6 +260,10 @@ export const messageExamples: readonly MessageExample[] = [
   {
     label: 'Generic and MCP tools',
     message: createMessage('assistant-tools', 'assistant', toolParts),
+  },
+  {
+    label: 'Written file',
+    message: createMessage('assistant-write-file', 'assistant', writeFileParts),
   },
   {
     label: 'Meta tools',

--- a/docs/references/agent/agent-tools-and-resources.md
+++ b/docs/references/agent/agent-tools-and-resources.md
@@ -3,6 +3,12 @@
 Status: **target design; application tool bindings and the Pi adapter are not yet complete**.
 Version 1 is local-only.
 
+One capability is as-built ahead of that design: `write_file` (see
+[Managed File Read And Edit](#managed-file-read-and-edit)). It ships as a minimal slice — the Host
+injects a fixed catalog into every turn, so the `ToolRef` identity, the durable bindings, the turn
+resource ledger, and the `{ value, artifacts }` result envelope described below do not exist in
+code yet. Sections that a shipped tool already diverges from carry an **As-built** note.
+
 This document defines how Cherry Mobile exposes application capabilities to Pi. Pi remains the
 sole conversation engine and owns the model → tool → result loop. Application services own every
 side effect, credential, system permission, managed file, and provider-specific capability.
@@ -53,6 +59,10 @@ generated aliases are never authority. Alias generation includes the source name
 digest, rejects collisions within the snapshot, and never falls back to display-name matching. The
 Host snapshots a display name separately so historical UI remains understandable after
 configuration changes.
+
+**As-built.** Neither representation exists yet. `write_file` is identified by its wire name alone,
+and the Host builds the same one-tool catalog for every Agent, so there is nothing to bind and no
+alias to derive. The `agent` table therefore still has no tool-policy column.
 
 The logical binding model is:
 
@@ -116,6 +126,10 @@ receives a [`file_entry`](../data/file-model.md) id. Protocol operations and fil
 that managed id; raw `file://`, `content://`, sandbox, provider, and user-entered paths are transient
 import sources, never authority.
 
+**As-built.** There is no `TurnResourceLedger` yet. `write_file` needs none: it only creates
+entries and never reads one, so it has no input to authorize. The ledger becomes necessary with the
+first tool that accepts a `fileEntryId`.
+
 For Version 1, the Host derives the initial ledger grants from:
 
 - managed files attached to the current user input;
@@ -154,6 +168,12 @@ Agent Protocol file part with `purpose: 'artifact'` so the transcript retains it
 display metadata. Its content is not automatically projected as a model attachment in later
 history. If the managed entry still exists, a user may explicitly attach it again or the model may
 read it through a controlled tool; otherwise the reference remains visible as unavailable.
+
+**As-built.** `RuntimeTool.execute` still returns bare JSON, so there is no envelope and no
+artifact projection. `write_file` reports its new entry as a `fileEntryId` inside that JSON, which
+the transcript persists with the tool call; chat renders it as the same file card an attachment
+gets, resolved from the id at read time. Nothing is stored as a `purpose: 'artifact'` file part,
+and later turns see the id as ordinary result data.
 
 If a capability delegates work to `JobRuntime`, its Runtime tool still waits for a terminal result
 or cancellation during Version 1. A route unmount does not cancel it, but process death interrupts
@@ -287,6 +307,15 @@ with its own approval policy.
   not an arbitrary path.
 - Edit tools use format-specific application services and copy-on-write output. There is no generic
   unrestricted byte writer in Version 1.
+
+**As-built.** `write_file` is the one writer that ships. It does not weaken the rule above: it
+accepts a display name rather than a path, writes bounded UTF-8 text (1 MB) as a *new* entry, and
+can neither address nor overwrite an existing one. The model receives
+`{ status, fileEntryId, filename, size }`; a name it could correct returns
+`{ status: 'error', message }` rather than throwing, since a thrown error reaches it only as an
+opaque failure. It runs without approval because it has no destructive form, and the Host offers it
+only to models that support function calling — handing tools to a model that cannot call them fails
+the whole turn. Implementation: `src/backend/ai/agentHost/tools/`.
 - Input size, extracted-text size, generated-file size, timeout, and cancellation limits are
   enforced by the capability service before provider or filesystem work grows without bound.
 

--- a/docs/references/data/file-model.md
+++ b/docs/references/data/file-model.md
@@ -57,7 +57,10 @@ An owner stores the entry ids it points at, inside its own row:
 | --- | --- |
 | Painting | `painting.files` — `{ input: string[], output: string[] }` |
 
-Agent Session attachments are not active in Version 1, so no current transcript row owns file ids.
+Agent Session attachments are not active in Version 1. The one transcript-side owner that exists is
+a `write_file` tool result, which carries the `fileEntryId` it created in its result JSON; chat
+resolves the id back to a card at read time. As with every owner here, the reference outlives the
+bytes and degrades to the unavailable placeholder.
 
 There is no association table and no foreign key from an owner to `file_entry`. That is the point:
 a foreign key would have to choose between `CASCADE` (deleting a file silently rewrites the
@@ -115,6 +118,11 @@ row).
 
 **Agent file writes and generated artifacts.** A write tool reads an entry in the turn's controlled
 resource ledger, creates a new one, and returns the new id; it must not rewrite a managed blob.
+
+As-built, one slice of this ships: the `write_file` tool stores UTF-8 text through the `'text'`
+source of `createInternalEntry`, so it creates entries but reads none — the resource ledger it
+would consult does not exist yet. Its id reaches the transcript inside tool-result JSON rather than
+as the `purpose: 'artifact'` file part described below.
 Office inputs are imported before inspection or editing, and every edit patches a copy into a new
 entry while preserving the source. Office and image tools follow the same rule for newly generated
 output. The file library is also the Version 1 artifact library; no parallel artifact blob store or

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -31,6 +31,7 @@ import type {
   AgentRuntime,
   AgentRuntimeSession,
   RuntimeEvent,
+  RuntimeTool,
   RuntimeUsageReport,
 } from '@/backend/ai/agent';
 import { PiRuntime } from '@/backend/ai/agent';
@@ -93,6 +94,7 @@ import {
   toRuntimeInputParts,
 } from './mapping';
 import { createPiModelResolver } from './piModelResolver';
+import { type AgentToolSource, createBuiltInToolSource } from './tools/builtInToolSource';
 
 const logger = loggerService.withContext('MobileAgentHost');
 
@@ -115,6 +117,7 @@ type MobileAgentHostOverrides = {
     'drain' | 'maybeRenameFromConversationSummary' | 'maybeRenameFromFirstUserMessage'
   >;
   usage: Pick<AgentSessionUsageRecorder, 'drain' | 'record'>;
+  tools: AgentToolSource;
 };
 
 /**
@@ -199,6 +202,12 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   }
 
   private lazyAgents: AgentDefinitionSource | undefined;
+
+  private get toolSource(): AgentToolSource {
+    return this.overrides.tools ?? (this.lazyTools ??= createBuiltInToolSource());
+  }
+
+  private lazyTools: AgentToolSource | undefined;
 
   /** Reconcile any unfinished state available from the selected store. */
   protected override async onInit(): Promise<void> {
@@ -318,6 +327,18 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
       }
 
+      // Frozen for the turn, so mid-turn configuration changes cannot alter it.
+      // Tools are an enhancement: if the catalog cannot be resolved the turn
+      // still runs, tool-less.
+      let tools: readonly RuntimeTool[] = [];
+      if (runtime.descriptor.capabilities.tools) {
+        try {
+          tools = await this.toolSource.getTools(agent.model);
+        } catch (error) {
+          logger.warn('Failed to resolve Agent tools; running this turn tool-less', error as Error);
+        }
+      }
+
       // History is everything stored before this turn.
       const priorMessages = await this.store.listMessages(sessionId);
 
@@ -382,6 +403,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         state,
         toRuntimeHistory(priorMessages),
         parsed.parts,
+        tools,
       );
       this.runningTurns.add(run);
       this.runningTurnsBySession.set(sessionId, run);
@@ -482,6 +504,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     state: ActiveTurnState,
     history: ReturnType<typeof toRuntimeHistory>,
     inputParts: AgentInputPart[],
+    tools: readonly RuntimeTool[],
   ): Promise<void> {
     try {
       const events = state.runtimeSession.execute({
@@ -490,8 +513,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         model: agent.model,
         history,
         input: toRuntimeInputParts(inputParts),
-        // V1 executes tool-less turns; Agent tools await the deferred definition.
-        tools: [],
+        tools: [...tools],
         options: agent.options,
       });
       for await (const event of events) {

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -6,7 +6,9 @@
 
 import {
   FakeRuntime,
+  type RuntimeDescriptor,
   type RuntimeExecutionRequest,
+  type RuntimeTool,
   type RuntimeUsageContext,
 } from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
@@ -22,6 +24,7 @@ import type { AgentDefinitionSource } from '../agentDefinitions';
 import type { AgentSessionNaming } from '../AgentSessionNaming';
 import { InMemoryAgentSessionStore } from '../InMemoryAgentSessionStore';
 import { MobileAgentHost } from '../MobileAgentHost';
+import type { AgentToolSource } from '../tools/builtInToolSource';
 
 const AGENT_ID = 'agent-under-test';
 
@@ -84,7 +87,22 @@ const usage = {
   record: jest.fn(),
 };
 
-function createHost(runtime: FakeRuntime, naming: NamingOverride = noOpNaming): MobileAgentHost {
+/** Keeps the suite off the production catalog, which reads the database. */
+const noOpTools: AgentToolSource = { getTools: async () => [] };
+
+const stubTool: RuntimeTool = {
+  name: 'stub_tool',
+  description: 'Does nothing.',
+  inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  approval: 'auto',
+  execute: async () => ({ status: 'ok' }),
+};
+
+function createHost(
+  runtime: FakeRuntime,
+  naming: NamingOverride = noOpNaming,
+  tools: AgentToolSource = noOpTools,
+): MobileAgentHost {
   return new MobileAgentHost(
     store,
     unusedAiService,
@@ -95,12 +113,17 @@ function createHost(runtime: FakeRuntime, naming: NamingOverride = noOpNaming): 
       agents,
       naming,
       usage,
+      tools,
     },
   );
 }
 
-function hostWithText(texts: string[], requests: RuntimeExecutionRequest[] = []): MobileAgentHost {
-  const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR });
+function hostWithText(
+  texts: string[],
+  requests: RuntimeExecutionRequest[] = [],
+  options: { descriptor?: RuntimeDescriptor; tools?: AgentToolSource } = {},
+): MobileAgentHost {
+  const runtime = new FakeRuntime({ descriptor: options.descriptor ?? FAKE_DESCRIPTOR });
   for (const text of texts) {
     runtime.script((controller) => {
       requests.push(controller.request);
@@ -125,7 +148,7 @@ function hostWithText(texts: string[], requests: RuntimeExecutionRequest[] = [])
       controller.emit({ type: 'completed' });
     });
   }
-  return createHost(runtime);
+  return createHost(runtime, noOpNaming, options.tools);
 }
 
 function createDeferred(): { promise: Promise<void>; resolve: () => void } {
@@ -273,6 +296,74 @@ describe('MobileAgentHost', () => {
     await host.submitMessage({ sessionId: session.id, parts: [{ type: 'text', text: 'More.' }] });
     await waitFor(() => terminalTurnEvent(secondEvents) !== undefined, 'the second turn');
     expect(requests[1]?.history.map((message) => message.role)).toEqual(['user', 'assistant']);
+  });
+
+  test('hands the turn the tools resolved for its model', async () => {
+    const requests: RuntimeExecutionRequest[] = [];
+    const getTools = jest.fn(async () => [stubTool]);
+    const host = hostWithText(['Saved.'], requests, { tools: { getTools } });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const events: AgentEvent[] = [];
+    await host.observeSession(session.id, (event) => events.push(event));
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Save it.' }],
+    });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the turn to settle');
+
+    expect(getTools).toHaveBeenCalledWith({ providerId: 'mock-provider', modelId: 'mock-model' });
+    expect(requests[0]?.tools).toEqual([stubTool]);
+  });
+
+  test('runs the turn tool-less when the catalog cannot be resolved', async () => {
+    const requests: RuntimeExecutionRequest[] = [];
+    const host = hostWithText(['Hi'], requests, {
+      tools: {
+        getTools: async () => {
+          throw new Error('database unavailable');
+        },
+      },
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const events: AgentEvent[] = [];
+    await host.observeSession(session.id, (event) => events.push(event));
+
+    await host.submitMessage({ sessionId: session.id, parts: [{ type: 'text', text: 'Hello.' }] });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the turn to settle');
+
+    expect(terminalTurnEvent(events)?.turn.status).toBe('completed');
+    expect(requests[0]?.tools).toEqual([]);
+  });
+
+  test('skips tool resolution for a runtime that cannot run tools', async () => {
+    const requests: RuntimeExecutionRequest[] = [];
+    const getTools = jest.fn(async () => [stubTool]);
+    const host = hostWithText(['Hi'], requests, {
+      descriptor: {
+        ...FAKE_DESCRIPTOR,
+        capabilities: { ...FAKE_DESCRIPTOR.capabilities, tools: false },
+      },
+      tools: { getTools },
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const events: AgentEvent[] = [];
+    await host.observeSession(session.id, (event) => events.push(event));
+
+    await host.submitMessage({ sessionId: session.id, parts: [{ type: 'text', text: 'Hello.' }] });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the turn to settle');
+
+    expect(getTools).not.toHaveBeenCalled();
+    expect(requests[0]?.tools).toEqual([]);
   });
 
   test('applies composer model and reasoning snapshots to only the submitted turn', async () => {

--- a/src/backend/ai/agentHost/agentDefinitions.ts
+++ b/src/backend/ai/agentHost/agentDefinitions.ts
@@ -4,8 +4,9 @@
  * The Agent tool configuration model is not settled yet
  * (docs/references/agent/README.md open questions). Basic chat needs only
  * id/name/model/instructions/inference options, so the Host consumes this
- * narrow source. Tools are deliberately absent because V1 executes tool-less
- * turns.
+ * narrow source. Tools are deliberately absent: the built-in catalog is
+ * Host-owned and identical for every Agent, so there is nothing to configure
+ * here until per-Agent bindings exist.
  */
 
 import { and, eq, isNull } from 'drizzle-orm';

--- a/src/backend/ai/agentHost/tools/__tests__/writeFileTool.test.ts
+++ b/src/backend/ai/agentHost/tools/__tests__/writeFileTool.test.ts
@@ -1,0 +1,151 @@
+import type { RuntimeJsonValue } from '@/backend/ai/agent';
+import { FileEntrySchema } from '@/shared/data/types/file';
+
+import {
+  createWriteFileTool,
+  WRITE_FILE_MAX_CONTENT_BYTES,
+  type WriteFileFiles,
+} from '../writeFileTool';
+
+describe('writeFileTool', () => {
+  test('writes text and reports the stored entry', async () => {
+    const files = createFilesPort();
+    const tool = createWriteFileTool(files);
+
+    const output = await execute(tool, { content: '# Report\n', filename: 'report.md' });
+
+    expect(files.createTextEntry).toHaveBeenCalledWith({
+      data: '# Report\n',
+      mediaType: 'text/markdown',
+      name: 'report.md',
+    });
+    expect(output).toEqual({
+      status: 'created',
+      fileEntryId: '00000000-0000-7000-8000-000000000001',
+      filename: 'report.md',
+      size: 9,
+    });
+  });
+
+  test('adds a text extension when the model omits one', async () => {
+    const files = createFilesPort();
+
+    await execute(createWriteFileTool(files), { content: 'notes', filename: 'meeting notes' });
+
+    expect(files.createTextEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: 'text/plain', name: 'meeting notes.txt' }),
+    );
+  });
+
+  test('drops a trailing dot rather than storing an empty extension', async () => {
+    const files = createFilesPort();
+
+    await execute(createWriteFileTool(files), { content: 'x', filename: 'draft.' });
+
+    expect(files.createTextEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'draft.txt' }),
+    );
+  });
+
+  test.each([
+    ['csv', 'text/csv'],
+    ['html', 'text/html'],
+    ['json', 'application/json'],
+    ['yml', 'application/yaml'],
+    // Source code stays text/plain: `ts` is video/mp2t in the IANA registry.
+    ['ts', 'text/plain'],
+    ['unknownext', 'text/plain'],
+  ])('maps .%s to %s', async (extension, mediaType) => {
+    const files = createFilesPort();
+
+    await execute(createWriteFileTool(files), { content: 'x', filename: `data.${extension}` });
+
+    expect(files.createTextEntry).toHaveBeenCalledWith(expect.objectContaining({ mediaType }));
+  });
+
+  test.each([
+    ['a path separator', 'docs/report.md'],
+    ['a parent directory', '..'],
+    ['only whitespace', '   '],
+    ['a name that cannot fit an extension', `${'a'.repeat(255)}`],
+  ])('rejects %s without writing', async (_case, filename) => {
+    const files = createFilesPort();
+
+    const output = await execute(createWriteFileTool(files), { content: 'x', filename });
+
+    expect(output).toEqual({ status: 'error', message: expect.stringContaining('filename') });
+    expect(files.createTextEntry).not.toHaveBeenCalled();
+  });
+
+  test('rejects unknown input keys', async () => {
+    const files = createFilesPort();
+
+    const output = await execute(createWriteFileTool(files), {
+      content: 'x',
+      filename: 'notes.txt',
+      path: '/etc/passwd',
+    });
+
+    expect(output).toEqual({ status: 'error', message: expect.stringContaining('Invalid input') });
+    expect(files.createTextEntry).not.toHaveBeenCalled();
+  });
+
+  test('measures the content limit in bytes, not characters', async () => {
+    const files = createFilesPort();
+    // Three bytes per character: under the limit by length, over it by size.
+    const content = '中'.repeat(WRITE_FILE_MAX_CONTENT_BYTES / 2);
+
+    const output = await execute(createWriteFileTool(files), { content, filename: 'big.txt' });
+
+    expect(output).toEqual({ status: 'error', message: expect.stringContaining('limit') });
+    expect(files.createTextEntry).not.toHaveBeenCalled();
+  });
+
+  test('lets storage failures surface as a tool error', async () => {
+    const files = createFilesPort();
+    files.createTextEntry.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(
+      execute(createWriteFileTool(files), { content: 'x', filename: 'notes.txt' }),
+    ).rejects.toThrow('disk full');
+  });
+
+  test('exposes a portable JSON Schema that forbids extra keys', () => {
+    const { inputSchema } = createWriteFileTool(createFilesPort());
+
+    expect(inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        content: expect.objectContaining({ type: 'string' }),
+        filename: expect.objectContaining({ type: 'string' }),
+      },
+      required: expect.arrayContaining(['content', 'filename']),
+      additionalProperties: false,
+    });
+  });
+});
+
+function createFilesPort() {
+  const createTextEntry = jest.fn(
+    async (input: { data: string; mediaType: string; name: string }) =>
+      FileEntrySchema.parse({
+        createdAt: 1,
+        filename: input.name,
+        id: '00000000-0000-7000-8000-000000000001',
+        mediaType: input.mediaType,
+        size: new TextEncoder().encode(input.data).length,
+        updatedAt: 1,
+      }),
+  );
+  return { createTextEntry } satisfies WriteFileFiles & { createTextEntry: jest.Mock };
+}
+
+function execute(
+  tool: ReturnType<typeof createWriteFileTool>,
+  input: RuntimeJsonValue,
+): Promise<RuntimeJsonValue> {
+  return tool.execute(input, {
+    signal: new AbortController().signal,
+    toolCallId: 'call-1',
+  });
+}

--- a/src/backend/ai/agentHost/tools/builtInToolSource.ts
+++ b/src/backend/ai/agentHost/tools/builtInToolSource.ts
@@ -1,0 +1,38 @@
+/**
+ * The Host's built-in tool catalog, resolved once per turn.
+ *
+ * Snapshot resolution in miniature (agent-tools-and-resources.md): the Host asks
+ * for the tools a turn may use, and the source projects only what the selected
+ * model can actually call. There are no per-Agent bindings yet, so the catalog
+ * is the same for every Agent.
+ */
+
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+
+import type { RuntimeModel, RuntimeTool } from '@/backend/ai/agent';
+import { modelService } from '@/backend/data/services/ModelService';
+import { fileContent } from '@/backend/services/file/fileContent';
+import { createUniqueModelId } from '@/shared/data/types/model';
+
+import { createWriteFileTool } from './writeFileTool';
+
+export type AgentToolSource = {
+  /** The tools this turn may use; empty when the model cannot call any. */
+  getTools(model: RuntimeModel): Promise<readonly RuntimeTool[]>;
+};
+
+export function createBuiltInToolSource(): AgentToolSource {
+  // Stateless tools: one instance serves every turn.
+  const tools: readonly RuntimeTool[] = [createWriteFileTool(fileContent)];
+
+  return {
+    async getTools(model) {
+      const configured = await modelService.getById(
+        createUniqueModelId(model.providerId, model.modelId),
+      );
+      // Handing tools to a model that cannot call them fails the whole turn, so
+      // an unknown or incapable model gets none.
+      return configured?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ? tools : [];
+    },
+  };
+}

--- a/src/backend/ai/agentHost/tools/writeFileTool.ts
+++ b/src/backend/ai/agentHost/tools/writeFileTool.ts
@@ -1,0 +1,133 @@
+/**
+ * `write_file`: the model saves text as a managed file.
+ *
+ * Bounded on purpose (docs/references/agent/agent-tools-and-resources.md): UTF-8
+ * text only, one new entry per call, no path and no overwrite. The model names
+ * the file; where the bytes live is Cherry's business, so the result carries an
+ * entry id rather than a URI.
+ */
+
+import * as z from 'zod';
+
+import type { RuntimeJsonValue, RuntimeTool } from '@/backend/ai/agent';
+import { type FileEntry, filenameExtension, SafeNameSchema } from '@/shared/data/types/file';
+
+export const WRITE_FILE_TOOL_NAME = 'write_file';
+
+/** Far above any model's output budget: a larger body is a malfunction. */
+export const WRITE_FILE_MAX_CONTENT_BYTES = 1_048_576;
+
+const DEFAULT_EXTENSION = 'txt';
+const FALLBACK_MEDIA_TYPE = 'text/plain';
+
+/**
+ * Only extensions whose media type earns something (preview, library filter).
+ * Anything absent falls back to `text/plain`, which is also why source-code
+ * extensions are left out: `ts` maps to `video/mp2t` in the IANA registry.
+ */
+const MEDIA_TYPES_BY_EXTENSION: Record<string, string> = {
+  css: 'text/css',
+  csv: 'text/csv',
+  htm: 'text/html',
+  html: 'text/html',
+  json: 'application/json',
+  markdown: 'text/markdown',
+  md: 'text/markdown',
+  tsv: 'text/tab-separated-values',
+  xml: 'application/xml',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+};
+
+export const writeFileInputSchema = z.strictObject({
+  content: z.string().describe('The full text to write. UTF-8, at most 1 MB.'),
+  filename: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe(
+      'Display name including its extension, e.g. `report.md`. Not a path: it must not contain `/` or `\\`.',
+    ),
+});
+
+/** The slice of the managed-file port this tool needs. */
+export type WriteFileFiles = {
+  createTextEntry(input: { data: string; mediaType: string; name: string }): Promise<FileEntry>;
+};
+
+export function createWriteFileTool(files: WriteFileFiles): RuntimeTool {
+  return {
+    name: WRITE_FILE_TOOL_NAME,
+    description:
+      "Save text as a file in the user's file library. Use it only when the user asks to save, export, or download something as a file; otherwise answer in the conversation.",
+    inputSchema: toolInputSchema(),
+    approval: 'auto',
+    async execute(input) {
+      const parsed = writeFileInputSchema.safeParse(input);
+      if (!parsed.success) {
+        return invalid(`Invalid input: ${z.prettifyError(parsed.error)}`);
+      }
+
+      const filename = normalizeFilename(parsed.data.filename);
+      if (!filename) {
+        return invalid(
+          'Invalid filename: give a plain name with an extension, such as `report.md`, without path separators.',
+        );
+      }
+
+      const size = new TextEncoder().encode(parsed.data.content).length;
+      if (size > WRITE_FILE_MAX_CONTENT_BYTES) {
+        return invalid(
+          `Content is ${size} bytes, over the ${WRITE_FILE_MAX_CONTENT_BYTES}-byte limit. Write less, or split it across files.`,
+        );
+      }
+
+      const entry = await files.createTextEntry({
+        data: parsed.data.content,
+        mediaType: mediaTypeForFilename(filename),
+        name: filename,
+      });
+
+      return {
+        status: 'created',
+        fileEntryId: entry.id,
+        filename: entry.filename,
+        size: entry.size,
+      };
+    },
+  };
+}
+
+/**
+ * A rejection the model can act on. Thrown errors reach it as an opaque
+ * "Tool execution failed", so anything it could fix by retrying is a value.
+ */
+function invalid(message: string): RuntimeJsonValue {
+  return { status: 'error', message };
+}
+
+/**
+ * Applies the same rules the file library stores by, and adds an extension when
+ * the model omitted one. Null means no safe name is recoverable.
+ */
+function normalizeFilename(filename: string): string | null {
+  const trimmed = filename.replace(/[\s.]+$/, '');
+  if (!SafeNameSchema.safeParse(trimmed).success) {
+    return null;
+  }
+  const named = filenameExtension(trimmed) ? trimmed : `${trimmed}.${DEFAULT_EXTENSION}`;
+  return SafeNameSchema.safeParse(named).success ? named : null;
+}
+
+function mediaTypeForFilename(filename: string): string {
+  const extension = filenameExtension(filename);
+  return (extension && MEDIA_TYPES_BY_EXTENSION[extension]) || FALLBACK_MEDIA_TYPE;
+}
+
+/** `RuntimeTool.inputSchema` is portable JSON Schema; the dialect key is noise. */
+function toolInputSchema(): RuntimeJsonValue {
+  const schema = z.toJSONSchema(writeFileInputSchema) as Record<string, unknown>;
+  delete schema.$schema;
+  return schema as RuntimeJsonValue;
+}

--- a/src/backend/data/db/schemas/agent.ts
+++ b/src/backend/data/db/schemas/agent.ts
@@ -14,8 +14,9 @@ import { userModelTable } from './userModel';
  * Agent table - stores user-configured Agent definitions
  * (docs/references/agent/agent-persistence.md).
  *
- * Tool policy and skill references are deliberately absent: Agent tools are an
- * undecided open question (agent/README.md) and V1 executes tool-less turns.
+ * Tool policy and skill references are deliberately absent: per-Agent tool
+ * bindings are an undecided open question (agent/README.md), and the built-in
+ * catalog the Host resolves per turn is the same for every Agent.
  * Sessions reference agents via FK (ON DELETE RESTRICT); agents soft-delete
  * first, so live Sessions never orphan.
  */

--- a/src/backend/services/file/__tests__/fileStorage.test.ts
+++ b/src/backend/services/file/__tests__/fileStorage.test.ts
@@ -326,6 +326,79 @@ describe('fileStorage', () => {
     ]);
   });
 
+  test('writes text verbatim under the caller-provided filename', async () => {
+    const entries = createEntryStore();
+
+    const entry = await createInternalEntry(entries, {
+      data: '# Report\n',
+      mediaType: 'text/markdown',
+      name: 'report.md',
+      source: 'text',
+    });
+
+    expect(entry).toEqual(
+      expect.objectContaining({
+        filename: 'report.md',
+        mediaType: 'text/markdown',
+        size: 9,
+      }),
+    );
+    // No encoding option: expo-file-system writes UTF-8 by default.
+    expect(testState.writes).toEqual([
+      {
+        content: '# Report\n',
+        options: undefined,
+        uri: 'file:///documents/Data/Files/00000000-0000-7000-8000-000000000001.md',
+      },
+    ]);
+  });
+
+  test('rejects a text filename that escapes the managed directory', async () => {
+    await expect(
+      createInternalEntry(createEntryStore(), {
+        data: 'x',
+        mediaType: 'text/plain',
+        name: '../escape.txt',
+        source: 'text',
+      }),
+    ).rejects.toThrow();
+
+    expect(testState.writes).toEqual([]);
+  });
+
+  test('removes a partially written text file on failure', async () => {
+    const uri = 'file:///documents/Data/Files/00000000-0000-7000-8000-000000000001.txt';
+    testState.writeFailures.add(uri);
+
+    await expect(
+      createInternalEntry(createEntryStore(), {
+        data: 'x',
+        mediaType: 'text/plain',
+        name: 'notes.txt',
+        source: 'text',
+      }),
+    ).rejects.toThrow('write failed');
+    expect(testState.files.has(uri)).toBe(false);
+  });
+
+  test('removes the text blob when FileEntry persistence fails', async () => {
+    const entries = createEntryStore();
+    entries.create.mockRejectedValueOnce(new Error('database failed'));
+
+    await expect(
+      createInternalEntry(entries, {
+        data: 'x',
+        mediaType: 'text/plain',
+        name: 'notes.txt',
+        source: 'text',
+      }),
+    ).rejects.toThrow('database failed');
+
+    expect(
+      testState.files.has('file:///documents/Data/Files/00000000-0000-7000-8000-000000000001.txt'),
+    ).toBe(false);
+  });
+
   test('removes a partially written generated image on failure', async () => {
     const uri = 'file:///documents/Data/Files/00000000-0000-7000-8000-000000000001.png';
     testState.writeFailures.add(uri);

--- a/src/backend/services/file/fileContent.ts
+++ b/src/backend/services/file/fileContent.ts
@@ -15,6 +15,7 @@ import {
   resolveCachedFilePreviewUris,
 } from './filePreviewStorage';
 import {
+  createInternalEntry,
   deleteInternalEntry,
   discardInternalEntries,
   getFileUri,
@@ -25,6 +26,12 @@ const createInternalEntryInputSchema = z.strictObject({
   mediaType: MediaTypeSchema.optional(),
   name: SafeNameSchema.optional(),
   uri: z.string().min(1),
+});
+
+const createTextEntryInputSchema = z.strictObject({
+  data: z.string(),
+  mediaType: MediaTypeSchema,
+  name: SafeNameSchema,
 });
 
 /**
@@ -49,6 +56,15 @@ export const fileContent = {
       throw new Error(`Created internal file cannot be resolved: ${entry.id}`);
     }
     return resolved;
+  },
+  /**
+   * Store UTF-8 text as a new managed entry. Unlike an imported attachment it
+   * has no preview to derive, so it skips the preview decorator, and the caller
+   * keeps the entry rather than a resolved URI (agent tools return ids).
+   */
+  createTextEntry: async (input: { data: string; mediaType: string; name: string }) => {
+    const validated = createTextEntryInputSchema.parse(input);
+    return createInternalEntry(fileEntryService, { ...validated, source: 'text' });
   },
   delete: (id: FileEntryId) => deleteInternalEntry(fileEntryService, FileEntryIdSchema.parse(id)),
   generatePreviewUri: generateFilePreviewUri,

--- a/src/backend/services/file/fileStorage.ts
+++ b/src/backend/services/file/fileStorage.ts
@@ -37,6 +37,14 @@ export type CreateInternalEntryInput =
       mediaType: string;
       name?: string;
       source: 'base64';
+    }
+  | {
+      /** UTF-8 text written verbatim. */
+      data: string;
+      mediaType: string;
+      /** Display name; the caller owns extension inference, so it is required. */
+      name: string;
+      source: 'text';
     };
 
 type WrittenInternalFile = {
@@ -112,13 +120,17 @@ async function writeInternalFile(input: CreateInternalEntryInput): Promise<Writt
     filename = projectFilename(input.name ?? source.name, source.name);
     mediaType = resolveMediaType(input.mediaType, source.type);
     write = (destination) => source.copy(destination);
-  } else {
+  } else if (input.source === 'base64') {
     mediaType = resolveMediaType(input.mediaType);
     const ext = SafeExtSchema.parse(generatedImageExtension(mediaType));
     const name = SafeNameSchema.parse(input.name ?? `painting-${id}`);
     filename = filenameExtension(name) ? name : `${name}.${ext}`;
     const payload = input.data.includes(',') ? (input.data.split(',', 2)[1] ?? '') : input.data;
     write = (destination) => destination.write(payload, { encoding: 'base64' });
+  } else {
+    mediaType = resolveMediaType(input.mediaType);
+    filename = SafeNameSchema.parse(input.name);
+    write = (destination) => destination.write(input.data);
   }
 
   const destination = new File(ensureFileDirectory(), `${id}${extSuffix(filename)}`);

--- a/src/frontend/components/messages/parts/tools/ToolPartRenderer.tsx
+++ b/src/frontend/components/messages/parts/tools/ToolPartRenderer.tsx
@@ -7,6 +7,7 @@ import {
   isWebSearchToolPart,
   WebSearchToolPart,
 } from './WebSearchToolPart';
+import { isWriteFileToolPart, WriteFileToolPart } from './WriteFileToolPart';
 
 type ToolPartRendererProps = {
   part: ToolMessagePart;
@@ -27,6 +28,10 @@ export function ToolPartRenderer({ part }: ToolPartRendererProps) {
 
   if (isMcpToolPart(part)) {
     return <McpToolPart part={part} />;
+  }
+
+  if (isWriteFileToolPart(part)) {
+    return <WriteFileToolPart part={part} />;
   }
 
   return <GenericToolPart part={part} />;

--- a/src/frontend/components/messages/parts/tools/WriteFileToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/WriteFileToolPart.tsx
@@ -1,0 +1,80 @@
+import { MessagePart } from '@cherrystudio/ui/components';
+import { useTranslation } from 'react-i18next';
+
+import { FileEntryPreview } from '@/frontend/components/FileEntryPreview';
+import { type FileEntryId, FileEntryIdSchema } from '@/shared/data/types/file';
+
+import { getBuiltInToolDisplay } from './builtInTool/builtInToolDisplay';
+import { GenericToolPart } from './GenericToolPart';
+import { getToolName, isRecord, type ToolMessagePart } from './toolPartState';
+
+const WRITE_FILE_TOOL_NAME = 'write_file';
+
+type WriteFileToolPartProps = {
+  part: ToolMessagePart;
+};
+
+type WriteFileResult =
+  | { status: 'created'; fileEntryId: FileEntryId }
+  | { status: 'error'; message: string };
+
+/**
+ * A written file is shown as the file itself rather than as a tool transcript:
+ * the same card an attachment gets, tappable straight into the system preview.
+ * Every other state falls back to the shared tool rendering.
+ */
+export function WriteFileToolPart({ part }: WriteFileToolPartProps) {
+  const { t } = useTranslation();
+  const result = part.state === 'output-available' ? parseWriteFileResult(part.output) : null;
+
+  if (result?.status === 'created') {
+    return <FileEntryPreview entryId={result.fileEntryId} />;
+  }
+
+  if (result?.status === 'error') {
+    // A rejected write settles as a normal result, so the reason would
+    // otherwise stay hidden inside the detail sheet.
+    const display = getBuiltInToolDisplay(WRITE_FILE_TOOL_NAME);
+    return (
+      <MessagePart.Tool
+        icon={display?.icon}
+        imageSource={display?.imageSource}
+        state="complete"
+        statusText={t('chat.tool.callError')}
+        statusTone="danger"
+        testID="write-file-tool-part"
+        title={t('chat.builtinTool.file.write')}
+      >
+        <MessagePart.TextSection
+          tone="danger"
+          title={t('chat.tool.error')}
+          value={result.message}
+        />
+      </MessagePart.Tool>
+    );
+  }
+
+  return <GenericToolPart part={part} />;
+}
+
+export function isWriteFileToolPart(part: ToolMessagePart) {
+  return getToolName(part) === WRITE_FILE_TOOL_NAME;
+}
+
+/** Persisted tool output is untrusted JSON; an unreadable shape renders generically. */
+function parseWriteFileResult(output: unknown): WriteFileResult | null {
+  if (!isRecord(output)) {
+    return null;
+  }
+
+  if (output.status === 'created') {
+    const id = FileEntryIdSchema.safeParse(output.fileEntryId);
+    return id.success ? { status: 'created', fileEntryId: id.data } : null;
+  }
+
+  if (output.status === 'error' && typeof output.message === 'string') {
+    return { status: 'error', message: output.message };
+  }
+
+  return null;
+}

--- a/src/frontend/components/messages/parts/tools/__tests__/ToolPartRenderer.test.tsx
+++ b/src/frontend/components/messages/parts/tools/__tests__/ToolPartRenderer.test.tsx
@@ -21,12 +21,17 @@ jest.mock('../WebSearchToolPart', () => ({
   isWebSearchToolPart: (part: ToolMessagePart) =>
     mockGetToolName(part) === 'provider-search' || mockGetToolName(part) === 'web-search',
 }));
+jest.mock('../WriteFileToolPart', () => ({
+  ...mockCreateToolPart('WriteFileToolPart'),
+  isWriteFileToolPart: (part: ToolMessagePart) => mockGetToolName(part) === 'write_file',
+}));
 
 describe('ToolPartRenderer', () => {
   it.each([
     ['web-search', 'WebSearchToolPart'],
     ['meta', 'MetaToolPartRenderer'],
     ['mcp', 'McpToolPart'],
+    ['write_file', 'WriteFileToolPart'],
     ['other', 'GenericToolPart'],
   ])('routes %s tools to %s', (toolName, expectedType) => {
     const part = makeToolPart(toolName);

--- a/src/frontend/components/messages/parts/tools/__tests__/WriteFileToolPart.test.tsx
+++ b/src/frontend/components/messages/parts/tools/__tests__/WriteFileToolPart.test.tsx
@@ -1,0 +1,97 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
+
+import type { ToolMessagePart } from '../toolPartState';
+import { isWriteFileToolPart, WriteFileToolPart } from '../WriteFileToolPart';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// The real component barrel reaches ESM-only packages Jest cannot parse.
+jest.mock('@cherrystudio/ui/components', () => {
+  const { createElement } = jest.requireActual('react');
+  return {
+    MessagePart: {
+      TextSection: (props: object) => createElement('TextSection', props),
+      Tool: (props: object) => createElement('Tool', props),
+    },
+  };
+});
+
+jest.mock('@/frontend/components/FileEntryPreview', () => {
+  const { createElement } = jest.requireActual('react');
+  return { FileEntryPreview: (props: object) => createElement('FileEntryPreview', props) };
+});
+jest.mock('../GenericToolPart', () => {
+  const { createElement } = jest.requireActual('react');
+  return { GenericToolPart: (props: object) => createElement('GenericToolPart', props) };
+});
+
+const ENTRY_ID = '00000000-0000-7000-8000-000000000001';
+
+describe('WriteFileToolPart', () => {
+  it('claims only write_file parts', () => {
+    expect(isWriteFileToolPart(toolPart({ output: {} }))).toBe(true);
+    expect(isWriteFileToolPart(toolPart({ output: {}, toolName: 'read_file' }))).toBe(false);
+  });
+
+  it('shows a written file as a preview card', () => {
+    const renderer = render(
+      toolPart({
+        output: { status: 'created', fileEntryId: ENTRY_ID, filename: 'report.md', size: 9 },
+      }),
+    );
+
+    expect(renderer.root.findByType('FileEntryPreview').props.entryId).toBe(ENTRY_ID);
+  });
+
+  it('surfaces a rejected write instead of the file card', () => {
+    const renderer = render(
+      toolPart({ output: { status: 'error', message: 'Invalid filename: ...' } }),
+    );
+
+    expect(renderer.root.findAllByType('FileEntryPreview')).toHaveLength(0);
+    expect(renderer.root.findByProps({ testID: 'write-file-tool-part' })).toBeDefined();
+  });
+
+  it.each([
+    ['a non-object output', 'written'],
+    ['an unknown status', { status: 'queued' }],
+    ['a malformed entry id', { status: 'created', fileEntryId: 'not-a-uuid' }],
+    ['a missing entry id', { status: 'created', filename: 'report.md' }],
+  ])('falls back to the generic rendering for %s', (_case, output) => {
+    const renderer = render(toolPart({ output }));
+
+    expect(renderer.root.findByType('GenericToolPart')).toBeDefined();
+    expect(renderer.root.findAllByType('FileEntryPreview')).toHaveLength(0);
+  });
+
+  it('falls back to the generic rendering while the write is still running', () => {
+    const renderer = render(
+      toolPart({ input: { filename: 'report.md' }, state: 'input-available' }),
+    );
+
+    expect(renderer.root.findByType('GenericToolPart')).toBeDefined();
+  });
+});
+
+function render(part: ToolMessagePart): ReactTestRenderer {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(<WriteFileToolPart part={part} />);
+  });
+  return renderer;
+}
+
+function toolPart(overrides: Partial<Record<string, unknown>>): ToolMessagePart {
+  return {
+    input: {},
+    state: 'output-available',
+    toolCallId: 'call-1',
+    toolName: 'write_file',
+    type: 'dynamic-tool',
+    ...overrides,
+  } as Extract<CherryMessagePart, { type: 'dynamic-tool' }>;
+}

--- a/src/frontend/components/messages/parts/tools/builtInTool/__tests__/builtInToolDisplay.test.ts
+++ b/src/frontend/components/messages/parts/tools/builtInTool/__tests__/builtInToolDisplay.test.ts
@@ -1,4 +1,5 @@
 import BellRingIcon from '@cherrystudio/app-icons/icons/bell-ring';
+import FileIcon from '@cherrystudio/app-icons/icons/file';
 
 import { getBuiltInToolDisplay } from '../builtInToolDisplay';
 import { getBuiltInToolIcon as getAndroidIcon } from '../builtInToolIcon/builtInToolIcon.android';
@@ -13,6 +14,15 @@ describe('built-in tool display', () => {
     expect(getAndroidIcon('reminders')).toEqual({ icon: BellRingIcon });
     expect(getIosIcon('reminders').imageSource).toBeDefined();
     expect(getIosIcon('reminders').icon).toBeUndefined();
+  });
+
+  test('draws a vector icon on both platforms when no system artwork exists', () => {
+    expect(getBuiltInToolDisplay('write_file')).toMatchObject({
+      titleKey: 'chat.builtinTool.file.write',
+    });
+
+    expect(getAndroidIcon('file')).toEqual({ icon: FileIcon });
+    expect(getIosIcon('file')).toEqual({ icon: FileIcon });
   });
 
   test('returns no display for a non-built-in tool', () => {

--- a/src/frontend/components/messages/parts/tools/builtInTool/builtInToolIcon/builtInToolIcon.android.ts
+++ b/src/frontend/components/messages/parts/tools/builtInTool/builtInToolIcon/builtInToolIcon.android.ts
@@ -1,6 +1,7 @@
 import type { LucideIconProps } from '@cherrystudio/app-icons';
 import BellRingIcon from '@cherrystudio/app-icons/icons/bell-ring';
 import CalendarIcon from '@cherrystudio/app-icons/icons/calendar';
+import FileIcon from '@cherrystudio/app-icons/icons/file';
 import HeartPulseIcon from '@cherrystudio/app-icons/icons/heart-pulse';
 import MapPinIcon from '@cherrystudio/app-icons/icons/map-pin';
 import type { ComponentType } from 'react';
@@ -10,6 +11,7 @@ import type { BuiltInToolIcon } from './builtInToolIcon.types';
 
 const icons: Record<BuiltInToolIconName, ComponentType<LucideIconProps>> = {
   calendar: CalendarIcon,
+  file: FileIcon,
   health: HeartPulseIcon,
   location: MapPinIcon,
   reminders: BellRingIcon,

--- a/src/frontend/components/messages/parts/tools/builtInTool/builtInToolIcon/builtInToolIcon.ios.ts
+++ b/src/frontend/components/messages/parts/tools/builtInTool/builtInToolIcon/builtInToolIcon.ios.ts
@@ -1,13 +1,23 @@
+import FileIcon from '@cherrystudio/app-icons/icons/file';
+
 import type { BuiltInToolIconName } from '../definitions';
 import type { BuiltInToolIcon } from './builtInToolIcon.types';
 
-const images: Record<BuiltInToolIconName, number> = {
-  calendar: require('../../../../../../../../assets/permissions/ios/calendar.png'),
-  health: require('../../../../../../../../assets/permissions/ios/health.png'),
-  location: require('../../../../../../../../assets/permissions/ios/location.png'),
-  reminders: require('../../../../../../../../assets/permissions/ios/reminders.png'),
+/**
+ * Tools that front an iOS permission borrow that permission's system artwork,
+ * which users already recognize from the settings screen. A tool with no
+ * system counterpart draws the shared vector icon instead.
+ */
+const icons: Record<BuiltInToolIconName, BuiltInToolIcon> = {
+  calendar: { imageSource: require('../../../../../../../../assets/permissions/ios/calendar.png') },
+  file: { icon: FileIcon },
+  health: { imageSource: require('../../../../../../../../assets/permissions/ios/health.png') },
+  location: { imageSource: require('../../../../../../../../assets/permissions/ios/location.png') },
+  reminders: {
+    imageSource: require('../../../../../../../../assets/permissions/ios/reminders.png'),
+  },
 };
 
 export function getBuiltInToolIcon(iconName: BuiltInToolIconName): BuiltInToolIcon {
-  return { imageSource: images[iconName] };
+  return icons[iconName];
 }

--- a/src/frontend/components/messages/parts/tools/builtInTool/definitions.ts
+++ b/src/frontend/components/messages/parts/tools/builtInTool/definitions.ts
@@ -1,4 +1,4 @@
-export type BuiltInToolIconName = 'calendar' | 'health' | 'location' | 'reminders';
+export type BuiltInToolIconName = 'calendar' | 'file' | 'health' | 'location' | 'reminders';
 
 type BuiltInToolDefinition = {
   iconName: BuiltInToolIconName;
@@ -57,5 +57,9 @@ export const builtInToolDefinitions: Record<string, BuiltInToolDefinition> = {
   reminder_update_item: {
     iconName: 'reminders',
     titleKey: 'chat.builtinTool.reminders.update',
+  },
+  write_file: {
+    iconName: 'file',
+    titleKey: 'chat.builtinTool.file.write',
   },
 };

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -49,6 +49,7 @@
   "chat.builtinTool.calendar.listCalendars": "Get calendar list",
   "chat.builtinTool.calendar.listEvents": "Find calendar events",
   "chat.builtinTool.calendar.updateEvent": "Update calendar event",
+  "chat.builtinTool.file.write": "Write file",
   "chat.builtinTool.health.listWorkouts": "Find workout records",
   "chat.builtinTool.health.summary": "Get health summary",
   "chat.builtinTool.location.current": "Get current location",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -49,6 +49,7 @@
   "chat.builtinTool.calendar.listCalendars": "获取日历列表",
   "chat.builtinTool.calendar.listEvents": "查询日程",
   "chat.builtinTool.calendar.updateEvent": "修改日程",
+  "chat.builtinTool.file.write": "写入文件",
   "chat.builtinTool.health.listWorkouts": "查询体能训练记录",
   "chat.builtinTool.health.summary": "获取健康摘要",
   "chat.builtinTool.location.current": "获取当前位置",


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: Agent turns were hardcoded tool-less (`tools: []`), so a model could not produce a file, and nothing but attachments and generated images reached the file library.

After this PR: a `write_file` built-in tool lets the model save text as a managed `file_entry`; the written file renders in chat as a tappable preview card and appears in `/library` like any other file. This is the first executable tool on the Agent path, so it also opens the Host's per-turn tool snapshot. It ships as a deliberately small slice — no `ToolRef`, bindings table, resource ledger, or result envelope — and the design documents are annotated to say so rather than silently drifting.

### Screenshots or videos

Reproducible in-repo instead of a static image: run `pnpm storybook`, open **Messages/Playground → Written file**, and the three states render — running, written (an `MD` card that opens the system preview), and rejected.

Verified end to end on the iOS simulator against a real function-calling model: the model called `write_file` unprompted, the card rendered with a thumbnail of the real content, the system preview showed the written text, and the file appeared in the file library. Screenshots can be attached on request.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Bounded, not general.** UTF-8 text only, 1 MB, a display name rather than a path, and one new entry per call. It cannot address or overwrite an existing file, so it does not need the turn resource ledger that does not exist yet.
- **Errors are values, not exceptions.** Pi collapses a thrown tool error into an opaque "tool execution failed", so a filename the model could correct returns `{ status: 'error', message }` instead. Only genuine failures (disk, database) throw.
- **No approval prompt.** The tool has no destructive form and the result is visible and deletable, so an approval sheet on every save would cost more than it protects.
- **Card rendered inline.** `MessagePart.Tool` puts children inside a disclosure sheet, which would have hidden the file behind a tap.
- **Model-capability gate in the Host.** Handing tools to a model without function calling fails the entire turn, so the catalog is filtered before the snapshot is frozen.

The following alternatives were considered: implementing the full `#633` tool contract first (an infrastructure project this feature would merely ride along with); reusing the existing `base64` write path (it is image-specific); and returning a plain-text result with no card (leaves the user to hunt through the drawer).

Links to places where the discussion took place: <!-- n/a -->

### Breaking changes

None. No schema change and no migration: the tool reuses the existing `file_entry` table and write path.

### Special notes for your reviewer

`fix(storybook): repair the messages story managed-file stub` is an unrelated pre-existing bug found while adding the fixture. The stub still described a file entry the desktop way (`ext`, `name`, `origin`, `contentHash`, `cleanupPolicy`), so `FileEntrySchema.parse` threw during module load and the entire Messages story was unopenable. It is isolated in its own commit.

Two comments asserting "V1 executes tool-less turns" are corrected rather than deleted — per-Agent tool bindings are still absent, which is what they should have said.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Agents can now save text as a file. Ask one to write something to a file and it appears in the conversation as a preview card and in the file library.
```
