### PR TITLE
fix(chat-tools): stop drawing a written file twice

### DIFF
--- a/src/frontend/components/messages/README.md
+++ b/src/frontend/components/messages/README.md
@@ -29,6 +29,10 @@ message items, `extraData`, or a feature-owned context/store read inside the row
 Part renderers, animation providers, and platform controls remain private implementation details.
 Callers import only from `@/frontend/components/messages`.
 
+A tool that returns managed artifacts already has them in the message: the Host persists each one
+as a `purpose: 'artifact'` file part that draws its own card. A per-tool renderer therefore renders
+the *call*, never the artifact, or the same file appears twice.
+
 ## Ownership
 
 The module accepts only visible `user` and `assistant` messages. A feature that stores additional

--- a/src/frontend/components/messages/parts/tools/WriteFileToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/WriteFileToolPart.tsx
@@ -1,9 +1,6 @@
 import { MessagePart } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
 
-import { FileEntryPreview } from '@/frontend/components/FileEntryPreview';
-import { type FileEntryId, FileEntryIdSchema } from '@/shared/data/types/file';
-
 import { getBuiltInToolDisplay } from './builtInTool/builtInToolDisplay';
 import { GenericToolPart } from './GenericToolPart';
 import { getToolName, isRecord, type ToolMessagePart } from './toolPartState';
@@ -14,67 +11,47 @@ type WriteFileToolPartProps = {
   part: ToolMessagePart;
 };
 
