### PR TITLE
feat(inline-search): search Agent, model service, and MCP lists in place

### DIFF
--- a/docs/references/navigation-and-insets.md
+++ b/docs/references/navigation-and-insets.md
@@ -104,13 +104,28 @@ Agent editing, painting input, provider connectivity checks, and model settings 
 place. Focusing search expands the sheet from `large` to `full`; a non-empty query keeps it expanded
 after the keyboard is dismissed, and clearing an unfocused search restores `large`.
 
-Model-service search, Agent search, and provider model search use the root `/search` route. It is one
-fixed view: callers adapt data, matching, optional filters, and result content rather than supplying
-business-specific search screens. Native back or an interactive pop cancels without calling business
-logic; selection resolves only after the route's exit transition completes. The route title is always
-Search, and it does not query or render a full result set until the user enters non-whitespace text.
-Provider model pull keeps persistent local search because its matching rows retain management or
-multi-selection actions.
+The app has two search shapes, and which one a screen takes follows from where the answer lives.
+
+A screen that already holds everything it can match keeps its search in place, through
+`components/inlineSearch`. The field sits between the screen's `RouteHeader` and its content: iOS
+mounts `Stack.SearchBar` with `placement="stacked"`, giving it a row under the title, while Android
+draws CherryUI's `SearchField` in that same spot. Android's own header search bar exists but arrives
+as a toolbar menu item, pinned right of the screen's actions and styled by the platform rather than
+by CherryUI, so it is deliberately not used. Agent list, model-service list, and MCP server list are
+all this shape.
+
+Search that has to leave the screen to find its answer — because results are paginated server-side,
+carry filters, or are not the rows the screen already draws — uses the root `/search` route. It is
+one fixed view: callers adapt data, matching, optional filters, and result content rather than
+supplying business-specific search screens. Native back or an interactive pop cancels without
+calling business logic; selection resolves only after the route's exit transition completes. The
+route title is always Search, and it does not query or render a full result set until the user
+enters non-whitespace text. Session search and provider model search are this shape.
+
+The two share their matching rules through `frontend/utils/search`, which is keyword-based: a query
+splits on whitespace and every keyword has to appear across an item's searchable fields. They share
+nothing else. Provider model pull keeps its own local search because its matching rows retain
+management and multi-selection actions that neither shape models.
 
 Route-level sheets remain appropriate for page-like flows that need navigation history, deep linking, or system-back dismissal semantics. Settings is the one route shaped that way (`/settings`), because it is a whole nested stack rather than a single picker.
 

--- a/packages/app-icons/src/icons/clock.tsx
+++ b/packages/app-icons/src/icons/clock.tsx
@@ -1,0 +1,5 @@
+import Icon from 'lucide-react-native/icons/clock';
+
+import { createIcon } from '../create-icon';
+
+export default createIcon(Icon, 'ClockIcon');

--- a/src/frontend/components/appSearch/README.md
+++ b/src/frontend/components/appSearch/README.md
@@ -1,7 +1,14 @@
 # App Search
 
-This app-shell module owns the single transient route used by currently connected product search
-entries.
+This app-shell module owns the single transient search route.
+
+## When To Use It
+
+Take this route when a screen cannot answer the query itself: results are paginated server-side,
+carry filters, or are not the rows the screen already draws. A screen that already holds everything
+it can match keeps its search in place with [Inline Search](../inlineSearch/README.md) instead.
+
+The two share their matching rules through `@/frontend/utils/search` and nothing else.
 
 ## Contract
 
@@ -30,5 +37,6 @@ items are never serialized into navigation state. Only one app-search session ca
 App Search is the application's one transient single-selection search view. Extend a business
 request through its search function, filter control, grouping, and result renderer. Do not add
 business-specific route variants or arbitrary full-page render slots. A workflow that needs a
-different interaction contract, such as persistent or multi-selection search, owns a separate
-feature instead of becoming another App Search mode.
+different interaction contract owns a separate feature instead of becoming another App Search mode —
+persistent in-place search is [Inline Search](../inlineSearch/README.md), and multi-selection search
+belongs to whichever feature needs it.

--- a/src/frontend/components/inlineSearch/InlineSearch.android.tsx
+++ b/src/frontend/components/inlineSearch/InlineSearch.android.tsx
@@ -1,0 +1,34 @@
+import { SearchField } from '@cherrystudio/ui/components';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
+
+import type { InlineSearchProps } from './InlineSearch.types';
+
+/**
+ * Draws the list search contract as a row between the header and the list.
+ *
+ * `Stack.SearchBar` works on Android too, but it arrives as an `androidx`
+ * `SearchView` mounted as a toolbar menu item: collapsed to an icon pinned
+ * right of the screen's own actions, expanding to cover the whole toolbar, and
+ * styled by the platform theme rather than by CherryUI. Drawing the field here
+ * instead puts it where iOS puts its `stacked` bar and keeps it looking like
+ * the rest of the app.
+ */
+export function InlineSearch({ onChangeText, value }: InlineSearchProps) {
+  const { t } = useTranslation();
+  const clear = useCallback(() => onChangeText(''), [onChangeText]);
+
+  return (
+    <View className="px-4 pb-2">
+      <SearchField
+        accessibilityLabel={t('navigation.search')}
+        clearAccessibilityLabel={t('common.clear')}
+        onChangeText={onChangeText}
+        onClear={clear}
+        placeholder={t('navigation.search')}
+        value={value}
+      />
+    </View>
+  );
+}

