### PR TITLE
fix(provider-routing): keep application instructions as system

### DIFF
--- a/docs/references/ai/provider-integration.md
+++ b/docs/references/ai/provider-integration.md
@@ -74,6 +74,12 @@ timeouts, retries, and caller-supplied tools. It owns no conversation persistenc
 lifecycle. AI SDK `ToolSet` is never the canonical Agent tool model: new Agent tool behavior
 resolves through the application-owned `RuntimeTool` contract and a Pi adapter.
 
+Mobile sends application instructions with the `system` role on OpenAI Chat Completions and OpenAI
+Responses endpoints. The Pi bridge disables its URL/model-based developer-role inference, and the
+native OpenAI AI SDK bridge sets `providerOptions.openai.systemMessageMode` to `system` after request
+overrides are merged. Generic OpenAI-compatible adapters already preserve system messages. This is
+a runtime-wide compatibility policy rather than a provider or model capability.
+
 ## Special Providers
 
 CherryAI:

--- a/packages/ai-runtime/src/runtime/aiSdk/params/__tests__/buildAgentPlugins.test.ts
+++ b/packages/ai-runtime/src/runtime/aiSdk/params/__tests__/buildAgentPlugins.test.ts
@@ -297,7 +297,6 @@ function createProvider(id: string): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: false,
       reportsActualCost: false,
       serviceTier: false,
       streamOptions: true,

--- a/packages/ai-runtime/src/utils/__tests__/anthropicHeaders.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/anthropicHeaders.test.ts
@@ -24,7 +24,6 @@ function createProvider(overrides: Partial<Provider> = {}): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       serviceTier: true,
       streamOptions: true,
       verbosity: false,

--- a/packages/ai-runtime/src/utils/__tests__/imageProviderOptions.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/imageProviderOptions.test.ts
@@ -7,7 +7,6 @@ function provider(id: string, presetProviderId?: string): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       serviceTier: true,
       streamOptions: true,
       verbosity: false,

--- a/packages/ai-runtime/src/utils/__tests__/modelParameters.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/modelParameters.test.ts
@@ -67,7 +67,6 @@ function createProvider(overrides: Partial<Provider> = {}): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       serviceTier: true,
       streamOptions: true,
       verbosity: false,

--- a/packages/ai-runtime/src/utils/__tests__/options.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/options.test.ts
@@ -120,7 +120,6 @@ function createProvider(id: string): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: false,
       reportsActualCost: false,
       serviceTier: false,
       streamOptions: true,

--- a/packages/ai-runtime/src/utils/__tests__/provider.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/provider.test.ts
@@ -50,7 +50,6 @@ function createProvider(overrides: Partial<Provider>): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       reportsActualCost: false,
       serviceTier: true,
       streamOptions: true,

