### PR TITLE
refactor(provider-serving): unify provider connection and language planning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ They are the source of truth for how the repository works today.
 | --- | --- |
 | [Agent Architecture](./references/agent/README.md) | Implemented Agent Host foundation and Pi-first local execution target design |
 | [AI Provider Integration](./references/ai/provider-integration.md) | Pi Agent provider resolution and non-conversation AI SDK generation |
+| [Provider Serving Boundaries](./references/ai/provider-serving-boundaries.md) | Shared Provider connection facts and capability-specific language and image execution boundaries |
 | [Chat Streaming And Rendering](./references/chat/streaming-and-rendering.md) | Chat Runtime streaming, message windows, persistence, and rendering boundaries |
 | [Data Layer](./references/data/README.md) | Data API, preferences, caches, SQLite ownership, and service composition |
 | [File Model](./references/data/file-model.md) | Sandbox file ownership, immutability, references, lifecycle, and user-triggered deletion |

--- a/docs/references/ai/provider-integration.md
+++ b/docs/references/ai/provider-integration.md
@@ -5,6 +5,10 @@ Status: **as-built Agent and provider-service paths**.
 This reference defines the mobile AI provider/model request architecture. Terms follow
 [Domain Language](../domain-language.md).
 
+The target ownership and staged migration for shared Provider connection facts are defined in
+[Provider Serving Boundaries](./provider-serving-boundaries.md). This document continues to describe
+the currently implemented runtime paths until each migration phase lands.
+
 ## Runtime Paths
 
 Agent conversation requests use one path:
@@ -14,8 +18,9 @@ MobileAgentHost -> PiRuntime -> piModelResolver -> provider/model services
 ```
 
 Pi is the only local Agent Runtime. It receives a normalized Agent transcript and resolves the
-selected Agent model through the Host-owned provider adapter. Provider coverage beyond the current
-OpenAI Responses-compatible Pi adapter is separate follow-up work.
+selected Agent model through the Host-owned provider adapter. The current Pi binding supports
+API-key-authenticated Anthropic Messages, Google Generate Content, OpenAI Chat Completions, and
+OpenAI Responses endpoint families; other protocol or authentication families fail explicitly.
 
 When application tools land, the capability path is:
 
@@ -57,12 +62,19 @@ documented runtime compatibility reason to diverge.
 
 ## AI SDK Provider Resolution
 
+`resolveProviderConnection()` is the shared, credential-selection-free connection resolver used by
+Pi and AI SDK request construction. It resolves the effective endpoint, endpoint-scoped adapter
+family, normalized wire model id, gateway provider-options key, and mobile/Provider request
+headers. It does not select API keys or IAM/OAuth credentials. Because configured extra headers may
+contain sensitive values, the result remains in memory and must not be persisted or logged.
+
 `resolveProviderAiSdkConfig()` converts a Provider and Model into the configuration used by
 `AiService`. Endpoint selection priority is:
 
 1. `model.endpointTypes[0]`;
-2. `provider.defaultChatEndpoint`;
-3. OpenAI chat completions fallback.
+2. a registered per-model gateway route;
+3. `provider.defaultChatEndpoint`;
+4. no selected endpoint, after which base-URL lookup applies its documented compatibility fallback.
 
 The endpoint and adapter-family logic chooses variants such as OpenAI, OpenAI-compatible, Azure,
 Azure Responses, Azure Anthropic, Gemini, CherryIN, NewAPI, AiHubMix, or Gateway. Provider settings
@@ -79,7 +91,8 @@ resolves through the application-owned `RuntimeTool` contract and a Pi adapter.
 CherryAI:
 
 - resolves to `openai-compatible`;
-- signs `/chat/completions` requests with its provider-specific fetch wrapper;
+- signs `/chat/completions` requests through the shared `ProviderLanguageTransportPolicy` consumed
+  by Pi and AI SDK bindings;
 - adds `X-Client-ID`, `X-Timestamp`, and `X-Signature`.
 
 CherryIN uses the normal endpoint configuration and API-key path.
@@ -93,8 +106,10 @@ configuration and API-version settings influence the generated provider settings
 ## Transport
 
 - Pi Agent requests use the Expo-compatible fetch supplied by `piModelResolver`.
+- Pi and AI SDK request construction consume the same `ResolvedProviderConnection` facts before
+  applying their client-specific URL formatting and credential materialization.
 - Generic AI SDK provider configs rely on runtime/provider-package fetch behavior.
-- CherryAI adds its signing fetch wrapper.
+- CherryAI adds its shared signing transport policy over the selected client fetch.
 - Painting image-edit requests inject Expo fetch for local image inputs.
 
 ## Reopen When

--- a/docs/references/ai/provider-integration.md
+++ b/docs/references/ai/provider-integration.md
@@ -68,6 +68,11 @@ family, normalized wire model id, gateway provider-options key, and mobile/Provi
 headers. It does not select API keys or IAM/OAuth credentials. Because configured extra headers may
 contain sensitive values, the result remains in memory and must not be persisted or logged.
 
+For language models, `resolveLanguageServingPlan()` adds declared authentication facts, the shared
+language transport policy, and a typed Pi compatibility result. Pi requires that result before
+selecting a credential. AI SDK language configuration consumes the same plan but retains its own
+broader Provider and IAM projections. Image models bypass the language plan.
+
 `resolveProviderAiSdkConfig()` converts a Provider and Model into the configuration used by
 `AiService`. Endpoint selection priority is:
 

--- a/docs/references/ai/provider-serving-boundaries.md
+++ b/docs/references/ai/provider-serving-boundaries.md
@@ -1,0 +1,165 @@
+# Provider Serving Boundaries
+
+Status: **Phase 1 landed; Phase 3 started; Phase 2 remains design**.
+
+This reference defines how Cherry Mobile shares Provider connection facts without turning image,
+language, embedding, rerank, audio, or video execution into one universal adapter. It complements
+[AI Provider Integration](./provider-integration.md), which remains the current runtime inventory.
+
+## Decision
+
+Cherry Mobile uses one Provider control plane and capability-specific execution planes:
+
+```text
+Provider + Model records
+        |
+        v
+ResolvedProviderConnection
+        |
+        +-- Language serving
+        |     +-- Pi binding (conversation and tool loop)
+        |     `-- AI SDK binding (generateText and model checks)
+        |
+        `-- Image serving
+              `-- image parameters, edit input, transport, polling, and artifact handling
+```
+
+Image execution remains independent. It reuses Provider identity and connection facts, but it does
+not consume a language request abstraction. Future embedding, rerank, audio, and video capabilities
+follow the same rule: share connection facts, then own their request and result semantics.
+
+Pi remains the sole local conversation Runtime. The AI SDK remains a non-conversation capability
+adapter and must not become a second conversation or tool-loop owner.
+
+## Ownership
+
+### Provider and model records
+
+The persisted Provider and Model rows remain authoritative for:
+
+- Provider identity and preset lineage;
+- endpoint configurations and default endpoint;
+- model wire id and endpoint declarations;
+- authentication method declarations;
+- Provider extra headers and endpoint dialect;
+- model capability, modality, limits, and pricing facts.
+
+The Provider registry supplies catalog defaults. Runtime code must not create a second Provider-id
+catalog to repeat these facts.
+
+### `ResolvedProviderConnection`
+
+The shared, credential-selection-free connection description owns facts that every capability can
+derive in the same way:
+
+- effective endpoint type and raw base URL;
+- endpoint-scoped `adapterFamily`;
+- gateway provider-options key, when present;
+- normalized wire model id;
+- mobile application headers merged with Provider extra headers.
+
+It does not select API keys, OAuth tokens, or IAM credentials, and it does not own request
+parameters, retries, timeouts, or stream state. Provider-configured extra headers may themselves
+contain sensitive values, so the resolved object is ephemeral and must not be persisted or logged.
+Selected credentials are materialized in memory by the capability executor at its existing request
+or connection boundary so credential rotation and usage attribution keep one owner.
+
+### Language serving
+
+Language support is protocol-oriented, not Provider-id-oriented. Standard Providers should become
+usable by declaring a supported endpoint and adapter family in the registry; adding a Provider must
+not require another entry in a Pi-specific Provider table.
+
+The Pi binding owns only Pi mechanics:
+
+- endpoint/protocol family to Pi API-family mapping;
+- Pi-specific base URL formatting;
+- `PiModel` construction and `streamFn` loading;
+- Pi context, reasoning, tools, events, cancellation, and usage conversion.
+
+The AI SDK binding owns only AI SDK mechanics:
+
+- AI SDK Provider selection and settings construction;
+- SDK-specific auth materialization and request hooks;
+- provider-options namespaces and generation parameters;
+- AI SDK result, error, and usage behavior.
+
+Provider-specific auth, header, or JSON-body behavior that both bindings need should be promoted to
+a shared transport policy. Do not promote an SDK-specific workaround merely because it names a
+Provider.
+
+### Image serving
+
+Image generation keeps its existing independent pipeline:
+
+- creator/model metadata declares provider-neutral parameter support;
+- Provider-model overrides declare Provider delivery routing;
+- the image executor owns generate/edit inputs, canonical parameter splitting, vendor options,
+  submit/poll/cancel behavior, downloads, and managed artifacts.
+
+An image-only transport must not be added to the language binding. A language-only transport must
+not acquire image parameter or artifact responsibilities.
+
+## Compatibility Rules
+
+Provider onboarding should follow this matrix:
+
+| Provider behavior | Required implementation |
+| --- | --- |
+| Existing language protocol and ordinary API-key auth | Registry/provider data only |
+| Existing protocol with Provider-specific shared request shaping | One shared transport policy |
+| A genuinely new language wire protocol | A binding in each Runtime that can speak it; unsupported Runtimes fail explicitly |
+| A non-standard image API | One image transport; no language adapter change |
+
+Full execution unification is intentionally not a goal. Pi and AI SDK use different model objects,
+base-URL conventions, tool and reasoning representations, stream events, and error contracts.
+Those projections remain explicit and small.
+
+## Mobile And Desktop Relationship
+
+Cherry Desktop is a semantic reference for:
+
+- one authoritative owner per Provider fact;
+- the `provider.id` -> `endpointType` -> `adapterFamily` identity stack;
+- Runtime drivers owning native mechanics rather than Provider catalogs;
+- image metadata and delivery transport remaining capability-specific.
+
+Mobile does not copy Desktop's local HTTP API Gateway as the default Pi bridge. A loopback server
+adds lifecycle, authentication, protocol-conversion, and suspension costs that are materially
+different on iOS and Android. Any future in-process AI SDK bridge requires a separate design and
+must prove tool calls, reasoning, images, usage, cancellation, and error parity before adoption.
+
+## Migration
+
+### Phase 1: shared connection facts — landed
+
+`resolveProviderConnection()` now owns the effective endpoint, adapter family, normalized wire
+model id, and common request headers consumed by Pi and AI SDK request construction. Existing
+credential selection and capability executors remain unchanged.
+
+### Phase 2: language serving materialization
+
+1. Introduce one language serving result that classifies supported protocol and auth behavior.
+2. Move shared compatibility errors and credential receipts to that boundary.
+3. Keep Pi and AI SDK projections client-specific.
+
+### Phase 3: shared transport policies — started
+
+`ProviderLanguageTransportPolicy` is the shared backend boundary for Provider-specific language
+HTTP behavior. The first policy owns CherryAI request signing and is composed over the AI SDK fetch
+or Pi's Expo-compatible fetch. Provider matching includes preset lineage so a cloned Provider
+receives the same transport behavior. It is not applied to image execution, and SDK-only request
+hooks remain in the owning binding.
+
+Further policies should be added only after identifying Provider-specific header, credential, or
+payload transformations that multiple language bindings actually need.
+
+## Acceptance Criteria
+
+- A standard compatible Provider can be added without editing Pi Provider-id dispatch code.
+- Pi and AI SDK resolve the same endpoint, adapter family, wire model id, and Provider extra headers.
+- Credentials are selected once at the owning request or connection boundary and never persisted in
+  `ResolvedProviderConnection`.
+- Unsupported protocol or authentication combinations fail explicitly before network execution.
+- Adding a custom image transport does not require a language adapter change.
+- Pi remains the sole local conversation Runtime.