--- a/src/frontend/components/inlineSearch/InlineSearch.ios.tsx
+++ b/src/frontend/components/inlineSearch/InlineSearch.ios.tsx
@@ -1,0 +1,32 @@
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+
+import type { InlineSearchProps } from './InlineSearch.types';
+
+/**
+ * Mounts the list search contract as the native header search bar.
+ *
+ * `stacked` gives the field its own row under the title. The `integrated`
+ * placement was the other candidate, but UIKit pins that one to the very end of
+ * the navigation bar — outside the toolbar's own actions, so the field lands to
+ * the right of a screen's overflow button and draws bare instead of picking up
+ * the glass circle every other top action wears. A row of its own sidesteps the
+ * ordering entirely, and it is the placement Android's field is drawn to match.
+ */
+export function InlineSearch({ onChangeText, value: _value }: InlineSearchProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Stack.SearchBar
+      autoCapitalize="none"
+      // The field is the screen's only search affordance, so it stays put
+      // rather than scrolling away with the list.
+      hideWhenScrolling={false}
+      obscureBackground={false}
+      onCancelButtonPress={() => onChangeText('')}
+      onChangeText={(event) => onChangeText(event.nativeEvent.text)}
+      placeholder={t('navigation.search')}
+      placement="stacked"
+    />
+  );
+}

--- a/src/frontend/components/inlineSearch/InlineSearch.tsx
+++ b/src/frontend/components/inlineSearch/InlineSearch.tsx
@@ -1,0 +1,2 @@
+export { InlineSearch } from './InlineSearch.android';
+export type { InlineSearchProps } from './InlineSearch.types';

--- a/src/frontend/components/inlineSearch/InlineSearch.types.ts
+++ b/src/frontend/components/inlineSearch/InlineSearch.types.ts
@@ -1,0 +1,12 @@
+export type InlineSearchProps = {
+  /**
+   * Called with the current query on every edit, including clears.
+   *
+   * The caller owns the query. Android binds `value` straight back into the
+   * field, while iOS hands the text to UIKit and only reports it back, so a
+   * caller that resets `value` on iOS must unmount this component to make the
+   * native field agree.
+   */
+  onChangeText: (value: string) => void;
+  value: string;
+};

--- a/src/frontend/components/inlineSearch/README.md
+++ b/src/frontend/components/inlineSearch/README.md
@@ -1,0 +1,44 @@
+# Inline Search
+
+This module owns the search field a screen keeps in place above its own content, the query behind
+it, and the one place that decides how each platform draws it.
+
+## Public Interface
+
+- `InlineSearch`, `InlineSearchProps`, `useInlineSearch`, `InlineSearchOptions`, and
+  `InlineSearchState` are exported from `index.ts`.
+- Callers should import from `@/frontend/components/inlineSearch`.
+
+## Contract
+
+- The field and the query are separable. `useInlineSearch` owns the query and the filtering;
+  `InlineSearch` draws the input. A screen that filters server-side takes the component alone, and a
+  screen whose field lives somewhere unusual takes the hook alone.
+- The component is placed between the screen's `RouteHeader` and its content. iOS renders nothing
+  there — the field lives in the native header — while Android draws a real row, so both platforms
+  read the same at the call site.
+- A screen that hides search for a mode, such as multi-select editing, unmounts the component. There
+  is no `hidden` prop: unmounting is what removes the native header options on iOS, and it is what
+  makes iOS drop the text UIKit is holding.
+- Matching is keyword-based, not substring-based, through `@/frontend/utils/search`. `gpt 4o` finds
+  `GPT-4o`, and a query may span an item's fields.
+- `isFiltering` separates "nothing matched" from "nothing exists yet". Screens need both empty
+  states and they do not say the same thing.
+
+## Organization
+
+- `InlineSearch.ios.tsx` mounts `Stack.SearchBar` with `placement="stacked"`, giving the field its
+  own row under the title.
+- `InlineSearch.android.tsx` draws CherryUI's `SearchField` in that same position. Android's native
+  search bar exists, but it is a toolbar menu item with platform styling that lands right of the
+  screen's own actions; drawing the field keeps both platforms aligned.
+- `InlineSearch.types.ts` holds the shared props, including why `value` binds on Android and only
+  seeds the initial mount on iOS.
+- `useInlineSearch.ts` holds the query state and the filtering, and nothing about placement.
+
+## Extension Boundary
+
+This is the persistent, in-place search for one screen's own content. Transient single-selection
+search that opens its own view belongs to [App Search](../appSearch/README.md). The two share their
+matching rules through `@/frontend/utils/search` and nothing else — App Search requests may query a
+server or apply filters, which this module deliberately does not model.