-type WriteFileResult =
-  | { status: 'created'; fileEntryId: FileEntryId }
-  | { status: 'error'; message: string };
-
 /**
- * A written file is shown as the file itself rather than as a tool transcript:
- * the same card an attachment gets, tappable straight into the system preview.
- * Every other state falls back to the shared tool rendering.
+ * A rejected write is the only state worth a custom rendering.
+ *
+ * The written file itself is already in the transcript: the tool returns it as
+ * an artifact, and the Host persists that as a `purpose: 'artifact'` file part
+ * which renders its own card. Drawing the file here too would show it twice.
+ * A rejection has no artifact, so its reason would otherwise stay hidden inside
+ * the detail sheet.
  */
 export function WriteFileToolPart({ part }: WriteFileToolPartProps) {
   const { t } = useTranslation();
-  const result = part.state === 'output-available' ? parseWriteFileResult(part.output) : null;
+  const message = part.state === 'output-available' ? parseRejection(part.output) : null;
 
-  if (result?.status === 'created') {
-    return <FileEntryPreview entryId={result.fileEntryId} />;
+  if (message === null) {
+    return <GenericToolPart part={part} />;
   }
 
-  if (result?.status === 'error') {
-    // A rejected write settles as a normal result, so the reason would
-    // otherwise stay hidden inside the detail sheet.
-    const display = getBuiltInToolDisplay(WRITE_FILE_TOOL_NAME);
-    return (
-      <MessagePart.Tool
-        icon={display?.icon}
-        imageSource={display?.imageSource}
-        state="complete"
-        statusText={t('chat.tool.callError')}
-        statusTone="danger"
-        testID="write-file-tool-part"
-        title={t('chat.builtinTool.file.write')}
-      >
-        <MessagePart.TextSection
-          tone="danger"
-          title={t('chat.tool.error')}
-          value={result.message}
-        />
-      </MessagePart.Tool>
-    );
-  }
-
-  return <GenericToolPart part={part} />;
+  const display = getBuiltInToolDisplay(WRITE_FILE_TOOL_NAME);
+  return (
+    <MessagePart.Tool
+      icon={display?.icon}
+      imageSource={display?.imageSource}
+      state="complete"
+      statusText={t('chat.tool.callError')}
+      statusTone="danger"
+      testID="write-file-tool-part"
+      title={t('chat.builtinTool.file.write')}
+    >
+      <MessagePart.TextSection tone="danger" title={t('chat.tool.error')} value={message} />
+    </MessagePart.Tool>
+  );
 }
 
 export function isWriteFileToolPart(part: ToolMessagePart) {
   return getToolName(part) === WRITE_FILE_TOOL_NAME;
 }
 
-/** Persisted tool output is untrusted JSON; an unreadable shape renders generically. */
-function parseWriteFileResult(output: unknown): WriteFileResult | null {
-  if (!isRecord(output)) {
+/** Persisted tool output is untrusted JSON; anything else renders generically. */
+function parseRejection(output: unknown): string | null {
+  if (!isRecord(output) || output.status !== 'error' || typeof output.message !== 'string') {
     return null;
   }
-
-  if (output.status === 'created') {
-    const id = FileEntryIdSchema.safeParse(output.fileEntryId);
-    return id.success ? { status: 'created', fileEntryId: id.data } : null;
-  }
-
-  if (output.status === 'error' && typeof output.message === 'string') {
-    return { status: 'error', message: output.message };
-  }
-
-  return null;
+  return output.message;
 }

--- a/src/frontend/components/messages/parts/tools/__tests__/WriteFileToolPart.test.tsx
+++ b/src/frontend/components/messages/parts/tools/__tests__/WriteFileToolPart.test.tsx
@@ -37,17 +37,20 @@ describe('WriteFileToolPart', () => {
     expect(isWriteFileToolPart(toolPart({ output: {}, toolName: 'read_file' }))).toBe(false);
   });
 
-  it('shows a written file as a preview card', () => {
+  it('leaves a successful write to its artifact file part', () => {
+    // The Host already persists the created entry as a `purpose: 'artifact'`
+    // file part, which draws the card; drawing one here too showed it twice.
     const renderer = render(
       toolPart({
         output: { status: 'created', fileEntryId: ENTRY_ID, filename: 'report.md', size: 9 },
       }),
     );
 
-    expect(renderer.root.findByType('FileEntryPreview').props.entryId).toBe(ENTRY_ID);
+    expect(renderer.root.findAllByType('FileEntryPreview')).toHaveLength(0);
+    expect(renderer.root.findByType('GenericToolPart')).toBeDefined();
   });
 
-  it('surfaces a rejected write instead of the file card', () => {
+  it('surfaces a rejected write, which has no artifact to speak for it', () => {
     const renderer = render(
       toolPart({ output: { status: 'error', message: 'Invalid filename: ...' } }),
     );
@@ -59,8 +62,7 @@ describe('WriteFileToolPart', () => {
   it.each([
     ['a non-object output', 'written'],
     ['an unknown status', { status: 'queued' }],
-    ['a malformed entry id', { status: 'created', fileEntryId: 'not-a-uuid' }],
-    ['a missing entry id', { status: 'created', filename: 'report.md' }],
+    ['an error without a message', { status: 'error' }],
   ])('falls back to the generic rendering for %s', (_case, output) => {
     const renderer = render(toolPart({ output }));
 

--- a/src/frontend/features/agents/AgentToolsSection.tsx
+++ b/src/frontend/features/agents/AgentToolsSection.tsx
@@ -107,9 +107,14 @@ export function AgentToolsSection({
         {t('agent.tools.description')}
       </Text>
       <AgentBuiltInTools bindings={bindings} onChange={onChange} />
-      <Text className="font-medium text-foreground text-sm" selectable>
-        {t('agent.tools.mcpSection')}
-      </Text>
+      <View className="gap-1">
+        <Text className="font-medium text-foreground text-sm" selectable>
+          {t('agent.tools.mcpSection')}
+        </Text>
+        <Text className="text-muted-foreground text-xs" selectable>
+          {t('agent.tools.mcpDescription')}
+        </Text>
+      </View>
       {serverOptions.length === 0 ? (
         <Text className="py-2 text-muted-foreground text-sm" selectable>
           {t('agent.tools.empty')}

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -228,7 +228,7 @@
   "agent.selection.start": "Select agents",
   "agent.toast.deleteFailed": "Agent was not deleted. Try again.",
   "agent.toast.saveFailed": "Agent was not saved. Try again.",
-  "agent.tools.description": "Choose which mobile-compatible MCP servers may offer tools to this agent.",
+  "agent.tools.description": "Choose which tools this agent may use.",
   "agent.tools.empty": "No mobile-compatible MCP servers are available.",
   "agent.tools.existingToolRules": "Existing tool rules",
   "agent.tools.nextTurn": "Changes apply from the next turn. Globally disabled tools always stay unavailable.",
@@ -742,5 +742,6 @@
   "agent.tools.builtInStatus.needs-painting-model": "Set a drawing model in Settings > Model",
   "agent.tools.builtInStatus.needs-permission": "Grant access in Settings > Permissions",
   "agent.tools.builtInStatus.unsupported": "Not available on this device",
-  "agent.tools.builtInAccessibilityLabel": "{{tool}}, {{status}}"
+  "agent.tools.builtInAccessibilityLabel": "{{tool}}, {{status}}",
+  "agent.tools.mcpDescription": "Mobile-compatible MCP servers that may offer tools to this agent."
 }

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -227,7 +227,7 @@
   "agent.selection.start": "选择智能体",
   "agent.toast.deleteFailed": "智能体未能删除，请重试。",
   "agent.toast.saveFailed": "智能体未能保存，请重试。",
-  "agent.tools.description": "选择允许向此智能体提供工具的移动端兼容 MCP 服务器。",
+  "agent.tools.description": "选择此智能体可以使用的工具。",
   "agent.tools.empty": "暂无移动端兼容的 MCP 服务器。",
   "agent.tools.existingToolRules": "已有工具规则",
   "agent.tools.nextTurn": "更改从下一轮对话开始生效。全局停用的工具始终不可用。",
@@ -741,5 +741,6 @@
   "agent.tools.builtInStatus.needs-painting-model": "请先在 设置 > 模型 中选择绘画模型",
   "agent.tools.builtInStatus.needs-permission": "请先在 设置 > 权限 中授权",
   "agent.tools.builtInStatus.unsupported": "当前设备不支持",
-  "agent.tools.builtInAccessibilityLabel": "{{tool}}，{{status}}"
+  "agent.tools.builtInAccessibilityLabel": "{{tool}}，{{status}}",
+  "agent.tools.mcpDescription": "可以向此智能体提供工具的移动端兼容 MCP 服务器。"
 }


### PR DESCRIPTION
Stacked on #676. Two defects found while running the restored built-in catalog on an iOS simulator.

## 1. A written file appeared twice

`write_file` returns the created entry as an artifact, and the Host persists that as a `purpose: 'artifact'` file part which draws its own card. `WriteFileToolPart` drew a second card from the tool result, so every successful write showed the same file twice.

Persisted message for one `write_file` call, as captured from the device database:

```
tool   write_file          → WriteFileToolPart drew a FileEntryPreview
file   artifact acceptance.md → the artifact part drew another one
text
```

The fix drops the duplicate and lets the artifact part speak for the file — which is what `generate_image` already does, and why it never had this bug. The rejection branch stays: a rejected write produces no artifact, so its reason would otherwise be buried in the detail sheet.

Before / after on device:

| | |
|---|---|
| before | two identical `MD` cards, no tool row |
| after | one `Write file ›` row + one `MD` card, matching `generate_image` |

The rule is now written down in `src/frontend/components/messages/README.md` so the next tool that returns artifacts doesn't repeat it.

## 2. The tool section described only half of itself

The Agent editor's tools description still said it chooses MCP servers, which stopped being the whole truth when the built-in tools landed above it in #676. The description now covers both, and the MCP sentence moved under its own heading.

## Verification

- `pnpm lint` — 0 errors; `pnpm format:check` — clean
- `pnpm typecheck` — unchanged from `v0.2` (the same 12 pre-existing fixture errors, none touched here)
- Affected suites: 143 passed
- Both fixes confirmed on `iPhone 17 Pro` / iOS 26.5 against a scripted model and a real Streamable HTTP MCP server

## Note on scope

Two other things I reported after that acceptance run are deliberately **not** here:

- The "editor header overlaps the first row" I flagged **does not reproduce** — the form insets correctly and the row is reachable. That was my automation scrolling the wrong scroll view; retracted.
- The composer's text field is exposed to accessibility as a generic element rather than a text input, because it is `EnrichedMarkdownTextInput` (a third-party Fabric host), not RN's `TextInput`. That blocks XCTest text entry and likely affects VoiceOver, but it belongs to an upstream component and deserves its own investigation rather than a blind fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