--- a/docs/references/ai/provider-serving-boundaries.md
+++ b/docs/references/ai/provider-serving-boundaries.md
@@ -1,6 +1,6 @@
 # Provider Serving Boundaries
 
-Status: **Phase 1 landed; Phase 3 started; Phase 2 remains design**.
+Status: **Phase 1 landed; Phases 2 and 3 started**.
 
 This reference defines how Cherry Mobile shares Provider connection facts without turning image,
 language, embedding, rerank, audio, or video execution into one universal adapter. It complements
@@ -70,6 +70,12 @@ Language support is protocol-oriented, not Provider-id-oriented. Standard Provid
 usable by declaring a supported endpoint and adapter family in the registry; adding a Provider must
 not require another entry in a Pi-specific Provider table.
 
+`resolveLanguageServingPlan()` is the shared language control-plane result. It contains the resolved
+connection, declared authentication facts, shared language transport policy, and a typed Pi
+compatibility result. AI SDK language configuration consumes the same plan but keeps its broader
+authentication and Provider projection inside the AI SDK binding. Image models bypass this plan and
+consume only `ResolvedProviderConnection`.
+
 The Pi binding owns only Pi mechanics:
 
 - endpoint/protocol family to Pi API-family mapping;
@@ -137,11 +143,17 @@ must prove tool calls, reasoning, images, usage, cancellation, and error parity 
 model id, and common request headers consumed by Pi and AI SDK request construction. Existing
 credential selection and capability executors remain unchanged.
 
-### Phase 2: language serving materialization
+### Phase 2: language serving materialization — started
 
-1. Introduce one language serving result that classifies supported protocol and auth behavior.
-2. Move shared compatibility errors and credential receipts to that boundary.
-3. Keep Pi and AI SDK projections client-specific.
+`LanguageServingPlan` now classifies declared auth behavior and returns a typed supported or
+unsupported Pi binding before credential selection or network execution. Pi compatibility failures
+carry stable codes while preserving the existing user-facing messages. Pi and non-image AI SDK
+configuration consume this plan; their native model/config projections remain client-specific.
+
+Credential selection and its non-secret receipt still belong to the binding that materializes the
+credential because AI SDK supports IAM paths that Pi cannot execute. A later slice may share an
+API-key credential materializer if it removes real duplication without selecting unnecessary keys
+for IAM Providers.
 
 ### Phase 3: shared transport policies — started
 

--- a/src/backend/ai/README.md
+++ b/src/backend/ai/README.md
@@ -14,8 +14,9 @@ owns the mobile platform and application-service boundaries around that package.
   (`@/shared/contracts/agent`) and the Runtime contract, plus the Agent definition source and the
   production Pi provider/model resolution adapter. Version 1 binds `local` directly to Pi without
   a Runtime registry or implementation router.
-- `provider/` injects Expo environment values and app headers, then builds provider configuration
-  from mobile data services.
+- `provider/` resolves credential-selection-free connection facts shared by Pi and AI SDK request
+  construction, owns shared Provider HTTP transport policies, injects Expo environment values and
+  app headers, then builds AI SDK provider configuration from mobile data services.
 - `runtime/aiSdk/` builds the AI SDK request parameters used by `AiService`; it is not a conversation
   runtime and owns no persisted turn state.
 - `mcp/` owns the mobile Streamable HTTP transport, connection lifecycle, server status, and tool

--- a/src/backend/ai/README.md
+++ b/src/backend/ai/README.md
@@ -15,8 +15,10 @@ owns the mobile platform and application-service boundaries around that package.
   production Pi provider/model resolution adapter. Version 1 binds `local` directly to Pi without
   a Runtime registry or implementation router.
 - `provider/` resolves credential-selection-free connection facts shared by Pi and AI SDK request
-  construction, owns shared Provider HTTP transport policies, injects Expo environment values and
-  app headers, then builds AI SDK provider configuration from mobile data services.
+  construction, materializes the shared language serving plan and typed compatibility result, owns
+  shared Provider HTTP transport policies, injects Expo environment values and app headers, then
+  builds AI SDK provider configuration from mobile data services. Image execution consumes shared
+  connection facts but bypasses the language plan.
 - `runtime/aiSdk/` builds the AI SDK request parameters used by `AiService`; it is not a conversation
   runtime and owns no persisted turn state.
 - `mcp/` owns the mobile Streamable HTTP transport, connection lifecycle, server status, and tool

--- a/src/backend/ai/agentHost/__tests__/piApiAdapters.test.ts
+++ b/src/backend/ai/agentHost/__tests__/piApiAdapters.test.ts
@@ -1,6 +1,8 @@
-import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
+import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
 import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type { Context, FetchFunction, Model as PiModel } from '@earendil-works/pi-ai';
+
+import type { PiLanguageEndpointType } from '@/backend/ai/provider/languageServingPlan';
 
 import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from '../piApiAdapters';
 
@@ -16,7 +18,7 @@ const context: Context = { messages: [] };
 const CASES: {
   api: SupportedPiApi;
   baseUrl: string;
-  endpointType: EndpointType;
+  endpointType: PiLanguageEndpointType;
   expectedBaseUrl: string;
   expectedFetch: FetchFunction | undefined;
   streamSimple: jest.Mock;
@@ -107,10 +109,5 @@ describe('Pi API adapters', () => {
         timeoutMs: 60_000,
       }),
     );
-  });
-
-  test('fails closed for endpoints outside the four supported protocols', () => {
-    expect(resolvePiApiAdapter(ENDPOINT_TYPE.OLLAMA_CHAT)).toBeUndefined();
-    expect(resolvePiApiAdapter(undefined)).toBeUndefined();
   });
 });