--- a/src/frontend/components/inlineSearch/index.ts
+++ b/src/frontend/components/inlineSearch/index.ts
@@ -1,0 +1,7 @@
+export { InlineSearch } from './InlineSearch';
+export type { InlineSearchProps } from './InlineSearch.types';
+export {
+  type InlineSearchOptions,
+  type InlineSearchState,
+  useInlineSearch,
+} from './useInlineSearch';

--- a/src/frontend/components/inlineSearch/useInlineSearch.ts
+++ b/src/frontend/components/inlineSearch/useInlineSearch.ts
@@ -1,0 +1,50 @@
+import { useMemo, useState } from 'react';
+
+import { matchesSearchKeywords, toSearchKeywords } from '@/frontend/utils/search';
+
+export type InlineSearchOptions<T> = {
+  /**
+   * The fields one item's query is compared against.
+   *
+   * They are joined into a single haystack, so a query may span them. React
+   * Compiler memoizes an inline arrow here; callers do not need `useCallback`.
+   */
+  fields: (item: T) => readonly (string | null | undefined)[];
+  items: readonly T[];
+};
+
+export type InlineSearchState<T> = {
+  /**
+   * True once the query holds something other than whitespace.
+   *
+   * Screens use this to tell "no rows because nothing matched" apart from "no
+   * rows because there is nothing yet", which need different empty states.
+   */
+  isFiltering: boolean;
+  query: string;
+  results: readonly T[];
+  setQuery: (value: string) => void;
+};
+
+/**
+ * Owns the query and the filtering behind an inline search field.
+ *
+ * The screen keeps the field itself — `InlineSearch` draws it — because where
+ * it goes and when it unmounts are the screen's decisions, not this hook's.
+ */
+export function useInlineSearch<T>({
+  fields,
+  items,
+}: InlineSearchOptions<T>): InlineSearchState<T> {
+  const [query, setQuery] = useState('');
+  const keywords = useMemo(() => toSearchKeywords(query), [query]);
+  const results = useMemo(
+    () =>
+      keywords.length === 0
+        ? items
+        : items.filter((item) => matchesSearchKeywords(keywords, fields(item))),
+    [fields, items, keywords],
+  );
+
+  return { isFiltering: keywords.length > 0, query, results, setQuery };
+}

--- a/src/frontend/features/agents/AgentListScreen.tsx
+++ b/src/frontend/features/agents/AgentListScreen.tsx
@@ -1,7 +1,7 @@
 import BotIcon from '@cherrystudio/app-icons/icons/bot';
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
+import ClockIcon from '@cherrystudio/app-icons/icons/clock';
 import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
-import SearchIcon from '@cherrystudio/app-icons/icons/search';
 import { ContentState, type MenuItem, useAlert } from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
@@ -10,9 +10,9 @@ import { type AccessibilityActionEvent, ScrollView, Text, View } from 'react-nat
 import { Pressable as GesturePressable } from 'react-native-gesture-handler';
 import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 