--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -482,9 +482,6 @@
       "name": "PPIO"
     },
     {
-      "apiFeatures": {
-        "developerRole": false
-      },
       "defaultChatEndpoint": "openai-chat-completions",
       "description": "Qiniu - AI model provider",
       "endpointConfigs": {
@@ -1608,8 +1605,7 @@
     },
     {
       "apiFeatures": {
-        "arrayContent": false,
-        "developerRole": false
+        "arrayContent": false
       },
       "defaultChatEndpoint": "openai-chat-completions",
       "description": "Poe - AI model provider",
@@ -1905,5 +1901,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "94468af9e56a8bbe"
+  "version": "88bac0adf8300df6"
 }

--- a/packages/provider-registry/src/providers/poe.ts
+++ b/packages/provider-registry/src/providers/poe.ts
@@ -50,7 +50,6 @@ export default openaiCompatible({
   },
   apiFeatures: {
     arrayContent: false,
-    developerRole: false,
   },
   overrides: [
     {

--- a/packages/provider-registry/src/providers/qiniu.ts
+++ b/packages/provider-registry/src/providers/qiniu.ts
@@ -11,8 +11,5 @@ export default openaiCompatible({
     models: 'https://developer.qiniu.com/aitokenapi/12883/model-list',
     official: 'https://qiniu.com',
   },
-  apiFeatures: {
-    developerRole: false,
-  },
   modelsDevProvider: 'qiniu-ai',
 });

--- a/packages/provider-registry/src/schemas/provider.ts
+++ b/packages/provider-registry/src/schemas/provider.ts
@@ -27,8 +27,6 @@ export const ApiFeaturesSchema = z.object({
 
   // --- Provider-specific parameter flags ---
 
-  /** Whether the provider supports the 'developer' role (OpenAI-specific) */
-  developerRole: z.boolean().default(false),
   /** Whether the provider supports service tier selection (OpenAI/Groq-specific) */
   serviceTier: z.boolean().default(false),
   /** Whether the provider supports verbosity settings (OpenAI-specific) */

--- a/packages/universal/src/data/types/provider.ts
+++ b/packages/universal/src/data/types/provider.ts
@@ -82,7 +82,6 @@ export type AuthConfig =
 
 export type ApiFeatures = {
   arrayContent?: boolean;
-  developerRole?: boolean;
   serviceTier?: boolean;
   streamOptions?: boolean;
   verbosity?: boolean;
@@ -93,7 +92,6 @@ export type RuntimeApiFeatures = Required<ApiFeatures>;
 
 export const DEFAULT_API_FEATURES: RuntimeApiFeatures = {
   arrayContent: true,
-  developerRole: false,
   serviceTier: false,
   streamOptions: true,
   verbosity: false,

--- a/src/backend/ai/__tests__/AiService.test.ts
+++ b/src/backend/ai/__tests__/AiService.test.ts
@@ -205,7 +205,6 @@ function createProvider(overrides: Partial<Provider> = {}): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       reportsActualCost: false,
       serviceTier: true,
       streamOptions: true,

--- a/src/backend/ai/__tests__/_harness/services.ts
+++ b/src/backend/ai/__tests__/_harness/services.ts
@@ -55,7 +55,6 @@ function createProvider(overrides: Partial<Provider> = {}): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       reportsActualCost: false,
       serviceTier: true,
       streamOptions: true,

--- a/src/backend/ai/agentHost/__tests__/piModelResolver.test.ts
+++ b/src/backend/ai/agentHost/__tests__/piModelResolver.test.ts
@@ -107,6 +107,11 @@ describe('Pi model resolver', () => {
       provider: 'test-provider',
       reasoning: true,
     });
+    expect(resolution.model.compat).toEqual(
+      testCase.api === 'openai-completions' || testCase.api === 'openai-responses'
+        ? { supportsDeveloperRole: false }
+        : undefined,
+    );
     expect(resolution.streamFn).toBe(mockBoundStreamFn);
     expect(resolution.supportsTools).toBe(true);
     expect(resolution.defaultThinkingLevel).toBe('high');

--- a/src/backend/ai/agentHost/piModelResolver.ts
+++ b/src/backend/ai/agentHost/piModelResolver.ts
@@ -54,6 +54,9 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       const piModel: PiModel<SupportedPiApi> = {
         api: adapter.api,
         baseUrl: adapter.formatBaseUrl(configuredBaseUrl),
+        ...(adapter.api === 'openai-completions' || adapter.api === 'openai-responses'
+          ? { compat: { supportsDeveloperRole: false } }
+          : {}),
         contextWindow: preflight.contextWindow,
         cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
         headers,

--- a/src/backend/ai/provider/__tests__/config.test.ts
+++ b/src/backend/ai/provider/__tests__/config.test.ts
@@ -473,7 +473,6 @@ function createProvider(overrides: Partial<Provider>): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       serviceTier: true,
       streamOptions: true,
       verbosity: false,

--- a/src/backend/ai/provider/__tests__/listModels.test.ts
+++ b/src/backend/ai/provider/__tests__/listModels.test.ts
@@ -29,7 +29,6 @@ function createProvider(): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       reportsActualCost: false,
       serviceTier: true,
       streamOptions: true,

--- a/src/backend/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/backend/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -15,7 +15,6 @@ function createProvider(providerId: string): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       reportsActualCost: false,
       serviceTier: true,
       streamOptions: true,
@@ -77,6 +76,54 @@ async function buildReasoningOptions(input: {
 }
 
 describe('buildAgentParams assistant-less contract', () => {
+  it.each([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.OPENAI_RESPONSES])(
+    'uses system instructions for the native OpenAI adapter on %s',
+    async (endpointType) => {
+      const provider = createProvider('openai');
+      provider.defaultChatEndpoint = endpointType;
+      provider.endpointConfigs = {
+        ...provider.endpointConfigs,
+        [endpointType]: { adapterFamily: 'openai', baseUrl: 'https://api.openai.com' },
+      };
+      const model = {
+        ...resolveModel(provider, 'gpt-4o-mini'),
+        endpointTypes: [endpointType],
+      };
+
+      const result = await buildAgentParams({
+        request: { uniqueModelId: model.id },
+        services: createServices(),
+        provider,
+        model,
+      });
+
+      expect(result.options.providerOptions).toEqual({
+        openai: { systemMessageMode: 'system' },
+      });
+    },
+  );
+
+  it('does not allow a call override to restore the developer role', async () => {
+    const provider = createProvider('openai');
+    const model = resolveModel(provider, 'gpt-4o-mini');
+
+    const result = await buildAgentParams({
+      request: {
+        callOverrides: {
+          providerOptions: { openai: { systemMessageMode: 'developer' } },
+        },
+        uniqueModelId: model.id,
+      },
+      services: createServices(),
+      provider,
+      model,
+    });
+
+    expect(result.options.providerOptions).toEqual({
+      openai: { systemMessageMode: 'system' },
+    });
+  });
+
   it('serializes an explicit reasoning selection', async () => {
     await expect(
       buildReasoningOptions({

--- a/src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -24,6 +24,7 @@ import {
   ENDPOINT_TYPE,
   endpointImpliedCapability,
   MODEL_CAPABILITY,
+  type EndpointType,
 } from '@cherrystudio/provider-registry';
 import { type ToolCallRepairFunction, type ToolSet } from 'ai';
 import * as Crypto from 'expo-crypto';
@@ -152,11 +153,15 @@ export async function buildAgentParams({
     request.callOverrides,
     model,
   );
-  const effectiveProviderOptions = applyFastModeToProviderOptions(
-    provider,
-    model,
-    overridden.providerOptions,
-    request.fastMode === true,
+  const effectiveProviderOptions = enforceSystemInstructionRole(
+    applyFastModeToProviderOptions(
+      provider,
+      model,
+      overridden.providerOptions,
+      request.fastMode === true,
+    ),
+    endpointType,
+    providerOptionsKey,
   );
 
   return {
@@ -183,6 +188,28 @@ export async function buildAgentParams({
       ...(tools && {
         stopWhen: [createToolCallLimitStopCondition(20), stopOnTerminalToolFailure],
       }),
+    },
+  };
+}
+
+/** Native OpenAI adapters otherwise promote reasoning-model instructions to `developer`. */
+function enforceSystemInstructionRole(
+  providerOptions: ProviderOptions,
+  endpointType: EndpointType | undefined,
+  providerOptionsKey: string,
+): ProviderOptions {
+  const isOpenAIInstructionEndpoint =
+    endpointType === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS ||
+    endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES;
+  if (!isOpenAIInstructionEndpoint || providerOptionsKey !== 'openai') {
+    return providerOptions;
+  }
+
+  return {
+    ...providerOptions,
+    openai: {
+      ...providerOptions.openai,
+      systemMessageMode: 'system',
     },
   };
 }

--- a/src/backend/data/db/seeding/seeders/PresetProviderSeeder.ts
+++ b/src/backend/data/db/seeding/seeders/PresetProviderSeeder.ts
@@ -47,7 +47,6 @@ function toApiFeatures(provider: ProtoProviderConfig): ApiFeatures | null {
 
   return {
     arrayContent: provider.apiFeatures.arrayContent,
-    developerRole: provider.apiFeatures.developerRole,
     reportsActualCost: provider.apiFeatures.reportsActualCost,
     serviceTier: provider.apiFeatures.serviceTier,
     streamOptions: provider.apiFeatures.streamOptions,

--- a/src/backend/data/services/ProviderService.ts
+++ b/src/backend/data/services/ProviderService.ts
@@ -112,7 +112,7 @@ function mergeCatalogEndpointConfigs(
   return Object.keys(merged).length > 0 ? merged : null;
 }
 
-function mergeCatalogApiFeatures(
+function mergeApiFeatures(
   existing: InsertUserProviderRow['apiFeatures'],
   catalog: InsertUserProviderRow['apiFeatures'],
 ): InsertUserProviderRow['apiFeatures'] {
@@ -120,10 +120,19 @@ function mergeCatalogApiFeatures(
     return null;
   }
 
+  const merged = {
+    ...catalog,
+    ...existing,
+  };
   return {
-    ...(catalog ?? {}),
-    ...(existing ?? {}),
-  } as InsertUserProviderRow['apiFeatures'];
+    ...(merged.arrayContent !== undefined && { arrayContent: merged.arrayContent }),
+    ...(merged.reportsActualCost !== undefined && {
+      reportsActualCost: merged.reportsActualCost,
+    }),
+    ...(merged.serviceTier !== undefined && { serviceTier: merged.serviceTier }),
+    ...(merged.streamOptions !== undefined && { streamOptions: merged.streamOptions }),
+    ...(merged.verbosity !== undefined && { verbosity: merged.verbosity }),
+  };
 }
 
 function withInferredAdapterFamilies(
@@ -225,8 +234,7 @@ function rowToProvider(row: UserProviderRow): Provider {
   return {
     apiFeatures: {
       ...DEFAULT_FEATURES,
-      ...metadata.apiFeatures,
-      ...row.apiFeatures,
+      ...mergeApiFeatures(row.apiFeatures, metadata.apiFeatures),
     },
     apiKeys,
     authMethods: metadata.authMethods,
@@ -600,7 +608,7 @@ export class ProviderService {
         await tx
           .update(userProviderTable)
           .set({
-            apiFeatures: mergeCatalogApiFeatures(row.apiFeatures, input.apiFeatures ?? null),
+            apiFeatures: mergeApiFeatures(row.apiFeatures, input.apiFeatures ?? null),
             defaultChatEndpoint: row.defaultChatEndpoint ?? input.defaultChatEndpoint ?? null,
             endpointConfigs: mergeCatalogEndpointConfigs(
               row.endpointConfigs as EndpointConfigs | null,

--- a/src/backend/data/services/__tests__/ProviderService.test.ts
+++ b/src/backend/data/services/__tests__/ProviderService.test.ts
@@ -91,7 +91,6 @@ describe('ProviderService', () => {
     jest.mocked(providerRegistryService.getProviderDisplayMetadata).mockReturnValueOnce({
       apiFeatures: {
         arrayContent: true,
-        developerRole: false,
         reportsActualCost: true,
         serviceTier: false,
         streamOptions: true,
@@ -108,6 +107,28 @@ describe('ProviderService', () => {
     await expect(service.getByProviderId(row.providerId)).resolves.toMatchObject({
       apiFeatures: { reportsActualCost: true },
     });
+  });
+
+  test('drops removed API features from legacy provider rows', async () => {
+    const row = createProviderRow(
+      {},
+      {
+        apiFeatures: {
+          developerRole: true,
+          reportsActualCost: true,
+        } as unknown as UserProviderRow['apiFeatures'],
+      },
+    );
+    const service = await createReadService({
+      select: () => ({
+        from: () => ({ where: () => ({ limit: async () => [row] }) }),
+      }),
+    });
+
+    const provider = await service.getByProviderId(row.providerId);
+
+    expect(provider.apiFeatures.reportsActualCost).toBe(true);
+    expect('developerRole' in provider.apiFeatures).toBe(false);
   });
 
   test('only exposes deletion for custom providers and user-created preset clones', () => {

--- a/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelAdd.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelAdd.test.ts
@@ -223,7 +223,6 @@ function provider(input: { id: string; presetProviderId?: string }): Provider {
   return {
     apiFeatures: {
       arrayContent: true,
-      developerRole: true,
       serviceTier: true,
       streamOptions: true,
       verbosity: false,


### PR DESCRIPTION
## Summary

- Force Pi OpenAI Chat Completions and Responses models to keep application instructions on the system role.
- Force the native OpenAI AI SDK adapters to apply system message mode after request overrides.
- Remove the obsolete developerRole provider feature and filter it from legacy persisted provider data.

## Validation

- `pnpm format` (passed)
- `pnpm --filter @cherrystudio/provider-registry generate` (passed)
- `pnpm lint` (Oxlint completed with existing warnings; Expo ESLint could not resolve the unbuilt `@cherrystudio/ai-core` workspace package)
- Tests, typecheck, and build were not run under the repository's local verification policy.