--- a/src/backend/ai/agentHost/__tests__/piModelResolver.test.ts
+++ b/src/backend/ai/agentHost/__tests__/piModelResolver.test.ts
@@ -3,6 +3,7 @@ import {
   MODEL_CAPABILITY,
   type EndpointType,
 } from '@cherrystudio/provider-registry';
+import { fetch as expoFetch } from 'expo/fetch';
 
 import type { PiRuntimeDependencies } from '@/backend/ai/agent';
 import type { Model } from '@/shared/data/types/model';
@@ -202,6 +203,26 @@ describe('Pi model resolver', () => {
       api: 'anthropic-messages',
       baseUrl: 'https://aihubmix.test',
     });
+  });
+
+  test('composes the shared Provider language transport over Expo fetch', async () => {
+    const provider = makeProvider(
+      ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      'https://api.cherry-ai.com',
+      'openai-compatible',
+    );
+    provider.id = 'cherryai';
+    provider.presetProviderId = 'cherryai';
+    const model = makeModel(ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, {
+      id: 'cherryai::test-model',
+      providerId: 'cherryai',
+    });
+    mockGetProviderById.mockResolvedValue(provider);
+    mockGetModelById.mockResolvedValue(model);
+
+    await resolver.resolveModel({ modelId: 'test-model', providerId: 'cherryai' }, {});
+
+    expect(mockBindPiStream.mock.calls[0]?.[1].fetch).not.toBe(expoFetch);
   });
 
   test.each([

--- a/src/backend/ai/agentHost/piApiAdapters.ts
+++ b/src/backend/ai/agentHost/piApiAdapters.ts
@@ -1,7 +1,9 @@
 import { formatApiHost, withoutTrailingApiVersion } from '@cherrystudio/ai-runtime/provider';
-import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
+import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
 import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type { FetchFunction } from '@earendil-works/pi-ai';
+
+import type { PiLanguageEndpointType } from '@/backend/ai/provider/languageServingPlan';
 
 export type SupportedPiApi =
   | 'anthropic-messages'
@@ -18,7 +20,7 @@ type PiApiAdapter = {
   supportsCustomFetch: boolean;
 };
 
-const PI_API_ADAPTERS: Partial<Record<EndpointType, PiApiAdapter>> = {
+const PI_API_ADAPTERS: Record<PiLanguageEndpointType, PiApiAdapter> = {
   [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: {
     api: 'anthropic-messages',
     formatBaseUrl: (baseUrl) => withoutTrailingApiVersion(formatApiHost(baseUrl, false)),
@@ -53,10 +55,8 @@ const PI_API_ADAPTERS: Partial<Record<EndpointType, PiApiAdapter>> = {
   },
 };
 
-export function resolvePiApiAdapter(
-  endpointType: EndpointType | undefined,
-): PiApiAdapter | undefined {
-  return endpointType ? PI_API_ADAPTERS[endpointType] : undefined;
+export function resolvePiApiAdapter(endpointType: PiLanguageEndpointType): PiApiAdapter {
+  return PI_API_ADAPTERS[endpointType];
 }
 
 type PiStreamBinding = {

--- a/src/backend/ai/agentHost/piModelResolver.ts
+++ b/src/backend/ai/agentHost/piModelResolver.ts
@@ -1,5 +1,5 @@
 import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
-import { MODEL_CAPABILITY, type EndpointType } from '@cherrystudio/provider-registry';
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import type { FetchFunction, Model as PiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
@@ -10,12 +10,13 @@ import type {
   RuntimeModelPreflight,
   RuntimeUsageContext,
 } from '@/backend/ai/agent';
-import { resolveProviderConnection } from '@/backend/ai/provider/providerConnection';
-import { resolveProviderLanguageTransportPolicy } from '@/backend/ai/provider/providerTransport';
+import {
+  requirePiLanguageBinding,
+  resolveLanguageServingPlan,
+} from '@/backend/ai/provider/languageServingPlan';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
-import type { Provider } from '@/shared/data/types/provider';
 
 import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from './piApiAdapters';
 
@@ -23,21 +24,13 @@ const DEFAULT_PI_CONTEXT_WINDOW = 128_000;
 const DEFAULT_PI_MAX_OUTPUT_TOKENS = 8_192;
 const DEFAULT_PI_TIMEOUT_MS = 10 * 60_000;
 
-const NON_STANDARD_ADAPTER_FAMILIES = new Set([
-  'azure',
-  'azure-responses',
-  'bedrock',
-  'google-vertex',
-  'google-vertex-anthropic',
-]);
-
 export function createPiModelResolver(): PiRuntimeDependencies {
   return {
     async preflightModel(runtimeModel): Promise<RuntimeModelPreflight> {
       return (await resolveConfiguredPiModel(runtimeModel)).preflight;
     },
     async resolveModel(runtimeModel, runtimeOptions): Promise<PiModelResolution> {
-      const { adapter, configuredBaseUrl, connection, model, preflight, provider } =
+      const { adapter, configuredBaseUrl, connection, model, preflight, provider, servingPlan } =
         await resolveConfiguredPiModel(runtimeModel);
 
       const selectedApiKey = await providerService.resolveApiKey(provider.id);
@@ -48,8 +41,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       const modelId = connection.wireModelId;
       const headers = connection.headers;
       const baseFetch = expoFetch as unknown as typeof globalThis.fetch;
-      const providerFetch =
-        resolveProviderLanguageTransportPolicy(provider)?.wrapFetch(baseFetch) ?? baseFetch;
+      const providerFetch = servingPlan.transportPolicy?.wrapFetch(baseFetch) ?? baseFetch;
       const piModel: PiModel<SupportedPiApi> = {
         api: adapter.api,
         baseUrl: adapter.formatBaseUrl(configuredBaseUrl),
@@ -115,19 +107,11 @@ async function resolveConfiguredPiModel(runtimeModel: RuntimeModel) {
   ]);
   if (!model) throw new Error(`Model is not configured: ${uniqueModelId}`);
 
-  const connection = resolveProviderConnection(provider, model);
-  const adapter = resolveSupportedAdapter(
-    provider,
-    connection.endpointType,
-    connection.adapterFamily,
-  );
+  const servingPlan = resolveLanguageServingPlan(provider, model);
+  const connection = servingPlan.connection;
+  const piBinding = requirePiLanguageBinding(servingPlan);
+  const adapter = resolvePiApiAdapter(piBinding.endpointType);
   const configuredBaseUrl = connection.baseUrl.trim();
-  if (!configuredBaseUrl) {
-    throw new Error('Pi Runtime requires a base URL from the selected provider.');
-  }
-  if (configuredBaseUrl.endsWith('#')) {
-    throw new Error('Pi Runtime does not support a separate custom endpoint path.');
-  }
 
   return {
     adapter,
@@ -136,6 +120,7 @@ async function resolveConfiguredPiModel(runtimeModel: RuntimeModel) {
     model,
     preflight: toPiModelPreflight(model),
     provider,
+    servingPlan,
   };
 }
 
@@ -157,32 +142,6 @@ export function toPiModelPreflight(model: Model): RuntimeModelPreflight {
     maxOutputTokens,
     supportsTools: model.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL),
   };
-}
-
-function resolveSupportedAdapter(
-  provider: Provider,
-  endpointType: EndpointType | undefined,
-  adapterFamily: string | undefined,
-) {
-  if (adapterFamily && NON_STANDARD_ADAPTER_FAMILIES.has(adapterFamily)) {
-    throw new Error(`Pi Runtime does not support provider adapter family: ${adapterFamily}.`);
-  }
-
-  const adapter = resolvePiApiAdapter(endpointType);
-  if (!adapter) {
-    throw new Error(
-      `Pi Runtime does not support the selected endpoint: ${endpointType ?? 'unknown'}.`,
-    );
-  }
-  if (provider.authType !== 'api-key') {
-    throw new Error(
-      `Pi Runtime does not support provider authentication type: ${provider.authType}.`,
-    );
-  }
-  if (provider.authMethods?.length && !provider.authMethods.includes('api-key')) {
-    throw new Error('Pi Runtime does not support this provider authentication flow.');
-  }
-  return adapter;
 }
 
 function collectRedactionValues(apiKey: string, headers: Record<string, string>): string[] {

--- a/src/backend/ai/agentHost/piModelResolver.ts
+++ b/src/backend/ai/agentHost/piModelResolver.ts
@@ -1,8 +1,3 @@
-import {
-  getExtraHeaders,
-  resolveEffectiveEndpoint,
-  resolveWireModelId,
-} from '@cherrystudio/ai-runtime/provider';
 import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
 import { MODEL_CAPABILITY, type EndpointType } from '@cherrystudio/provider-registry';
 import type { FetchFunction, Model as PiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
@@ -15,9 +10,10 @@ import type {
   RuntimeModelPreflight,
   RuntimeUsageContext,
 } from '@/backend/ai/agent';
+import { resolveProviderConnection } from '@/backend/ai/provider/providerConnection';
+import { resolveProviderLanguageTransportPolicy } from '@/backend/ai/provider/providerTransport';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
-import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 
@@ -41,7 +37,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       return (await resolveConfiguredPiModel(runtimeModel)).preflight;
     },
     async resolveModel(runtimeModel, runtimeOptions): Promise<PiModelResolution> {
-      const { adapter, configuredBaseUrl, model, preflight, provider, resolvedEndpoint } =
+      const { adapter, configuredBaseUrl, connection, model, preflight, provider } =
         await resolveConfiguredPiModel(runtimeModel);
 
       const selectedApiKey = await providerService.resolveApiKey(provider.id);
@@ -49,8 +45,11 @@ export function createPiModelResolver(): PiRuntimeDependencies {
         throw new Error('Pi Runtime requires an API key from the selected provider.');
       }
 
-      const modelId = resolveWireModelId(model, resolvedEndpoint.endpointType);
-      const headers = { ...defaultAppHeaders(), ...getExtraHeaders(provider) };
+      const modelId = connection.wireModelId;
+      const headers = connection.headers;
+      const baseFetch = expoFetch as unknown as typeof globalThis.fetch;
+      const providerFetch =
+        resolveProviderLanguageTransportPolicy(provider)?.wrapFetch(baseFetch) ?? baseFetch;
       const piModel: PiModel<SupportedPiApi> = {
         api: adapter.api,
         baseUrl: adapter.formatBaseUrl(configuredBaseUrl),
@@ -66,7 +65,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       };
       const streamFn = await bindPiStream(adapter, {
         apiKey: selectedApiKey.value,
-        fetch: expoFetch as FetchFunction,
+        fetch: providerFetch as FetchFunction,
         headers,
         maxRetries: 0,
         maxTokens: runtimeOptions.maxOutputTokens ?? piModel.maxTokens,
@@ -116,9 +115,13 @@ async function resolveConfiguredPiModel(runtimeModel: RuntimeModel) {
   ]);
   if (!model) throw new Error(`Model is not configured: ${uniqueModelId}`);
 
-  const resolvedEndpoint = resolveEffectiveEndpoint(provider, model);
-  const adapter = resolveSupportedAdapter(provider, resolvedEndpoint.endpointType);
-  const configuredBaseUrl = resolvedEndpoint.baseUrl.trim();
+  const connection = resolveProviderConnection(provider, model);
+  const adapter = resolveSupportedAdapter(
+    provider,
+    connection.endpointType,
+    connection.adapterFamily,
+  );
+  const configuredBaseUrl = connection.baseUrl.trim();
   if (!configuredBaseUrl) {
     throw new Error('Pi Runtime requires a base URL from the selected provider.');
   }
@@ -129,10 +132,10 @@ async function resolveConfiguredPiModel(runtimeModel: RuntimeModel) {
   return {
     adapter,
     configuredBaseUrl,
+    connection,
     model,
     preflight: toPiModelPreflight(model),
     provider,
-    resolvedEndpoint,
   };
 }
 
@@ -156,10 +159,11 @@ export function toPiModelPreflight(model: Model): RuntimeModelPreflight {
   };
 }
 
-function resolveSupportedAdapter(provider: Provider, endpointType: EndpointType | undefined) {
-  const adapterFamily = endpointType
-    ? provider.endpointConfigs?.[endpointType]?.adapterFamily
-    : undefined;
+function resolveSupportedAdapter(
+  provider: Provider,
+  endpointType: EndpointType | undefined,
+  adapterFamily: string | undefined,
+) {
   if (adapterFamily && NON_STANDARD_ADAPTER_FAMILIES.has(adapterFamily)) {
     throw new Error(`Pi Runtime does not support provider adapter family: ${adapterFamily}.`);
   }

--- a/src/backend/ai/provider/__tests__/config.test.ts
+++ b/src/backend/ai/provider/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 
 import type { ResolvedProviderApiKey } from '@/backend/data/services/ProviderService';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
@@ -89,6 +89,28 @@ describe('providerToAiSdkConfig', () => {
 
     expect(config.providerId).toBe('openai-compatible');
     expect(config.providerSettings.fetch).toBeUndefined();
+  });
+
+  it('keeps CherryAI image execution outside the language transport policy', async () => {
+    const provider = createProvider({
+      id: 'cherryai',
+      presetProviderId: 'cherryai',
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          baseUrl: 'https://api.cherry-ai.com',
+        },
+      },
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    });
+    const model = {
+      ...createModel(provider.id, 'image-model'),
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+    };
+
+    const config = await providerToAiSdkConfig(provider, model, createRuntime());
+
+    expect(config.providerSettings.fetch).toBeUndefined();
+    expect(generateSignature).not.toHaveBeenCalled();
   });
 
   it('resolves registered adapter extensions before falling back to openai-compatible', async () => {

--- a/src/backend/ai/provider/__tests__/languageServingPlan.test.ts
+++ b/src/backend/ai/provider/__tests__/languageServingPlan.test.ts
@@ -1,0 +1,132 @@
+import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
+
+import {
+  LanguageServingCompatibilityError,
+  requirePiLanguageBinding,
+  resolveLanguageServingPlan,
+} from '../languageServingPlan';
+
+describe('resolveLanguageServingPlan', () => {
+  it('classifies shared auth and Pi protocol facts without selecting credentials', () => {
+    const provider = createProvider();
+    const plan = resolveLanguageServingPlan(provider, createModel());
+
+    expect(plan).toMatchObject({
+      auth: { declaredMethods: ['api-key'], type: 'api-key' },
+      bindings: {
+        pi: { endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES, status: 'supported' },
+      },
+      connection: {
+        adapterFamily: 'openai',
+        baseUrl: 'https://api.example.com/v1',
+        endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES,
+        wireModelId: 'gpt-test',
+      },
+    });
+    expect(JSON.stringify(plan)).not.toContain('key-1');
+  });
+
+  it.each([
+    {
+      code: 'unsupported-endpoint',
+      provider: createProvider({
+        defaultChatEndpoint: ENDPOINT_TYPE.OLLAMA_CHAT,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OLLAMA_CHAT]: {
+            adapterFamily: 'ollama',
+            baseUrl: 'http://localhost:11434',
+          },
+        },
+      }),
+    },
+    {
+      code: 'unsupported-adapter-family',
+      provider: createProvider({
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+            adapterFamily: 'azure-responses',
+            baseUrl: 'https://azure.example.com',
+          },
+        },
+      }),
+    },
+    {
+      code: 'unsupported-auth-type',
+      provider: createProvider({ authType: 'iam-aws' }),
+    },
+    {
+      code: 'unsupported-auth-flow',
+      provider: createProvider({ authMethods: ['oauth'] }),
+    },
+    {
+      code: 'missing-base-url',
+      provider: createProvider({
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+            adapterFamily: 'openai',
+            baseUrl: '',
+          },
+        },
+      }),
+    },
+    {
+      code: 'custom-endpoint-path',
+      provider: createProvider({
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+            adapterFamily: 'openai',
+            baseUrl: 'https://api.example.com/responses#',
+          },
+        },
+      }),
+    },
+  ] as const)('returns a typed Pi compatibility issue for $code', ({ code, provider }) => {
+    const plan = resolveLanguageServingPlan(provider, createModel(undefined));
+
+    expect(plan.bindings.pi).toMatchObject({
+      issue: { binding: 'pi', code },
+      status: 'unsupported',
+    });
+    expect(() => requirePiLanguageBinding(plan)).toThrow(LanguageServingCompatibilityError);
+  });
+});
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    apiFeatures: { ...DEFAULT_API_FEATURES },
+    apiKeys: [{ id: 'key-1', isEnabled: true }],
+    authMethods: ['api-key'],
+    authType: 'api-key',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+        adapterFamily: 'openai',
+        baseUrl: 'https://api.example.com/v1',
+      },
+    },
+    id: 'test-provider',
+    isEnabled: true,
+    name: 'Test Provider',
+    settings: {},
+    ...overrides,
+  };
+}
+
+function createModel(
+  endpointType: EndpointType | undefined = ENDPOINT_TYPE.OPENAI_RESPONSES,
+): Model {
+  return {
+    capabilities: [],
+    endpointTypes: endpointType ? [endpointType] : undefined,
+    id: createUniqueModelId('test-provider', 'gpt-test'),
+    isEnabled: true,
+    isHidden: false,
+    modelId: 'gpt-test',
+    name: 'GPT Test',
+    providerId: 'test-provider',
+    supportsStreaming: true,
+  };
+}

--- a/src/backend/ai/provider/__tests__/languageServingPlan.test.ts
+++ b/src/backend/ai/provider/__tests__/languageServingPlan.test.ts
@@ -12,7 +12,7 @@ import {
 describe('resolveLanguageServingPlan', () => {
   it('classifies shared auth and Pi protocol facts without selecting credentials', () => {
     const provider = createProvider();
-    const plan = resolveLanguageServingPlan(provider, createModel());
+    const plan = resolveLanguageServingPlan(provider, createModel(ENDPOINT_TYPE.OPENAI_RESPONSES));
 
     expect(plan).toMatchObject({
       auth: { declaredMethods: ['api-key'], type: 'api-key' },
@@ -115,9 +115,7 @@ function createProvider(overrides: Partial<Provider> = {}): Provider {
   };
 }
 
-function createModel(
-  endpointType: EndpointType | undefined = ENDPOINT_TYPE.OPENAI_RESPONSES,
-): Model {
+function createModel(endpointType: EndpointType | undefined): Model {
   return {
     capabilities: [],
     endpointTypes: endpointType ? [endpointType] : undefined,

--- a/src/backend/ai/provider/__tests__/providerConnection.test.ts
+++ b/src/backend/ai/provider/__tests__/providerConnection.test.ts
@@ -25,13 +25,13 @@ describe('resolveProviderConnection', () => {
     });
   });
 
-  it('does not expose stored Provider API key entries', () => {
+  it('does not expose runtime API key metadata', () => {
     const provider = createProvider();
-    provider.apiKeys = [{ id: 'key-1', isEnabled: true, key: 'provider-secret' }];
+    provider.apiKeys = [{ id: 'key-1', isEnabled: true, label: 'primary' }];
 
     const serialized = JSON.stringify(resolveProviderConnection(provider, createModel()));
 
-    expect(serialized).not.toContain('provider-secret');
+    expect(serialized).not.toContain('key-1');
     expect(serialized).not.toContain('apiKeys');
   });
 });

--- a/src/backend/ai/provider/__tests__/providerConnection.test.ts
+++ b/src/backend/ai/provider/__tests__/providerConnection.test.ts
@@ -1,0 +1,81 @@
+import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
+
+import { resolveProviderConnection } from '../providerConnection';
+
+describe('resolveProviderConnection', () => {
+  it('resolves shared endpoint, adapter, wire model, and request header facts', () => {
+    const provider = createProvider();
+    const model = createModel();
+
+    expect(resolveProviderConnection(provider, model)).toEqual({
+      adapterFamily: 'google',
+      baseUrl: 'https://generativelanguage.googleapis.com',
+      endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+      headers: {
+        Authorization: 'Bearer header-secret',
+        'User-Agent': 'CherryStudioMobile/1.0',
+        'X-App-Name': 'CherryStudioMobile',
+        'X-Custom': 'custom',
+      },
+      providerOptionsKey: undefined,
+      wireModelId: 'gemini-2.5-flash',
+    });
+  });
+
+  it('does not expose stored Provider API key entries', () => {
+    const provider = createProvider();
+    provider.apiKeys = [{ id: 'key-1', isEnabled: true, key: 'provider-secret' }];
+
+    const serialized = JSON.stringify(resolveProviderConnection(provider, createModel()));
+
+    expect(serialized).not.toContain('provider-secret');
+    expect(serialized).not.toContain('apiKeys');
+  });
+});
+
+function createProvider(): Provider {
+  return {
+    apiFeatures: { ...DEFAULT_API_FEATURES },
+    apiKeys: [],
+    authMethods: ['api-key'],
+    authType: 'api-key',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]: {
+        adapterFamily: 'google',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+      },
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+        adapterFamily: 'openai-compatible',
+        baseUrl: 'https://openai-compatible.example.com/v1',
+      },
+    },
+    id: 'test-provider',
+    isEnabled: true,
+    name: 'Test Provider',
+    settings: {
+      extraHeaders: {
+        Authorization: 'Bearer header-secret',
+        'X-Custom': 'custom',
+      },
+    },
+  };
+}
+
+function createModel(): Model {
+  return {
+    apiModelId: 'models/gemini-2.5-flash',
+    capabilities: [],
+    endpointTypes: [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT],
+    id: createUniqueModelId('test-provider', 'gemini-2.5-flash'),
+    isEnabled: true,
+    isHidden: false,
+    modelId: 'gemini-2.5-flash',
+    name: 'Gemini 2.5 Flash',
+    providerId: 'test-provider',
+    supportsStreaming: true,
+  };
+}

--- a/src/backend/ai/provider/__tests__/providerTransport.test.ts
+++ b/src/backend/ai/provider/__tests__/providerTransport.test.ts
@@ -1,0 +1,70 @@
+import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
+
+import { resolveProviderLanguageTransportPolicy } from '../providerTransport';
+
+jest.mock('@/backend/ai/provider/cherryai', () => ({
+  generateSignature: jest.fn(() => ({
+    'X-Client-ID': 'cherry-studio',
+    'X-Signature': 'signed',
+    'X-Timestamp': '1700000000',
+  })),
+}));
+
+const { generateSignature } = jest.requireMock('@/backend/ai/provider/cherryai') as {
+  generateSignature: jest.Mock;
+};
+
+describe('resolveProviderLanguageTransportPolicy', () => {
+  beforeEach(() => {
+    generateSignature.mockClear();
+  });
+
+  it('shares CherryAI request signing with every language binding', async () => {
+    const baseFetch = jest.fn(async () => new Response(null, { status: 204 }));
+    const policy = resolveProviderLanguageTransportPolicy(
+      createProvider('custom-cherryai', 'cherryai'),
+    );
+    const fetch = policy?.wrapFetch(baseFetch as unknown as typeof globalThis.fetch);
+
+    await fetch?.('https://api.cherry-ai.com/chat/completions', {
+      body: JSON.stringify({ messages: [{ content: 'hi', role: 'user' }] }),
+      headers: { Existing: 'header' },
+      method: 'POST',
+    });
+
+    expect(generateSignature).toHaveBeenCalledWith({
+      body: { messages: [{ content: 'hi', role: 'user' }] },
+      method: 'POST',
+      path: '/chat/completions',
+      query: '',
+    });
+    expect(baseFetch).toHaveBeenCalledWith('https://api.cherry-ai.com/chat/completions', {
+      body: JSON.stringify({ messages: [{ content: 'hi', role: 'user' }] }),
+      headers: {
+        Existing: 'header',
+        'X-Client-ID': 'cherry-studio',
+        'X-Signature': 'signed',
+        'X-Timestamp': '1700000000',
+      },
+      method: 'POST',
+    });
+  });
+
+  it('does not add a transport policy to ordinary compatible Providers', () => {
+    expect(resolveProviderLanguageTransportPolicy(createProvider('custom-openai'))).toBeUndefined();
+  });
+});
+
+function createProvider(id: string, presetProviderId?: string): Provider {
+  return {
+    apiFeatures: { ...DEFAULT_API_FEATURES },
+    apiKeys: [],
+    authType: 'api-key',
+    endpointConfigs: {},
+    id,
+    isEnabled: true,
+    name: id,
+    presetProviderId,
+    settings: {},
+  };
+}

--- a/src/backend/ai/provider/config.ts
+++ b/src/backend/ai/provider/config.ts
@@ -17,15 +17,13 @@ import {
   formatApiHost,
   formatOllamaApiHost,
   getBaseUrl,
-  getExtraHeaders,
   isVertexMaasModelId,
   isWithTrailingSharp,
   normalizeVertexCredentials,
   type ProviderConfig,
   registerProviderExtensions,
-  resolveAiSdkProviderId,
+  resolveProviderVariant,
   type ResolvedEndpoint,
-  resolveEffectiveEndpoint,
   routeToEndpoint,
   stripArkUnsupportedIncludes,
   transformZhipuRequestBody,
@@ -34,9 +32,12 @@ import {
 import type { CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider';
 import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 
-import { generateSignature } from '@/backend/ai/provider/cherryai';
+import {
+  resolveProviderConnection,
+  type ResolvedProviderConnection,
+} from '@/backend/ai/provider/providerConnection';
+import { resolveProviderLanguageTransportPolicy } from '@/backend/ai/provider/providerTransport';
 import type { ResolvedProviderApiKey } from '@/backend/data/services/ProviderService';
-import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
 import type { ServingCredentialReceipt } from '@/shared/data/types/aiUsageRecord';
 import type { EndpointType, Model } from '@/shared/data/types/model';
 import type { AuthConfig, Provider } from '@/shared/data/types/provider';
@@ -60,6 +61,7 @@ interface ProviderConfigRuntime {
 interface BuilderContext {
   actualProvider: Provider;
   model: Model;
+  connection: ResolvedProviderConnection;
   baseConfig: BaseConfig;
   endpoint?: string;
   endpointType?: EndpointType;
@@ -75,6 +77,7 @@ type ApiKeyBuilderContext = BuilderContext & {
 
 interface ProviderToAiSdkConfigOptions {
   apiKeyOverride?: string;
+  resolvedConnection?: ResolvedProviderConnection;
   resolvedEndpoint?: ResolvedEndpoint;
   sessionId?: string;
 }
@@ -174,12 +177,12 @@ export async function resolveProviderAiSdkConfig(
   runtime: ProviderConfigRuntime,
   options?: ProviderToAiSdkConfigOptions,
 ): Promise<ResolvedProviderAiSdkConfig> {
-  const { endpointType, baseUrl } =
-    options?.resolvedEndpoint ?? resolveEffectiveEndpoint(provider, model);
+  const connection =
+    options?.resolvedConnection ??
+    resolveProviderConnection(provider, model, { resolvedEndpoint: options?.resolvedEndpoint });
+  const { endpointType, baseUrl } = connection;
 
-  const aiSdkProviderId = appProviderIdMap[
-    resolveAiSdkProviderId(provider, endpointType)
-  ] as StringKeys<AppProviderSettingsMap>;
+  const aiSdkProviderId = resolveConnectionAiSdkProviderId(connection);
 
   const formattedBaseUrl = formatBaseURL(baseUrl, provider, endpointType);
   const { baseURL, endpoint } = routeToEndpoint(formattedBaseUrl);
@@ -187,6 +190,7 @@ export async function resolveProviderAiSdkConfig(
   const ctx: BuilderContext = {
     actualProvider: provider,
     model,
+    connection,
     baseConfig: { baseURL, apiKey: '' },
     apiKeyOverride: options?.apiKeyOverride,
     endpoint,
@@ -269,7 +273,7 @@ export async function resolveProviderAiSdkConfig(
         endpoint: builderContext.endpoint,
         providerSettings: {
           ...builderContext.baseConfig,
-          headers: { ...defaultAppHeaders(), ...getExtraHeaders(builderContext.actualProvider) },
+          headers: { ...builderContext.connection.headers },
         },
       })),
     },
@@ -281,7 +285,7 @@ export async function resolveProviderAiSdkConfig(
         endpoint: builderContext.endpoint,
         providerSettings: {
           ...builderContext.baseConfig,
-          headers: { ...defaultAppHeaders(), ...getExtraHeaders(builderContext.actualProvider) },
+          headers: { ...builderContext.connection.headers },
         },
       })),
     },
@@ -308,8 +312,32 @@ export async function resolveProviderAiSdkConfig(
     resolved = await withSelectedApiKey(buildOpenAICompatibleConfig)(ctx);
   }
 
-  resolved.config.providerSettings.fetch ??= runtime.fetch;
+  const transportPolicy = isImageGenerationModel(model)
+    ? undefined
+    : resolveProviderLanguageTransportPolicy(provider);
+  if (transportPolicy) {
+    resolved.config.providerSettings.fetch = transportPolicy.wrapFetch(
+      resolved.config.providerSettings.fetch ??
+        runtime.fetch ??
+        ((input, init) => globalThis.fetch(input, init)),
+    );
+  } else {
+    resolved.config.providerSettings.fetch ??= runtime.fetch;
+  }
   return resolved;
+}
+
+function resolveConnectionAiSdkProviderId(
+  connection: ResolvedProviderConnection,
+): StringKeys<AppProviderSettingsMap> {
+  const baseProviderId =
+    connection.adapterFamily && connection.adapterFamily in appProviderIdMap
+      ? appProviderIdMap[connection.adapterFamily]
+      : appProviderIdMap['openai-compatible'];
+  return resolveProviderVariant(
+    baseProviderId,
+    connection.endpointType,
+  ) as StringKeys<AppProviderSettingsMap>;
 }
 
 // ── Config Builders ──
@@ -331,10 +359,7 @@ function buildOpenCodeConfig(ctx: BuilderContext): ProviderConfig {
 
 function buildCommonOptions(ctx: BuilderContext) {
   const options: Record<string, any> = {
-    headers: {
-      ...defaultAppHeaders(),
-      ...getExtraHeaders(ctx.actualProvider),
-    },
+    headers: { ...ctx.connection.headers },
   };
   if (ctx.aiSdkProviderId === 'openai') {
     options.headers['X-Api-Key'] = ctx.baseConfig.apiKey;
@@ -370,35 +395,11 @@ function buildCherryAIConfig(ctx: BuilderContext): ProviderConfig<'openai-compat
     endpoint: ctx.endpoint,
     providerSettings: {
       ...ctx.baseConfig,
-      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      headers: { ...ctx.connection.headers },
       includeUsage: ctx.actualProvider.apiFeatures.streamOptions,
       name: ctx.actualProvider.id,
-      fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-        const signature = generateSignature({
-          method: 'POST',
-          path: '/chat/completions',
-          query: '',
-          body: getJsonBody(init?.body),
-        });
-        return (ctx.runtime.fetch ?? globalThis.fetch)(input, {
-          ...init,
-          headers: { ...init?.headers, ...signature },
-        });
-      },
     },
   };
-}
-
-function getJsonBody(body: BodyInit | null | undefined): Record<string, unknown> | undefined {
-  if (typeof body !== 'string') {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(body) as Record<string, unknown>;
-  } catch {
-    return undefined;
-  }
 }
 
 function formatAzureBaseURL(baseURL: string, forAnthropic: boolean): string {
@@ -427,7 +428,7 @@ async function buildAzureConfig(
       providerSettings: {
         ...ctx.baseConfig,
         baseURL: formatAzureBaseURL(ctx.baseConfig.baseURL, true),
-        headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+        headers: { ...ctx.connection.headers },
       },
     };
   }
@@ -440,7 +441,7 @@ async function buildAzureConfig(
   } = {
     ...ctx.baseConfig,
     baseURL: formatAzureBaseURL(ctx.baseConfig.baseURL, false),
-    headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+    headers: { ...ctx.connection.headers },
   };
 
   if (apiVersion) {
@@ -481,10 +482,7 @@ function buildOpenAICompatibleConfig(ctx: BuilderContext): ProviderConfig<'opena
 }
 
 function buildOllamaConfig(ctx: BuilderContext): ProviderConfig<'ollama'> {
-  const headers: Record<string, string> = {
-    ...defaultAppHeaders(),
-    ...getExtraHeaders(ctx.actualProvider),
-  };
+  const headers = { ...ctx.connection.headers };
   if (ctx.baseConfig.apiKey) {
     headers.Authorization = `Bearer ${ctx.baseConfig.apiKey}`;
   }
@@ -557,7 +555,7 @@ async function buildVertexConfig(ctx: BuilderContext): Promise<ResolvedProviderC
         location,
         ...(ctx.baseConfig.baseURL && { baseURL: ctx.baseConfig.baseURL }),
         ...(normalizedCredentials && { googleCredentials: normalizedCredentials }),
-        headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+        headers: { ...ctx.connection.headers },
       },
     };
   } else {
@@ -616,7 +614,7 @@ function buildAiHubMixConfig(ctx: BuilderContext): ProviderConfig<'aihubmix'> {
     providerSettings: {
       ...ctx.baseConfig,
       endpointBaseURLs: buildEndpointBaseURLs(ctx.actualProvider),
-      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      headers: { ...ctx.connection.headers },
     },
   };
 }
@@ -628,7 +626,7 @@ function buildDmxapiConfig(ctx: BuilderContext): ProviderConfig<'dmxapi'> {
     providerSettings: {
       ...ctx.baseConfig,
       endpointBaseURLs: buildEndpointBaseURLs(ctx.actualProvider),
-      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      headers: { ...ctx.connection.headers },
     },
   };
 }
@@ -639,7 +637,7 @@ function buildDashScopeConfig(ctx: BuilderContext): ProviderConfig<'dashscope'> 
     endpoint: ctx.endpoint,
     providerSettings: {
       ...ctx.baseConfig,
-      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      headers: { ...ctx.connection.headers },
       includeUsage: ctx.actualProvider.apiFeatures.streamOptions,
     },
   };
@@ -663,7 +661,7 @@ function buildCherryInConfig(ctx: BuilderContext): ProviderConfig {
       anthropicBaseURL,
       endpointType: mapGatewayEndpointType(ctx.endpointType),
       geminiBaseURL,
-      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      headers: { ...ctx.connection.headers },
     },
   };
 }
@@ -688,7 +686,7 @@ function buildNewApiConfig(ctx: BuilderContext): ProviderConfig<'newapi'> {
       ...ctx.baseConfig,
       baseURL: formatNewApiBaseURL(rawBaseURL, ctx.endpointType),
       endpointType: mapGatewayEndpointType(ctx.endpointType),
-      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      headers: { ...ctx.connection.headers },
     },
   };
 }