-import { useAppSearch } from '@/frontend/components/appSearch';
 import { AgentAvatar } from '@/frontend/components/avatar';
 import { RouteHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
+import { InlineSearch, useInlineSearch } from '@/frontend/components/inlineSearch';
 import { ContextMenuLink, type ContextMenuLinkItem } from '@/frontend/components/navigation';
 import {
   areAllSelected,
@@ -26,7 +26,6 @@ import type { Agent } from '@/shared/data/types/agent';
 export default function AgentListScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { open: openAppSearch } = useAppSearch();
   const { agents, error, isLoading, refetch } = useAgentsApi();
   const { deleteAgent, deleteAgents } = useAgentMutations();
   const { alert } = useAlert();
@@ -45,14 +44,27 @@ export default function AgentListScreen() {
         : agents.filter((agent) => !pendingDeletionIds.has(agent.id)),
     [agents, pendingDeletionIds],
   );
+  const {
+    isFiltering,
+    query,
+    results: listedAgents,
+    setQuery,
+  } = useInlineSearch({
+    fields: (agent: Agent) => [agent.name, agent.modelName],
+    items: visibleAgents,
+  });
 
   const enterEditing = useCallback(() => {
     if (isBatchDeleting) {
       return;
     }
 
+    // Selection acts on the whole list, and the search field is hidden while
+    // editing, so an active query would silently narrow what "select all"
+    // covers with nothing on screen to explain why.
+    setQuery('');
     setIsEditing(true);
-  }, [isBatchDeleting]);
+  }, [isBatchDeleting, setQuery]);
   const exitEditing = useCallback(() => {
     setIsEditing(false);
     setSelectedIds(new Set());
@@ -82,37 +94,6 @@ export default function AgentListScreen() {
     },
     [router],
   );
-  const openAgentChat = useCallback(
-    (agentId: string) => {
-      router.push({ pathname: '/', params: { agentId } });
-    },
-    [router],
-  );
-  const openAgentSearch = useCallback(() => {
-    void openAppSearch<Agent>({
-      emptyText: t('agent.list.noResults'),
-      getAccessibilityLabel: (agent) => agent.name,
-      keyExtractor: (agent) => agent.id,
-      placeholder: t('navigation.search'),
-      renderItem: (agent) => <AgentSearchResult agent={agent} />,
-      search: ({ query }) => {
-        const normalizedQuery = query.trim().toLocaleLowerCase();
-        const items = normalizedQuery
-          ? visibleAgents.filter((agent) =>
-              [agent.name, agent.modelName].some((value) =>
-                value?.toLocaleLowerCase().includes(normalizedQuery),
-              ),
-            )
-          : visibleAgents;
-
-        return { groups: [{ items, key: 'agents' }] };
-      },
-    }).then((outcome) => {
-      if (outcome.type === 'selected') {
-        openAgentChat(outcome.item.id);
-      }
-    });
-  }, [openAgentChat, openAppSearch, t, visibleAgents]);
   const menuItems = useMemo<readonly MenuItem[]>(
     () => [
       {
@@ -121,27 +102,23 @@ export default function AgentListScreen() {
         onPress: openCreateAgent,
       },
       {
-        id: 'view-sessions',
-        label: t('agent.actions.viewSessions'),
-        onPress: openSessionList,
-      },
-      {
         disabled: visibleAgents.length === 0 || isBatchDeleting,
         id: 'select-agents',
         label: t('agent.selection.start'),
         onPress: enterEditing,
       },
     ],
-    [enterEditing, isBatchDeleting, openCreateAgent, openSessionList, t, visibleAgents.length],
+    [enterEditing, isBatchDeleting, openCreateAgent, t, visibleAgents.length],
   );
+  // Leading the overflow menu, so the two read as "history, then everything
+  // else" rather than burying the session list inside the menu.
   const rightActions = useMemo<HeaderToolbarAction[]>(
     () => [
       {
-        accessibilityLabel: t('navigation.search'),
-        disabled: visibleAgents.length === 0 || isBatchDeleting,
-        icon: SearchIcon,
-        key: 'search-agents',
-        onPress: openAgentSearch,
+        accessibilityLabel: t('agent.actions.viewSessions'),
+        icon: ClockIcon,
+        key: 'view-sessions',
+        onPress: openSessionList,
         type: 'icon',
       },
       {
@@ -152,7 +129,7 @@ export default function AgentListScreen() {
         type: 'menu',
       },
     ],
-    [isBatchDeleting, menuItems, openAgentSearch, t, visibleAgents.length],
+    [menuItems, openSessionList, t],
   );
   const doneActions = useMemo<HeaderToolbarAction[]>(
     () => [
@@ -222,6 +199,10 @@ export default function AgentListScreen() {
         rightActions={isEditing ? doneActions : rightActions}
         title={t('agent.list.title')}
       />
+      {/* Unmounting is what clears the field: iOS holds the text natively and
+          only reports it back, so leaving it mounted would keep a stale query
+          filtering rows that selection mode has no way to show. */}
+      {isEditing ? null : <InlineSearch onChangeText={setQuery} value={query} />}
       <ScrollView
         alwaysBounceVertical={false}
         className="flex-1"
@@ -229,9 +210,9 @@ export default function AgentListScreen() {
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
       >
-        {visibleAgents.length > 0 ? (
+        {listedAgents.length > 0 ? (
           <View>
-            {visibleAgents.map((agent) => (
+            {listedAgents.map((agent) => (
               <AgentListRow
                 key={agent.id}
                 agent={agent}
@@ -243,6 +224,8 @@ export default function AgentListScreen() {
               />
             ))}
           </View>
+        ) : isFiltering ? (
+          <ContentState.Empty className="px-8 py-16" title={t('agent.list.noResults')} />
         ) : isLoading ? (
           <ContentState.Loading className="px-8 py-16" title={t('agent.list.loading')} />
         ) : error ? (
@@ -283,24 +266,6 @@ export default function AgentListScreen() {
         />
       ) : null}
     </>
-  );
-}
-
-function AgentSearchResult({ agent }: { agent: Agent }) {
-  const { t } = useTranslation();
-
-  return (
-    <View className="min-h-12 flex-row items-center gap-3">
-      <AgentAvatar name={agent.name} uri={agent.avatarUri} />
-      <View className="min-w-0 flex-1 gap-0.5">
-        <Text className="font-semibold text-base text-foreground" numberOfLines={1}>
-          {agent.name}
-        </Text>
-        <Text className="text-foreground-tertiary text-xs" numberOfLines={1}>
-          {agent.modelName ?? t('agent.model.none')}
-        </Text>
-      </View>
-    </View>
   );
 }
 

--- a/src/frontend/features/sessions/README.md
+++ b/src/frontend/features/sessions/README.md
@@ -8,8 +8,10 @@ This module owns the Agent Session list surfaces backed by the `/agent-sessions`
   rename, delete, and multi-select batch deletion under the `agent-sessions` selection scope.
 - `SessionList` embeds the list with its own `SessionListProvider`.
 - Rows link to the Agent chat surface with a `sessionId` param.
-- There is no search: the session list API has no query filter yet; content search arrives with
-  the desktop-shaped search work.
+- Search opens the `/search` route rather than filtering the list in place. The list is a
+  cursor-paginated infinite query, so filtering what happens to be loaded would silently miss
+  sessions further down; the route queries `/search/entities` for titles and `/search/contents` for
+  message text, and a result press navigates to that session in chat.
 - Batch deletion issues per-id deletes (`useAgentSessionMutations`); the backend cancels and
   drains an active turn before removing a session.
 

--- a/src/frontend/features/settings/McpScreen/McpScreen.tsx
+++ b/src/frontend/features/settings/McpScreen/McpScreen.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 
 import type { HeaderToolbarAction } from '@/frontend/components/headers';
+import { InlineSearch, useInlineSearch } from '@/frontend/components/inlineSearch';
 import { useMcpServerRuntimeSummaries, useMcpServersApi } from '@/frontend/hooks/mcp/useMcpServers';
 import type { McpServerRuntimeSummary } from '@/shared/contracts';
 import type { McpServer } from '@/shared/data/types/mcpServer';
@@ -19,6 +20,16 @@ export function McpScreen() {
   const { error, isLoading, refetch, servers } = useMcpServersApi();
   const { summaries } = useMcpServerRuntimeSummaries(servers);
   const [pressedServerId, setPressedServerId] = useState<string>();
+  // The endpoint is searchable alongside the name: a server is often easier to
+  // recall by the host it points at than by whatever it was named on creation.
+  const {
+    query,
+    results: listedServers,
+    setQuery,
+  } = useInlineSearch({
+    fields: (server: McpServer) => [server.name, server.endpointUrl],
+    items: servers,
+  });
 
   const handleServerPressedChange = useCallback((id: string, isPressed: boolean) => {
     setPressedServerId((currentId) => (isPressed ? id : currentId === id ? undefined : currentId));
@@ -45,6 +56,7 @@ export function McpScreen() {
     <SettingsScrollPage
       contentClassName="flex-grow gap-6"
       headerProps={{ rightActions, title: t('settings.pages.mcp.title') }}
+      search={<InlineSearch onChangeText={setQuery} value={query} />}
     >
       {isLoading ? (
         <ContentState.Loading className="px-1 py-8" title={t('settings.mcp.list.loading')} />
@@ -69,10 +81,12 @@ export function McpScreen() {
           }}
           title={t('settings.mcp.empty')}
         />
+      ) : listedServers.length === 0 ? (
+        <ContentState.Empty className="px-6 py-8" title={t('settings.mcp.list.noResults')} />
       ) : (
         <View className="overflow-hidden rounded-2xl bg-grouped-surface">
-          {servers.map((server, index) => {
-            const previousServerId = servers[index - 1]?.id;
+          {listedServers.map((server, index) => {
+            const previousServerId = listedServers[index - 1]?.id;
             const summary = summaries[server.id];
             const status = getServerStatus(server, summary);
 

--- a/src/frontend/features/settings/ProviderListScreen.tsx
+++ b/src/frontend/features/settings/ProviderListScreen.tsx
@@ -1,5 +1,4 @@
 import PlusIcon from '@cherrystudio/app-icons/icons/plus';
-import SearchIcon from '@cherrystudio/app-icons/icons/search';
 import { Section } from '@cherrystudio/ui/components';
 import { SectionList } from '@legendapp/list/section-list';
 import { useFocusEffect, useRouter } from 'expo-router';
@@ -7,8 +6,8 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet, Text, View } from 'react-native';
 
-import { useAppSearch } from '@/frontend/components/appSearch';
 import { RouteHeader, type HeaderToolbarAction } from '@/frontend/components/headers';
+import { InlineSearch, useInlineSearch } from '@/frontend/components/inlineSearch';
 import { useQuery } from '@/frontend/data';
 import { hiddenProviderListIds } from '@/frontend/utils/constants';
 import type { Provider } from '@/shared/data/types/provider';
@@ -37,7 +36,6 @@ const renderProviderSectionHeader = ({ section }: { section: ProviderListSection
 export default function ProviderSettingsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { open: openAppSearch } = useAppSearch();
   const isNavigatingRef = useRef(false);
   const hasFocusedOnceRef = useRef(false);
 
@@ -90,9 +88,17 @@ export default function ProviderSettingsScreen() {
       })),
     [openProvider, providers],
   );
+  const {
+    query,
+    results: listedProviderItems,
+    setQuery,
+  } = useInlineSearch({
+    fields: (item: ProviderListRow) => [item.name],
+    items: providerItems,
+  });
   const providerSections = useMemo<ProviderListSection[]>(() => {
-    const enabledProviders = providerItems.filter(({ isEnabled }) => isEnabled);
-    const disabledProviders = providerItems.filter(({ isEnabled }) => !isEnabled);
+    const enabledProviders = listedProviderItems.filter(({ isEnabled }) => isEnabled);
+    const disabledProviders = listedProviderItems.filter(({ isEnabled }) => !isEnabled);
 
     return [
       {
@@ -108,8 +114,8 @@ export default function ProviderSettingsScreen() {
         }),
       },
     ].filter(({ data }) => data.length > 0);
-  }, [providerItems, t]);
-  const measuredItemCount = providerItems.length + providerSections.length;
+  }, [listedProviderItems, t]);
+  const measuredItemCount = listedProviderItems.length + providerSections.length;
   const [measuredList, setMeasuredList] = useState<{ height: number; itemCount: number }>();
   const handleContentSizeChange = useCallback(
     (_width: number, height: number) => setMeasuredList({ height, itemCount: measuredItemCount }),
@@ -118,44 +124,13 @@ export default function ProviderSettingsScreen() {
   const cardHeight =
     measuredList?.itemCount === measuredItemCount
       ? measuredList.height
-      : providerItems.length * PROVIDER_ROW_ESTIMATED_HEIGHT +
+      : listedProviderItems.length * PROVIDER_ROW_ESTIMATED_HEIGHT +
         providerSections.length * PROVIDER_SECTION_HEADER_ESTIMATED_HEIGHT;
-  const openProviderSearch = useCallback(() => {
-    void openAppSearch<Provider>({
-      emptyText: t('settings.provider.search.empty'),
-      getAccessibilityLabel: (provider) => provider.name,
-      keyExtractor: (provider) => provider.id,
-      placeholder: t('navigation.search'),
-      renderItem: (provider) => <ProviderSearchResult provider={provider} />,
-      search: ({ query }) => {
-        const normalizedQuery = query.trim().toLocaleLowerCase();
-        const items = normalizedQuery
-          ? providers.filter((provider) =>
-              provider.name.toLocaleLowerCase().includes(normalizedQuery),
-            )
-          : providers;
-
-        return { groups: [{ items, key: 'providers' }] };
-      },
-    }).then((outcome) => {
-      if (outcome.type === 'selected') {
-        openProvider(outcome.item);
-      }
-    });
-  }, [openAppSearch, openProvider, providers, t]);
   const openCreateProvider = useCallback(() => {
     router.push('/settings/provider/new');
   }, [router]);
   const rightActions = useMemo<HeaderToolbarAction[]>(
     () => [
-      {
-        accessibilityLabel: t('navigation.search'),
-        disabled: providers.length === 0,
-        icon: SearchIcon,
-        key: 'search-providers',
-        onPress: openProviderSearch,
-        type: 'icon',
-      },
       {
         accessibilityLabel: t('settings.provider.add.title'),
         icon: PlusIcon,
@@ -164,14 +139,15 @@ export default function ProviderSettingsScreen() {
         type: 'icon',
       },
     ],
-    [openCreateProvider, openProviderSearch, providers.length, t],
+    [openCreateProvider, t],
   );
 
   return (
     <>
       <RouteHeader rightActions={rightActions} title={t('settings.pages.provider.title')} />
+      <InlineSearch onChangeText={setQuery} value={query} />
       <View className="flex-1 px-4 pb-5">
-        {providerItems.length > 0 ? (
+        {listedProviderItems.length > 0 ? (
           <View className="-mx-4 min-h-0 flex-1">
             <View style={{ height: cardHeight, maxHeight: '100%' }}>
               <SectionList
@@ -205,21 +181,6 @@ export default function ProviderSettingsScreen() {
         )}
       </View>
     </>
-  );
-}
-
-function ProviderSearchResult({ provider }: { provider: Provider }) {
-  return (
-    <View className="min-h-12 flex-row items-center gap-3">
-      <ProviderAvatar
-        presetProviderId={provider.presetProviderId}
-        providerId={provider.id}
-        providerName={provider.name}
-      />
-      <Text className="min-w-0 flex-1 text-base text-foreground" numberOfLines={1}>
-        {provider.name}
-      </Text>
-    </View>
   );
 }
 

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelSearch.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelSearch.ts
@@ -1,22 +1,14 @@
+import { matchesSearchKeywords, toSearchKeywords } from '@/frontend/utils/search';
 import type { Model } from '@/shared/data/types/model';
 
 export function filterModelsByKeywords(searchText: string, models: Model[]): Model[] {
-  const keywords = searchText
-    .toLocaleLowerCase()
-    .split(/\s+/)
-    .map((keyword) => keyword.trim())
-    .filter(Boolean);
+  const keywords = toSearchKeywords(searchText);
 
   if (keywords.length === 0) {
     return models;
   }
 
-  return models.filter((model) => {
-    const haystack = [model.id, model.name, model.group, model.description]
-      .filter(Boolean)
-      .join(' ')
-      .toLocaleLowerCase();
-
-    return keywords.every((keyword) => haystack.includes(keyword));
-  });
+  return models.filter((model) =>
+    matchesSearchKeywords(keywords, [model.id, model.name, model.group, model.description]),
+  );
 }

--- a/src/frontend/features/settings/components/SettingsScrollPage.tsx
+++ b/src/frontend/features/settings/components/SettingsScrollPage.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@cherrystudio/ui/utils';
-import type { PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 import { ScrollView, type ScrollViewProps } from 'react-native';
 
 import { RouteHeader, type RouteHeaderProps } from '@/frontend/components/headers';
@@ -11,6 +11,14 @@ type SettingsScrollPageProps = PropsWithChildren<
   > & {
     contentClassName?: string;
     headerProps: RouteHeaderProps;
+    /**
+     * An `InlineSearch` for pages that filter their own content.
+     *
+     * It sits outside the scroll view on purpose: iOS mounts it into the native
+     * header, and Android draws a row that has to stay put while the content
+     * below it scrolls.
+     */
+    search?: ReactNode;
   }
 >;
 
@@ -21,10 +29,12 @@ export function SettingsScrollPage({
   headerProps,
   keyboardDismissMode,
   keyboardShouldPersistTaps,
+  search,
 }: SettingsScrollPageProps) {
   return (
     <>
       <RouteHeader {...headerProps} />
+      {search}
       <ScrollView
         alwaysBounceVertical={false}
         className="flex-1"

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -339,6 +339,7 @@
   "settings.mcp.fields.name": "Name",
   "settings.mcp.list.loadFailed": "Failed to load MCP servers.",
   "settings.mcp.list.loading": "Loading MCP servers...",
+  "settings.mcp.list.noResults": "No matching MCP servers",
   "settings.mcp.list.status.connected": "Enabled",
   "settings.mcp.list.status.connecting": "Connecting",
   "settings.mcp.list.status.disabled": "Disabled",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -338,6 +338,7 @@
   "settings.mcp.fields.name": "名称",
   "settings.mcp.list.loadFailed": "加载 MCP 服务器失败。",
   "settings.mcp.list.loading": "正在加载 MCP 服务器……",
+  "settings.mcp.list.noResults": "没有匹配的 MCP 服务器",
   "settings.mcp.list.status.connected": "已开启",
   "settings.mcp.list.status.connecting": "连接中",
   "settings.mcp.list.status.disabled": "已停用",

--- a/src/frontend/utils/__tests__/search.test.ts
+++ b/src/frontend/utils/__tests__/search.test.ts
@@ -1,0 +1,38 @@
+import { matchesSearchKeywords, toSearchKeywords } from '../search';
+
+describe('toSearchKeywords', () => {
+  it('splits on whitespace and lowercases', () => {
+    expect(toSearchKeywords('GPT 4o')).toEqual(['gpt', '4o']);
+  });
+
+  it('drops padding and collapses runs of whitespace', () => {
+    expect(toSearchKeywords('  qwen   vision  ')).toEqual(['qwen', 'vision']);
+  });
+
+  it('returns nothing for a whitespace-only query', () => {
+    expect(toSearchKeywords('   ')).toEqual([]);
+  });
+});
+
+describe('matchesSearchKeywords', () => {
+  it('matches when every keyword appears', () => {
+    expect(matchesSearchKeywords(['gpt', '4o'], ['GPT-4o', 'OpenAI'])).toBe(true);
+  });
+
+  it('rejects when one keyword is missing', () => {
+    expect(matchesSearchKeywords(['gpt', 'sonnet'], ['GPT-4o', 'OpenAI'])).toBe(false);
+  });
+
+  it('lets one query span several fields', () => {
+    expect(matchesSearchKeywords(['qwen', 'vision'], ['Qwen', 'A vision model'])).toBe(true);
+  });
+
+  it('ignores absent fields rather than matching against them', () => {
+    expect(matchesSearchKeywords(['qwen'], ['Qwen', null, undefined])).toBe(true);
+    expect(matchesSearchKeywords(['null'], ['Qwen', null, undefined])).toBe(false);
+  });
+
+  it('treats an empty keyword list as no filter', () => {
+    expect(matchesSearchKeywords([], ['anything'])).toBe(true);
+  });
+});

--- a/src/frontend/utils/search.ts
+++ b/src/frontend/utils/search.ts
@@ -1,0 +1,34 @@
+/**
+ * Splits a raw query into the keywords a match has to contain.
+ *
+ * Whitespace separates keywords instead of belonging to one, so `gpt 4o` finds
+ * a model named `GPT-4o` the way a single substring never would, and the order
+ * the words were typed in stops mattering.
+ */
+export function toSearchKeywords(raw: string): string[] {
+  return raw
+    .toLocaleLowerCase()
+    .split(/\s+/)
+    .map((keyword) => keyword.trim())
+    .filter(Boolean);
+}
+
+/**
+ * True when every keyword appears somewhere across the given fields.
+ *
+ * The fields are joined into one haystack rather than tested individually, so a
+ * query can span them — `qwen vision` matches an item whose name carries one
+ * word and whose description carries the other. No keywords means no filter.
+ */
+export function matchesSearchKeywords(
+  keywords: readonly string[],
+  fields: readonly (string | null | undefined)[],
+): boolean {
+  if (keywords.length === 0) {
+    return true;
+  }
+
+  const haystack = fields.filter(Boolean).join(' ').toLocaleLowerCase();
+
+  return keywords.every((keyword) => haystack.includes(keyword));
+}


### PR DESCRIPTION
## What

Agent list, model service list, and MCP server list now search **in place** instead of pushing App Search's transient `/search` route. The field sits between the header and the content, and filters the rows already on screen.

App Search is not removed — it becomes one of two shapes, and this PR writes down which one a screen should take.

## Why two shapes

The judgement is **whether the answer is already in the screen's hands**.

| Screen | Shape | Because |
| --- | --- | --- |
| Agent list | inline | every Agent it can match is loaded |
| Model service list | inline | same |
| MCP server list | inline | same |
| Session list | route | cursor-paginated infinite query; filtering what happens to be loaded would silently miss sessions further down |
| Provider model search | route | carries a model-type filter |

Session search is deliberately left alone for this reason, and `features/sessions/README.md` is corrected — it claimed there was no search at all, which stopped being true when `/search/entities` and `/search/contents` landed.

## Platform split

iOS mounts `Stack.SearchBar` with `placement="stacked"`, giving the field its own row under the title.

`integrated` was the other candidate and was tried on device first: UIKit pins it past the end of the toolbar's own actions, so it lands to the *right* of a screen's overflow button and draws bare, without the glass circle every other top action wears. `stacked` sidesteps the ordering entirely.

Android's native search bar does exist (`isSearchBarAvailableForCurrentPlatform` covers both platforms), but it arrives as an `androidx` `SearchView` mounted as a toolbar menu item — collapsed to an icon pinned right of the screen's actions, expanding to cover the whole toolbar, styled by the platform theme rather than by CherryUI. Android therefore draws CherryUI's `SearchField` in the same spot iOS puts its row.

## Matching is now shared, and stronger

`frontend/utils/search` holds the rule both shapes use. It is keyword-based rather than substring-based — which is what provider model search already did and what the other call sites did not:

- `12 qw` matches an Agent named `123` running `Qwen` — one keyword per field
- `12 zz` matches nothing — every keyword has to land

`filterModelsByKeywords` now calls the shared pair instead of carrying its own copy.

## Also

The Agent list's session entry moves out of the overflow menu onto a clock action left of it. It was the one menu entry that navigated somewhere rather than acting on the list. The sidebar's own "view all" entry is untouched, so `/sessions` keeps two ways in.

## Verification

iOS, **cold start** each time (Fast Refresh hides header-layout bugs):

- Agent list — `zzz` → empty state; `qw` → matches by model name; `12 qw` / `12 zz` → the keyword cases above
- Model service list — `cloud` → 3 rows, and the section header follows to `未启用 (3)`, so counts describe what is on screen
- MCP list — field present, empty state intact
- Clock action → navigates to the session list

Gates on the final head: `typecheck` clean, `lint` 0 errors, `format:check` clean, `docs:check-links` clean, and 24 suites / 82 tests across `search`, `ProviderModelList`, and `app-icons`. 8 of those tests are new, covering the shared matcher.

## Not verified

**Android has not been run at all** — no Android device was available in this workspace. All three screens share one `InlineSearch.android.tsx`, so a single device pass covers the lot. Worth doing before this leaves draft.

## Note on the branch name

`paintings-route-in-drawer` predates this work and does not describe it. A PR's head branch cannot be changed after creation, so it stays; the commits and this description carry the actual story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
