### PR TITLE
fix(model-picker): filter models by supported capabilities

### DIFF
--- a/src/backend/ai/provider/__tests__/systemModelSupport.test.ts
+++ b/src/backend/ai/provider/__tests__/systemModelSupport.test.ts
@@ -1,0 +1,108 @@
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
+
+import { isModelSupportedBySystem } from '../systemModelSupport';
+
+describe('isModelSupportedBySystem', () => {
+  it('accepts Pi-compatible text models', () => {
+    expect(isModelSupportedBySystem(createProvider(), createModel())).toBe(true);
+  });
+
+  it('rejects text models whose endpoint cannot run through Pi', () => {
+    const provider = createProvider({
+      defaultChatEndpoint: ENDPOINT_TYPE.OLLAMA_CHAT,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OLLAMA_CHAT]: {
+          adapterFamily: 'ollama',
+          baseUrl: 'http://localhost:11434',
+        },
+      },
+    });
+
+    expect(
+      isModelSupportedBySystem(
+        provider,
+        createModel({ endpointTypes: [ENDPOINT_TYPE.OLLAMA_CHAT] }),
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts image models supported by the configured AI SDK adapter', () => {
+    const provider = createProvider({
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION]: {
+          adapterFamily: 'openai-compatible',
+          baseUrl: 'https://api.example.com/v1',
+        },
+      },
+    });
+    const model = createModel({
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION],
+    });
+
+    expect(isModelSupportedBySystem(provider, model)).toBe(true);
+  });
+
+  it('rejects image models when the configured AI SDK adapter cannot generate images', () => {
+    const provider = createProvider({
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION]: {
+          adapterFamily: 'anthropic',
+          baseUrl: 'https://api.example.com/v1',
+        },
+      },
+    });
+    const model = createModel({
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION],
+    });
+
+    expect(isModelSupportedBySystem(provider, model)).toBe(false);
+  });
+
+  it('rejects models that only serve unsupported product capabilities', () => {
+    const model = createModel({ capabilities: [MODEL_CAPABILITY.EMBEDDING] });
+
+    expect(isModelSupportedBySystem(createProvider(), model)).toBe(false);
+  });
+});
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    apiFeatures: { ...DEFAULT_API_FEATURES },
+    apiKeys: [{ id: 'key-1', isEnabled: true }],
+    authMethods: ['api-key'],
+    authType: 'api-key',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+        adapterFamily: 'openai-compatible',
+        baseUrl: 'https://api.example.com/v1',
+      },
+    },
+    id: 'test-provider',
+    isEnabled: true,
+    name: 'Test Provider',
+    settings: {},
+    ...overrides,
+  };
+}
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    capabilities: [],
+    endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS],
+    id: createUniqueModelId('test-provider', 'test-model'),
+    isDeprecated: false,
+    isEnabled: true,
+    isHidden: false,
+    modelId: 'test-model',
+    name: 'Test Model',
+    providerId: 'test-provider',
+    supportsStreaming: true,
+    ...overrides,
+  };
+}

--- a/src/backend/ai/provider/systemModelSupport.ts
+++ b/src/backend/ai/provider/systemModelSupport.ts
@@ -1,0 +1,43 @@
+import { extensionRegistry } from '@cherrystudio/ai-core/provider';
+import { getAiSdkProviderId } from '@cherrystudio/ai-runtime/provider';
+
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
+import { isImageGenerationModel, isTextGenerationModel } from '@/shared/utils/modelPurpose';
+
+import { resolveLanguageServingPlan } from './languageServingPlan';
+
+/**
+ * Whether one configured model can be executed by at least one product feature
+ * currently shipped on mobile.
+ *
+ * Conversation support is owned by Pi. Image generation remains an independent
+ * AI SDK capability, so either path is sufficient to admit the model.
+ */
+export function isModelSupportedBySystem(provider: Provider, model: Model): boolean {
+  if (isImageGenerationModel(model) && isImageGenerationSupported(provider, model)) {
+    return true;
+  }
+
+  return (
+    isTextGenerationModel(model) &&
+    resolveLanguageServingPlan(provider, model).bindings.pi.status === 'supported'
+  );
+}
+
+export function filterModelsSupportedBySystem(
+  models: readonly Model[],
+  providers: readonly Provider[],
+): Model[] {
+  const providersById = new Map(providers.map((provider) => [provider.id, provider]));
+
+  return models.filter((model) => {
+    const provider = providersById.get(model.providerId);
+    return provider ? isModelSupportedBySystem(provider, model) : false;
+  });
+}
+
+function isImageGenerationSupported(provider: Provider, model: Model): boolean {
+  const extension = extensionRegistry.get(getAiSdkProviderId(provider, model));
+  return extension?.config.supportsImageGeneration === true;
+}

--- a/src/backend/data/api/handlers/apiHandlers.ts
+++ b/src/backend/data/api/handlers/apiHandlers.ts
@@ -20,7 +20,7 @@ import { createAiUsageRecordHandlers } from './aiUsageRecords';
 import { createFileHandlers } from './files';
 import { createJobHandlers } from './jobs';
 import { createMcpServerHandlers, type McpServerMutations } from './mcpServers';
-import { createModelHandlers } from './models';
+import { createModelHandlers, type SystemModelSupportFilter } from './models';
 import { createPaintingHandlers } from './paintings';
 import { createProviderHandlers } from './providers';
 import { createSearchHandlers } from './search';
@@ -40,6 +40,7 @@ export type DataApiDependencies = {
   mcpServerMutations: McpServerMutations;
   mcpServers: McpServerService;
   models: import('../../services/ModelService').ModelService;
+  systemModelSupport: SystemModelSupportFilter;
   paintings: PaintingService;
   providers: ProviderService;
 };
