### PR TITLE
fix(agent-runtime): harden tool execution boundaries

### DIFF
--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -139,6 +139,12 @@ type RuntimeToolResult = {
   artifacts: RuntimeArtifact[]
 }
 
+type RuntimeToolCall = {
+  input: RuntimeJsonValue
+  signal: AbortSignal
+  toolCallId: string
+}
+
 type RuntimeExecutionRequest = {
   turnId: string
   instructions: string
@@ -296,10 +302,7 @@ type RuntimeTool = {
   description: string
   inputSchema: RuntimeJsonValue
   approval: 'auto' | 'ask' | 'deny'
-  execute(
-    input: RuntimeJsonValue,
-    context: { signal: AbortSignal; toolCallId: string },
-  ): Promise<RuntimeToolResult>
+  execute(call: RuntimeToolCall): Promise<RuntimeToolResult>
 }
 ```
 
@@ -475,16 +478,15 @@ Runtime that cannot report usage emits no `usage` event, and the assistant messa
 ## Host execution flow
 
 1. The Host validates that the Session is idle.
-2. It validates that the Session target is `local` and resolves the current Agent, public model
-    facts, input, and immutable tool catalog.
-3. It builds the versioned, credential-free inference snapshot from the same model, options, and
-    tools that will be sent to the Runtime.
-4. It atomically persists the user message and assistant placeholder with the selected model id and
-    inference snapshot.
-5. The Host uses its injected Pi Runtime, creates the turn resource ledger, loads the latest valid
-   context checkpoint, and normalizes instructions, model, grouped structured history after its
-   anchor, the immutable tool snapshot, input, and options. Invalid candidates fall back to the full
-   history.
+2. It validates that the Session target is `local`, resolves the current Agent, public model facts,
+   input and history, then creates the turn resource ledger.
+3. It freezes the immutable tool catalog against that ledger and builds the versioned,
+   credential-free inference snapshot from the same model, options, and tools sent to the Runtime.
+4. It preflights attachments, then atomically persists the user message and assistant placeholder
+   with the selected model id and inference snapshot.
+5. The Host uses its injected Pi Runtime, loads the latest valid context checkpoint, and normalizes
+   instructions, model, grouped structured history after its anchor, the immutable tool snapshot,
+   input, and options. Invalid candidates fall back to the full history.
 6. The selected Runtime executes the prepared request.
 7. The Host maps Runtime parts, approvals, usage, and terminal events into Agent Protocol state.
 8. Terminal message and turn state commit before the Host publishes terminal protocol events.

--- a/docs/references/agent/agent-tools-and-resources.md
+++ b/docs/references/agent/agent-tools-and-resources.md
@@ -8,8 +8,8 @@ The built-in catalog ships device calendar and reminders, health, location, web 
 image generation, and `write_file`, all using the settled `ToolRef` and `{ value, artifacts }`
 contracts. For each turn the Host resolves that catalog against model tool support, platform, OS
 permission, app configuration, and the Agent's persisted built-in bindings, then combines it with
-persisted executable MCP bindings. Office generation and the turn resource ledger do not exist yet.
-Sections that a shipped tool still diverges from carry an **As-built** note.
+persisted executable MCP bindings. Office generation does not exist yet. Sections that a shipped
+tool still diverges from carry an **As-built** note.
 
 This document defines how Cherry Mobile exposes application capabilities to Pi. Pi remains the
 sole conversation engine and owns the model → tool → result loop. Application services own every
@@ -121,10 +121,10 @@ tool.
 
 Before admitting a turn, the Host resolves tools in this order:
 
-1. Read the current Agent's enabled built-in and MCP bindings.
-2. Project only capabilities implemented on the current mobile platform.
-3. Resolve configured MCP servers and their currently enabled tool descriptors.
-4. Create the turn resource ledger from controlled managed-file facts.
+1. Create the turn resource ledger from controlled current-input and transcript managed-file facts.
+2. Read the current Agent's enabled built-in and MCP bindings.
+3. Project only capabilities implemented on the current mobile platform.
+4. Resolve configured MCP servers and their currently enabled tool descriptors.
 5. Apply system permission state, model tool-calling support, and application policy.
 6. Freeze stable refs, provider-safe aliases, callbacks, and approval modes into `RuntimeTool[]` for
    the turn.
@@ -147,16 +147,17 @@ receives a [`file_entry`](../data/file-model.md) id. Protocol operations and fil
 that managed id; raw `file://`, `content://`, sandbox, provider, and user-entered paths are transient
 import sources, never authority.
 
-**As-built.** There is no `TurnResourceLedger` yet. `write_file` needs none: it only creates
-entries and never reads one, so it has no input to authorize. `generate_image` does accept
-`image_ids`, and until the ledger exists it authorizes them only by resolving each id to an
-available managed image entry — it cannot yet tell a transcript-visible image from any other library
-entry. Closing that gap is the first job of the ledger.
+**As-built.** The Host creates `TurnResourceLedger` before freezing the built-in catalog. Read tools
+receive only its membership view; `generate_image` rejects an `image_id` outside that view before
+touching the global managed-file service. A Host-owned catalog wrapper validates and grants every
+built-in artifact before returning the tool result to Pi, and Host event projection repeats the
+grant idempotently. `write_file` needs no read grant because it only creates entries.
 
 For Version 1, the Host derives the initial ledger grants from:
 
 - managed files attached to the current user input;
-- managed file parts already visible in the Session transcript whose entries remain available; and
+- valid managed-file refs already visible in the Session transcript (the read callback still
+  revalidates that the entry remains available); and
 - files created by earlier tools in the same active turn.
 
 The Host creates a `TurnResourceLedger` containing explicit readable and derivable `fileEntryId`
@@ -290,13 +291,15 @@ with its own approval policy.
 
 - Persistence retains desktop-compatible `stdio`, `sse`, `streamableHttp`, `inMemory`, and unknown
   transport data unchanged; only `streamableHttp` projects into the mobile Runtime.
-- `McpRuntimeService` owns clients, discovery caches, connection disposal, credentials, and wire
+- `McpRuntimeService` owns clients, live discovery state, connection disposal, credentials, and wire
   errors. Pi receives sanitized tool definitions and callbacks, never MCP configuration secrets.
 - Discovery retains every paginated raw tool name and plain JSON Schema. Selected descriptors are
   adapted with deterministic ref-derived aliases, schema revalidation, a 60-second call bound, and
   a 256 KiB JSON result projection; remote payloads stay under `value` with `artifacts: []`.
-- The Host freezes the discovered tools for the turn. A reconnect may refresh the next snapshot but
-  cannot silently replace the active catalog.
+- The Host freezes the discovered tools for the turn, including the endpoint URL and live Runtime
+  generation that produced them. An endpoint edit, invalidation, or reconnect makes an old callback
+  unavailable; rediscovery may populate the next snapshot but never silently retargets the active
+  catalog, even when the server row keeps the same URL.
 - Third-party MCP tools execute only with per-call `ask` approval in this version. An explicit
   `deny` remains denied, while any legacy `auto` row is downgraded to `ask` during projection.
 

--- a/src/backend/ai/agent/__tests__/FakeRuntime.test.ts
+++ b/src/backend/ai/agent/__tests__/FakeRuntime.test.ts
@@ -199,7 +199,8 @@ const harness: RuntimeConformanceHarness = {
             approvalId,
           },
         });