--- a/src/backend/ai/provider/config.ts
+++ b/src/backend/ai/provider/config.ts
@@ -32,11 +32,11 @@ import {
 import type { CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider';
 import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 
+import { resolveLanguageServingPlan } from '@/backend/ai/provider/languageServingPlan';
 import {
   resolveProviderConnection,
   type ResolvedProviderConnection,
 } from '@/backend/ai/provider/providerConnection';
-import { resolveProviderLanguageTransportPolicy } from '@/backend/ai/provider/providerTransport';
 import type { ResolvedProviderApiKey } from '@/backend/data/services/ProviderService';
 import type { ServingCredentialReceipt } from '@/shared/data/types/aiUsageRecord';
 import type { EndpointType, Model } from '@/shared/data/types/model';
@@ -177,9 +177,13 @@ export async function resolveProviderAiSdkConfig(
   runtime: ProviderConfigRuntime,
   options?: ProviderToAiSdkConfigOptions,
 ): Promise<ResolvedProviderAiSdkConfig> {
-  const connection =
+  const resolvedConnection =
     options?.resolvedConnection ??
     resolveProviderConnection(provider, model, { resolvedEndpoint: options?.resolvedEndpoint });
+  const languageServingPlan = isImageGenerationModel(model)
+    ? undefined
+    : resolveLanguageServingPlan(provider, model, { resolvedConnection });
+  const connection = languageServingPlan?.connection ?? resolvedConnection;
   const { endpointType, baseUrl } = connection;
 
   const aiSdkProviderId = resolveConnectionAiSdkProviderId(connection);
@@ -312,9 +316,7 @@ export async function resolveProviderAiSdkConfig(
     resolved = await withSelectedApiKey(buildOpenAICompatibleConfig)(ctx);
   }
 
-  const transportPolicy = isImageGenerationModel(model)
-    ? undefined
-    : resolveProviderLanguageTransportPolicy(provider);
+  const transportPolicy = languageServingPlan?.transportPolicy;
   if (transportPolicy) {
     resolved.config.providerSettings.fetch = transportPolicy.wrapFetch(
       resolved.config.providerSettings.fetch ??

--- a/src/backend/ai/provider/languageServingPlan.ts
+++ b/src/backend/ai/provider/languageServingPlan.ts
@@ -1,0 +1,177 @@
+import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
+
+import {
+  resolveProviderConnection,
+  type ResolvedProviderConnection,
+} from '@/backend/ai/provider/providerConnection';
+import {
+  resolveProviderLanguageTransportPolicy,
+  type ProviderLanguageTransportPolicy,
+} from '@/backend/ai/provider/providerTransport';
+import type { Model } from '@/shared/data/types/model';
+import type { AuthType, Provider, ProviderAuthMethod } from '@/shared/data/types/provider';
+
+const PI_LANGUAGE_ENDPOINT_TYPES = [
+  ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+  ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+  ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+  ENDPOINT_TYPE.OPENAI_RESPONSES,
+] as const;
+
+const NON_STANDARD_PI_ADAPTER_FAMILIES = new Set([
+  'azure',
+  'azure-responses',
+  'bedrock',
+  'google-vertex',
+  'google-vertex-anthropic',
+]);
+
+export type PiLanguageEndpointType = (typeof PI_LANGUAGE_ENDPOINT_TYPES)[number];
+
+export type LanguageServingCompatibilityCode =
+  | 'custom-endpoint-path'
+  | 'missing-base-url'
+  | 'unsupported-adapter-family'
+  | 'unsupported-auth-flow'
+  | 'unsupported-auth-type'
+  | 'unsupported-endpoint';
+
+export interface LanguageServingCompatibilityIssue {
+  binding: 'pi';
+  code: LanguageServingCompatibilityCode;
+  message: string;
+}
+
+export type PiLanguageBinding =
+  | {
+      endpointType: PiLanguageEndpointType;
+      status: 'supported';
+    }
+  | {
+      issue: LanguageServingCompatibilityIssue;
+      status: 'unsupported';
+    };
+
+export interface LanguageServingPlan {
+  auth: {
+    declaredMethods: readonly ProviderAuthMethod[] | undefined;
+    type: AuthType;
+  };
+  bindings: {
+    pi: PiLanguageBinding;
+  };
+  connection: ResolvedProviderConnection;
+  transportPolicy: ProviderLanguageTransportPolicy | undefined;
+}
+
+interface ResolveLanguageServingPlanOptions {
+  resolvedConnection?: ResolvedProviderConnection;
+}
+
+/**
+ * Resolve language-serving facts before projecting them into Pi or AI SDK objects.
+ *
+ * The result is intentionally credential-selection-free. It may contain sensitive
+ * configured headers through `connection`, so it remains ephemeral and must not be
+ * persisted or logged.
+ */
+export function resolveLanguageServingPlan(
+  provider: Provider,
+  model: Model,
+  options: ResolveLanguageServingPlanOptions = {},
+): LanguageServingPlan {
+  const connection = options.resolvedConnection ?? resolveProviderConnection(provider, model);
+
+  return {
+    auth: {
+      declaredMethods: provider.authMethods ? [...provider.authMethods] : undefined,
+      type: provider.authType,
+    },
+    bindings: {
+      pi: resolvePiLanguageBinding(provider, connection),
+    },
+    connection,
+    transportPolicy: resolveProviderLanguageTransportPolicy(provider),
+  };
+}
+
+export class LanguageServingCompatibilityError extends Error {
+  readonly binding: LanguageServingCompatibilityIssue['binding'];
+  readonly code: LanguageServingCompatibilityCode;
+
+  constructor(issue: LanguageServingCompatibilityIssue) {
+    super(issue.message);
+    this.name = 'LanguageServingCompatibilityError';
+    this.binding = issue.binding;
+    this.code = issue.code;
+  }
+}
+
+export function requirePiLanguageBinding(
+  plan: LanguageServingPlan,
+): Extract<PiLanguageBinding, { status: 'supported' }> {
+  if (plan.bindings.pi.status === 'unsupported') {
+    throw new LanguageServingCompatibilityError(plan.bindings.pi.issue);
+  }
+  return plan.bindings.pi;
+}
+
+function resolvePiLanguageBinding(
+  provider: Provider,
+  connection: ResolvedProviderConnection,
+): PiLanguageBinding {
+  if (connection.adapterFamily && NON_STANDARD_PI_ADAPTER_FAMILIES.has(connection.adapterFamily)) {
+    return unsupported(
+      'unsupported-adapter-family',
+      `Pi Runtime does not support provider adapter family: ${connection.adapterFamily}.`,
+    );
+  }
+
+  if (!isPiLanguageEndpointType(connection.endpointType)) {
+    return unsupported(
+      'unsupported-endpoint',
+      `Pi Runtime does not support the selected endpoint: ${connection.endpointType ?? 'unknown'}.`,
+    );
+  }
+
+  if (provider.authType !== 'api-key') {
+    return unsupported(
+      'unsupported-auth-type',
+      `Pi Runtime does not support provider authentication type: ${provider.authType}.`,
+    );
+  }
+
+  if (provider.authMethods?.length && !provider.authMethods.includes('api-key')) {
+    return unsupported(
+      'unsupported-auth-flow',
+      'Pi Runtime does not support this provider authentication flow.',
+    );
+  }
+
+  const configuredBaseUrl = connection.baseUrl.trim();
+  if (!configuredBaseUrl) {
+    return unsupported(
+      'missing-base-url',
+      'Pi Runtime requires a base URL from the selected provider.',
+    );
+  }
+
+  if (configuredBaseUrl.endsWith('#')) {
+    return unsupported(
+      'custom-endpoint-path',
+      'Pi Runtime does not support a separate custom endpoint path.',
+    );
+  }
+
+  return { endpointType: connection.endpointType, status: 'supported' };
+}
+
+function isPiLanguageEndpointType(
+  endpointType: EndpointType | undefined,
+): endpointType is PiLanguageEndpointType {
+  return PI_LANGUAGE_ENDPOINT_TYPES.some((supported) => supported === endpointType);
+}
+
+function unsupported(code: LanguageServingCompatibilityCode, message: string): PiLanguageBinding {
+  return { issue: { binding: 'pi', code, message }, status: 'unsupported' };
+}

--- a/src/backend/ai/provider/providerConnection.ts
+++ b/src/backend/ai/provider/providerConnection.ts
@@ -1,0 +1,53 @@
+import {
+  getExtraHeaders,
+  resolveEffectiveEndpoint,
+  resolveWireModelId,
+  type ResolvedEndpoint,
+} from '@cherrystudio/ai-runtime/provider';
+import type { EndpointType } from '@cherrystudio/provider-registry';
+
+import { defaultAppHeaders } from '@/backend/utils/defaultAppHeaders';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
+
+export interface ResolvedProviderConnection {
+  adapterFamily: string | undefined;
+  baseUrl: string;
+  endpointType: EndpointType | undefined;
+  headers: Record<string, string>;
+  providerOptionsKey: string | undefined;
+  wireModelId: string;
+}
+
+interface ResolveProviderConnectionOptions {
+  resolvedEndpoint?: ResolvedEndpoint;
+}
+
+/**
+ * Resolve the Provider connection facts shared by capability executors.
+ *
+ * Selected API keys and IAM/OAuth credentials deliberately stay out of this
+ * value. Provider-configured extra headers can still contain sensitive values,
+ * so the result is ephemeral and must not be persisted or logged. The owning
+ * request or Runtime connection materializes credentials exactly once so key
+ * rotation and usage attribution cannot drift between consumers.
+ */
+export function resolveProviderConnection(
+  provider: Provider,
+  model: Model,
+  options: ResolveProviderConnectionOptions = {},
+): ResolvedProviderConnection {
+  const resolvedEndpoint = options.resolvedEndpoint ?? resolveEffectiveEndpoint(provider, model);
+  const { endpointType } = resolvedEndpoint;
+
+  return {
+    adapterFamily: endpointType
+      ? provider.endpointConfigs?.[endpointType]?.adapterFamily
+      : undefined,
+    baseUrl: resolvedEndpoint.baseUrl,
+    endpointType,
+    headers: { ...defaultAppHeaders(), ...getExtraHeaders(provider) },
+    providerOptionsKey: resolvedEndpoint.providerOptionsKey,
+    wireModelId: resolveWireModelId(model, endpointType),
+  };
+}

--- a/src/backend/ai/provider/providerTransport.ts
+++ b/src/backend/ai/provider/providerTransport.ts
@@ -1,0 +1,59 @@
+import { generateSignature } from '@/backend/ai/provider/cherryai';
+import { isManagedCherryAiProviderId } from '@/shared/data/presets/cherryai';
+import type { Provider } from '@/shared/data/types/provider';
+
+export type ProviderFetch = typeof globalThis.fetch;
+
+export interface ProviderLanguageTransportPolicy {
+  wrapFetch(baseFetch: ProviderFetch): ProviderFetch;
+}
+
+interface ProviderLanguageTransportPolicyRegistration {
+  matches(provider: Provider): boolean;
+  policy: ProviderLanguageTransportPolicy;
+}
+
+const CHERRY_AI_LANGUAGE_TRANSPORT_POLICY: ProviderLanguageTransportPolicy = {
+  wrapFetch: (baseFetch) => async (input, init) => {
+    const signature = generateSignature({
+      method: 'POST',
+      path: '/chat/completions',
+      query: '',
+      body: getJsonBody(init?.body),
+    });
+    return baseFetch(input, {
+      ...init,
+      headers: { ...init?.headers, ...signature },
+    });
+  },
+};
+
+const PROVIDER_LANGUAGE_TRANSPORT_POLICIES: readonly ProviderLanguageTransportPolicyRegistration[] =
+  [
+    {
+      matches: (provider) =>
+        isManagedCherryAiProviderId(provider.id) ||
+        isManagedCherryAiProviderId(provider.presetProviderId ?? ''),
+      policy: CHERRY_AI_LANGUAGE_TRANSPORT_POLICY,
+    },
+  ];
+
+/** Resolve shared Provider-specific language HTTP behavior without selecting user credentials. */
+export function resolveProviderLanguageTransportPolicy(
+  provider: Provider,
+): ProviderLanguageTransportPolicy | undefined {
+  return PROVIDER_LANGUAGE_TRANSPORT_POLICIES.find((registration) => registration.matches(provider))
+    ?.policy;
+}
+
+function getJsonBody(body: BodyInit | null | undefined): Record<string, unknown> | undefined {
+  if (typeof body !== 'string') {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(body) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/backend/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/backend/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -77,6 +77,23 @@ async function buildReasoningOptions(input: {
 }
 
 describe('buildAgentParams assistant-less contract', () => {
+  it('uses the shared normalized wire model id', async () => {
+    const provider = createProvider('gemini');
+    const model = {
+      ...resolveModel(provider, 'gemini-2.5-flash'),
+      apiModelId: 'models/gemini-2.5-flash',
+    };
+
+    const result = await buildAgentParams({
+      request: { uniqueModelId: model.id },
+      services: createServices(),
+      provider,
+      model,
+    });
+
+    expect(result.sdkConfig.modelId).toBe('gemini-2.5-flash');
+  });
+
   it('serializes an explicit reasoning selection', async () => {
     await expect(
       buildReasoningOptions({

--- a/src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/backend/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -1,10 +1,6 @@
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import type { AiPlugin } from '@cherrystudio/ai-core';
-import {
-  type ProviderConfig,
-  resolveEffectiveEndpoint,
-  resolveProviderOptionsKey,
-} from '@cherrystudio/ai-runtime/provider';
+import { type ProviderConfig, resolveProviderOptionsKey } from '@cherrystudio/ai-runtime/provider';
 import {
   buildAgentPlugins,
   createToolCallLimitStopCondition,
@@ -38,6 +34,7 @@ import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 
 import { resolveProviderAiSdkConfig } from '../../../provider/config';
+import { resolveProviderConnection } from '../../../provider/providerConnection';
 import type { AgentOptions } from '../Agent';
 
 export interface BuildAgentParamsDependencies {
@@ -71,8 +68,8 @@ export async function buildAgentParams({
   model,
   getRepairUsagePlugins,
 }: BuildAgentParamsInput): Promise<BuiltAgentParams> {
-  const resolvedEndpoint = resolveEffectiveEndpoint(provider, model);
-  const impliedCapability = endpointImpliedCapability(resolvedEndpoint.endpointType);
+  const connection = resolveProviderConnection(provider, model);
+  const impliedCapability = endpointImpliedCapability(connection.endpointType);
   if (
     model.capabilities.includes(MODEL_CAPABILITY.EMBEDDING) ||
     model.capabilities.includes(MODEL_CAPABILITY.RERANK) ||
@@ -90,13 +87,13 @@ export async function buildAgentParams({
       resolveApiKey: (providerId, override) =>
         services.provider.resolveApiKey(providerId, override),
     },
-    { apiKeyOverride: request.apiKeyOverride, resolvedEndpoint },
+    { apiKeyOverride: request.apiKeyOverride, resolvedConnection: connection },
   );
-  const endpointType = resolvedEndpoint.endpointType;
+  const endpointType = connection.endpointType;
   const providerOptionsKey = resolveProviderOptionsKey(sdkConfig.providerId, {
     actualProviderId: provider.id,
     endpointType,
-    gatewayProviderOptionsKey: resolvedEndpoint.providerOptionsKey,
+    gatewayProviderOptionsKey: connection.providerOptionsKey,
   });
   const reasoningEndpointType =
     sdkConfig.providerId === 'google-vertex-maas'
@@ -142,7 +139,7 @@ export async function buildAgentParams({
   });
   const tools = request.callOverrides?.tools;
   const repairToolCall = createAiRepair({
-    modelId: model.apiModelId ?? model.modelId,
+    modelId: connection.wireModelId,
     providerId: sdkConfig.providerId,
     providerSettings: sdkConfig.providerSettings,
     getUsagePlugins: getRepairUsagePlugins,
@@ -161,7 +158,7 @@ export async function buildAgentParams({
 
   return {
     credentialReceipt,
-    sdkConfig: { ...sdkConfig, modelId: model.apiModelId ?? model.modelId },
+    sdkConfig: { ...sdkConfig, modelId: connection.wireModelId },
     context: {
       abortSignal: request.requestOptions?.signal,
       requestId: Crypto.randomUUID(),


### PR DESCRIPTION
## Summary

- centralize credential-free Provider connection facts shared by Pi and AI SDK request construction
- add a shared language serving plan with typed Pi compatibility results
- share Provider-specific language transport policies, starting with CherryAI request signing
- keep image execution independent while reusing Provider identity and connection facts
- document the Provider control-plane and capability-specific execution boundaries

## Design

This change adopts one Provider control plane with capability-specific execution planes:

- Pi remains the sole local conversation and tool-loop runtime
- the AI SDK remains the adapter for non-conversation language operations and model checks
- image generation bypasses the language serving plan and retains its own request, polling, and artifact semantics
- standard API-key Providers use endpoint and adapter-family declarations instead of Provider-id dispatch in Pi
- unsupported Pi protocol and authentication combinations fail before credential selection or network execution

Provider-specific behavior should be promoted into the shared language transport boundary only when multiple language bindings need it. Existing SDK-only workarounds and future image transports remain with their owning executor.

## Desktop relationship

Classification: `mobile-extension`.

Cherry Desktop commit `31750284d6854ced897417d342305985a445f5c1` was used as a semantic reference for Provider identity, endpoint and adapter-family ownership, and capability-specific runtime mechanics. This PR does not copy the Desktop loopback HTTP gateway and does not advance the Desktop sync manifest.

## Validation

- `pnpm format`: passed
- `pnpm format:check`: passed
- `git diff --check`: passed
- changed-file `oxlint`: passed with one pre-existing `prefer-set-has` warning in `provider/config.ts`
- `pnpm lint`: blocked in `expo lint` by the existing workspace alias resolution failure for `@cherrystudio/ai-core` imports (7 unresolved-import errors across the repository)

Tests, typecheck, builds, exports, and device acceptance were not run under the repository verification policy. The Desktop sync audit was not advanced because its source-set invariant currently reports unclassified Desktop runtime files.

## Follow-ups

Provider-specific request transformations should be promoted into shared language transport policies only when a concrete Pi compatibility requirement appears. They are intentionally not merge blockers for this foundation.