@@ -54,7 +55,7 @@ export function createDataApiHandlers(dependencies: DataApiDependencies): ApiImp
     ...createFileHandlers(dependencies.files),
     ...createJobHandlers(dependencies.jobs),
     ...createMcpServerHandlers(dependencies.mcpServers, dependencies.mcpServerMutations),
-    ...createModelHandlers(dependencies.models),
+    ...createModelHandlers(dependencies.models, dependencies.systemModelSupport),
     ...createPaintingHandlers(dependencies.paintings),
     ...createProviderHandlers(dependencies.providers),
     ...createSearchHandlers(dependencies.contentSearch, dependencies.entitySearch),

--- a/src/backend/data/api/handlers/models.ts
+++ b/src/backend/data/api/handlers/models.ts
@@ -12,7 +12,11 @@ import {
   UpdateModelSchema,
 } from '@/shared/data/api/schemas/models';
 import type { HandlersFor } from '@/shared/data/api/types';
-import { isUniqueModelId, parseUniqueModelId } from '@/shared/data/types/model';
+import { isUniqueModelId, type Model, parseUniqueModelId } from '@/shared/data/types/model';
+
+export type SystemModelSupportFilter = {
+  filter(models: readonly Model[]): Promise<Model[]>;
+};
 
 function parseUniqueId(uniqueModelId: string) {
   if (!isUniqueModelId(uniqueModelId)) {
@@ -23,14 +27,32 @@ function parseUniqueId(uniqueModelId: string) {
   return parseUniqueModelId(uniqueModelId);
 }
 
-export function createModelHandlers(service: ModelService): HandlersFor<ModelSchemas> {
+export function createModelHandlers(
+  service: ModelService,
+  systemModelSupport: SystemModelSupportFilter,
+): HandlersFor<ModelSchemas> {
   return {
     '/models': {
       DELETE: async ({ query }) => {
         const parsed = DeleteModelsQuerySchema.parse(query);
         await service.bulkDelete(parsed.ids.map(parseUniqueId));
       },
-      GET: async ({ query }) => service.list(ListModelsQuerySchema.parse(query ?? {})),
+      GET: async ({ query }) => {
+        const { isSystemSupported, ...listQuery } = ListModelsQuerySchema.parse(query ?? {});
+        const models = await service.list(listQuery);
+
+        if (isSystemSupported === undefined) {
+          return models;
+        }
+
+        const supportedModels = await systemModelSupport.filter(models);
+        if (isSystemSupported) {
+          return supportedModels;
+        }
+
+        const supportedIds = new Set(supportedModels.map((model) => model.id));
+        return models.filter((model) => !supportedIds.has(model.id));
+      },
       PATCH: async ({ body }) =>
         service.bulkUpdate(
           BulkUpdateModelsSchema.parse(body).map(({ patch, uniqueModelId }) => ({

--- a/src/backend/data/services/ModelService.ts
+++ b/src/backend/data/services/ModelService.ts
@@ -7,7 +7,7 @@ import { userModelTable } from '@/backend/data/db/schemas/userModel';
 import { DataApiErrorFactory, ErrorCode } from '@/shared/data/api/errors';
 import type {
   CreateModelDto,
-  ListModelsQuery,
+  ModelListQuery,
   UpdateModelDto,
 } from '@/shared/data/api/schemas/models';
 import {
@@ -298,7 +298,7 @@ export class ModelService {
     return this.dbService.getDb();
   }
 
-  async list(query: ListModelsQuery = {}): Promise<Model[]> {
+  async list(query: ModelListQuery = {}): Promise<Model[]> {
     const conditions: SQL[] = [];
     if (query.providerId) {
       conditions.push(eq(userModelTable.providerId, query.providerId));

--- a/src/backend/services/models/__tests__/createModelsModule.test.ts
+++ b/src/backend/services/models/__tests__/createModelsModule.test.ts
@@ -31,6 +31,7 @@ function createSubject(overrides: Partial<ModelsModuleDependencies> = {}) {
       checkModel: jest.fn(async () => ({ latency: 12 })),
       listModels: jest.fn(async () => []),
     },
+    isSystemSupportedModel: jest.fn(() => true),
     materializeRemoteModels: (_provider, models) => models as Model[],
     models: {
       get: jest.fn(async (id: UniqueModelId) => model(id.split('::')[1] ?? id)),
@@ -75,6 +76,22 @@ describe('createModelsModule', () => {
     await expect(backend.pull('openai')).resolves.toEqual({
       preview: { added: [remote], missing: [] },
       status: 'changes',
+    });
+  });
+
+  it('keeps unsupported local and remote models out of the pull preview', async () => {
+    const supported = model('supported');
+    const unsupportedLocal = model('unsupported-local', { presetModelId: 'unsupported-local' });
+    const unsupportedRemote = model('unsupported-remote');
+    const { backend, dependencies } = createSubject({
+      isSystemSupportedModel: jest.fn((_provider, candidate) => candidate.id === supported.id),
+    });
+    jest.mocked(dependencies.models.list).mockResolvedValue([supported, unsupportedLocal]);
+    jest.mocked(dependencies.ai.listModels).mockResolvedValue([supported, unsupportedRemote]);
+
+    await expect(backend.pull('openai')).resolves.toEqual({
+      providerEnabled: true,
+      status: 'up-to-date',
     });
   });
 

--- a/src/backend/services/models/createModelsModule.ts
+++ b/src/backend/services/models/createModelsModule.ts
@@ -49,6 +49,7 @@ type ModelsAi = {
 
 export type ModelsModuleDependencies = {
   ai: ModelsAi;
+  isSystemSupportedModel(provider: Provider, model: Model): boolean;
   materializeRemoteModels(provider: Provider, models: readonly RemoteModel[]): Model[];
   models: ModelWorkflowData;
   providers: ProviderWorkflowData;
@@ -163,8 +164,18 @@ export function createModelsModule(dependencies: ModelsModuleDependencies): Mode
         }),
       ]),
     );
-    const normalizedRemoteModels = dependencies.materializeRemoteModels(provider, remoteModels);
-    const preview = buildPullPreview(providerId, localModels, normalizedRemoteModels);
+    const supportedLocalModels = localModels.filter((model) =>
+      dependencies.isSystemSupportedModel(provider, model),
+    );
+    const supportedRemoteModels = dependencies
+      .materializeRemoteModels(provider, remoteModels)
+      .filter((model) => dependencies.isSystemSupportedModel(provider, model));
+    const preview = buildPullPreview(
+      providerId,
+      supportedLocalModels,
+      supportedRemoteModels,
+      localModels,
+    );
 
     if (preview.added.length > 0 || preview.missing.length > 0) {
       return { preview, status: 'changes' };
@@ -172,7 +183,7 @@ export function createModelsModule(dependencies: ModelsModuleDependencies): Mode
 
     const providerEnabled = await enableProviderWhenModelsAvailable(
       provider,
-      localModels.length,
+      supportedLocalModels.length,
       'pull-up-to-date',
     );
     return { providerEnabled, status: 'up-to-date' };
@@ -207,8 +218,9 @@ function buildPullPreview(
   providerId: string,
   localModels: readonly Model[],
   remoteModels: readonly Model[],
+  existingModels: readonly Model[] = localModels,
 ) {
-  const localIds = new Set(localModels.map((model) => model.id));
+  const localIds = new Set(existingModels.map((model) => model.id));
   const remoteIds = new Set(remoteModels.map((model) => model.id));
 
   return {

--- a/src/bootstrap/composition/createBackend.ts
+++ b/src/bootstrap/composition/createBackend.ts
@@ -1,7 +1,12 @@
 import {
+  filterModelsSupportedBySystem,
+  isModelSupportedBySystem,
+} from '@/backend/ai/provider/systemModelSupport';
+import {
   createMcpServerMutations,
   type McpServerMutations,
 } from '@/backend/data/api/handlers/mcpServers';
+import type { SystemModelSupportFilter } from '@/backend/data/api/handlers/models';
 import type { DbService } from '@/backend/data/db/DbService';
 import { materializeRemoteModels } from '@/backend/data/services/materializeRemoteModels';
 import { canDeleteProvider } from '@/backend/data/services/ProviderService';
@@ -36,6 +41,7 @@ export type BackendComposition = {
   dataApiDependencies: {
     agentAvatars: AgentAvatars;
     mcpServerMutations: McpServerMutations;
+    systemModelSupport: SystemModelSupportFilter;
   };
 };
 
@@ -44,8 +50,13 @@ export function createBackend(
   infrastructure: { dbService: DbService },
 ): BackendComposition {
   const { dbService } = infrastructure;
+  const systemModelSupport: SystemModelSupportFilter = {
+    filter: async (candidateModels) =>
+      filterModelsSupportedBySystem(candidateModels, await services.provider.list()),
+  };
   const models = createModelsModule({
     ai: services.ai,
+    isSystemSupportedModel: isModelSupportedBySystem,
     materializeRemoteModels,
     models: {
       get: (id) => services.model.getById(id),
@@ -136,6 +147,7 @@ export function createBackend(
     dataApiDependencies: {
       agentAvatars,
       mcpServerMutations,
+      systemModelSupport,
     },
   };
 }

--- a/src/bootstrap/runtime/createAppBootstrapRuntime.ts
+++ b/src/bootstrap/runtime/createAppBootstrapRuntime.ts
@@ -90,6 +90,7 @@ export function createAppBootstrapRuntime(
       models: services.model,
       paintings: services.painting,
       providers: services.provider,
+      systemModelSupport: dataApiDependencies.systemModelSupport,
     }),
   );
 

--- a/src/frontend/components/modelPicker/components/ModelPickerDrawer.tsx
+++ b/src/frontend/components/modelPicker/components/ModelPickerDrawer.tsx
@@ -6,11 +6,13 @@ import { View } from 'react-native';
 import { useModelPickerData } from '../hooks/useModelPickerData';
 import { type ModelPickerModelItem, type ModelPickerTag } from '../utils/modelPickerData';
 import { buildModelPickerListItems } from '../utils/modelPickerListItems';
+import type { ModelTypeFilter } from '../utils/modelTypeFilter';
 import { ModelPickerList } from './ModelPickerList';
 
 const DEFAULT_SELECTED_TAGS: readonly ModelPickerTag[] = [];
 
 type ModelPickerDrawerProps = {
+  modelType: ModelTypeFilter;
   onClose: () => void;
   onSelect: (item: ModelPickerModelItem) => void;
   open: boolean;
@@ -22,6 +24,7 @@ type ModelPickerDrawerProps = {
 
 /** The complete model-picking interaction; callers only supply business state and actions. */
 export function ModelPickerDrawer({
+  modelType,
   onClose,
   onSelect,
   open,
@@ -46,6 +49,7 @@ export function ModelPickerDrawer({
     >
       <ModelPickerDrawerContent
         deferredSearchText={deferredSearchText}
+        modelType={modelType}
         onSelect={onSelect}
         onSearchFocusChange={setIsSearchFocused}
         onSearchTextChange={setSearchText}
@@ -61,6 +65,7 @@ export function ModelPickerDrawer({
 
 function ModelPickerDrawerContent({
   deferredSearchText,
+  modelType,
   onSelect,
   onSearchFocusChange,
   onSearchTextChange,
@@ -71,7 +76,7 @@ function ModelPickerDrawerContent({
   selectedModelId,
 }: Pick<
   ModelPickerDrawerProps,
-  'onSelect' | 'open' | 'providerId' | 'selectedModelId' | 'selectedTags'
+  'modelType' | 'onSelect' | 'open' | 'providerId' | 'selectedModelId' | 'selectedTags'
 > & {
   deferredSearchText: string;
   onSearchFocusChange: (isFocused: boolean) => void;
@@ -80,6 +85,7 @@ function ModelPickerDrawerContent({
 }) {
   const { t } = useTranslation();
   const { groups, isLoading } = useModelPickerData({
+    modelType,
     providerId,
     searchText: deferredSearchText,
     selectedTags,

--- a/src/frontend/components/modelPicker/components/__tests__/ModelPickerDrawer.test.tsx
+++ b/src/frontend/components/modelPicker/components/__tests__/ModelPickerDrawer.test.tsx
@@ -44,7 +44,13 @@ describe('ModelPickerDrawer', () => {
   beforeEach(() => {
     act(() => {
       renderer = create(
-        <ModelPickerDrawer onClose={jest.fn()} onSelect={jest.fn()} open selectedModelId={null} />,
+        <ModelPickerDrawer
+          modelType="text"
+          onClose={jest.fn()}
+          onSelect={jest.fn()}
+          open
+          selectedModelId={null}
+        />,
       );
     });
   });

--- a/src/frontend/components/modelPicker/hooks/__tests__/useModelPickerData.test.tsx
+++ b/src/frontend/components/modelPicker/hooks/__tests__/useModelPickerData.test.tsx
@@ -26,7 +26,7 @@ describe('useModelPickerData', () => {
   });
 
   test('returns the same reference across re-renders', () => {
-    const results = renderHookTwice(() => useModelPickerData());
+    const results = renderHookTwice(() => useModelPickerData({ modelType: 'text' }));
 
     expect(results[1]).toBe(results[0]);
   });
@@ -34,13 +34,15 @@ describe('useModelPickerData', () => {
   test('stays stable when the caller omits selectedTags', () => {
     // A `= []` default would allocate a new array per call and invalidate the
     // `groups` memo — the most expensive computation in the hook.
-    const results = renderHookTwice(() => useModelPickerData({ searchText: '' }));
+    const results = renderHookTwice(() =>
+      useModelPickerData({ modelType: 'text', searchText: '' }),
+    );
 
     expect(results[1]?.groups).toBe(results[0]?.groups);
   });
 
   test('exposes only reference-stable fields', () => {
-    const [result] = renderHookTwice(() => useModelPickerData());
+    const [result] = renderHookTwice(() => useModelPickerData({ modelType: 'text' }));
 
     // `queries` (react-query hands back a newly tracked proxy each render) can
     // never be stable, so the hook must not surface it.
@@ -48,9 +50,13 @@ describe('useModelPickerData', () => {
   });
 
   test('limits the model query to one provider when requested', () => {
-    renderHookTwice(() => useModelPickerData({ providerId: 'provider-1' }));
+    renderHookTwice(() => useModelPickerData({ modelType: 'text', providerId: 'provider-1' }));
 
-    expect(mockModelQueries).toContainEqual({ enabled: true, providerId: 'provider-1' });
+    expect(mockModelQueries).toContainEqual({
+      enabled: true,
+      isSystemSupported: true,
+      providerId: 'provider-1',
+    });
   });
 });
 

--- a/src/frontend/components/modelPicker/hooks/useModelPickerData.ts
+++ b/src/frontend/components/modelPicker/hooks/useModelPickerData.ts
@@ -9,8 +9,10 @@ import {
   type ModelPickerModelItem,
   type ModelPickerTag,
 } from '../utils/modelPickerData';
+import type { ModelTypeFilter } from '../utils/modelTypeFilter';
 
 type UseModelPickerDataOptions = {
+  modelType: ModelTypeFilter;
   providerId?: string;
   searchText?: string;
   selectedTags?: readonly ModelPickerTag[];
@@ -23,11 +25,16 @@ type UseModelPickerDataOptions = {
 const EMPTY_TAGS: readonly ModelPickerTag[] = Object.freeze([]);
 
 export function useModelPickerData({
+  modelType,
   providerId,
   searchText = '',
   selectedTags = EMPTY_TAGS,
-}: UseModelPickerDataOptions = {}) {
-  const { isLoading: isModelsLoading, models } = useModels({ enabled: true, providerId });
+}: UseModelPickerDataOptions) {
+  const { isLoading: isModelsLoading, models } = useModels({
+    enabled: true,
+    isSystemSupported: true,
+    providerId,
+  });
   const { isLoading: isProvidersLoading, providers: enabledProviders } = useProviders({
     enabled: true,
   });
@@ -39,20 +46,20 @@ export function useModelPickerData({
     [enabledProviders, providerId],
   );
   const groups = useMemo(
-    () => buildModelPickerGroups({ models, providers, searchText, selectedTags }),
-    [models, providers, searchText, selectedTags],
+    () => buildModelPickerGroups({ modelType, models, providers, searchText, selectedTags }),
+    [modelType, models, providers, searchText, selectedTags],
   );
   const availableTags = useMemo(
-    () => getAvailableModelPickerFilterTags({ models, providers }),
-    [models, providers],
+    () => getAvailableModelPickerFilterTags({ modelType, models, providers }),
+    [modelType, models, providers],
   );
   const modelItems = useMemo<ModelPickerModelItem[]>(
     () => groups.flatMap((group) => group.items),
     [groups],
   );
   const getModelItem = useCallback(
-    (modelId: string | null) => getModelPickerModelItem(modelId, { models, providers }),
-    [models, providers],
+    (modelId: string | null) => getModelPickerModelItem(modelId, { modelType, models, providers }),
+    [modelType, models, providers],
   );
 
   // Memoized so consumers can key their own memos/effects on the returned object.

--- a/src/frontend/components/modelPicker/utils/__tests__/modelPickerData.test.ts
+++ b/src/frontend/components/modelPicker/utils/__tests__/modelPickerData.test.ts
@@ -267,10 +267,10 @@ describe('model picker data helpers', () => {
       }),
     ];
     const groups = buildModelPickerGroups({
+      modelType: 'image',
       models: imageModels,
       providers,
       searchText: '',
-      selectedTags: [MODEL_CAPABILITY.IMAGE_GENERATION],
     });
 
     expect(groups.flatMap((group) => group.items.map((item) => item.modelId))).toEqual([

--- a/src/frontend/components/modelPicker/utils/modelPickerData.ts
+++ b/src/frontend/components/modelPicker/utils/modelPickerData.ts
@@ -3,6 +3,8 @@ import { MODALITY, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import type { Model, UniqueModelId } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 
+import { matchesModelTypeFilter, type ModelTypeFilter } from './modelTypeFilter';
+
 export type ModelPickerModelItem = {
   key: string;
   model: Model;
@@ -59,14 +61,16 @@ const MODEL_PICKER_TAG_LABEL_KEYS = {
 export function getModelPickerModelItem(
   modelId: string | null,
   {
+    modelType = 'all',
     models,
     providers,
   }: {
+    modelType?: ModelTypeFilter;
     models: readonly Model[];
     providers: readonly Provider[];
   },
 ): ModelPickerModelItem | undefined {
-  const selectableModels = getSelectableModelPickerModels(models, providers);
+  const selectableModels = getSelectableModelPickerModels(models, providers, modelType);
   const model = selectableModels.find((item) => item.id === modelId);
   const provider = model ? providers.find((item) => item.id === model.providerId) : undefined;
 
@@ -97,13 +101,15 @@ export function getModelPickerRowTags(model: Model): ModelPickerTag[] {
 }
 
 export function getAvailableModelPickerFilterTags({
+  modelType = 'all',
   models,
   providers,
 }: {
+  modelType?: ModelTypeFilter;
   models: readonly Model[];
   providers: readonly Provider[];
 }): ModelPickerTag[] {
-  const selectableModels = getSelectableModelPickerModels(models, providers);
+  const selectableModels = getSelectableModelPickerModels(models, providers, modelType);
 
   return getAvailableModelPickerFilterTagsForModels(selectableModels);
 }
@@ -128,11 +134,13 @@ export function filterModelsByModelPickerTags(
 }
 
 export function buildModelPickerGroups({
+  modelType = 'all',
   models,
   providers,
   searchText,
   selectedTags = [],
 }: {
+  modelType?: ModelTypeFilter;
   models: readonly Model[];
   providers: readonly Provider[];
   searchText: string;
@@ -140,7 +148,7 @@ export function buildModelPickerGroups({
 }): ModelPickerGroup[] {
   const providerById = new Map(providers.map((provider) => [provider.id, provider]));
   const keywords = getSearchKeywords(searchText);
-  const selectableModels = getSelectableModelPickerModels(models, providers);
+  const selectableModels = getSelectableModelPickerModels(models, providers, modelType);
   const filteredModels = selectableModels.filter((model) => {
     const provider = providerById.get(model.providerId);
 
@@ -231,20 +239,11 @@ function matchesModelPickerSelectedTags(
   return selectedTags.every((tag) => matchesModelPickerTag(model, tag));
 }
 
-// Capabilities for models that can't be used in chat, so they're excluded from the picker.
-const CHAT_UNSUPPORTED_CAPABILITIES = [
-  MODEL_CAPABILITY.AUDIO_RECOGNITION,
-  MODEL_CAPABILITY.EMBEDDING,
-  MODEL_CAPABILITY.RERANK,
-] as const;
-
-function isChatCapableModel(model: Model): boolean {
-  return !CHAT_UNSUPPORTED_CAPABILITIES.some((capability) =>
-    model.capabilities.includes(capability),
-  );
-}
-
-function getSelectableModelPickerModels(models: readonly Model[], providers: readonly Provider[]) {
+function getSelectableModelPickerModels(
+  models: readonly Model[],
+  providers: readonly Provider[],
+  modelType: ModelTypeFilter,
+) {
   const enabledProviderIds = new Set(
     providers.flatMap((provider) => (provider.isEnabled ? [provider.id] : [])),
   );
@@ -254,7 +253,7 @@ function getSelectableModelPickerModels(models: readonly Model[], providers: rea
       model.isEnabled &&
       !model.isHidden &&
       enabledProviderIds.has(model.providerId) &&
-      isChatCapableModel(model),
+      matchesModelTypeFilter(model, modelType),
   );
 }
 

--- a/src/frontend/components/modelPicker/utils/modelTypeFilter.ts
+++ b/src/frontend/components/modelPicker/utils/modelTypeFilter.ts
@@ -1,11 +1,14 @@
-import {
-  ENDPOINT_TYPE,
-  endpointImpliedCapability,
-  MODALITY,
-  MODEL_CAPABILITY,
-} from '@cherrystudio/provider-registry';
-
 import type { Model } from '@/shared/data/types/model';
+import {
+  hasTextToSpeechEndpoint,
+  isAudioGenerationModel,
+  isEmbeddingModel,
+  isImageGenerationModel,
+  isRerankModel,
+  isSpeechToTextModel,
+  isTextGenerationModel,
+  isVideoGenerationModel,
+} from '@/shared/utils/modelPurpose';
 
 /**
  * The pull screen filters by what a model is *for*, not by the overlapping
@@ -42,16 +45,16 @@ export const MODEL_TYPE_LABEL_KEYS = {
 export function matchesModelTypeFilter(model: Model, filter: ModelTypeFilter): boolean {
   switch (filter) {
     case 'text':
-      return !isNonChatModel(model);
+      return isTextGenerationModel(model);
     case 'image':
-      return isGenerateImageModel(model);
+      return isImageGenerationModel(model);
     case 'embedding':
       return isEmbeddingModel(model);
     case 'audio':
       // "Generate audio", excluding text-to-speech, which has its own tab.
-      return isGenerateAudioModel(model) && !hasTextToSpeechEndpoint(model);
+      return isAudioGenerationModel(model) && !hasTextToSpeechEndpoint(model);
     case 'video':
-      return isGenerateVideoModel(model);
+      return isVideoGenerationModel(model);
     case 'rerank':
       return isRerankModel(model);
     case 'speech':
@@ -88,57 +91,4 @@ export function filterModelsByType(models: readonly Model[], filter: ModelTypeFi
   return filter === 'all'
     ? [...models]
     : models.filter((model) => matchesModelTypeFilter(model, filter));
-}
-
-// Text-to-speech is the only audio-output sub-kind that can be singled out from
-// generic audio generation today — the `AUDIO_GENERATION` capability backs both,
-// so the dedicated endpoint is the distinguishing signal.
-function hasTextToSpeechEndpoint(model: Model): boolean {
-  return model.endpointTypes?.includes(ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH) ?? false;
-}
-
-function isEmbeddingModel(model: Model): boolean {
-  return model.capabilities.includes(MODEL_CAPABILITY.EMBEDDING);
-}
-
-function isRerankModel(model: Model): boolean {
-  return model.capabilities.includes(MODEL_CAPABILITY.RERANK);
-}
-
-function isGenerateImageModel(model: Model): boolean {
-  return model.capabilities.includes(MODEL_CAPABILITY.IMAGE_GENERATION);
-}
-
-function isGenerateAudioModel(model: Model): boolean {
-  return model.capabilities.includes(MODEL_CAPABILITY.AUDIO_GENERATION);
-}
-
-function isGenerateVideoModel(model: Model): boolean {
-  return model.capabilities.includes(MODEL_CAPABILITY.VIDEO_GENERATION);
-}
-
-// Prefer the explicit transcript capability. A catalog that only exposes
-// modalities still identifies a dedicated speech-to-text model by audio in and
-// text out with no text input; that last guard is what keeps a multimodal chat
-// model (Gemini, GPT-4o, …) out of this bucket.
-function isSpeechToTextModel(model: Model): boolean {
-  return (
-    model.capabilities.includes(MODEL_CAPABILITY.AUDIO_TRANSCRIPT) ||
-    (model.capabilities.includes(MODEL_CAPABILITY.AUDIO_RECOGNITION) &&
-      model.inputModalities?.includes(MODALITY.AUDIO) === true &&
-      !model.inputModalities.includes(MODALITY.TEXT) &&
-      model.outputModalities?.includes(MODALITY.TEXT) === true)
-  );
-}
-
-function isNonChatModel(model: Model): boolean {
-  return (
-    endpointImpliedCapability(model.endpointTypes?.[0]) != null ||
-    isEmbeddingModel(model) ||
-    isRerankModel(model) ||
-    isGenerateImageModel(model) ||
-    isGenerateVideoModel(model) ||
-    isGenerateAudioModel(model) ||
-    isSpeechToTextModel(model)
-  );
 }

--- a/src/frontend/data/queryKeys/models.ts
+++ b/src/frontend/data/queryKeys/models.ts
@@ -1,5 +1,11 @@
 export const modelQueryKeys = {
   detail: (modelId: string) => [`/models/${modelId}`] as const,
-  list: (params: { capability?: string; enabled?: boolean; providerId?: string } = {}) =>
-    ['/models', params] as const,
+  list: (
+    params: {
+      capability?: string;
+      enabled?: boolean;
+      isSystemSupported?: boolean;
+      providerId?: string;
+    } = {},
+  ) => ['/models', params] as const,
 };

--- a/src/frontend/features/agents/AgentEditScreen.tsx
+++ b/src/frontend/features/agents/AgentEditScreen.tsx
@@ -118,7 +118,7 @@ function AgentEditForm({
   const { createAgent, isCreating, isSettingAvatar, isUpdating, setAgentAvatar, updateAgent } =
     useAgentMutations();
   const { isReplacing, replaceAgentToolBindings } = useAgentToolBindingMutations();
-  const modelPickerData = useModelPickerData();
+  const modelPickerData = useModelPickerData({ modelType: 'text' });
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
   const [defaultModelPreference] = usePreference('agent.default_model_id');
   const [form, setForm] = useState<AgentFormState>(() => createAgentFormState(agent));
@@ -350,6 +350,7 @@ function AgentEditForm({
       </KeyboardAwareScrollView>
       {isModelPickerOpen ? (
         <ModelPickerDrawer
+          modelType="text"
           open
           onClose={closeModelPicker}
           onSelect={handleModelSelect}

--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -60,7 +60,7 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
   const { cancel, isBusy, sendMessage } = useAgentChatControls({ agentId, sessionId });
   const { agent } = useAgentApiById(agentId);
   const { updateAgent } = useAgentMutations();
-  const modelPickerData = useModelPickerData();
+  const modelPickerData = useModelPickerData({ modelType: 'text' });
   const persistModel = useCallback(
     (targetAgentId: string, modelId: ModelPickerModelItem['modelId']) =>
       updateAgent(targetAgentId, { modelId }),
@@ -292,6 +292,7 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
       </ChatInputEffortOverlay>
       {isModelPickerOpen ? (
         <ModelPickerDrawer
+          modelType="text"
           open
           onClose={closeModelPicker}
           onSelect={handleModelSelect}

--- a/src/frontend/features/paintings/components/PaintingInput.tsx
+++ b/src/frontend/features/paintings/components/PaintingInput.tsx
@@ -84,6 +84,7 @@ export function PaintingInput({
   const { models: enabledImageModels } = useModels({
     capability: MODEL_CAPABILITY.IMAGE_GENERATION,
     enabled: true,
+    isSystemSupported: true,
   });
   const { providers: enabledProviders } = useProviders({ enabled: true });
   const enabledProviderIds = new Set(enabledProviders.map((provider) => provider.id));
@@ -287,11 +288,11 @@ export function PaintingInput({
       ) : null}
       {isModelPickerOpen ? (
         <ModelPickerDrawer
+          modelType="image"
           open
           onClose={closeModelPicker}
           onSelect={handleModelSelect}
           selectedModelId={selectedModelId}
-          selectedTags={[MODEL_CAPABILITY.IMAGE_GENERATION]}
         />
       ) : null}
     </>

--- a/src/frontend/features/settings/ModelSettingsScreen.tsx
+++ b/src/frontend/features/settings/ModelSettingsScreen.tsx
@@ -1,5 +1,4 @@
 import ChevronDownIcon from '@cherrystudio/app-icons/icons/chevron-down';
-import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import { Section } from '@cherrystudio/ui/components';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,12 +16,11 @@ import {
   useModelSettingSelections,
 } from '@/frontend/components/modelPicker';
 
-const IMAGE_GENERATION_MODEL_TAGS = [MODEL_CAPABILITY.IMAGE_GENERATION] as const;
-
 export default function ModelSettingsScreen() {
   const { t } = useTranslation();
   const { onSelectionChange, selections } = useModelSettingSelections();
-  const modelPickerData = useModelPickerData();
+  const imageModelPickerData = useModelPickerData({ modelType: 'image' });
+  const textModelPickerData = useModelPickerData({ modelType: 'text' });
   const [activeKind, setActiveKind] = useState<ModelSettingKind>();
   const closeModelPicker = useCallback(() => setActiveKind(undefined), []);
   const handleModelSelect = useCallback(
@@ -44,12 +42,16 @@ export default function ModelSettingsScreen() {
         onPress: () => setActiveKind(kind),
         trailing: (
           <SelectedModelName
-            item={modelPickerData.getModelItem(selections[kind])}
+            item={
+              kind === 'painting'
+                ? imageModelPickerData.getModelItem(selections[kind])
+                : textModelPickerData.getModelItem(selections[kind])
+            }
             placeholder={t('settings.select.placeholder')}
           />
         ),
       })),
-    [modelPickerData, selections, t],
+    [imageModelPickerData, selections, t, textModelPickerData],
   );
   const selectedModelId = activeKind ? selections[activeKind] : null;
 
@@ -72,11 +74,11 @@ export default function ModelSettingsScreen() {
       </ScrollView>
       {activeKind ? (
         <ModelPickerDrawer
+          modelType={activeKind === 'painting' ? 'image' : 'text'}
           open
           onClose={closeModelPicker}
           onSelect={handleModelSelect}
           selectedModelId={selectedModelId}
-          selectedTags={activeKind === 'painting' ? IMAGE_GENERATION_MODEL_TAGS : undefined}
           title={t(MODEL_SETTING_KIND_TITLE_KEYS[activeKind])}
         />
       ) : null}

--- a/src/frontend/features/settings/ProviderScreen/apiService/hooks/useProviderApiServiceQueries.ts
+++ b/src/frontend/features/settings/ProviderScreen/apiService/hooks/useProviderApiServiceQueries.ts
@@ -27,7 +27,7 @@ export function useProviderApiServiceQueries(providerId: string) {
     retry: false,
   });
   const saveMutation = useMutation('PATCH', '/providers/:id', {
-    refresh: ['/providers', `/providers/${providerId}`, `/providers/${providerId}/auth`],
+    refresh: ['/models', '/providers', `/providers/${providerId}`, `/providers/${providerId}/auth`],
   });
   const replaceMutation = useMutation('PUT', '/providers/:id/api-keys', {
     onMutate: async (variables) => {

--- a/src/frontend/features/settings/ProviderScreen/detail/hooks/useProviderDetailSettings.ts
+++ b/src/frontend/features/settings/ProviderScreen/detail/hooks/useProviderDetailSettings.ts
@@ -13,7 +13,7 @@ export function useProviderDetailSettings(providerId: string) {
   const provider = providerQuery.data;
   const modelsQuery = useQuery('/models', {
     enabled: Boolean(providerId),
-    query: { enabled: true, providerId },
+    query: { enabled: true, isSystemSupported: true, providerId },
     staleTime: providerModelStaleTime,
   });
   const updateProviderMutation = useMutation('PATCH', '/providers/:id', {

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelCheckSection.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelCheckSection.tsx
@@ -1,10 +1,11 @@
 import ChevronDownIcon from '@cherrystudio/app-icons/icons/chevron-down';
 import { Button, Section } from '@cherrystudio/ui/components';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
 
 import {
+  filterModelsByType,
   ModelPickerDrawer,
   ModelPickerIcon,
   type ModelPickerModelItem,
@@ -32,9 +33,10 @@ export function ProviderModelCheckSection({
   const { t } = useTranslation();
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
   const [selectedModelId, setSelectedModelId] = useState<string>();
+  const textModels = useMemo(() => filterModelsByType(models, 'text'), [models]);
   const { isChecking, modelStatus, selectedModel, startCheck } = useProviderModelCheck({
     apiKeys,
-    models,
+    models: textModels,
     providerId,
     selectedModelId,
   });
@@ -60,7 +62,7 @@ export function ProviderModelCheckSection({
               accessibilityLabel={
                 selectedModel?.name ?? t('settings.provider.models.checkNoModels')
               }
-              disabled={isChecking || isLoading || models.length === 0}
+              disabled={isChecking || isLoading || textModels.length === 0}
               onPress={openModelPicker}
             >
               <View className="flex-row items-center gap-2">
@@ -90,6 +92,7 @@ export function ProviderModelCheckSection({
       {modelStatus?.status === 'success' ? <ModelCheckResult status={modelStatus} /> : null}
       {isModelPickerOpen ? (
         <ModelPickerDrawer
+          modelType="text"
           open
           onClose={closeModelPicker}
           onSelect={handleModelSelect}

--- a/src/shared/data/api/schemas/models.ts
+++ b/src/shared/data/api/schemas/models.ts
@@ -18,10 +18,11 @@ import {
 export const ListModelsQuerySchema = z.object({
   capability: z.enum(objectValues(MODEL_CAPABILITY)).optional(),
   enabled: z.boolean().optional(),
+  isSystemSupported: z.boolean().optional(),
   providerId: z.string().optional(),
 });
 export type ListModelsQuery = z.infer<typeof ListModelsQuerySchema>;
-export type ModelListQuery = ListModelsQuery;
+export type ModelListQuery = Omit<ListModelsQuery, 'isSystemSupported'>;
 
 export const CreateModelSchema = z.strictObject({
   capabilities: z.array(z.enum(objectValues(MODEL_CAPABILITY))).optional(),

--- a/src/shared/utils/modelPurpose.ts
+++ b/src/shared/utils/modelPurpose.ts
@@ -1,0 +1,58 @@
+import {
+  ENDPOINT_TYPE,
+  endpointImpliedCapability,
+  MODALITY,
+  MODEL_CAPABILITY,
+} from '@cherrystudio/provider-registry';
+
+import type { Model } from '@/shared/data/types/model';
+
+export function isTextGenerationModel(model: Model): boolean {
+  return !isNonTextGenerationModel(model);
+}
+
+export function isImageGenerationModel(model: Model): boolean {
+  return model.capabilities.includes(MODEL_CAPABILITY.IMAGE_GENERATION);
+}
+
+export function isEmbeddingModel(model: Model): boolean {
+  return model.capabilities.includes(MODEL_CAPABILITY.EMBEDDING);
+}
+
+export function isRerankModel(model: Model): boolean {
+  return model.capabilities.includes(MODEL_CAPABILITY.RERANK);
+}
+
+export function isAudioGenerationModel(model: Model): boolean {
+  return model.capabilities.includes(MODEL_CAPABILITY.AUDIO_GENERATION);
+}
+
+export function isVideoGenerationModel(model: Model): boolean {
+  return model.capabilities.includes(MODEL_CAPABILITY.VIDEO_GENERATION);
+}
+
+export function hasTextToSpeechEndpoint(model: Model): boolean {
+  return model.endpointTypes?.includes(ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH) ?? false;
+}
+
+export function isSpeechToTextModel(model: Model): boolean {
+  return (
+    model.capabilities.includes(MODEL_CAPABILITY.AUDIO_TRANSCRIPT) ||
+    (model.capabilities.includes(MODEL_CAPABILITY.AUDIO_RECOGNITION) &&
+      model.inputModalities?.includes(MODALITY.AUDIO) === true &&
+      !model.inputModalities.includes(MODALITY.TEXT) &&
+      model.outputModalities?.includes(MODALITY.TEXT) === true)
+  );
+}
+
+function isNonTextGenerationModel(model: Model): boolean {
+  return (
+    endpointImpliedCapability(model.endpointTypes?.[0]) != null ||
+    isEmbeddingModel(model) ||
+    isRerankModel(model) ||
+    isImageGenerationModel(model) ||
+    isVideoGenerationModel(model) ||
+    isAudioGenerationModel(model) ||
+    isSpeechToTextModel(model)
+  );
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

Provider settings and shared model pickers could expose models that the mobile runtime could not execute. Applying the language-runtime filter globally would also hide image-generation models that are valid for the painting flow.

After this PR:

- Provider model lists and pull previews expose the union of Pi-compatible language models and AI SDK-compatible image-generation models.
- Agent, chat, and provider health-check entry points select language models only.
- Painting entry points select image-generation models only.
- Global model settings resolve and select models according to each setting's purpose.
- Provider connection changes invalidate the supported-model query cache.

### Screenshots or videos

N/A — this changes which existing model rows are eligible without changing layout. The exact rows depend on the user's configured providers, and manual device verification was not run.

### Why we need it and why it was done in this way

The backend owns one system-level admission rule because it knows the actual execution adapters. The frontend owns purpose-specific filtering because each entry point knows whether it needs language or image generation.

The following tradeoffs were made:

- Unsupported persisted models remain stored for historical references, but supported-model list queries and pull previews do not expose them as selectable rows.
- Model-purpose classification is shared between backend admission and frontend pickers to prevent drift.

The following alternatives were considered:

- A global Pi-only filter was rejected because it incorrectly removes supported image-generation models.
- Frontend-only runtime compatibility checks were rejected because provider pull and settings data would still expose unsupported models and duplicate backend knowledge.

### Breaking changes

None.

### Special notes for your reviewer

Validation performed:

- `pnpm format`
- `pnpm lint` (passes with existing repository warnings and no errors)

Tests, type checking, builds, and manual UI verification were not run per repository verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Filter model choices to options supported by each feature, including image-generation models where appropriate.
```