-        const output = await tool.execute(toolInput, {
+        const output = await tool.execute({
+          input: toolInput,
           signal: controller.signal,
           toolCallId,
         });

--- a/src/backend/ai/agent/__tests__/raceAbort.test.ts
+++ b/src/backend/ai/agent/__tests__/raceAbort.test.ts
@@ -1,0 +1,34 @@
+import { raceAbort, settleWithin } from '../raceAbort';
+
+describe('raceAbort', () => {
+  test('releases the consumer with the AbortSignal reason', async () => {
+    let rejectLate!: (reason: Error) => void;
+    const operation = new Promise<void>((_resolve, reject) => {
+      rejectLate = reject;
+    });
+    const controller = new AbortController();
+    const raced = raceAbort(operation, controller.signal);
+
+    controller.abort(new Error('turn cancelled'));
+
+    await expect(raced).rejects.toThrow('turn cancelled');
+    rejectLate(new Error('late provider failure'));
+    await Promise.resolve();
+  });
+});
+
+describe('settleWithin', () => {
+  test('bounds a dependency that never settles', async () => {
+    jest.useFakeTimers();
+    try {
+      const settling = settleWithin(new Promise<void>(() => undefined), 1_000);
+
+      await jest.advanceTimersByTimeAsync(1_000);
+
+      await expect(settling).resolves.toBeUndefined();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/backend/ai/agent/__tests__/runtimeContracts.test.ts
+++ b/src/backend/ai/agent/__tests__/runtimeContracts.test.ts
@@ -34,10 +34,11 @@ describe('Agent Runtime settled contracts', () => {
       execute: async () => expected,
     };
 
-    const result = await tool.execute(
-      { query: 'Cherry Studio' },
-      { signal: new AbortController().signal, toolCallId: 'call-1' },
-    );
+    const result = await tool.execute({
+      input: { query: 'Cherry Studio' },
+      signal: new AbortController().signal,
+      toolCallId: 'call-1',
+    });
 
     expect(JSON.parse(JSON.stringify({ ref, result }))).toEqual({ ref, result: expected });
   });

--- a/src/backend/ai/agent/index.ts
+++ b/src/backend/ai/agent/index.ts
@@ -21,6 +21,7 @@ export type {
   RuntimeOutputPart,
   RuntimeTextAttachmentPart,
   RuntimeTool,
+  RuntimeToolCall,
   RuntimeToolRef,
   RuntimeToolResult,
   RuntimeUsage,

--- a/src/backend/ai/agent/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/pi/PiRuntime.ts
@@ -14,6 +14,7 @@ import type {
   Usage as PiUsage,
 } from '@earendil-works/pi-ai';
 
+import { raceAbort, settleWithin } from '../raceAbort';
 import { RuntimeEventChannel } from '../RuntimeEventChannel';
 import {
   createDeniedToolResult,
@@ -113,6 +114,19 @@ const TURN_TIMEOUT_ERROR: RuntimeError = {
   message: 'The Agent turn timed out.',
   retryable: true,
 };
+const DUPLICATE_TOOL_CALL_ERROR: RuntimeError = {
+  code: 'duplicate_tool_call_id',
+  message: 'The provider reused a tool call id while its approval was pending.',
+  retryable: false,
+};
+
+/**
+ * After `cancel()`/`close()` abort a turn, the underlying pi loop gets this
+ * long to unwind before the Runtime settles the terminal outcome itself. The
+ * loop's late settlement is then discarded by the terminal fence in `emit()`.
+ * Keep it well below the Host's five-second service teardown ceiling.
+ */
+export const PI_TURN_SETTLE_GRACE_MS = 1_000;
 
 const DEFAULT_EXECUTION_ERROR_MESSAGE = 'The model provider call failed.';
 const MAX_EXECUTION_ERROR_MESSAGE_CHARS = 4_000;
@@ -446,7 +460,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
     turn.abortController.abort();
     turn.agent?.abort();
     this.rejectApprovals(turn, new Error('The turn was cancelled.'));
-    await turn.agent?.waitForIdle().catch(() => undefined);
+    await settleWithin(turn.agent?.waitForIdle(), PI_TURN_SETTLE_GRACE_MS);
     this.emit(turn, { type: 'cancelled' });
   }
 
@@ -472,7 +486,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       turn.abortController.abort();
       turn.agent?.abort();
       this.rejectApprovals(turn, new Error('The session was closed.'));
-      await turn.agent?.waitForIdle().catch(() => undefined);
+      await settleWithin(turn.agent?.waitForIdle(), PI_TURN_SETTLE_GRACE_MS);
       this.emit(turn, { type: 'cancelled' });
     }
     this.activeTurn = undefined;
@@ -482,7 +496,10 @@ class PiRuntimeSession implements AgentRuntimeSession {
     let unsubscribe: (() => void) | undefined;
     let secrets: readonly string[] = [];
     try {
-      const resolution = await this.dependencies.resolveModel(request.model, request.options);
+      const resolution = await raceAbort(
+        this.dependencies.resolveModel(request.model, request.options),
+        turn.abortController.signal,
+      );
       secrets = sensitiveValues(resolution);
       turn.usageContext = resolution.usageContext;
       if (turn.terminated || turn.cancelRequested) return;
@@ -520,11 +537,21 @@ class PiRuntimeSession implements AgentRuntimeSession {
       }
 
       const conversation = toPiConversation(request, resolution.model);
+      // Compose the turn signal into every provider call: cancellation must
+      // reach the HTTP transport directly, not only through pi's own loop
+      // signal — which is absent in the pre-agent window and third-party after.
+      const streamFn: PiModelResolution['streamFn'] = (model, context, options) =>
+        resolution.streamFn(model, context, {
+          ...options,
+          signal: options?.signal
+            ? AbortSignal.any([options.signal, turn.abortController.signal])
+            : turn.abortController.signal,
+        });
       const models: Pick<Models, 'completeSimple'> = {
         completeSimple:
           this.contextOptions.completeSimple ??
           (async (model, context, options) => {
-            const stream = await resolution.streamFn(model, context, options);
+            const stream = await streamFn(model, context, options);
             return stream.result();
           }),
       };
@@ -534,18 +561,21 @@ class PiRuntimeSession implements AgentRuntimeSession {
         ...textAttachmentBodies(request),
       ];
       const thinkingLevel = resolveThinkingLevel(request, resolution);
-      const contextPlan = await planPiContext({
-        checkpoint: request.contextCheckpoint,
-        conversation,
-        model: resolution.model,
-        models,
-        options: this.contextOptions,
-        outputReserveTokens: request.options.maxOutputTokens ?? resolution.model.maxTokens,
-        redactSummary: (summary) => redactCompactionSummary(summary, compactionRedactions),
-        signal: turn.abortController.signal,
-        thinkingLevel,
-        tools: request.tools,
-      });
+      const contextPlan = await raceAbort(
+        planPiContext({
+          checkpoint: request.contextCheckpoint,
+          conversation,
+          model: resolution.model,
+          models,
+          options: this.contextOptions,
+          outputReserveTokens: request.options.maxOutputTokens ?? resolution.model.maxTokens,
+          redactSummary: (summary) => redactCompactionSummary(summary, compactionRedactions),
+          signal: turn.abortController.signal,
+          thinkingLevel,
+          tools: request.tools,
+        }),
+        turn.abortController.signal,
+      );
       if (turn.terminated) return;
       if (turn.timedOut) {
         this.emit(turn, { type: 'failed', error: TURN_TIMEOUT_ERROR });
@@ -593,7 +623,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
           }
           return turn.limitError !== undefined || turn.timedOut || turn.cancelRequested;
         },
-        streamFn: resolution.streamFn,
+        streamFn,
         toolExecution: 'parallel',
       };
       const agent = this.createAgent
@@ -606,7 +636,10 @@ class PiRuntimeSession implements AgentRuntimeSession {
       }
       unsubscribe = agent.subscribe((event) => this.handlePiEvent(turn, event));
 
-      await agent.prompt(conversation.prompt);
+      // Consumer-side cancellation: the abort releases this wait immediately
+      // rather than trusting the third-party loop to return. A late settlement
+      // is fenced by `turn.terminated` in `emit()` and `handlePiEvent()`.
+      await raceAbort(agent.prompt(conversation.prompt), turn.abortController.signal);
       if (turn.terminated) return;
       if (turn.timedOut) {
         this.emit(turn, { type: 'failed', error: TURN_TIMEOUT_ERROR });
@@ -822,6 +855,20 @@ class PiRuntimeSession implements AgentRuntimeSession {
 
     if (runtimeTool.approval === 'ask') {
       const approvalId = `approval-${toolCallId}`;
+      // A failed registration must never publish an approval card: a duplicate
+      // provider call id would orphan the earlier waiter, so the collision
+      // settles this call as an error instead (fail closed).
+      if (turn.approvalWaiters.has(approvalId)) {
+        const output = createErrorToolResult(DUPLICATE_TOOL_CALL_ERROR);
+        this.replaceToolPart(turn, part, {
+          state: 'error',
+          error: DUPLICATE_TOOL_CALL_ERROR,
+          output,
+        });
+        turn.failedToolCalls.add(toolCallId);
+        turn.settledToolCalls.add(toolCallId);
+        return this.piToolResult(output);
+      }
       // Register before publishing the request: callers may cancel as soon as
       // they observe that event, and cancellation must always find the waiter.
       const decisionPromise = this.waitForApproval(turn, approvalId);
@@ -866,7 +913,8 @@ class PiRuntimeSession implements AgentRuntimeSession {
       const callbackSignal = signal
         ? AbortSignal.any([turn.abortController.signal, signal])
         : turn.abortController.signal;
-      const output = await runtimeTool.execute(input, {
+      const output = await runtimeTool.execute({
+        input,
         signal: callbackSignal,
         toolCallId,
       });

--- a/src/backend/ai/agent/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/pi/__tests__/PiRuntime.test.ts
@@ -26,6 +26,7 @@ import {
 import { PI_TEXT_ATTACHMENT_ENVELOPE_PREFIX, toPiConversation } from '../modelMessages';
 import {
   DEFAULT_PI_RUNTIME_LIMITS,
+  PI_TURN_SETTLE_GRACE_MS,
   PiRuntime,
   type PiModelResolution,
   type PiRuntimeAgent,
@@ -431,6 +432,7 @@ const harness: RuntimeConformanceHarness = {
   sourceFiles: [
     path.resolve(__dirname, '../../types.ts'),
     path.resolve(__dirname, '../../RuntimeEventChannel.ts'),
+    path.resolve(__dirname, '../../raceAbort.ts'),
     path.resolve(__dirname, '../../toolResults.ts'),
     path.resolve(__dirname, '../PiRuntime.ts'),
     path.resolve(__dirname, '../contextCompaction.ts'),
@@ -1141,9 +1143,53 @@ describe('PiRuntime mapping', () => {
       systemPrompt: 'Be helpful.\n\nPrior system note.',
       thinkingLevel: 'high',
     });
-    expect(holder.lastOptions?.streamFn).toBe(holder.resolution.streamFn);
+    expect(holder.lastOptions?.streamFn).not.toBe(holder.resolution.streamFn);
     expect(holder.lastOptions?.getApiKey).toBeUndefined();
     await session.close();
+  });
+
+  test('propagates cancellation into provider streams and bounds a stuck Pi loop', async () => {
+    jest.useFakeTimers();
+    try {
+      const runtime = createTestRuntime();
+      const holder = holders.get(runtime);
+      if (!holder) throw new Error('missing Runtime holder');
+      let providerSignal: AbortSignal | undefined;
+      const providerStream: PiModelResolution['streamFn'] = (_model, _context, options) => {
+        providerSignal = options?.signal;
+        return undefined as never;
+      };
+      holder.resolution = { ...holder.resolution, streamFn: providerStream };
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      arrange(runtime, () => {
+        markStarted();
+        return new Promise<void>(() => undefined);
+      });
+      const session = await runtime.open();
+      const eventsPromise = collect(session.execute(baseRequest('turn-stuck-cancel')));
+      await started;
+      const upstream = new AbortController();
+      const streamFn = holder.lastOptions?.streamFn;
+      if (!streamFn) throw new Error('Pi stream function was not installed.');
+
+      streamFn(holder.resolution.model, undefined as never, { signal: upstream.signal } as never);
+      expect(providerSignal?.aborted).toBe(false);
+
+      const cancelling = session.cancel('turn-stuck-cancel');
+      const events = await eventsPromise;
+
+      expect(events.at(-1)).toEqual({ type: 'cancelled' });
+      expect(providerSignal?.aborted).toBe(true);
+      await jest.advanceTimersByTimeAsync(PI_TURN_SETTLE_GRACE_MS);
+      await cancelling;
+      await session.close();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   test('rejects tools for a model without native tool calling before starting Pi', async () => {
@@ -1335,6 +1381,55 @@ describe('PiRuntime mapping', () => {
       ]),
     );
     expect(events.at(-1)).toEqual({ type: 'completed' });
+    await session.close();
+  });
+
+  test('does not publish a second approval when a provider reuses a pending call id', async () => {
+    const runtime = createTestRuntime();
+    let executionCount = 0;
+    let duplicateResult: unknown;
+    const tool = askTool(() => {
+      executionCount += 1;
+    });
+    arrange(runtime, async (context) => {
+      const piTool = context.options.initialState?.tools?.[0];
+      if (!piTool) throw new Error('Duplicate approval program requires one tool.');
+      const first = piTool.execute('duplicate-call', { fileEntryId: 'file-1' }, context.signal);
+      duplicateResult = (
+        await piTool.execute('duplicate-call', { fileEntryId: 'file-2' }, context.signal)
+      ).details;
+      await first;
+      await emitText(context, 'Duplicate handled.');
+    });
+    const session = await runtime.open();
+    const events: RuntimeEvent[] = [];
+    const collecting = (async () => {
+      for await (const event of session.execute(
+        baseRequest('turn-duplicate-approval', { tools: [tool] }),
+      )) {
+        events.push(event);
+      }
+    })();
+    await waitFor(
+      () => events.some((event) => event.type === 'approval.requested'),
+      'the first approval request',
+    );
+
+    await session.respondApproval({
+      approvalId: 'approval-duplicate-call',
+      decision: 'deny',
+      turnId: 'turn-duplicate-approval',
+    });
+    await collecting;
+
+    expect(events.filter((event) => event.type === 'approval.requested')).toHaveLength(1);
+    expect(duplicateResult).toMatchObject({
+      value: {
+        status: 'error',
+        error: { code: 'duplicate_tool_call_id', retryable: false },
+      },
+    });
+    expect(executionCount).toBe(0);
     await session.close();
   });
 
@@ -1564,10 +1659,10 @@ describe('PiRuntime mapping', () => {
       maxToolSteps: 8,
       turnTimeoutMs: 5,
     });
-    arrange(runtime, async (context) => {
-      await new Promise<void>((resolve) => {
-        context.signal.addEventListener('abort', () => resolve(), { once: true });
-      });
+    let agentSignal: AbortSignal | undefined;
+    arrange(runtime, (context) => {
+      agentSignal = context.signal;
+      return new Promise<void>(() => undefined);
     });
     const session = await runtime.open();
 
@@ -1579,6 +1674,7 @@ describe('PiRuntime mapping', () => {
         error: { code: 'turn_timeout', message: 'The Agent turn timed out.', retryable: true },
       },
     ]);
+    expect(agentSignal?.aborted).toBe(true);
     await session.close();
   });
 });

--- a/src/backend/ai/agent/raceAbort.ts
+++ b/src/backend/ai/agent/raceAbort.ts
@@ -1,0 +1,52 @@
+/**
+ * Consumer-side cancellation: release the caller's wait when the signal aborts.
+ *
+ * The underlying work is NOT cancelled here — the abort is expected to reach it
+ * through its own signal wiring — so a hung or frozen operation can no longer
+ * pin the caller. The loser is consumed after the race settles, so its late
+ * rejection never surfaces as an unhandled rejection, and the abort listener is
+ * removed either way so long-lived signals do not accumulate one closure per
+ * call.
+ */
+export function raceAbort<T>(operation: Promise<T> | T, signal: AbortSignal): Promise<T> {
+  const settled = Promise.resolve(operation);
+  if (signal.aborted) {
+    settled.catch(() => undefined);
+    return Promise.reject(abortReason(signal));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortReason(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    // Attaching both handlers also consumes the loser's late rejection.
+    settled.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
+/**
+ * Wait for an operation to settle, but never longer than the grace window.
+ * Used where the caller itself initiated the abort and only wants to give the
+ * underlying loop a bounded chance to unwind before it settles the outcome.
+ */
+export async function settleWithin(
+  operation: Promise<unknown> | undefined,
+  graceMs: number,
+): Promise<void> {
+  if (!operation) return;
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      operation.catch(() => undefined),
+      new Promise<void>((resolve) => {
+        handle = setTimeout(resolve, graceMs);
+      }),
+    ]);
+  } finally {
+    if (handle !== undefined) clearTimeout(handle);
+  }
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error('The operation was aborted.');
+}

--- a/src/backend/ai/agent/types.ts
+++ b/src/backend/ai/agent/types.ts
@@ -149,6 +149,17 @@ export type RuntimeContextCheckpoint = {
   payload: RuntimeJsonValue;
 };
 
+/**
+ * One tool invocation. A single object on purpose: a positional context
+ * parameter can be silently dropped by an implementation, while an ignored
+ * `signal` field stays visible at the destructuring site.
+ */
+export type RuntimeToolCall = {
+  input: RuntimeJsonValue;
+  signal: AbortSignal;
+  toolCallId: string;
+};
+
 export type RuntimeTool = {
   ref: RuntimeToolRef;
   providerName: string;
@@ -156,10 +167,7 @@ export type RuntimeTool = {
   description: string;
   inputSchema: RuntimeJsonValue;
   approval: 'auto' | 'ask' | 'deny';
-  execute(
-    input: RuntimeJsonValue,
-    context: { signal: AbortSignal; toolCallId: string },
-  ): Promise<RuntimeToolResult>;
+  execute(call: RuntimeToolCall): Promise<RuntimeToolResult>;
 };
 
 export type RuntimeExecutionRequest = {

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -39,7 +39,7 @@ import type {
 } from '@/backend/ai/agent';
 import { PiRuntime } from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
-import { application } from '@/backend/core/application/Application';
+import type { McpRuntimeService } from '@/backend/ai/mcp';
 import {
   AppStatePolicy,
   BaseService,
@@ -56,6 +56,7 @@ import type {
   BackgroundReplyLifecycle,
   BackgroundReplyTurn,
 } from '@/backend/services/backgroundReply';
+import type { WebSearchService } from '@/backend/services/webSearch/WebSearchService';
 import {
   AgentCancelTurnInputSchema,
   AgentCreateSessionInputSchema,
@@ -195,7 +196,17 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
 
 @Injectable('MobileAgentHost')
 @ServicePhase(Phase.PostReady)
-@DependsOn(['AgentSessionStore', 'AiService', 'PreferenceService', 'BackgroundReplyRuntime'])
+// Tool Runtime owners stop after this Host has drained its frozen turn
+// catalogs. Constructor injection keeps runtime ownership and lifecycle
+// ordering on the same declared edges. Covered by a stop-order test.
+@DependsOn([
+  'AgentSessionStore',
+  'AiService',
+  'PreferenceService',
+  'BackgroundReplyRuntime',
+  'McpRuntimeService',
+  'WebSearchService',
+])
 @AppStatePolicy('continue')
 export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
@@ -224,6 +235,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     aiService: AiService,
     preferenceService: PreferenceService,
     private readonly backgroundReply: BackgroundReplyLifecycle,
+    mcpRuntime: McpRuntimeService,
+    private readonly webSearchService: WebSearchService,
     private readonly runtime: AgentRuntime = new PiRuntime(createPiModelResolver()),
     private readonly overrides: Partial<MobileAgentHostOverrides> = {},
   ) {
@@ -245,7 +258,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       overrides.runtimeTools ??
       createAgentRuntimeToolResolver({
         bindings: agentToolBindingService,
-        getMcpRuntime: () => application.get('McpRuntimeService'),
+        getMcpRuntime: () => mcpRuntime,
       });
   }
 
@@ -256,7 +269,10 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private lazyAgents: AgentDefinitionSource | undefined;
 
   private get toolSource(): AgentToolSource {
-    return this.overrides.tools ?? (this.lazyTools ??= createBuiltInToolSource());
+    return (
+      this.overrides.tools ??
+      (this.lazyTools ??= createBuiltInToolSource({ webSearch: this.webSearchService }))
+    );
   }
 
   private lazyTools: AgentToolSource | undefined;
@@ -266,21 +282,31 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     await this.reconcileInterruptedTurns();
   }
 
-  protected override async onDestroy(): Promise<void> {
+  /**
+   * Stop owns the work: abort every turn synchronously first, then close the
+   * Runtime sessions (each close is internally bounded) and join what remains.
+   * Destroy only releases references, so a stop that ran out of budget cannot
+   * leave live work behind a torn-down listener surface.
+   */
+  protected override async onStop(): Promise<void> {
     for (const state of this.activeTurns.values()) {
-      state.abortController.abort(new Error('The Agent Host was disposed.'));
+      state.abortController.abort(new Error('The Agent Host is stopping.'));
     }
-    for (const { session } of this.runtimeSessions.values()) {
-      try {
-        await session.close();
-      } catch (error) {
-        logger.warn('Failed to close a runtime session during disposal', error as Error);
-      }
-    }
+    const closing = [...this.runtimeSessions.values()].map(({ session }) =>
+      session
+        .close()
+        .catch((error) =>
+          logger.warn('Failed to close a runtime session during stop', error as Error),
+        ),
+    );
     this.runtimeSessions.clear();
+    await Promise.allSettled(closing);
     await Promise.allSettled([...this.runningTurns]);
     await this.naming.drain();
     await this.usage.drain();
+  }
+
+  protected override onDestroy(): void {
     this.runningTurnsBySession.clear();
     this.listeners.clear();
   }
@@ -382,46 +408,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
       }
 
-      // Freeze built-in and configured tools for the turn so mid-turn changes
-      // cannot alter the active catalog. Built-in discovery remains optional;
-      // configured binding resolution fails closed.
-      let builtInTools: readonly RuntimeTool[] = [];
-      let configuredTools: readonly RuntimeTool[] = [];
-      if (runtime.descriptor.capabilities.tools) {
-        try {
-          builtInTools = await this.toolSource.getTools({ agentId: agent.id, model: agent.model });
-        } catch (error) {
-          logger.warn(
-            'Failed to resolve built-in Agent tools; continuing without them',
-            error as Error,
-          );
-        }
-        configuredTools = await this.runtimeTools
-          .resolve(agent.id)
-          .catch(() =>
-            fail('EXECUTION_UNAVAILABLE', 'The configured Agent tools are unavailable.'),
-          );
-      }
-      const tools = [...builtInTools, ...configuredTools];
-
-      const inferenceModel = await this.inferenceModel(agent.model).catch(() =>
-        fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.'),
-      );
-      if (tools.length > 0) {
-        const supportsTools = await this.modelSupportsTools(agent.model).catch(() => false);
-        if (!supportsTools) {
-          fail(
-            'CAPABILITY_UNSUPPORTED',
-            'The selected model does not support native tool calling.',
-          );
-        }
-      }
-      const inferenceSnapshot = createAgentInferenceSnapshot({
-        model: inferenceModel,
-        options: agent.options,
-        tools,
-      });
-
       // History is everything stored before this turn.
       const priorMessages = await this.store.listMessages(sessionId);
       const storedContextCandidate = await this.store.getLatestContextCheckpoint(sessionId);
@@ -441,6 +427,51 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         priorMessages,
       );
       const resources = createTurnResourceLedger(inputFiles, priorMessages, availableFiles);
+
+      // Freeze built-in and configured tools for the turn so mid-turn changes
+      // cannot alter the active catalog. The catalog closes over this turn's
+      // resource ledger, never a global file surface. Built-in discovery
+      // remains optional; configured binding resolution fails closed.
+      let builtInTools: readonly RuntimeTool[] = [];
+      let configuredTools: readonly RuntimeTool[] = [];
+      if (runtime.descriptor.capabilities.tools) {
+        try {
+          builtInTools = await this.toolSource.getTools({
+            agentId: agent.id,
+            model: agent.model,
+            resources,
+          });
+        } catch (error) {
+          logger.warn(
+            'Failed to resolve built-in Agent tools; continuing without them',
+            error as Error,
+          );
+        }
+        configuredTools = await this.runtimeTools
+          .resolve(agent.id)
+          .catch(() =>
+            fail('EXECUTION_UNAVAILABLE', 'The configured Agent tools are unavailable.'),
+          );
+      }
+      const tools = [...builtInTools, ...configuredTools];
+      const inferenceModel = await this.inferenceModel(agent.model).catch(() =>
+        fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.'),
+      );
+      if (tools.length > 0) {
+        const supportsTools = await this.modelSupportsTools(agent.model).catch(() => false);
+        if (!supportsTools) {
+          fail(
+            'CAPABILITY_UNSUPPORTED',
+            'The selected model does not support native tool calling.',
+          );
+        }
+      }
+      const inferenceSnapshot = createAgentInferenceSnapshot({
+        model: inferenceModel,
+        options: agent.options,
+        tools,
+      });
+
       const modelPreflight = await this.preflightModel(runtime, agent);
       this.assertAttachmentRequestSupported(
         runtime,
@@ -692,6 +723,12 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     switch (event.type) {
       case 'part.add': {
         const part = toAgentMessagePart(event.part);
+        if (part.type === 'file') {
+          // A Host-validated artifact joins the turn ledger, so the model may
+          // reference it later in this same turn (monotonic grant, never a
+          // tool-side widening).
+          state.resources.grantFile(part.fileEntryId);
+        }
         state.assistantMessage.parts.push(part);
         if (state.assistantMessage.status === 'pending') {
           state.assistantMessage.status = 'streaming';

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -12,7 +12,9 @@ import {
   type RuntimeUsageContext,
 } from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
+import type { McpRuntimeService } from '@/backend/ai/mcp';
 import type { PreferenceService } from '@/backend/data/PreferenceService';
+import type { WebSearchService } from '@/backend/services/webSearch/WebSearchService';
 import {
   AgentEventSchema,
   AgentProtocolError,
@@ -69,7 +71,9 @@ const FAKE_DESCRIPTOR = {
 } as const;
 
 const unusedAiService = {} as AiService;
+const unusedMcpRuntime = {} as McpRuntimeService;
 const unusedPreferenceService = {} as PreferenceService;
+const unusedWebSearchService = {} as WebSearchService;
 type NamingOverride = Pick<
   AgentSessionNaming,
   'drain' | 'maybeRenameFromConversationSummary' | 'maybeRenameFromFirstUserMessage'
@@ -140,6 +144,8 @@ function createHost(
     unusedAiService,
     unusedPreferenceService,
     backgroundReply,
+    unusedMcpRuntime,
+    unusedWebSearchService,
     runtime,
     {
       agents,
@@ -543,7 +549,9 @@ describe('MobileAgentHost', () => {
 
   test('hands the turn the tools resolved for its model', async () => {
     const requests: RuntimeExecutionRequest[] = [];
-    const getTools = jest.fn(async () => [stubTool]);
+    const getTools = jest.fn(async (_input: Parameters<AgentToolSource['getTools']>[0]) => [
+      stubTool,
+    ]);
     const host = hostWithText(['Saved.'], requests, { tools: { getTools } });
     const session = await host.createSession({
       agentId: AGENT_ID,
@@ -561,7 +569,9 @@ describe('MobileAgentHost', () => {
     expect(getTools).toHaveBeenCalledWith({
       agentId: AGENT_ID,
       model: { providerId: 'mock-provider', modelId: 'mock-model' },
+      resources: expect.objectContaining({ fileEntryIds: expect.any(Set) }),
     });
+    expect([...getTools.mock.calls[0]![0].resources.fileEntryIds]).toEqual([]);
     expect(requests[0]?.tools).toEqual([stubTool]);
     expect((await store.listMessages(session.id))[1]?.inferenceSnapshot).toMatchObject({
       status: 'supported',
@@ -576,6 +586,46 @@ describe('MobileAgentHost', () => {
         ],
       },
     });
+  });
+
+  test('grants validated Runtime artifacts to the frozen turn resource scope', async () => {
+    let resources: Parameters<AgentToolSource['getTools']>[0]['resources'] | undefined;
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script((controller) => {
+      controller.emit({
+        type: 'part.add',
+        index: 0,
+        part: {
+          id: 'artifact-1',
+          type: 'file',
+          ref: { kind: 'managed-file', fileEntryId: SECOND_FILE_ENTRY_ID },
+          mediaType: 'image/png',
+          name: 'generated.png',
+          purpose: 'artifact',
+        },
+      });
+      controller.emit({ type: 'completed' });
+    });
+    const host = createHost(runtime, noOpNaming, noFiles, {
+      getTools: async (input) => {
+        resources = input.resources;
+        return [];
+      },
+    });
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const events: AgentEvent[] = [];
+    await host.observeSession(session.id, (event) => events.push(event));
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Create an image.' }],
+    });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the artifact turn');
+
+    expect(resources).toBeDefined();
+    expect([...(resources?.fileEntryIds ?? [])]).toEqual([SECOND_FILE_ENTRY_ID]);
   });
 
   test('runs the turn tool-less when the catalog cannot be resolved', async () => {
@@ -873,6 +923,43 @@ describe('MobileAgentHost', () => {
     // The session is idle again.
     const observation = await host.observeSession(session.id, () => {});
     expect(observation.snapshot.activeTurn).toBeNull();
+  });
+
+  test('stops active turns before draining Host-owned lifecycle work', async () => {
+    const started = createDeferred();
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script(async (controller) => {
+      started.resolve();
+      if (!controller.signal.aborted) {
+        await new Promise<void>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+    });
+    const finalize = jest.spyOn(store, 'finalizeAssistantMessage');
+    const naming: NamingOverride = {
+      ...noOpNaming,
+      drain: jest.fn(async () => {
+        expect(finalize).toHaveBeenCalledTimes(1);
+      }),
+    };
+    const host = createHost(runtime, naming);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Keep working.' }],
+    });
+    await started.promise;
+
+    await host._doStop();
+
+    expect((await store.listMessages(session.id))[1]?.status).toBe('cancelled');
+    expect(naming.drain).toHaveBeenCalledTimes(1);
+    expect(usage.drain).toHaveBeenCalledTimes(1);
+    await host._doDestroy();
+    expect(host.isDestroyed).toBe(true);
   });
 
   test('updates an active background reply when its Session is renamed', async () => {

--- a/src/backend/ai/agentHost/__tests__/managedFileResolver.test.ts
+++ b/src/backend/ai/agentHost/__tests__/managedFileResolver.test.ts
@@ -5,6 +5,7 @@ import { createManagedFileResolver, createTurnResourceLedger } from '../managedF
 
 const AVAILABLE_ID = FileEntryIdSchema.parse('00000000-0000-7000-8000-000000000001');
 const MISSING_BLOB_ID = FileEntryIdSchema.parse('00000000-0000-7000-8000-000000000002');
+const GENERATED_ID = FileEntryIdSchema.parse('00000000-0000-7000-8000-000000000003');
 
 describe('managedFileResolver', () => {
   test('returns authoritative facts only when both the live row and managed blob exist', async () => {
@@ -115,8 +116,9 @@ describe('managedFileResolver', () => {
     ]);
 
     const ledger = createTurnResourceLedger(inputFiles, history);
+    ledger.grantFile(GENERATED_ID);
 
-    expect([...ledger.fileEntryIds]).toEqual([AVAILABLE_ID, MISSING_BLOB_ID]);
+    expect([...ledger.fileEntryIds]).toEqual([AVAILABLE_ID, MISSING_BLOB_ID, GENERATED_ID]);
     expect(ledger.inputFiles).toBe(inputFiles);
   });
 });

--- a/src/backend/ai/agentHost/__tests__/piApiAdapters.test.ts
+++ b/src/backend/ai/agentHost/__tests__/piApiAdapters.test.ts
@@ -82,11 +82,13 @@ describe('Pi API adapters', () => {
       timeoutMs: 60_000,
     });
     const model = { api: testCase.api } as PiModel<SupportedPiApi>;
+    const signal = new AbortController().signal;
     const result = streamFn(model, context, {
       fetch: jest.fn() as unknown as FetchFunction,
       headers: { 'X-Request': 'request' },
       maxTokens: 32,
       reasoning: 'high',
+      signal,
     });
 
     expect(result).toBe(mockStreamResult);
@@ -100,6 +102,7 @@ describe('Pi API adapters', () => {
         maxRetries: 0,
         maxTokens: 32,
         reasoning: 'high',
+        signal,
         temperature: 0.2,
         timeoutMs: 60_000,
       }),

--- a/src/backend/ai/agentHost/__tests__/runtimeTools.test.ts
+++ b/src/backend/ai/agentHost/__tests__/runtimeTools.test.ts
@@ -30,6 +30,8 @@ function descriptor(serverId: string, rawToolName: string): McpExecutableToolDes
   return {
     description: `${rawToolName} description`,
     displayName: rawToolName,
+    endpointUrl: `https://${serverId}.example/mcp`,
+    generation: 1,
     inputSchema: { type: 'object' },
     rawToolName,
     serverId,

--- a/src/backend/ai/agentHost/managedFileResolver.ts
+++ b/src/backend/ai/agentHost/managedFileResolver.ts
@@ -22,7 +22,20 @@ export type TurnResourceLedger = {
   inputFiles: ReadonlyMap<string, ManagedFileFact>;
   /** Current and historical facts whose row and managed blob passed preflight. */
   availableFiles: ReadonlyMap<string, ManagedFileFact>;
+  /**
+   * Monotonic Host-side grant: an artifact produced during this turn joins the
+   * ledger so the model may reference it later in the same turn. Only the Host
+   * or its catalog wrapper calls this with validated ids; tools never widen
+   * their own scope.
+   */
+  grantFile(fileEntryId: FileEntryId): void;
 };
+
+/** The slice of the turn ledger a tool may consult: membership, not content. */
+export type TurnFileScope = Pick<TurnResourceLedger, 'fileEntryIds'>;
+
+/** Host-owned catalog capability: tools can consult membership; the wrapper grants outputs. */
+export type TurnToolResources = Pick<TurnResourceLedger, 'fileEntryIds' | 'grantFile'>;
 
 /** Host-only managed-file boundary. It never exposes a device path to Pi. */
 export interface ManagedFileResolver {
@@ -119,7 +132,14 @@ export function createTurnResourceLedger(
     }
   }
 
-  return { availableFiles, fileEntryIds, inputFiles };
+  return {
+    availableFiles,
+    fileEntryIds,
+    inputFiles,
+    grantFile(fileEntryId) {
+      fileEntryIds.add(fileEntryId);
+    },
+  };
 }
 
 function throwIfAborted(signal: AbortSignal): void {

--- a/src/backend/ai/agentHost/piApiAdapters.ts
+++ b/src/backend/ai/agentHost/piApiAdapters.ts
@@ -83,6 +83,7 @@ export async function bindPiStream(
       headers: { ...options?.headers, ...binding.headers },
       maxRetries: binding.maxRetries,
       maxTokens: options?.maxTokens ?? binding.maxTokens,
+      signal: options?.signal,
       temperature: options?.temperature ?? binding.temperature,
       timeoutMs: binding.timeoutMs,
     });

--- a/src/backend/ai/agentHost/tools/__tests__/builtInToolSource.test.ts
+++ b/src/backend/ai/agentHost/tools/__tests__/builtInToolSource.test.ts
@@ -1,15 +1,26 @@
 import type { RuntimeModel, RuntimeTool } from '@/backend/ai/agent';
+import { fileContent } from '@/backend/services/file/fileContent';
 import type { DevicePermissionScope, SystemPermissionState } from '@/shared/contracts';
 import type { AgentToolBinding } from '@/shared/data/types/agentToolBinding';
+import { FileEntrySchema } from '@/shared/data/types/file';
 import { createUniqueModelId } from '@/shared/data/types/model';
 
+import type { TurnToolResources } from '../../managedFileResolver';
 import { type BuiltInToolSourceDependencies, createBuiltInToolSource } from '../builtInToolSource';
 import type { ConfiguredPaintingModel } from '../painting';
 
 const AGENT_ID = '00000000-0000-7000-8000-0000000000a1';
 const MODEL: RuntimeModel = { providerId: 'openai', modelId: 'gpt-test' };
+const TURN_RESOURCES: TurnToolResources = {
+  fileEntryIds: new Set<string>(),
+  grantFile: () => undefined,
+};
 
 describe('createBuiltInToolSource', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('offers the always-available catalog when nothing is granted or configured', async () => {
     const tools = await resolve({ deviceAccess: {}, paintingModel: null });
 
@@ -118,9 +129,9 @@ describe('createBuiltInToolSource', () => {
 
     // The Host turns this into a tool-less turn rather than one authorized by
     // catalog defaults the user may have overridden.
-    await expect(source.getTools({ agentId: AGENT_ID, model: MODEL })).rejects.toThrow(
-      'database unavailable',
-    );
+    await expect(
+      source.getTools({ agentId: AGENT_ID, model: MODEL, resources: TURN_RESOURCES }),
+    ).rejects.toThrow('database unavailable');
   });
 
   test('describes every tool with a stable built-in ref and JSON Schema input', async () => {
@@ -140,6 +151,36 @@ describe('createBuiltInToolSource', () => {
       expect(tool.inputSchema).not.toHaveProperty('$schema');
     }
   });
+
+  test('grants a created artifact before returning the built-in tool result', async () => {
+    const entry = FileEntrySchema.parse({
+      createdAt: 1,
+      filename: 'report.txt',
+      id: '00000000-0000-7000-8000-000000000001',
+      mediaType: 'text/plain',
+      size: 6,
+      updatedAt: 1,
+    });
+    jest.spyOn(fileContent, 'createTextEntry').mockResolvedValueOnce(entry);
+    const grantFile = jest.fn();
+    const resources: TurnToolResources = { fileEntryIds: new Set(), grantFile };
+    const source = createBuiltInToolSource(dependencies({}));
+    const tools = await source.getTools({ agentId: AGENT_ID, model: MODEL, resources });
+    const writeFile = tools.find((tool) => tool.providerName === 'write_file');
+    if (!writeFile) throw new Error('write_file was not available.');
+
+    const result = await writeFile.execute({
+      input: { content: 'report', filename: 'report.txt' },
+      signal: new AbortController().signal,
+      toolCallId: 'call-1',
+    });
+
+    expect(grantFile).toHaveBeenCalledWith(entry.id);
+    expect(result.artifacts[0]?.ref).toEqual({
+      kind: 'managed-file',
+      fileEntryId: entry.id,
+    });
+  });
 });
 
 type Scenario = {
@@ -158,7 +199,7 @@ async function resolve(
     ...dependencies(scenario),
     platform: options.platform ?? 'ios',
   });
-  return source.getTools({ agentId: AGENT_ID, model: MODEL });
+  return source.getTools({ agentId: AGENT_ID, model: MODEL, resources: TURN_RESOURCES });
 }
 
 function dependencies(scenario: Scenario): Partial<BuiltInToolSourceDependencies> {

--- a/src/backend/ai/agentHost/tools/__tests__/writeFileTool.test.ts
+++ b/src/backend/ai/agentHost/tools/__tests__/writeFileTool.test.ts
@@ -142,6 +142,22 @@ describe('writeFileTool', () => {
     ).rejects.toThrow('disk full');
   });
 
+  test('does not start a write after the turn is cancelled', async () => {
+    const files = createFilesPort();
+    const tool = createWriteFileTool(files);
+    const controller = new AbortController();
+    controller.abort(new Error('turn cancelled'));
+
+    await expect(
+      tool.execute({
+        input: { content: 'late', filename: 'late.txt' },
+        signal: controller.signal,
+        toolCallId: 'call-1',
+      }),
+    ).rejects.toThrow('turn cancelled');
+    expect(files.createTextEntry).not.toHaveBeenCalled();
+  });
+
   test('exposes a portable JSON Schema that forbids extra keys', () => {
     const { inputSchema } = createWriteFileTool(createFilesPort());
 
@@ -176,8 +192,5 @@ function execute(
   tool: ReturnType<typeof createWriteFileTool>,
   input: RuntimeJsonValue,
 ): Promise<RuntimeToolResult> {
-  return tool.execute(input, {
-    signal: new AbortController().signal,
-    toolCallId: 'call-1',
-  });
+  return tool.execute({ input, signal: new AbortController().signal, toolCallId: 'call-1' });
 }

--- a/src/backend/ai/agentHost/tools/builtInToolSource.ts
+++ b/src/backend/ai/agentHost/tools/builtInToolSource.ts
@@ -31,8 +31,10 @@ import {
   type BuiltInToolDescriptor,
   BUILT_IN_TOOL_DESCRIPTORS,
 } from '@/shared/data/types/builtInTool';
+import { FileEntryIdSchema } from '@/shared/data/types/file';
 import { createUniqueModelId } from '@/shared/data/types/model';
 
+import type { TurnToolResources } from '../managedFileResolver';
 import {
   createCalendarTools,
   createHealthTools,
@@ -70,9 +72,15 @@ export type BuiltInToolScope = {
   platform: string;
 };
 
+export type { TurnFileScope, TurnToolResources } from '../managedFileResolver';
+
 export type AgentToolSource = {
   /** The tools this turn may use; empty when the model cannot call any. */
-  getTools(input: { agentId: string; model: RuntimeModel }): Promise<readonly RuntimeTool[]>;
+  getTools(input: {
+    agentId: string;
+    model: RuntimeModel;
+    resources: TurnToolResources;
+  }): Promise<readonly RuntimeTool[]>;
 };
 
 export type BuiltInToolSourceDependencies = DeviceToolDependencies &
@@ -87,7 +95,7 @@ export function createBuiltInToolSource(
   overrides: Partial<BuiltInToolSourceDependencies> = {},
 ): AgentToolSource {
   return {
-    async getTools({ agentId, model }) {
+    async getTools({ agentId, model, resources }) {
       const deps = resolveDependencies(overrides);
       if (!(await deps.supportsToolCalling(model))) {
         // Handing tools to a model that cannot call them fails the whole turn.
@@ -95,11 +103,11 @@ export function createBuiltInToolSource(
       }
 
       const scope = await resolveScope(deps, agentId);
-      const catalog = createCatalog(deps, scope);
+      const catalog = createCatalog(deps, scope, resources);
       return BUILT_IN_TOOL_DESCRIPTORS.flatMap((descriptor) => {
         const approval = resolveApproval(descriptor, scope);
         const tool = catalog.get(descriptor.capabilityId);
-        return approval && tool ? [{ ...tool, approval }] : [];
+        return approval && tool ? [bindTurnResources({ ...tool, approval }, resources)] : [];
       });
     },
   };
@@ -151,6 +159,7 @@ function isPlatformSupported(descriptor: BuiltInToolDescriptor, platform: string
 function createCatalog(
   deps: BuiltInToolSourceDependencies,
   scope: BuiltInToolScope,
+  resources: TurnToolResources,
 ): ReadonlyMap<string, RuntimeTool> {
   const deviceDeps: DeviceToolDependencies = { devicePermissions: deps.devicePermissions };
   const tools = [
@@ -160,13 +169,31 @@ function createCatalog(
     ...createHealthTools(deviceDeps),
     ...createLocationTools(deviceDeps),
     ...createWebTools({ webSearch: deps.webSearch }),
-    createGenerateImageTool(deps.painting, scope.paintingModel),
+    createGenerateImageTool(deps.painting, scope.paintingModel, resources),
   ];
   return new Map(
     tools.flatMap((tool) =>
       tool.ref.source === 'builtin' ? [[tool.ref.capabilityId, tool] as const] : [],
     ),
   );
+}
+
+/** Grant validated built-in artifacts before Pi can start its next tool step. */
+function bindTurnResources(tool: RuntimeTool, resources: TurnToolResources): RuntimeTool {
+  return {
+    ...tool,
+    async execute(call) {
+      const output = await tool.execute(call);
+      for (const artifact of output.artifacts) {
+        const fileEntryId = FileEntryIdSchema.safeParse(artifact.ref.fileEntryId);
+        if (!fileEntryId.success) {
+          throw new Error('Built-in tool returned an invalid managed file artifact.');
+        }
+        resources.grantFile(fileEntryId.data);
+      }
+      return output;
+    },
+  };
 }
 
 async function resolveScope(

--- a/src/backend/ai/agentHost/tools/device/__tests__/deviceRuntimeTool.test.ts
+++ b/src/backend/ai/agentHost/tools/device/__tests__/deviceRuntimeTool.test.ts
@@ -77,7 +77,7 @@ describe('createDeviceRuntimeTool', () => {
     });
 
     await expect(
-      tool.execute({ id: 'event-1' }, { signal: controller.signal, toolCallId: 'call-1' }),
+      tool.execute({ input: { id: 'event-1' }, signal: controller.signal, toolCallId: 'call-1' }),
     ).rejects.toThrow();
   });
 
@@ -88,7 +88,7 @@ describe('createDeviceRuntimeTool', () => {
     const tool = build({ run });
 
     await expect(
-      tool.execute({ id: 'event-1' }, { signal: controller.signal, toolCallId: 'call-1' }),
+      tool.execute({ input: { id: 'event-1' }, signal: controller.signal, toolCallId: 'call-1' }),
     ).rejects.toThrow();
     expect(run).not.toHaveBeenCalled();
   });
@@ -117,5 +117,5 @@ function execute(
   tool: ReturnType<typeof build>,
   input: RuntimeJsonValue,
 ): Promise<RuntimeToolResult> {
-  return tool.execute(input, { signal: new AbortController().signal, toolCallId: 'call-1' });
+  return tool.execute({ input, signal: new AbortController().signal, toolCallId: 'call-1' });
 }

--- a/src/backend/ai/agentHost/tools/device/deviceRuntimeTool.ts
+++ b/src/backend/ai/agentHost/tools/device/deviceRuntimeTool.ts
@@ -59,7 +59,7 @@ export function createDeviceRuntimeTool<TSchema extends z.ZodType>(
     // The catalog overrides this from the resolved binding policy; the value
     // here is only the floor a tool declares for itself.
     approval: 'ask',
-    async execute(rawInput, context) {
+    async execute({ input: rawInput, signal }) {
       const parsed = input.inputSchema.safeParse(rawInput);
       if (!parsed.success) {
         // The model wrote this call, so it is the one that can fix it.
@@ -74,13 +74,13 @@ export function createDeviceRuntimeTool<TSchema extends z.ZodType>(
       }
 
       try {
-        throwIfAborted(context.signal);
+        throwIfAborted(signal);
         await assertPermissions(input.deps, input.permissionScopes, input.capabilityId);
-        const value = await input.run(parsed.data, context.signal);
-        throwIfAborted(context.signal);
+        const value = await input.run(parsed.data, signal);
+        throwIfAborted(signal);
         return { value: (value ?? null) as RuntimeJsonValue, artifacts: [] };
       } catch (error) {
-        if (context.signal.aborted || isAbortError(error)) {
+        if (signal.aborted || isAbortError(error)) {
           throw error;
         }
         const message = error instanceof Error ? error.message : String(error);

--- a/src/backend/ai/agentHost/tools/painting/__tests__/generateImageTool.test.ts
+++ b/src/backend/ai/agentHost/tools/painting/__tests__/generateImageTool.test.ts
@@ -2,6 +2,7 @@ import type { RuntimeJsonValue, RuntimeTool, RuntimeToolResult } from '@/backend
 import { FileEntrySchema } from '@/shared/data/types/file';
 import { createUniqueModelId } from '@/shared/data/types/model';
 
+import type { TurnFileScope } from '../../../managedFileResolver';
 import type { ConfiguredPaintingModel, PaintingToolDependencies } from '../generateImage';
 import { createGenerateImageTool } from '../generateImageTool';
 
@@ -18,11 +19,17 @@ const MODEL: ConfiguredPaintingModel = {
   support: null,
   uniqueModelId: createUniqueModelId('openai', 'gpt-image-1'),
 };
+const EDIT_MODEL: ConfiguredPaintingModel = {
+  support: { modes: { edit: { supports: {} } } },
+  uniqueModelId: MODEL.uniqueModelId,
+};
+
+const TURN_FILES: TurnFileScope = { fileEntryIds: new Set([ENTRY.id]) };
 
 describe('createGenerateImageTool', () => {
   test('imports generated images before reporting them as artifacts', async () => {
     const deps = createDependencies();
-    const tool = createGenerateImageTool(deps, MODEL);
+    const tool = createGenerateImageTool(deps, MODEL, TURN_FILES);
 
     const result = await execute(tool, { prompt: 'A cherry orchard at dawn' });
 
@@ -43,7 +50,7 @@ describe('createGenerateImageTool', () => {
 
   test('tells the model to stop when no drawing model is configured', async () => {
     const deps = createDependencies();
-    const tool = createGenerateImageTool(deps, null);
+    const tool = createGenerateImageTool(deps, null, TURN_FILES);
 
     const result = await execute(tool, { prompt: 'A cherry orchard at dawn' });
 
@@ -58,7 +65,7 @@ describe('createGenerateImageTool', () => {
         throw new Error('provider exploded');
       },
     });
-    const tool = createGenerateImageTool(deps, MODEL);
+    const tool = createGenerateImageTool(deps, MODEL, TURN_FILES);
 
     const result = await execute(tool, { prompt: 'A cherry orchard at dawn' });
 
@@ -79,7 +86,7 @@ describe('createGenerateImageTool', () => {
     deps.files.createInternalEntry
       .mockResolvedValueOnce(ENTRY)
       .mockRejectedValueOnce(new Error('disk full'));
-    const tool = createGenerateImageTool(deps, MODEL);
+    const tool = createGenerateImageTool(deps, MODEL, TURN_FILES);
 
     const result = await execute(tool, { prompt: 'A cherry orchard at dawn' });
 
@@ -90,7 +97,7 @@ describe('createGenerateImageTool', () => {
 
   test('rejects an empty prompt without calling the provider', async () => {
     const deps = createDependencies();
-    const tool = createGenerateImageTool(deps, MODEL);
+    const tool = createGenerateImageTool(deps, MODEL, TURN_FILES);
 
     const result = await execute(tool, { prompt: '   ' });
 
@@ -98,8 +105,25 @@ describe('createGenerateImageTool', () => {
     expect(result.value).toMatchObject({ status: 'error', retryable: true });
   });
 
+  test('rejects an image id outside the turn before reading the file', async () => {
+    const deps = createDependencies();
+    const tool = createGenerateImageTool(deps, EDIT_MODEL, { fileEntryIds: new Set() });
+
+    const result = await execute(tool, {
+      image_ids: [ENTRY.id],
+      prompt: 'Turn this into a watercolor.',
+    });
+
+    expect(result.value).toMatchObject({
+      status: 'error',
+      message: expect.stringContaining('not part of this conversation'),
+    });
+    expect(deps.files.resolve).not.toHaveBeenCalled();
+    expect(deps.ai.generateImage).not.toHaveBeenCalled();
+  });
+
   test('carries the stable built-in ref and asks before spending provider quota', () => {
-    const tool = createGenerateImageTool(createDependencies(), MODEL);
+    const tool = createGenerateImageTool(createDependencies(), MODEL, TURN_FILES);
 
     expect(tool.ref).toEqual({ source: 'builtin', capabilityId: 'generate_image' });
     expect(tool.approval).toBe('ask');
@@ -129,5 +153,5 @@ function createDependencies(overrides: { generateImage?: () => Promise<never> } 
 }
 
 function execute(tool: RuntimeTool, input: RuntimeJsonValue): Promise<RuntimeToolResult> {
-  return tool.execute(input, { signal: new AbortController().signal, toolCallId: 'call-1' });
+  return tool.execute({ input, signal: new AbortController().signal, toolCallId: 'call-1' });
 }

--- a/src/backend/ai/agentHost/tools/painting/generateImage.ts
+++ b/src/backend/ai/agentHost/tools/painting/generateImage.ts
@@ -25,6 +25,7 @@ import { loggerService } from '@/shared/core/logger/LoggerService';
 import { type FileEntry, type FileEntryId, FileEntryIdSchema } from '@/shared/data/types/file';
 import { isUniqueModelId, parseUniqueModelId, type UniqueModelId } from '@/shared/data/types/model';
 
+import type { TurnFileScope } from '../../managedFileResolver';
 import { type GenerateImageToolInput, limitGenerateImageInputIds } from './generateImageSchema';
 
 const logger = loggerService.withContext('GenerateImageTool');
@@ -51,6 +52,8 @@ export const PAINTING_GENERATE_NOT_SUPPORTED_NOTE =
   "The configured drawing model can't generate a new image without input images. Ask for image references or tell the user to choose a generation-capable drawing model.";
 export const PAINTING_INPUT_IMAGE_ERROR_NOTE =
   'One or more image references could not be read as images. Ask the user for valid generated-image file entry ids.';
+export const PAINTING_INPUT_IMAGE_NOT_IN_TURN_NOTE =
+  'One or more image references are not part of this conversation. Only file entry ids visible in this session may be used; ask the user to attach the image instead.';
 
 export type ConfiguredPaintingModel = {
   support: ImageGenerationSupport | null;
@@ -98,7 +101,8 @@ export async function generateImageFromPrompt(
   dependencies: PaintingToolDependencies,
   input: GenerateImageToolInput,
   signal: AbortSignal,
-  configuredModel: ConfiguredPaintingModel | null = null,
+  configuredModel: ConfiguredPaintingModel | null,
+  turnFiles: TurnFileScope,
 ): Promise<PaintingResult> {
   throwIfAborted(signal);
   const resolvedModel = configuredModel ?? (await resolveConfiguredPaintingModel(dependencies));
@@ -120,6 +124,12 @@ export async function generateImageFromPrompt(
 
   let inputImages: string[] | undefined;
   if (mode === 'edit') {
+    // The turn ledger is the authority for what this conversation may read. A
+    // valid-looking id from anywhere else (another session, the wider library)
+    // proves existence, not authorization.
+    if ((input.image_ids ?? []).some((id) => !turnFiles.fileEntryIds.has(id))) {
+      return { error: PAINTING_INPUT_IMAGE_NOT_IN_TURN_NOTE };
+    }
     try {
       inputImages = await resolveInputImages(dependencies, input.image_ids ?? []);
     } catch (error) {

--- a/src/backend/ai/agentHost/tools/painting/generateImageTool.ts
+++ b/src/backend/ai/agentHost/tools/painting/generateImageTool.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 
 import type { RuntimeTool } from '@/backend/ai/agent';
 
+import type { TurnFileScope } from '../../managedFileResolver';
 import { toRuntimeInputSchema } from '../runtimeToolSchema';
 import {
   type ConfiguredPaintingModel,
@@ -24,6 +25,7 @@ export { GENERATE_IMAGE_TOOL_NAME };
 export function createGenerateImageTool(
   dependencies: PaintingToolDependencies,
   configuredModel: ConfiguredPaintingModel | null,
+  turnFiles: TurnFileScope,
 ): RuntimeTool {
   const inputSchema = buildGenerateImageToolSchema(configuredModel?.support);
 
@@ -36,7 +38,7 @@ export function createGenerateImageTool(
     // Generation spends the user's provider quota, so it asks unless an Agent
     // binding says otherwise (agent-tools-and-resources.md, Image Generation).
     approval: 'ask',
-    async execute(input, context) {
+    async execute({ input, signal }) {
       const parsed = inputSchema.safeParse(input);
       if (!parsed.success) {
         return {
@@ -52,8 +54,9 @@ export function createGenerateImageTool(
       const result = await generateImageFromPrompt(
         dependencies,
         parsed.data as GenerateImageToolInput,
-        context.signal,
+        signal,
         configuredModel,
+        turnFiles,
       );
       if (isPaintingError(result)) {
         return {

--- a/src/backend/ai/agentHost/tools/web/__tests__/webTools.test.ts
+++ b/src/backend/ai/agentHost/tools/web/__tests__/webTools.test.ts
@@ -123,5 +123,5 @@ function toolNamed(
 }
 
 function execute(tool: RuntimeTool, input: RuntimeJsonValue): Promise<RuntimeToolResult> {
-  return tool.execute(input, { signal: new AbortController().signal, toolCallId: 'call-1' });
+  return tool.execute({ input, signal: new AbortController().signal, toolCallId: 'call-1' });
 }

--- a/src/backend/ai/agentHost/tools/web/webTools.ts
+++ b/src/backend/ai/agentHost/tools/web/webTools.ts
@@ -46,14 +46,12 @@ export function createWebTools(deps: WebSearchToolDependencies): RuntimeTool[] {
       description: WEB_SEARCH_DESCRIPTION,
       inputSchema: toRuntimeInputSchema(webSearchInputSchema),
       approval: 'auto',
-      execute: async (input, context) => {
+      execute: async ({ input, signal }) => {
         const parsed = webSearchInputSchema.safeParse(input);
         if (!parsed.success) {
           return invalidInput(parsed.error);
         }
-        return webLookupToolResult(
-          await searchWeb(deps.webSearch, parsed.data.query, context.signal),
-        );
+        return webLookupToolResult(await searchWeb(deps.webSearch, parsed.data.query, signal));
       },
     },
     {
@@ -63,14 +61,12 @@ export function createWebTools(deps: WebSearchToolDependencies): RuntimeTool[] {
       description: WEB_FETCH_DESCRIPTION,
       inputSchema: toRuntimeInputSchema(webFetchInputSchema),
       approval: 'auto',
-      execute: async (input, context) => {
+      execute: async ({ input, signal }) => {
         const parsed = webFetchInputSchema.safeParse(input);
         if (!parsed.success) {
           return invalidInput(parsed.error);
         }
-        return webLookupToolResult(
-          await fetchWeb(deps.webSearch, parsed.data.urls, context.signal),
-        );
+        return webLookupToolResult(await fetchWeb(deps.webSearch, parsed.data.urls, signal));
       },
     },
   ];

--- a/src/backend/ai/agentHost/tools/writeFileTool.ts
+++ b/src/backend/ai/agentHost/tools/writeFileTool.ts
@@ -69,7 +69,7 @@ export function createWriteFileTool(files: WriteFileFiles): RuntimeTool {
     // The catalog overrides this from the resolved binding policy; the value
     // here is only the floor this tool declares for itself.
     approval: 'auto',
-    async execute(input) {
+    async execute({ input, signal }) {
       const parsed = writeFileInputSchema.safeParse(input);
       if (!parsed.success) {
         return invalid(`Invalid input: ${z.prettifyError(parsed.error)}`);
@@ -89,6 +89,8 @@ export function createWriteFileTool(files: WriteFileFiles): RuntimeTool {
         );
       }
 
+      // A cancelled turn must not add entries to the library.
+      signal.throwIfAborted();
       const entry = await files.createTextEntry({
         data: parsed.data.content,
         mediaType: mediaTypeForFilename(filename),

--- a/src/backend/ai/mcp/McpRuntimeService.ts
+++ b/src/backend/ai/mcp/McpRuntimeService.ts
@@ -159,6 +159,7 @@ function isMcpToolCallingClient(client: MCPClient): client is McpToolCallingClie
 @Injectable('McpRuntimeService')
 @ServicePhase(Phase.PostReady)
 export class McpRuntimeService extends BaseService implements McpModule {
+  private nextGeneration = 0;
   private readonly runtimeStates = new Map<string, ServerRuntimeState>();
   private readonly runtimeSnapshots = new Map<string, McpServerRuntimeSnapshot>();
 
@@ -210,11 +211,19 @@ export class McpRuntimeService extends BaseService implements McpModule {
       );
     }
     const disabledTools = new Set(server.disabledTools);
+    const state = this.runtimeStates.get(server.id);
+    if (!state) {
+      throw unavailableToolError();
+    }
     return definitions
       .filter((tool) => !disabledTools.has(tool.name))
       .map((tool) => ({
         description: tool.description ?? '',
         displayName: tool.title ?? tool.annotations?.title ?? tool.name,
+        // Pin the catalog to both its endpoint and live connection generation;
+        // edits, invalidation, or reconnects cannot retarget a frozen tool.
+        endpointUrl: server.endpointUrl,
+        generation: state.generation,
         inputSchema: prepareMcpInputSchema(tool.inputSchema),
         rawToolName: tool.name,
         serverId: server.id,
@@ -224,7 +233,8 @@ export class McpRuntimeService extends BaseService implements McpModule {
   /** Adapt an already selected catalog without reading Agent bindings or injecting the Host. */
   createRuntimeTools(selections: readonly McpRuntimeToolSelection[]): RuntimeTool[] {
     return createMcpRuntimeTools(selections, {
-      invoke: (ref, input, signal) => this.invokeTool(ref, input, signal),
+      invoke: (ref, input, signal, discoveredEndpointUrl, discoveredGeneration) =>
+        this.invokeTool(ref, input, signal, discoveredEndpointUrl, discoveredGeneration),
     });
   }
 
@@ -275,7 +285,6 @@ export class McpRuntimeService extends BaseService implements McpModule {
       return current;
     }
 
-    const generation = current ? current.generation + 1 : 0;
     if (current) {
       this.retireState(current);
     }
@@ -284,7 +293,7 @@ export class McpRuntimeService extends BaseService implements McpModule {
       abort: new AbortController(),
       discoveredToolNames: new Set(),
       endpointUrl: server.endpointUrl,
-      generation,
+      generation: this.allocateGeneration(),
       serverId: server.id,
     };
     this.runtimeStates.set(server.id, state);
@@ -398,7 +407,7 @@ export class McpRuntimeService extends BaseService implements McpModule {
       return;
     }
 
-    state.generation += 1;
+    state.generation = this.allocateGeneration();
     state.abort.abort();
     state.abort = new AbortController();
     state.connectionPromise = undefined;
@@ -412,7 +421,7 @@ export class McpRuntimeService extends BaseService implements McpModule {
     if (this.runtimeStates.get(state.serverId) === state) {
       this.runtimeStates.delete(state.serverId);
     }
-    state.generation += 1;
+    state.generation = this.allocateGeneration();
     state.abort.abort();
     state.connectionPromise = undefined;
     if (state.client) {
@@ -425,10 +434,18 @@ export class McpRuntimeService extends BaseService implements McpModule {
     return this.runtimeStates.get(state.serverId) === state && state.generation === generation;
   }
 
+  private allocateGeneration(): number {
+    const generation = this.nextGeneration;
+    this.nextGeneration += 1;
+    return generation;
+  }
+
   private async invokeTool(
     ref: Extract<RuntimeToolRef, { source: 'mcp' }>,
     input: RuntimeJsonValue,
     signal: AbortSignal,
+    discoveredEndpointUrl: string,
+    discoveredGeneration: number,
   ): Promise<unknown> {
     if (input === null || Array.isArray(input) || typeof input !== 'object') {
       throw new McpRuntimeToolError(
@@ -451,11 +468,17 @@ export class McpRuntimeService extends BaseService implements McpModule {
     ) {
       throw unavailableToolError();
     }
+    // An endpoint edit retargets the server row, but never a frozen catalog:
+    // the tool the user saw and approved fails unavailable instead.
+    if (server.endpointUrl !== discoveredEndpointUrl) {
+      throw unavailableToolError();
+    }
 
     const state = this.runtimeStates.get(server.id);
     if (
       !state ||
       state.endpointUrl !== server.endpointUrl ||
+      state.generation !== discoveredGeneration ||
       !state.discoveredToolNames.has(ref.rawToolName)
     ) {
       throw unavailableToolError();

--- a/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/backend/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -285,6 +285,8 @@ describe('Runtime tool adapter', () => {
       {
         description: 'Search issues',
         displayName: 'Issue Search',
+        endpointUrl: server.endpointUrl,
+        generation: expect.any(Number),
         inputSchema: {
           properties: { query: { minLength: 1, type: 'string' } },
           required: ['query'],
@@ -330,7 +332,11 @@ describe('Runtime tool adapter', () => {
     const controller = new AbortController();
 
     await expect(
-      tool!.execute({ query: 'cherry' }, { signal: controller.signal, toolCallId: 'call-1' }),
+      tool!.execute({
+        input: { query: 'cherry' },
+        signal: controller.signal,
+        toolCallId: 'call-1',
+      }),
     ).resolves.toEqual({
       artifacts: [],
       value: {
@@ -348,6 +354,7 @@ describe('Runtime tool adapter', () => {
   it.each([
     { disabledTools: ['search'] },
     { isEnabled: false },
+    { endpointUrl: 'https://b.example/mcp' },
     { endpointUrl: 'ftp://private.example/mcp' },
   ])('refuses execution after the server policy changes', async (serverPatch) => {
     const client = makeClient(makeRawTools(['search']));
@@ -359,12 +366,35 @@ describe('Runtime tool adapter', () => {
     Object.assign(server, serverPatch);
 
     await expect(
-      tool!.execute(
-        { query: 'cherry' },
-        { signal: new AbortController().signal, toolCallId: 'call-1' },
-      ),
+      tool!.execute({
+        input: { query: 'cherry' },
+        signal: new AbortController().signal,
+        toolCallId: 'call-1',
+      }),
     ).rejects.toMatchObject({ code: 'mcp_tool_unavailable' });
     expect(client.callTool).not.toHaveBeenCalled();
+  });
+
+  it('does not revive a frozen tool after the same endpoint is rediscovered', async () => {
+    const firstClient = makeClient(makeRawTools(['search']));
+    const secondClient = makeClient(makeRawTools(['search']));
+    mockCreateMCPClient.mockResolvedValueOnce(firstClient).mockResolvedValue(secondClient);
+    const server = makeServer();
+    const { service } = makeService([server]);
+    const [descriptor] = await service.listExecutableToolDescriptors(server.id);
+    const [frozenTool] = service.createRuntimeTools([{ approval: 'ask', descriptor: descriptor! }]);
+
+    service.invalidateServer(server.id);
+    await service.listExecutableToolDescriptors(server.id);
+
+    await expect(
+      frozenTool!.execute({
+        input: { query: 'cherry' },
+        signal: new AbortController().signal,
+        toolCallId: 'call-1',
+      }),
+    ).rejects.toMatchObject({ code: 'mcp_tool_unavailable' });
+    expect(secondClient.callTool).not.toHaveBeenCalled();
   });
 });
 

--- a/src/backend/ai/mcp/__tests__/mcpRuntimeAdapter.test.ts
+++ b/src/backend/ai/mcp/__tests__/mcpRuntimeAdapter.test.ts
@@ -20,6 +20,8 @@ function descriptor(overrides: Partial<McpExecutableToolDescriptor> = {}) {
   return {
     description: 'Search the remote service',
     displayName: 'Search',
+    endpointUrl: 'https://mcp.example/mcp',
+    generation: 7,
     inputSchema: VALID_INPUT_SCHEMA,
     rawToolName: 'search',
     serverId: '00000000-0000-4000-8000-000000000001',
@@ -92,9 +94,32 @@ describe('MCP Runtime adapter', () => {
 
     const tool = createTool(capability);
     await expect(
-      tool.execute({ query: 42 }, { signal: new AbortController().signal, toolCallId: 'call-1' }),
+      tool.execute({
+        input: { query: 42 },
+        signal: new AbortController().signal,
+        toolCallId: 'call-1',
+      }),
     ).rejects.toMatchObject({ code: 'mcp_tool_input_invalid', retryable: false });
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('carries the frozen endpoint generation into invocation', async () => {
+    const invoke = jest.fn(async () => null);
+    const tool = createTool({ invoke });
+
+    await tool.execute({
+      input: { query: 'cherry' },
+      signal: new AbortController().signal,
+      toolCallId: 'call-1',
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({ rawToolName: 'search', source: 'mcp' }),
+      { query: 'cherry' },
+      expect.any(AbortSignal),
+      'https://mcp.example/mcp',
+      7,
+    );
   });
 
   it('propagates cancellation and discards a late result', async () => {
@@ -117,10 +142,11 @@ describe('MCP Runtime adapter', () => {
     const tool = createTool(capability);
     const controller = new AbortController();
 
-    const execution = tool.execute(
-      { query: 'cherry' },
-      { signal: controller.signal, toolCallId: 'call-1' },
-    );
+    const execution = tool.execute({
+      input: { query: 'cherry' },
+      signal: controller.signal,
+      toolCallId: 'call-1',
+    });
     controller.abort();
 
     await expect(execution).rejects.toMatchObject({ code: 'mcp_tool_cancelled' });
@@ -135,10 +161,11 @@ describe('MCP Runtime adapter', () => {
       const capability = {
         invoke: jest.fn(() => new Promise(() => undefined)),
       } satisfies McpToolInvocationCapability;
-      const execution = createTool(capability).execute(
-        { query: 'cherry' },
-        { signal: new AbortController().signal, toolCallId: 'call-1' },
-      );
+      const execution = createTool(capability).execute({
+        input: { query: 'cherry' },
+        signal: new AbortController().signal,
+        toolCallId: 'call-1',
+      });
 
       jest.advanceTimersByTime(MCP_TOOL_CALL_TIMEOUT_MS);
       await expect(execution).rejects.toMatchObject({
@@ -161,7 +188,11 @@ describe('MCP Runtime adapter', () => {
     };
 
     const error = await createTool(capability)
-      .execute({ query: 'cherry' }, { signal: new AbortController().signal, toolCallId: 'call-1' })
+      .execute({
+        input: { query: 'cherry' },
+        signal: new AbortController().signal,
+        toolCallId: 'call-1',
+      })
       .catch((failure: unknown) => failure);
 
     expect(error).toMatchObject({
@@ -192,10 +223,11 @@ describe('MCP Runtime adapter', () => {
       const tool = createTool({ invoke: jest.fn(async () => remotePayload) });
 
       await expect(
-        tool.execute(
-          { query: 'cherry' },
-          { signal: new AbortController().signal, toolCallId: 'call-1' },
-        ),
+        tool.execute({
+          input: { query: 'cherry' },
+          signal: new AbortController().signal,
+          toolCallId: 'call-1',
+        }),
       ).resolves.toEqual({ artifacts: [], value: remotePayload });
     },
   );
@@ -206,10 +238,11 @@ describe('MCP Runtime adapter', () => {
       invoke: jest.fn(async () => ({ content: [{ data: binary, type: 'image' }] })),
     });
 
-    const output = await tool.execute(
-      { query: 'cherry' },
-      { signal: new AbortController().signal, toolCallId: 'call-1' },
-    );
+    const output = await tool.execute({
+      input: { query: 'cherry' },
+      signal: new AbortController().signal,
+      toolCallId: 'call-1',
+    });
     const serialized = JSON.stringify(output);
 
     expect(output).toMatchObject({

--- a/src/backend/ai/mcp/mcpRuntimeAdapter.ts
+++ b/src/backend/ai/mcp/mcpRuntimeAdapter.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeError,
   RuntimeJsonValue,
   RuntimeTool,
+  RuntimeToolCall,
   RuntimeToolRef,
 } from '@/backend/ai/agent';
 
@@ -23,6 +24,14 @@ export type McpExecutableToolDescriptor = {
   displayName: string;
   description: string;
   inputSchema: RuntimeJsonValue;
+  /**
+   * The endpoint this catalog was discovered against. Execution is pinned to
+   * it: editing the server row must fail the frozen tool as unavailable, never
+   * silently retarget the approved call to a new remote authority.
+   */
+  endpointUrl: string;
+  /** Monotonic identity of the live catalog that produced this descriptor. */
+  generation: number;
 };
 
 export type McpRuntimeToolSelection = {
@@ -35,6 +44,8 @@ export type McpToolInvocationCapability = {
     ref: Extract<RuntimeToolRef, { source: 'mcp' }>,
     input: RuntimeJsonValue,
     signal: AbortSignal,
+    discoveredEndpointUrl: string,
+    discoveredGeneration: number,
   ): Promise<unknown>;
 };
 
@@ -112,7 +123,13 @@ export function createMcpRuntimeTools(
   const invoke = capability.invoke.bind(capability);
 
   return selections.map(({ approval, descriptor }) => {
-    if (!descriptor.serverId || !descriptor.rawToolName) {
+    if (
+      !descriptor.serverId ||
+      !descriptor.rawToolName ||
+      !descriptor.endpointUrl ||
+      !Number.isSafeInteger(descriptor.generation) ||
+      descriptor.generation < 0
+    ) {
       throw new McpRuntimeToolError(
         'mcp_tool_unavailable',
         'The MCP tool catalog contains an invalid tool identity.',
@@ -145,13 +162,15 @@ export function createMcpRuntimeTools(
     providerNames.add(providerName);
 
     const { inputSchema, inputValidator } = compileMcpInputSchema(descriptor.inputSchema);
+    const endpointUrl = descriptor.endpointUrl;
+    const generation = descriptor.generation;
 
     return {
       approval,
       description: descriptor.description,
       displayName: descriptor.displayName,
-      execute: (input, context) =>
-        executeMcpRuntimeTool({ context, input, inputValidator, invoke, ref }),
+      execute: (call) =>
+        executeMcpRuntimeTool({ call, endpointUrl, generation, inputValidator, invoke, ref }),
       inputSchema,
       providerName,
       ref,
@@ -160,16 +179,18 @@ export function createMcpRuntimeTools(
 }
 
 async function executeMcpRuntimeTool(input: {
-  context: { signal: AbortSignal; toolCallId: string };
-  input: RuntimeJsonValue;
+  call: RuntimeToolCall;
+  endpointUrl: string;
+  generation: number;
   inputValidator: z.ZodType;
   invoke: McpToolInvocationCapability['invoke'];
   ref: Extract<RuntimeToolRef, { source: 'mcp' }>;
 }) {
-  if (input.context.signal.aborted) {
+  const { call } = input;
+  if (call.signal.aborted) {
     throw cancelledError();
   }
-  if (!input.inputValidator.safeParse(input.input).success) {
+  if (!input.inputValidator.safeParse(call.input).success) {
     throw new McpRuntimeToolError(
       'mcp_tool_input_invalid',
       'The MCP tool input did not match its JSON Schema.',
@@ -177,16 +198,16 @@ async function executeMcpRuntimeTool(input: {
     );
   }
 
-  const bound = createBoundedSignal(MCP_TOOL_CALL_TIMEOUT_MS, input.context.signal);
+  const bound = createBoundedSignal(MCP_TOOL_CALL_TIMEOUT_MS, call.signal);
   try {
     const remoteResult = await settleOrAbort(
-      input.invoke(input.ref, input.input, bound.signal),
+      input.invoke(input.ref, call.input, bound.signal, input.endpointUrl, input.generation),
       bound.signal,
     );
     if (bound.didTimeout()) {
       throw timeoutError();
     }
-    if (input.context.signal.aborted) {
+    if (call.signal.aborted) {
       throw cancelledError();
     }
 
@@ -195,7 +216,7 @@ async function executeMcpRuntimeTool(input: {
     if (bound.didTimeout()) {
       throw timeoutError();
     }
-    if (input.context.signal.aborted) {
+    if (call.signal.aborted) {
       throw cancelledError();
     }
     if (error instanceof McpRuntimeToolError) {

--- a/src/backend/core/application/__tests__/serviceRegistry.test.ts
+++ b/src/backend/core/application/__tests__/serviceRegistry.test.ts
@@ -2,6 +2,7 @@ import { serviceList, services } from '@/backend/core/application/serviceRegistr
 import {
   getAppStatePolicy,
   getDependencies,
+  getPhase,
   getServiceName,
   isInjectable,
 } from '@/backend/core/lifecycle/decorators';
@@ -95,12 +96,19 @@ describe('service registry', () => {
       container.buildDependencyGraph(Phase.PostReady),
     );
     const layerOf = (name: string) => layers.findIndex((layer) => layer.includes(name));
+    const hostDependencies = getDependencies(services.MobileAgentHost);
 
-    // Initialization is dependency-first; teardown reverses these layers.
+    expect(hostDependencies).toEqual(
+      expect.arrayContaining(['McpRuntimeService', 'WebSearchService']),
+    );
+
+    // MCP and the Host share PostReady, so their dependency layers carry the
+    // ordering. WebSearch is a Gate service: the phase boundary initializes it
+    // before every PostReady service, and global teardown reverses that order.
     expect(layerOf('McpRuntimeService')).toBeGreaterThanOrEqual(0);
     expect(layerOf('McpRuntimeService')).toBeLessThan(layerOf('MobileAgentHost'));
-    expect(layerOf('WebSearchService')).toBeGreaterThanOrEqual(0);
-    expect(layerOf('WebSearchService')).toBeLessThan(layerOf('MobileAgentHost'));
+    expect(getPhase(services.WebSearchService)).toBe(Phase.Gate);
+    expect(getPhase(services.MobileAgentHost)).toBe(Phase.PostReady);
   });
 
   test('declares the background policy of long-running and native-surface owners', () => {

--- a/src/backend/core/application/__tests__/serviceRegistry.test.ts
+++ b/src/backend/core/application/__tests__/serviceRegistry.test.ts
@@ -88,6 +88,21 @@ describe('service registry', () => {
     expect(layerOf('DbService')).toBeLessThan(layerOf('PreferenceService'));
   });
 
+  test('stops MobileAgentHost before retiring tool Runtime state', () => {
+    const container = new ServiceContainer();
+    container.registerAll(serviceList);
+    const layers = new DependencyResolver().resolveLayered(
+      container.buildDependencyGraph(Phase.PostReady),
+    );
+    const layerOf = (name: string) => layers.findIndex((layer) => layer.includes(name));
+
+    // Initialization is dependency-first; teardown reverses these layers.
+    expect(layerOf('McpRuntimeService')).toBeGreaterThanOrEqual(0);
+    expect(layerOf('McpRuntimeService')).toBeLessThan(layerOf('MobileAgentHost'));
+    expect(layerOf('WebSearchService')).toBeGreaterThanOrEqual(0);
+    expect(layerOf('WebSearchService')).toBeLessThan(layerOf('MobileAgentHost'));
+  });
+
   test('declares the background policy of long-running and native-surface owners', () => {
     expect(getAppStatePolicy(services.JobRuntime)).toBe('continue');
     expect(getAppStatePolicy(services.BackgroundReplyRuntime)).toBe('background-presentation');


### PR DESCRIPTION
### What this PR does

Before this PR:

- Agent turn cancellation could remain blocked on third-party Pi/provider work that ignored an abort.
- The Host did not own an explicit per-turn managed-file authorization ledger for tool reads and same-turn artifacts.
- Frozen MCP callbacks could be retargeted after a server endpoint change or Runtime invalidation.
- Tool Runtime services could begin teardown before the Agent Host had drained active turns.

After this PR:

- Runtime tool calls carry a single explicit context object with the input, tool call ID, and AbortSignal. Provider streaming, context planning, Pi prompting, and tool callbacks propagate cancellation directly, with a bounded consumer-side settle window.
- The Host creates a monotonic turn resource ledger, scopes image edits to conversation-visible managed files, and grants validated built-in artifacts before Pi can begin the next tool step.
- MCP descriptors pin the endpoint URL and live Runtime generation, so stale callbacks fail unavailable instead of silently targeting a different remote authority.
- Host stop/destroy responsibilities and lifecycle dependency ordering keep MCP and web tool owners alive until active turns have been cancelled and drained.
- Regression coverage documents stuck cancellation, duplicate approval IDs, artifact grants, lifecycle ordering, and stale MCP catalogs.

### Screenshots or videos

N/A — this is an internal Agent Runtime reliability and authorization change with no visible UI changes.

### Why we need it and why it was done in this way

The Agent loop crosses provider networking, application tools, managed files, approval state, and MCP connections. Cancellation and authorization therefore have to be explicit at every boundary; relying on a producer to eventually settle can pin teardown, while treating file existence as authority can expose entries outside the current conversation.

The following tradeoffs were made:

- Consumer-side cancellation releases Cherry's wait immediately, while terminal fencing discards late third-party settlement. The underlying producer still receives the same AbortSignal so cooperative cancellation remains the primary path.
- The resource ledger exposes only membership to read tools. A Host-owned catalog wrapper validates and grants artifacts rather than allowing tools to widen their own scope.
- MCP snapshots use a monotonic process-local generation. Reconfigured or reconnected tools fail closed and become available again only through a newly resolved turn catalog.
- The Pi settle grace is one second so it remains below the Host service teardown ceiling.

The following alternatives were considered:

- A new global invocation-token or forced-terminal subsystem was deferred because the existing Runtime terminal fence and Host lifecycle can enforce the required behavior with a smaller change.
- Granting access to the entire managed-file library was rejected because existence is not conversation authorization.
- URL-only MCP pinning was rejected because invalidation and rediscovery can retain the same URL.

Links to places where the discussion took place: N/A

### Breaking changes

The process-local `RuntimeTool.execute` signature now accepts one `RuntimeToolCall` object. All in-repository built-in and MCP adapters have been migrated. There is no public protocol or persisted-data migration.

### Special notes for your reviewer

Validation run:

- `pnpm format`
- `pnpm lint` (0 errors; existing repository warnings remain)
- `git diff --check`

Tests and typecheck were not run under the workspace's user-owned verification policy. Remote CI remains the complete-suite gate.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: N/A; this change has no visible UI effect
- [x] Code: The implementation keeps the existing Host/Runtime boundaries and uses narrow capabilities
- [x] Refactor: Changes are limited to the Agent Runtime hardening story
- [x] Upgrade: No persisted schema or upgrade flow changes are required
- [x] Documentation: Internal Agent Runtime and controlled-resource references were updated; no user guide change is required
- [x] Self-review: The staged diff and lifecycle/tool boundaries were reviewed before publication

### Release note

```release-note
NONE
```