### PR TITLE
fix(agent-tools): restore binding CI gates

### DIFF
--- a/src/backend/data/api/handlers/agentToolBindings.ts
+++ b/src/backend/data/api/handlers/agentToolBindings.ts
@@ -15,14 +15,14 @@ export function createAgentToolBindingHandlers(
   return {
     '/agents/:agentId/tool-bindings': {
       GET: ({ params }) => service.list(params.agentId),
-      POST: ({ body, params }) => {
+      POST: async ({ body, params }) => {
         const parsed = WriteAgentToolBindingSchema.safeParse(body);
         if (!parsed.success) {
           throw toDataApiError(parsed.error, 'Agent tool binding upsert');
         }
         return service.upsert(params.agentId, parsed.data);
       },
-      PUT: ({ body, params }) => {
+      PUT: async ({ body, params }) => {
         const parsed = ReplaceAgentToolBindingsSchema.safeParse(body);
         if (!parsed.success) {
           throw toDataApiError(parsed.error, 'Agent tool binding replace');

--- a/src/backend/data/services/AgentToolBindingService.ts
+++ b/src/backend/data/services/AgentToolBindingService.ts
@@ -16,8 +16,10 @@ import {
   DeleteAgentToolBindingResultSchema,
   ListAgentToolBindingsResponseSchema,
   type ReplaceAgentToolBindingsDto,
+  type ReplaceAgentToolBindingsInput,
   ReplaceAgentToolBindingsSchema,
   type WriteAgentToolBinding,
+  type WriteAgentToolBindingInput,
   WriteAgentToolBindingSchema,
 } from '@/shared/data/api/schemas/agentToolBindings';
 import {
@@ -51,7 +53,7 @@ export class AgentToolBindingService {
     return ListAgentToolBindingsResponseSchema.parse({ items: rows.map(rowToBinding) });
   }
 
-  async upsert(agentId: string, input: WriteAgentToolBinding): Promise<AgentToolBinding> {
+  async upsert(agentId: string, input: WriteAgentToolBindingInput): Promise<AgentToolBinding> {
     const parsed = parseWriteBinding(input);
 
     const row = await this.dbService.withWriteTx(async (tx) => {
@@ -69,7 +71,7 @@ export class AgentToolBindingService {
 
   async replace(
     agentId: string,
-    input: ReplaceAgentToolBindingsDto,
+    input: ReplaceAgentToolBindingsInput,
   ): Promise<{ items: AgentToolBinding[] }> {
     const parsed = parseReplaceBindings(input);
     assertUniqueBindings(parsed.bindings);
@@ -138,7 +140,8 @@ export class AgentToolBindingService {
       .where(eq(mcpServerTable.id, parsed.serverId))
       .limit(1);
     const candidates = items.filter(
-      (binding) => binding.source === 'mcp' && binding.serverId === parsed.serverId,
+      (binding): binding is Extract<AgentToolBinding, { source: 'mcp' }> =>
+        binding.source === 'mcp' && binding.serverId === parsed.serverId,
     );
     const binding =
       candidates.find((candidate) => candidate.rawToolName === parsed.rawToolName) ??
@@ -268,7 +271,7 @@ export class AgentToolBindingService {
   }
 }
 
-function parseWriteBinding(input: WriteAgentToolBinding): WriteAgentToolBinding {
+function parseWriteBinding(input: WriteAgentToolBindingInput): WriteAgentToolBinding {
   const result = WriteAgentToolBindingSchema.safeParse(input);
   if (!result.success) {
     throw toDataApiError(result.error, 'Agent tool binding upsert');
@@ -276,7 +279,7 @@ function parseWriteBinding(input: WriteAgentToolBinding): WriteAgentToolBinding 
   return result.data;
 }
 
-function parseReplaceBindings(input: ReplaceAgentToolBindingsDto): ReplaceAgentToolBindingsDto {
+function parseReplaceBindings(input: ReplaceAgentToolBindingsInput): ReplaceAgentToolBindingsDto {
   const result = ReplaceAgentToolBindingsSchema.safeParse(input);
   if (!result.success) {
     throw toDataApiError(result.error, 'Agent tool binding replace');
@@ -310,13 +313,15 @@ function assertUniqueBindings(bindings: readonly WriteAgentToolBinding[]): void 
 }
 
 function bindingIdentity(binding: AgentToolBindingRow | WriteAgentToolBinding): string {
+  if ('mcpServerId' in binding) {
+    return binding.source === 'builtin'
+      ? JSON.stringify(['builtin', binding.capabilityId])
+      : JSON.stringify(['mcp', binding.mcpServerId, binding.rawToolName ?? null]);
+  }
+
   return binding.source === 'builtin'
     ? JSON.stringify(['builtin', binding.capabilityId])
-    : JSON.stringify([
-        'mcp',
-        'mcpServerId' in binding ? binding.mcpServerId : binding.serverId,
-        binding.rawToolName ?? null,
-      ]);
+    : JSON.stringify(['mcp', binding.serverId, binding.rawToolName ?? null]);
 }
 
 function rowToBinding(row: AgentToolBindingRow): AgentToolBinding {

--- a/src/backend/data/services/__tests__/AgentToolBindingService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentToolBindingService.integration.test.ts
@@ -212,7 +212,10 @@ describe('AgentToolBindingService', () => {
         ],
       }),
     ).resolves.toMatchObject({
-      items: expect.arrayContaining([{ id: serverDefault.id }, { id: specific.id }]),
+      items: expect.arrayContaining([
+        expect.objectContaining({ id: serverDefault.id }),
+        expect.objectContaining({ id: specific.id }),
+      ]),
     });
     await expect(
       bindingService.upsert(agent.id, {

--- a/src/shared/data/api/schemas/agentToolBindings.ts
+++ b/src/shared/data/api/schemas/agentToolBindings.ts
@@ -31,12 +31,14 @@ export const WriteAgentToolBindingSchema = z.discriminatedUnion('source', [
   BuiltinAgentToolBindingInputSchema,
   McpAgentToolBindingInputSchema,
 ]);
-export type WriteAgentToolBinding = z.infer<typeof WriteAgentToolBindingSchema>;
+export type WriteAgentToolBindingInput = z.input<typeof WriteAgentToolBindingSchema>;
+export type WriteAgentToolBinding = z.output<typeof WriteAgentToolBindingSchema>;
 
 export const ReplaceAgentToolBindingsSchema = z.strictObject({
   bindings: z.array(WriteAgentToolBindingSchema),
 });
-export type ReplaceAgentToolBindingsDto = z.infer<typeof ReplaceAgentToolBindingsSchema>;
+export type ReplaceAgentToolBindingsInput = z.input<typeof ReplaceAgentToolBindingsSchema>;
+export type ReplaceAgentToolBindingsDto = z.output<typeof ReplaceAgentToolBindingsSchema>;
 
 export const ListAgentToolBindingsResponseSchema = z.strictObject({
   items: z.array(AgentToolBindingSchema),
@@ -52,12 +54,12 @@ export type AgentToolBindingSchemas = {
       response: { items: AgentToolBinding[] };
     };
     POST: {
-      body: WriteAgentToolBinding;
+      body: WriteAgentToolBindingInput;
       params: { agentId: string };
       response: AgentToolBinding;
     };
     PUT: {
-      body: ReplaceAgentToolBindingsDto;
+      body: ReplaceAgentToolBindingsInput;
       params: { agentId: string };
       response: { items: AgentToolBinding[] };
     };


### PR DESCRIPTION
## Summary

- distinguish raw agent tool binding inputs from their parsed Zod output types
- preserve MCP binding narrowing across service lookups
- keep handler validation failures on the asynchronous API contract
- correct partial matching for preserved dangling bindings

## Validation

- `pnpm typecheck`
- `pnpm exec oxlint`
- `pnpm exec expo lint --no-cache`
- `pnpm format:check`

Tests were not run locally in accordance with the repository verification policy; remote PR CI owns the complete suite.