### PR TITLE
fix(agent-runtime): harden session consistency and lifecycle

### DIFF
--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -268,7 +268,9 @@ projection:
 - The latest assistant row with a non-null checkpoint is the replay candidate. The Host validates
   schema version, anchor membership, and the 256 KiB payload ceiling. Invalid, incompatible,
   oversized, or orphaned candidates are classified in logs and ignored; execution receives full
-  history instead.
+  history instead. The store resolves anchor membership and loads rows after the anchor directly;
+  it also returns lightweight full-transcript Turn-id and file-reference indexes, so the Host does
+  not materialize the complete transcript merely to discard its checkpoint-covered prefix.
 - Turn reads and live-status transitions leave the store: the Host holds the active turn's live
   state (`running`/`awaiting-approval`/`cancelling`) in memory and synthesizes `AgentTurnView`
   from it plus the assistant message row. Terminal statuses derive from the message row alone,

--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -189,8 +189,9 @@ implementations therefore receive only an executable effort level.
 
 File input is resolved by the Host before it reaches a Runtime: attachments enter the application's
 file storage first, `AgentInputPart` carries the resulting `fileEntryId`, and the Host validates the
-live entry and managed blob before message reservation. The Host has a process-local ledger of the
-managed ids referenced by the current input and visible history. A Runtime never reads the device
+live entry and managed blob before message reservation. The Host authorizes tools from managed ids
+referenced by the current input and complete Session transcript, while it resolves attachment
+content only for the current input and checkpoint-visible history. A Runtime never reads the device
 filesystem. For supported images, the Host enforces the shared JPEG/PNG/GIF/WebP whitelist plus
 at most 9 images, 10 MiB per file, 20 MiB total, and a conservative context reserve of 4,096 input
 tokens per image plus 1,024 tokens for text. This remains the Host's current-input admission ceiling;
@@ -496,17 +497,21 @@ Runtime that cannot report usage emits no `usage` event, and the assistant messa
 
 1. The Host validates that the Session is idle.
 2. It validates that the Session target is `local`, resolves the current Agent, public model facts,
-   input and history, then creates the turn resource ledger.
+   the latest checkpoint candidate, its Store-loaded history tail, and lightweight authorization
+   indexes, then creates the turn resource ledger. Invalid candidates load the full history.
 3. It freezes the immutable tool catalog against that ledger and builds the versioned,
    credential-free inference snapshot from the same model, options, and tools sent to the Runtime.
-4. It preflights attachments, then atomically persists the user message and assistant placeholder
-   with the selected model id and inference snapshot.
-5. The Host uses its injected Pi Runtime, loads the latest valid context checkpoint, and normalizes
-   instructions, model, grouped structured history after its anchor, the immutable tool snapshot,
-   input, and options. Invalid candidates fall back to the full history.
+4. It preflights attachments and opens the injected Pi Runtime Session. Only after that succeeds
+   does it atomically persist the user message and assistant placeholder with the selected model id
+   and inference snapshot.
+5. The Host normalizes instructions, model, grouped structured history after the checkpoint anchor,
+   the immutable tool snapshot, input, and options.
 6. The selected Runtime executes the prepared request.
 7. The Host maps Runtime parts, approvals, usage, and terminal events into Agent Protocol state.
-8. Terminal message and turn state commit before the Host publishes terminal protocol events.
+8. Terminal message and turn state commit before the Host publishes terminal protocol events. A
+   transient terminal-write failure retries the same outcome; a persistently unwritable store makes
+   that Host generation reject new submissions and leaves startup reconciliation to settle the
+   durable placeholder.
 
 The Runtime never writes application storage. The Host never interprets Pi-native events outside
 the Pi implementation.
@@ -515,6 +520,10 @@ the Pi implementation.
 
 Route unmount does not own or cancel execution; the app-owned Host and Runtime session do. A
 foreground transition creates a fresh protocol observation from the Host snapshot.
+
+Host shutdown closes submission admission before aborting both in-flight admission work and active
+turns. Attachment reads and automatic naming generation inherit the same lifecycle cancellation
+boundary; shutdown joins admissions before closing Runtime Sessions.
 
 Local execution depends on the Mobile JavaScript process. If the process is suspended or killed and
 the turn cannot reach a terminal event, startup reconciliation marks the persisted placeholder and

--- a/src/backend/ai/agent/index.ts
+++ b/src/backend/ai/agent/index.ts
@@ -38,6 +38,7 @@ export type {
   FakeRuntimeProgram,
 } from './FakeRuntime';
 export { FakeRuntime } from './FakeRuntime';
+export { raceAbort, settleWithin } from './raceAbort';
 export {
   createDeniedToolResult,
   createErrorToolResult,

--- a/src/backend/ai/agentHost/AgentSessionNaming.ts
+++ b/src/backend/ai/agentHost/AgentSessionNaming.ts
@@ -25,6 +25,7 @@ type AgentSessionNamingDependencies = {
   model: Pick<ModelService, 'getById'>;
   preference: Pick<PreferenceService, 'get'>;
   provider: Pick<ProviderService, 'getByProviderId'>;
+  signal?: AbortSignal;
   store: AgentSessionStore;
 };
 
@@ -77,7 +78,9 @@ export class AgentSessionNaming {
 
   private track(run: () => Promise<AgentSessionView | null>): Promise<AgentSessionView | null> {
     const promise = run().catch((error: unknown) => {
-      logger.warn('Failed to auto-rename Agent Session', error as Error);
+      if (!this.dependencies.signal?.aborted) {
+        logger.warn('Failed to auto-rename Agent Session', error as Error);
+      }
       return null;
     });
     this.inFlightWrites.add(promise);
@@ -89,11 +92,13 @@ export class AgentSessionNaming {
     sessionId: string,
     parts: readonly AgentInputPart[],
   ): Promise<AgentSessionView | null> {
+    this.dependencies.signal?.throwIfAborted();
     const userText = extractInputText(parts);
     const nextTitle = buildFirstUserMessageTitle(userText).slice(0, 255);
     if (!nextTitle) return null;
 
     const session = await this.dependencies.store.getSession(sessionId);
+    this.dependencies.signal?.throwIfAborted();
     if (!session || session.titleIsManual || !canAutoRename(session.title)) return null;
 
     return this.dependencies.store.autoRenameSession(sessionId, session.title, nextTitle);
@@ -109,7 +114,9 @@ export class AgentSessionNaming {
     this.summaryLocks.add(sessionId);
 
     try {
+      this.dependencies.signal?.throwIfAborted();
       const enabled = await this.dependencies.preference.get('agent.session_naming.enabled');
+      this.dependencies.signal?.throwIfAborted();
       if (!enabled) return null;
 
       const userText = extractInputText(input.userParts);
@@ -117,10 +124,13 @@ export class AgentSessionNaming {
       if (!userText || !assistantText) return null;
 
       const session = await this.dependencies.store.getSession(sessionId);
+      this.dependencies.signal?.throwIfAborted();
       if (!session || session.titleIsManual || !canAutoRename(session.title, userText)) return null;
 
       const uniqueModelId = await this.resolveNamingModelId();
+      this.dependencies.signal?.throwIfAborted();
       const system = await this.resolveNamingPrompt();
+      this.dependencies.signal?.throwIfAborted();
       const prompt = JSON.stringify([
         { mainText: userText, role: 'user' },
         { mainText: assistantText, role: 'assistant' },
@@ -130,11 +140,16 @@ export class AgentSessionNaming {
         reasoningEffort: 'none',
         system,
         uniqueModelId,
+        ...(this.dependencies.signal
+          ? { requestOptions: { signal: this.dependencies.signal } }
+          : {}),
       });
+      this.dependencies.signal?.throwIfAborted();
       const nextTitle = sanitizeConversationTitle(text).slice(0, 255);
       if (!nextTitle) return null;
 
       const latestSession = await this.dependencies.store.getSession(sessionId);
+      this.dependencies.signal?.throwIfAborted();
       if (
         !latestSession ||
         latestSession.titleIsManual ||

--- a/src/backend/ai/agentHost/AgentSessionStore.ts
+++ b/src/backend/ai/agentHost/AgentSessionStore.ts
@@ -13,6 +13,19 @@ export type StoredRuntimeContextCheckpoint = {
   checkpoint: unknown;
 };
 
+export type StoredRuntimeTurnContext = {
+  /** False only when an `afterTurnId` was requested but is not in this Session. */
+  anchorFound: boolean;
+  /** Model-visible history: full transcript or only rows after the requested turn. */
+  history: AgentMessageView[];
+  /** Distinguishes a truly empty Session from a checkpoint-trimmed history tail. */
+  hasMessages: boolean;
+  /** Lightweight authorization projection across the complete transcript. */
+  referencedFileEntryIds: string[];
+  /** Lightweight checkpoint-anchor projection across the complete transcript. */
+  sessionTurnIds: string[];
+};
+
 export type ReserveSubmissionResult = {
   /** Fresh correlation id shared by the reserved user/assistant pair. */
   turnId: string;
@@ -70,6 +83,15 @@ export interface AgentSessionStore {
   reserveSubmission(input: ReserveSubmissionInput): Promise<ReserveSubmissionResult>;
 
   listMessages(sessionId: string): Promise<AgentMessageView[]>;
+
+  /**
+   * Loads the bounded Runtime replay tail plus full-transcript authorization
+   * indexes without materializing every message in the Host.
+   */
+  loadRuntimeTurnContext(
+    sessionId: string,
+    afterTurnId: string | null,
+  ): Promise<StoredRuntimeTurnContext>;
 
   /** Returns the newest assistant row carrying an opaque checkpoint candidate. */
   getLatestContextCheckpoint(sessionId: string): Promise<StoredRuntimeContextCheckpoint | null>;

--- a/src/backend/ai/agentHost/InMemoryAgentSessionStore.ts
+++ b/src/backend/ai/agentHost/InMemoryAgentSessionStore.ts
@@ -169,6 +169,41 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
     return cloneJson((this.messages.get(sessionId) ?? []).map((stored) => stored.view));
   }
 
+  async loadRuntimeTurnContext(sessionId: string, afterTurnId: string | null) {
+    const transcript = this.messages.get(sessionId) ?? [];
+    let anchorIndex = -1;
+    if (afterTurnId !== null) {
+      for (let index = transcript.length - 1; index >= 0; index -= 1) {
+        if (transcript[index]?.view.turnId === afterTurnId) {
+          anchorIndex = index;
+          break;
+        }
+      }
+    }
+    const anchorFound = afterTurnId === null || anchorIndex >= 0;
+    const history = (
+      anchorFound && afterTurnId !== null ? transcript.slice(anchorIndex + 1) : transcript
+    ).map((stored) => stored.view);
+    const referencedFileEntryIds = [
+      ...new Set(
+        transcript.flatMap(({ view }) =>
+          view.parts.flatMap((part) => (part.type === 'file' ? [part.fileEntryId] : [])),
+        ),
+      ),
+    ].sort();
+    const sessionTurnIds = [
+      ...new Set(transcript.flatMap(({ view }) => (view.turnId === null ? [] : [view.turnId]))),
+    ].sort();
+
+    return cloneJson({
+      anchorFound,
+      hasMessages: transcript.length > 0,
+      history,
+      referencedFileEntryIds,
+      sessionTurnIds,
+    });
+  }
+
   async getLatestContextCheckpoint(sessionId: string) {
     const transcript = this.messages.get(sessionId) ?? [];
     for (let index = transcript.length - 1; index >= 0; index -= 1) {

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -37,7 +37,7 @@ import type {
   RuntimeTool,
   RuntimeUsageReport,
 } from '@/backend/ai/agent';
-import { PiRuntime } from '@/backend/ai/agent';
+import { PiRuntime, raceAbort } from '@/backend/ai/agent';
 import type { AiService } from '@/backend/ai/AiService';
 import type { McpRuntimeService } from '@/backend/ai/mcp';
 import {
@@ -93,7 +93,10 @@ import {
 import { AgentSessionNaming } from './AgentSessionNaming';
 import type { AgentSessionStore } from './AgentSessionStore';
 import { AgentSessionUsageRecorder } from './AgentSessionUsageRecorder';
-import { selectRuntimeContext, validateRuntimeContextCheckpoint } from './contextCheckpoints';
+import {
+  validateRuntimeContextCheckpoint,
+  validateRuntimeContextCheckpointCandidate,
+} from './contextCheckpoints';
 import { findImageAttachmentLimit, type ImageAttachmentLimit } from './imageAttachments';
 import {
   createAgentInferenceSnapshot,
@@ -142,6 +145,8 @@ const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
   update: () => {},
 };
 
+const TERMINAL_PERSISTENCE_RETRY_DELAYS_MS = [0, 50, 200] as const;
+
 type MobileAgentHostOverrides = {
   agents: AgentDefinitionSource;
   files: ManagedFileResolver;
@@ -177,6 +182,19 @@ type ActiveTurnState = {
   runtimeSession: AgentRuntimeSession;
 };
 
+type AdmissionState = {
+  abortController: AbortController;
+  completion: Promise<void>;
+};
+
+class TerminalPersistenceError extends Error {
+  override readonly name = 'TerminalPersistenceError';
+
+  constructor(readonly failure: unknown) {
+    super('The Agent Host could not persist a terminal turn state.');
+  }
+}
+
 function fail(code: AgentErrorView['code'], message: string, retryable = false): never {
   throw new AgentProtocolError({ code, message, retryable });
 }
@@ -211,7 +229,7 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
 export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
   private readonly activeTurns = new Map<string, ActiveTurnState>();
-  private readonly admittingSessions = new Map<string, Promise<void>>();
+  private readonly admittingSessions = new Map<string, AdmissionState>();
   private readonly deletingSessions = new Set<string>();
   private readonly runningTurnsBySession = new Map<string, Promise<void>>();
   private readonly runtimeSessions = new Map<
@@ -225,6 +243,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly inferenceModel: MobileAgentHostOverrides['inferenceModel'];
   private readonly modelSupportsTools: MobileAgentHostOverrides['modelSupportsTools'];
   private readonly runtimeTools: MobileAgentHostOverrides['runtimeTools'];
+  private readonly lifecycleAbortController = new AbortController();
+  private acceptingSubmissions = true;
 
   /**
    * Lifecycle composition supplies the selected store adapter. Production
@@ -249,6 +269,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         model: modelService,
         preference: preferenceService,
         provider: providerService,
+        signal: this.lifecycleAbortController.signal,
         store,
       });
     this.usage = overrides.usage ?? new AgentSessionUsageRecorder();
@@ -289,8 +310,22 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
    * leave live work behind a torn-down listener surface.
    */
   protected override async onStop(): Promise<void> {
+    this.acceptingSubmissions = false;
+    const reason = new Error('The Agent Host is stopping.');
+    this.lifecycleAbortController.abort(reason);
     for (const state of this.activeTurns.values()) {
-      state.abortController.abort(new Error('The Agent Host is stopping.'));
+      state.abortController.abort(reason);
+    }
+    for (const admission of this.admittingSessions.values()) {
+      admission.abortController.abort(reason);
+    }
+    await Promise.allSettled(
+      [...this.admittingSessions.values()].map(({ completion }) => completion),
+    );
+    // An admission already committing its reservation may have installed a
+    // turn while the first abort pass was running.
+    for (const state of this.activeTurns.values()) {
+      state.abortController.abort(reason);
     }
     const closing = [...this.runtimeSessions.values()].map(({ session }) =>
       session
@@ -357,7 +392,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     try {
       const admission = this.admittingSessions.get(sessionId);
       if (admission) {
-        await admission;
+        await admission.completion;
       }
       const active = this.activeTurns.get(sessionId);
       if (active) {
@@ -391,14 +426,19 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     this.assertIdle(sessionId);
     // Synchronous admission guard: a second submit that interleaves at any
     // await below still fails SESSION_BUSY (invariant 1).
-    const admission = createCompletionSignal();
-    this.admittingSessions.set(sessionId, admission.promise);
+    const completion = createCompletionSignal();
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    this.admittingSessions.set(sessionId, {
+      abortController,
+      completion: completion.promise,
+    });
     try {
-      const session = await this.store.getSession(sessionId);
+      const session = await raceAbort(this.store.getSession(sessionId), signal);
       if (!session) {
         fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
       }
-      const configuredAgent = await this.requireAgent(session.agentId);
+      const configuredAgent = await raceAbort(this.requireAgent(session.agentId), signal);
       const agent = applyTurnOverrides(configuredAgent, parsed);
       const runtime = this.routeExecutionTarget(session.executionTarget);
       if (
@@ -408,25 +448,42 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
       }
 
-      // History is everything stored before this turn.
-      const priorMessages = await this.store.listMessages(sessionId);
-      const storedContextCandidate = await this.store.getLatestContextCheckpoint(sessionId);
-      const runtimeContext = selectRuntimeContext(
-        priorMessages,
-        storedContextCandidate?.checkpoint ?? null,
+      const storedContextCandidate = await raceAbort(
+        this.store.getLatestContextCheckpoint(sessionId),
+        signal,
       );
-      if (runtimeContext.issue) {
+      const checkpointValidation = storedContextCandidate
+        ? validateRuntimeContextCheckpointCandidate(storedContextCandidate.checkpoint)
+        : null;
+      const requestedCheckpoint = checkpointValidation?.checkpoint ?? null;
+      const storedTurnContext = await raceAbort(
+        this.store.loadRuntimeTurnContext(sessionId, requestedCheckpoint?.anchorTurnId ?? null),
+        signal,
+      );
+      const runtimeContextCheckpoint =
+        requestedCheckpoint && storedTurnContext.anchorFound ? requestedCheckpoint : null;
+      const runtimeContextIssue =
+        checkpointValidation?.issue ??
+        (requestedCheckpoint && !storedTurnContext.anchorFound
+          ? 'CONTEXT_CHECKPOINT_ANCHOR_INVALID'
+          : null);
+      if (runtimeContextIssue) {
         logger.warn('Agent context checkpoint rejected; replaying full history', {
-          code: runtimeContext.issue,
+          code: runtimeContextIssue,
           checkpointMessageId: storedContextCandidate?.assistantMessageId,
           sessionId,
         });
       }
       const { availableFiles, inputFiles, parts } = await this.resolveManagedInput(
         parsed.parts,
-        priorMessages,
+        storedTurnContext.history,
+        signal,
       );
-      const resources = createTurnResourceLedger(inputFiles, priorMessages, availableFiles);
+      const resources = createTurnResourceLedger(
+        inputFiles,
+        storedTurnContext.referencedFileEntryIds,
+        availableFiles,
+      );
 
       // Freeze built-in and configured tools for the turn so mid-turn changes
       // cannot alter the active catalog. The catalog closes over this turn's
@@ -436,29 +493,43 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       let configuredTools: readonly RuntimeTool[] = [];
       if (runtime.descriptor.capabilities.tools) {
         try {
-          builtInTools = await this.toolSource.getTools({
-            agentId: agent.id,
-            model: agent.model,
-            resources,
-          });
+          builtInTools = await raceAbort(
+            this.toolSource.getTools({
+              agentId: agent.id,
+              model: agent.model,
+              resources,
+            }),
+            signal,
+          );
         } catch (error) {
+          signal.throwIfAborted();
           logger.warn(
             'Failed to resolve built-in Agent tools; continuing without them',
             error as Error,
           );
         }
-        configuredTools = await this.runtimeTools
-          .resolve(agent.id)
-          .catch(() =>
-            fail('EXECUTION_UNAVAILABLE', 'The configured Agent tools are unavailable.'),
-          );
+        try {
+          configuredTools = await raceAbort(this.runtimeTools.resolve(agent.id), signal);
+        } catch {
+          signal.throwIfAborted();
+          fail('EXECUTION_UNAVAILABLE', 'The configured Agent tools are unavailable.');
+        }
       }
       const tools = [...builtInTools, ...configuredTools];
-      const inferenceModel = await this.inferenceModel(agent.model).catch(() =>
-        fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.'),
-      );
+      let inferenceModel: Awaited<ReturnType<AgentInferenceModelResolver>>;
+      try {
+        inferenceModel = await raceAbort(this.inferenceModel(agent.model), signal);
+      } catch {
+        signal.throwIfAborted();
+        fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.');
+      }
       if (tools.length > 0) {
-        const supportsTools = await this.modelSupportsTools(agent.model).catch(() => false);
+        let supportsTools = false;
+        try {
+          supportsTools = await raceAbort(this.modelSupportsTools(agent.model), signal);
+        } catch {
+          signal.throwIfAborted();
+        }
         if (!supportsTools) {
           fail(
             'CAPABILITY_UNSUPPORTED',
@@ -472,19 +543,25 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         tools,
       });
 
-      const modelPreflight = await this.preflightModel(runtime, agent);
+      const modelPreflight = await this.preflightModel(runtime, agent, signal);
       this.assertAttachmentRequestSupported(
         runtime,
         parts,
-        runtimeContext.history,
+        storedTurnContext.history,
         resources,
         modelPreflight,
       );
       const runtimeTextAttachments = await this.resolveRuntimeTextAttachments(
         parts,
-        runtimeContext.history,
+        storedTurnContext.history,
         resources,
+        signal,
       );
+
+      // Open the Runtime before creating durable pending rows. A failed open
+      // must leave no reservation that startup reconciliation has to repair.
+      const runtimeSession = await this.getRuntimeSession(sessionId, runtime, signal);
+      signal.throwIfAborted();
 
       const userParts: AgentMessagePart[] = parts.map((part, index) =>
         part.type === 'text'
@@ -506,7 +583,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         modelId: inferenceSnapshot.model.uniqueModelId,
         inferenceSnapshot,
       });
-      const runtimeSession = await this.getRuntimeSession(sessionId, runtime);
 
       // The Turn projection starts here: reservation time is the turn start.
       const turn: AgentTurnView = {
@@ -520,11 +596,11 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       };
       const state: ActiveTurnState = {
         agent,
-        abortController: new AbortController(),
+        abortController,
         turn,
         assistantMessage: reserved.assistantMessage,
         autoNamePromise: null,
-        autoNameUserParts: priorMessages.length === 0 ? parts : null,
+        autoNameUserParts: storedTurnContext.hasMessages ? null : parts,
         backgroundReply: this.startBackgroundReply({
           agentId: agent.id,
           agentName: agent.name,
@@ -534,10 +610,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         pendingApprovals: new Map(),
         pendingContextCheckpoint: null,
         resources,
-        sessionTurnIds: new Set([
-          ...priorMessages.flatMap((message) => (message.turnId ? [message.turnId] : [])),
-          reserved.turnId,
-        ]),
+        sessionTurnIds: new Set([...storedTurnContext.sessionTurnIds, reserved.turnId]),
         usage: null,
         runtimeSession,
       };
@@ -546,7 +619,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       this.publish(sessionId, { type: 'message.created', message: reserved.userMessage });
       this.publish(sessionId, { type: 'message.created', message: reserved.assistantMessage });
       this.publish(sessionId, { type: 'turn.updated', turn });
-      if (state.autoNameUserParts) {
+      if (state.autoNameUserParts && !signal.aborted) {
         state.autoNamePromise = this.naming.maybeRenameFromFirstUserMessage(
           sessionId,
           state.autoNameUserParts,
@@ -558,9 +631,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         sessionId,
         agent,
         state,
-        runtimeContext.history,
+        storedTurnContext.history,
         parts,
-        runtimeContext.checkpoint,
+        runtimeContextCheckpoint,
         runtimeTextAttachments,
         tools,
       );
@@ -580,7 +653,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       };
     } finally {
       this.admittingSessions.delete(sessionId);
-      admission.resolve();
+      completion.resolve();
     }
   }
 
@@ -707,23 +780,35 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         }),
       );
     } catch (error) {
+      if (error instanceof TerminalPersistenceError) {
+        this.handleTerminalPersistenceFailure(sessionId, state, error);
+        return;
+      }
       if (state.abortController.signal.aborted) {
-        await this.finalize(sessionId, state, 'cancelled', null).catch(() => undefined);
+        try {
+          await this.finalize(sessionId, state, 'cancelled', null);
+        } catch (finalizeError) {
+          this.handleTerminalPersistenceFailure(sessionId, state, finalizeError);
+        }
         return;
       }
       logger.error('Agent turn failed outside the runtime event stream', error as Error);
-      await this.finalize(
-        sessionId,
-        state,
-        'failed',
-        toAgentErrorView({
-          code: 'host_error',
-          message: 'The turn failed unexpectedly.',
-          retryable: false,
-          origin: 'host',
-          ...(error instanceof Error ? { name: error.name } : {}),
-        }),
-      ).catch(() => undefined);
+      try {
+        await this.finalize(
+          sessionId,
+          state,
+          'failed',
+          toAgentErrorView({
+            code: 'host_error',
+            message: 'The turn failed unexpectedly.',
+            retryable: false,
+            origin: 'host',
+            ...(error instanceof Error ? { name: error.name } : {}),
+          }),
+        );
+      } catch (finalizeError) {
+        this.handleTerminalPersistenceFailure(sessionId, state, finalizeError);
+      }
     }
   }
 
@@ -865,7 +950,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     // Invariant 5: the terminal message state (including the turn-level error)
     // commits before the terminal events publish. The terminal turn view is a
     // projection of that committed message.
-    const finalized = await this.store.finalizeAssistantMessage({
+    const finalized = await this.persistTerminalState({
       assistantMessageId: state.assistantMessage.id,
       status: messageStatus,
       parts,
@@ -926,9 +1011,52 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     );
   }
 
+  private async persistTerminalState(
+    input: Parameters<AgentSessionStore['finalizeAssistantMessage']>[0],
+  ): Promise<AgentMessageView> {
+    let lastFailure: unknown;
+    for (const delayMs of TERMINAL_PERSISTENCE_RETRY_DELAYS_MS) {
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
+      try {
+        return await this.store.finalizeAssistantMessage(input);
+      } catch (error) {
+        lastFailure = error;
+      }
+    }
+    throw new TerminalPersistenceError(lastFailure);
+  }
+
+  private handleTerminalPersistenceFailure(
+    sessionId: string,
+    state: ActiveTurnState,
+    error: unknown,
+  ): void {
+    // There is no valid volatile terminal projection without its durable row.
+    // Fail the entire Host generation closed and retain the active turn; the
+    // next generation's startup reconciliation will mark the placeholder
+    // interrupted once persistence is available again.
+    this.acceptingSubmissions = false;
+    const failure = error instanceof TerminalPersistenceError ? error.failure : error;
+    logger.error(
+      'Agent Host entered a fatal state after terminal persistence failed',
+      failure as Error,
+      {
+        assistantMessageId: state.assistantMessage.id,
+        sessionId,
+        turnId: state.turn.id,
+      },
+    );
+  }
+
   // ── Helpers ──
 
-  private async resolveManagedInput(parts: AgentInputPart[], history: AgentMessageView[]) {
+  private async resolveManagedInput(
+    parts: AgentInputPart[],
+    history: AgentMessageView[],
+    signal: AbortSignal,
+  ) {
     const fileEntryIds = parts.flatMap((part) => {
       if (part.type !== 'file') {
         return [];
@@ -952,11 +1080,12 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     let availableFiles: Awaited<ReturnType<ManagedFileResolver['resolveAvailable']>> = new Map();
     if (fileEntryIds.length > 0 || historicalFileEntryIds.length > 0) {
       try {
-        availableFiles = await this.files.resolveAvailable([
-          ...fileEntryIds,
-          ...historicalFileEntryIds,
-        ]);
+        availableFiles = await raceAbort(
+          this.files.resolveAvailable([...fileEntryIds, ...historicalFileEntryIds]),
+          signal,
+        );
       } catch {
+        signal.throwIfAborted();
         fail('ATTACHMENT_UNAVAILABLE', 'An attached file could not be verified.');
       }
     }
@@ -996,10 +1125,12 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private async preflightModel(
     runtime: AgentRuntime,
     agent: AgentDefinition,
+    signal: AbortSignal,
   ): Promise<RuntimeModelPreflight> {
     try {
-      return await runtime.preflightModel(agent.model);
+      return await raceAbort(runtime.preflightModel(agent.model), signal);
     } catch {
+      signal.throwIfAborted();
       fail(
         'CAPABILITY_UNSUPPORTED',
         'The selected model or provider endpoint cannot execute this turn.',
@@ -1071,6 +1202,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     input: AgentInputPart[],
     history: AgentMessageView[],
     resources: TurnResourceLedger,
+    signal: AbortSignal,
   ): Promise<RuntimeAttachmentContents> {
     const currentFileEntryIds = input.flatMap((part) =>
       part.type === 'file' ? [part.fileEntryId] : [],
@@ -1092,9 +1224,10 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         currentFileEntryIds,
         historicalFileEntryIds,
         readBytes: (file, signal) => this.files.readAsBytes(file, signal),
-        signal: new AbortController().signal,
+        signal,
       });
     } catch (error) {
+      signal.throwIfAborted();
       if (error instanceof TextAttachmentError) {
         fail(
           error.failure === 'unavailable' ? 'ATTACHMENT_UNAVAILABLE' : 'ATTACHMENT_INVALID',
@@ -1142,6 +1275,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   }
 
   private assertIdle(sessionId: string): void {
+    if (!this.acceptingSubmissions) {
+      fail('EXECUTION_UNAVAILABLE', 'The Agent Host is stopping.');
+    }
     if (this.deletingSessions.has(sessionId)) {
       fail('SESSION_BUSY', 'The session is being deleted.');
     }
@@ -1194,17 +1330,33 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private async getRuntimeSession(
     sessionId: string,
     runtime: AgentRuntime,
+    signal: AbortSignal,
   ): Promise<AgentRuntimeSession> {
+    signal.throwIfAborted();
     const cached = this.runtimeSessions.get(sessionId);
     if (cached && cached.runtimeId === runtime.descriptor.id) {
       return cached.session;
     }
     if (cached) {
-      await cached.session.close();
+      this.runtimeSessions.delete(sessionId);
+      await raceAbort(cached.session.close(), signal);
     }
-    const session = await runtime.open();
-    this.runtimeSessions.set(sessionId, { runtimeId: runtime.descriptor.id, session });
-    return session;
+    const opening = runtime.open();
+    try {
+      const session = await raceAbort(opening, signal);
+      signal.throwIfAborted();
+      this.runtimeSessions.set(sessionId, { runtimeId: runtime.descriptor.id, session });
+      return session;
+    } catch (error) {
+      if (signal.aborted) {
+        void opening
+          .then((session) => session.close())
+          .catch((closeError: unknown) =>
+            logger.warn('Failed to close an aborted runtime session open', closeError as Error),
+          );
+      }
+      throw error;
+    }
   }
 
   private publish(sessionId: string, event: AgentEvent): void {

--- a/src/backend/ai/agentHost/SqliteAgentSessionStore.ts
+++ b/src/backend/ai/agentHost/SqliteAgentSessionStore.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNotNull, or, sql } from 'drizzle-orm';
 
 import {
   AppStatePolicy,
@@ -167,6 +167,81 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       .where(eq(agentSessionMessageTable.sessionId, sessionId))
       .orderBy(agentSessionMessageTable.createdAt, agentSessionMessageTable.id);
     return rows.map(toAgentMessageView);
+  }
+
+  async loadRuntimeTurnContext(sessionId: string, afterTurnId: string | null) {
+    const db = this.dbService.getDb();
+    const [anchor] =
+      afterTurnId === null
+        ? []
+        : await db
+            .select({
+              createdAt: agentSessionMessageTable.createdAt,
+              id: agentSessionMessageTable.id,
+            })
+            .from(agentSessionMessageTable)
+            .where(
+              and(
+                eq(agentSessionMessageTable.sessionId, sessionId),
+                eq(agentSessionMessageTable.turnId, afterTurnId),
+              ),
+            )
+            .orderBy(desc(agentSessionMessageTable.createdAt), desc(agentSessionMessageTable.id))
+            .limit(1);
+    const anchorFound = afterTurnId === null || anchor !== undefined;
+    const historyCondition =
+      anchorFound && anchor
+        ? and(
+            eq(agentSessionMessageTable.sessionId, sessionId),
+            or(
+              gt(agentSessionMessageTable.createdAt, anchor.createdAt),
+              and(
+                eq(agentSessionMessageTable.createdAt, anchor.createdAt),
+                gt(agentSessionMessageTable.id, anchor.id),
+              ),
+            ),
+          )
+        : eq(agentSessionMessageTable.sessionId, sessionId);
+
+    const [historyRows, messageRows, turnRows, fileRows] = await Promise.all([
+      db
+        .select()
+        .from(agentSessionMessageTable)
+        .where(historyCondition)
+        .orderBy(agentSessionMessageTable.createdAt, agentSessionMessageTable.id),
+      db
+        .select({ id: agentSessionMessageTable.id })
+        .from(agentSessionMessageTable)
+        .where(eq(agentSessionMessageTable.sessionId, sessionId))
+        .limit(1),
+      db
+        .select({ turnId: agentSessionMessageTable.turnId })
+        .from(agentSessionMessageTable)
+        .where(
+          and(
+            eq(agentSessionMessageTable.sessionId, sessionId),
+            isNotNull(agentSessionMessageTable.turnId),
+          ),
+        )
+        .groupBy(agentSessionMessageTable.turnId),
+      db.all<{ fileEntryId: string | null }>(sql`
+        SELECT DISTINCT json_extract(part.value, '$.fileEntryId') AS "fileEntryId"
+        FROM agent_session_message AS message,
+             json_each(json_extract(message.data, '$.parts')) AS part
+        WHERE message.session_id = ${sessionId}
+          AND json_extract(part.value, '$.type') = 'file'
+      `),
+    ]);
+
+    return {
+      anchorFound,
+      hasMessages: messageRows.length > 0,
+      history: historyRows.map(toAgentMessageView),
+      referencedFileEntryIds: fileRows
+        .flatMap(({ fileEntryId }) => (typeof fileEntryId === 'string' ? [fileEntryId] : []))
+        .sort(),
+      sessionTurnIds: turnRows.flatMap(({ turnId }) => (turnId === null ? [] : [turnId])).sort(),
+    };
   }
 
   async getLatestContextCheckpoint(sessionId: string) {

--- a/src/backend/ai/agentHost/__tests__/AgentSessionNaming.test.ts
+++ b/src/backend/ai/agentHost/__tests__/AgentSessionNaming.test.ts
@@ -18,6 +18,7 @@ function deferred<TValue>() {
 function createNaming(input: {
   generateText?: AiService['generateText'];
   namingEnabled?: boolean;
+  signal?: AbortSignal;
 }) {
   const store = new InMemoryAgentSessionStore();
   const generateText = jest.fn(input.generateText ?? (async () => ({ text: 'Generated summary' })));
@@ -37,6 +38,7 @@ function createNaming(input: {
     provider: {
       getByProviderId: jest.fn(),
     } as unknown as Pick<ProviderService, 'getByProviderId'>,
+    ...(input.signal ? { signal: input.signal } : {}),
     store,
   });
   return { generateText, naming, store };
@@ -79,6 +81,24 @@ describe('AgentSessionNaming', () => {
         reasoningEffort: 'none',
         uniqueModelId: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID,
       }),
+    );
+  });
+
+  test('propagates the Host lifecycle signal to summary generation', async () => {
+    const controller = new AbortController();
+    const { generateText, naming, store } = createNaming({ signal: controller.signal });
+    const session = await store.createSession({ agentId: 'agent-1' });
+    const userParts = [{ type: 'text' as const, text: 'Explain lunar eclipses' }];
+    await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
+
+    await naming.maybeRenameFromConversationSummary({
+      assistantParts: [{ id: 'text-1', state: 'done', text: 'First answer', type: 'text' }],
+      sessionId: session.id,
+      userParts,
+    });
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({ requestOptions: { signal: controller.signal } }),
     );
   });
 

--- a/src/backend/ai/agentHost/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agentHost/__tests__/AgentSessionStore.test.ts
@@ -29,6 +29,8 @@ const INTERRUPTED: AgentErrorView = {
 };
 
 const MODEL_ID = 'mock-provider::mock-model' as const;
+const INPUT_FILE_ID = '00000000-0000-7000-8000-000000000001';
+const ARTIFACT_FILE_ID = '00000000-0000-7000-8000-000000000002';
 const INFERENCE_SNAPSHOT: AgentInferenceSnapshotV1 = {
   version: 1,
   model: {
@@ -305,6 +307,68 @@ describe.each([
     expect(transcript[0]?.turnId).toBe(transcript[1]?.turnId);
     expect(transcript[2]?.turnId).toBe(transcript[3]?.turnId);
     expect(transcript[0]?.turnId).not.toBe(transcript[2]?.turnId);
+  });
+
+  test('loads a checkpoint tail separately from full-transcript authorization indexes', async () => {
+    const session = await store.createSession({ agentId });
+    const first = await store.reserveSubmission({
+      ...RESERVATION_FACTS,
+      sessionId: session.id,
+      userParts: [
+        {
+          fileEntryId: INPUT_FILE_ID,
+          id: 'input-0',
+          mediaType: 'image/png',
+          name: 'input.png',
+          purpose: 'input-attachment',
+          type: 'file',
+        },
+      ],
+    });
+    await store.finalizeAssistantMessage({
+      assistantMessageId: first.assistantMessage.id,
+      status: 'success',
+      parts: [
+        {
+          fileEntryId: ARTIFACT_FILE_ID,
+          id: 'artifact-0',
+          mediaType: 'text/plain',
+          name: 'result.txt',
+          purpose: 'artifact',
+          type: 'file',
+        },
+      ],
+      usage: null,
+      error: null,
+      contextCheckpoint: null,
+    });
+    const second = await store.reserveSubmission({
+      ...RESERVATION_FACTS,
+      sessionId: session.id,
+      userParts: [{ id: 'input-0', type: 'text', text: 'two', state: 'done' }],
+    });
+    await store.finalizeAssistantMessage({
+      assistantMessageId: second.assistantMessage.id,
+      status: 'success',
+      parts: [],
+      usage: null,
+      error: null,
+      contextCheckpoint: null,
+    });
+
+    const tail = await store.loadRuntimeTurnContext(session.id, first.turnId);
+
+    expect(tail).toMatchObject({
+      anchorFound: true,
+      hasMessages: true,
+      referencedFileEntryIds: expect.arrayContaining([INPUT_FILE_ID, ARTIFACT_FILE_ID]),
+      sessionTurnIds: expect.arrayContaining([first.turnId, second.turnId]),
+    });
+    expect(tail.history.map((message) => message.turnId)).toEqual([second.turnId, second.turnId]);
+
+    const missingAnchor = await store.loadRuntimeTurnContext(session.id, 'missing-turn');
+    expect(missingAnchor.anchorFound).toBe(false);
+    expect(missingAnchor.history).toHaveLength(4);
   });
 
   test('stores a checkpoint on the assistant terminal write and reads the newest candidate', async () => {

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -962,6 +962,41 @@ describe('MobileAgentHost', () => {
     expect(host.isDestroyed).toBe(true);
   });
 
+  test('aborts an in-flight submission admission before stopping', async () => {
+    const admissionStarted = createDeferred();
+    const releaseAdmission = createDeferred();
+    const fake = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR });
+    const host = createHost(fake);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const getSession = store.getSession.bind(store);
+    jest.spyOn(store, 'getSession').mockImplementationOnce(async (sessionId) => {
+      admissionStarted.resolve();
+      await releaseAdmission.promise;
+      return getSession(sessionId);
+    });
+
+    const submission = host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Stop before admission completes.' }],
+    });
+    await admissionStarted.promise;
+
+    await host._doStop();
+
+    await expect(submission).rejects.toThrow('The Agent Host is stopping.');
+    await expect(
+      host.submitMessage({
+        sessionId: session.id,
+        parts: [{ type: 'text', text: 'Do not admit after stop.' }],
+      }),
+    ).rejects.toMatchObject({ view: { code: 'EXECUTION_UNAVAILABLE' } });
+    await expect(store.listMessages(session.id)).resolves.toEqual([]);
+    releaseAdmission.resolve();
+  });
+
   test('updates an active background reply when its Session is renamed', async () => {
     const started = createDeferred();
     const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script(async (controller) => {
@@ -1491,6 +1526,56 @@ describe('MobileAgentHost', () => {
         },
       ]),
     );
+  });
+
+  test('retries the same terminal outcome when persistence fails transiently', async () => {
+    const events: AgentEvent[] = [];
+    const host = hostWithText(['Recovered']);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    await host.observeSession(session.id, (event) => events.push(event));
+    const finalize = jest
+      .spyOn(store, 'finalizeAssistantMessage')
+      .mockRejectedValueOnce(new Error('database busy'))
+      .mockRejectedValueOnce(new Error('database busy'));
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'text', text: 'Retry the terminal write.' }],
+    });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the retried turn to settle');
+
+    expect(finalize).toHaveBeenCalledTimes(3);
+    expect(finalize.mock.calls.map(([input]) => input.status)).toEqual([
+      'success',
+      'success',
+      'success',
+    ]);
+    expect(terminalTurnEvent(events)?.turn.status).toBe('completed');
+    expect((await store.listMessages(session.id))[1]?.status).toBe('success');
+  });
+
+  test('does not reserve transcript rows when the Runtime session cannot open', async () => {
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR });
+    jest.spyOn(runtime, 'open').mockRejectedValueOnce(new Error('runtime unavailable'));
+    const reserve = jest.spyOn(store, 'reserveSubmission');
+    const host = createHost(runtime);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+
+    await expect(
+      host.submitMessage({
+        sessionId: session.id,
+        parts: [{ type: 'text', text: 'Do not persist this.' }],
+      }),
+    ).rejects.toThrow('runtime unavailable');
+
+    expect(reserve).not.toHaveBeenCalled();
+    await expect(store.listMessages(session.id)).resolves.toEqual([]);
   });
 
   test('rejects unsupported models and endpoints before reserving image messages', async () => {

--- a/src/backend/ai/agentHost/__tests__/contextCheckpoints.test.ts
+++ b/src/backend/ai/agentHost/__tests__/contextCheckpoints.test.ts
@@ -1,33 +1,23 @@
-import type { RuntimeHistoryTurn } from '@/backend/ai/agent';
-
 import {
   MAX_RUNTIME_CONTEXT_CHECKPOINT_BYTES,
-  selectRuntimeContext,
   validateRuntimeContextCheckpoint,
+  validateRuntimeContextCheckpointCandidate,
 } from '../contextCheckpoints';
 
-const history: RuntimeHistoryTurn[] = [
-  {
-    turnId: 'turn-1',
-    messages: [{ role: 'user', parts: [{ type: 'text', text: 'one' }] }],
-  },
-  {
-    turnId: 'turn-2',
-    messages: [{ role: 'user', parts: [{ type: 'text', text: 'two' }] }],
-  },
-];
-
 describe('Runtime context checkpoints', () => {
-  test('replays a valid checkpoint with only complete turns after its anchor', () => {
+  test('accepts a valid candidate whose anchor belongs to the Session', () => {
     const checkpoint = {
       version: 1 as const,
       anchorTurnId: 'turn-1',
       payload: { summary: 'one' },
     };
 
-    expect(selectRuntimeContext(history, checkpoint)).toEqual({
+    expect(validateRuntimeContextCheckpointCandidate(checkpoint)).toEqual({
       checkpoint,
-      history: [history[1]],
+      issue: null,
+    });
+    expect(validateRuntimeContextCheckpoint(checkpoint, new Set(['turn-1']))).toEqual({
+      checkpoint,
       issue: null,
     });
   });
@@ -39,17 +29,20 @@ describe('Runtime context checkpoints', () => {
       { version: 2, anchorTurnId: 'turn-1', payload: {} },
       'CONTEXT_CHECKPOINT_VERSION_UNSUPPORTED',
     ],
-    [
-      'missing anchor',
-      { version: 1, anchorTurnId: 'missing', payload: {} },
-      'CONTEXT_CHECKPOINT_ANCHOR_INVALID',
-    ],
-  ] as const)('falls back to full history for a %s checkpoint', (_name, candidate, issue) => {
-    expect(selectRuntimeContext(history, candidate)).toEqual({
+  ] as const)('rejects a %s checkpoint candidate', (_name, candidate, issue) => {
+    expect(validateRuntimeContextCheckpointCandidate(candidate)).toEqual({
       checkpoint: null,
-      history,
       issue,
     });
+  });
+
+  test('rejects a candidate whose anchor does not belong to the Session', () => {
+    expect(
+      validateRuntimeContextCheckpoint(
+        { version: 1, anchorTurnId: 'missing', payload: {} },
+        new Set(['turn-1']),
+      ),
+    ).toEqual({ checkpoint: null, issue: 'CONTEXT_CHECKPOINT_ANCHOR_INVALID' });
   });
 
   test('rejects an oversized payload without truncating it', () => {
@@ -64,14 +57,5 @@ describe('Runtime context checkpoints', () => {
       issue: 'CONTEXT_CHECKPOINT_TOO_LARGE',
     });
     expect(checkpoint.payload).toHaveLength(MAX_RUNTIME_CONTEXT_CHECKPOINT_BYTES);
-  });
-
-  test('keeps the full grouped history byte-equivalent when no checkpoint exists', () => {
-    const serialized = JSON.stringify(history);
-
-    const selected = selectRuntimeContext(history, null);
-
-    expect(selected.checkpoint).toBeNull();
-    expect(JSON.stringify(selected.history)).toBe(serialized);
   });
 });

--- a/src/backend/ai/agentHost/__tests__/managedFileResolver.test.ts
+++ b/src/backend/ai/agentHost/__tests__/managedFileResolver.test.ts
@@ -1,4 +1,3 @@
-import type { AgentMessageView } from '@/shared/contracts/agent';
 import { FileEntryIdSchema, FileEntrySchema } from '@/shared/data/types/file';
 
 import { createManagedFileResolver, createTurnResourceLedger } from '../managedFileResolver';
@@ -79,30 +78,6 @@ describe('managedFileResolver', () => {
   });
 
   test('keeps historical managed ids in the ledger without requiring them to resolve', () => {
-    const history: AgentMessageView[] = [
-      {
-        createdAt: '2026-08-26T00:00:00.000Z',
-        id: 'message-1',
-        parts: [
-          {
-            fileEntryId: MISSING_BLOB_ID,
-            id: 'input-0',
-            mediaType: 'image/png',
-            name: 'missing.png',
-            purpose: 'input-attachment',
-            type: 'file',
-          },
-        ],
-        role: 'user',
-        sessionId: 'session-1',
-        status: 'success',
-        turnId: 'turn-1',
-        updatedAt: '2026-08-26T00:00:00.000Z',
-        usage: null,
-        modelId: null,
-        inferenceSnapshot: null,
-      },
-    ];
     const inputFiles = new Map([
       [
         AVAILABLE_ID,
@@ -115,7 +90,7 @@ describe('managedFileResolver', () => {
       ],
     ]);
 
-    const ledger = createTurnResourceLedger(inputFiles, history);
+    const ledger = createTurnResourceLedger(inputFiles, [MISSING_BLOB_ID]);
     ledger.grantFile(GENERATED_ID);
 
     expect([...ledger.fileEntryIds]).toEqual([AVAILABLE_ID, MISSING_BLOB_ID, GENERATED_ID]);

--- a/src/backend/ai/agentHost/contextCheckpoints.ts
+++ b/src/backend/ai/agentHost/contextCheckpoints.ts
@@ -13,9 +13,9 @@ export type RuntimeContextCheckpointValidation =
   | { checkpoint: RuntimeContextCheckpoint; issue: null }
   | { checkpoint: null; issue: RuntimeContextCheckpointIssueCode };
 
-export function validateRuntimeContextCheckpoint(
+/** Validates the opaque artifact itself; anchor membership is Store-backed. */
+export function validateRuntimeContextCheckpointCandidate(
   value: unknown,
-  sessionTurnIds: ReadonlySet<string>,
 ): RuntimeContextCheckpointValidation {
   if (typeof value === 'object' && value !== null && 'version' in value && value.version !== 1) {
     return { checkpoint: null, issue: 'CONTEXT_CHECKPOINT_VERSION_UNSUPPORTED' };
@@ -29,9 +29,6 @@ export function validateRuntimeContextCheckpoint(
   }
   if (!parsed.success) {
     return { checkpoint: null, issue: 'CONTEXT_CHECKPOINT_INVALID' };
-  }
-  if (!sessionTurnIds.has(parsed.data.anchorTurnId)) {
-    return { checkpoint: null, issue: 'CONTEXT_CHECKPOINT_ANCHOR_INVALID' };
   }
 
   let payloadBytes: number;
@@ -47,40 +44,16 @@ export function validateRuntimeContextCheckpoint(
   return { checkpoint: parsed.data, issue: null };
 }
 
-export function selectRuntimeContext<THistoryItem extends { turnId: string | null }>(
-  history: THistoryItem[],
-  candidate: unknown,
-): {
-  checkpoint: RuntimeContextCheckpoint | null;
-  history: THistoryItem[];
-  issue: RuntimeContextCheckpointIssueCode | null;
-} {
-  if (candidate === null || candidate === undefined) {
-    return { checkpoint: null, history, issue: null };
-  }
-
-  const sessionTurnIds = new Set(
-    history.flatMap((turn) => (turn.turnId === null ? [] : [turn.turnId])),
-  );
-  const validation = validateRuntimeContextCheckpoint(candidate, sessionTurnIds);
+export function validateRuntimeContextCheckpoint(
+  value: unknown,
+  sessionTurnIds: ReadonlySet<string>,
+): RuntimeContextCheckpointValidation {
+  const validation = validateRuntimeContextCheckpointCandidate(value);
   if (!validation.checkpoint) {
-    return { checkpoint: null, history, issue: validation.issue };
+    return validation;
   }
-
-  const checkpoint = validation.checkpoint;
-  let anchorIndex = -1;
-  for (let index = history.length - 1; index >= 0; index -= 1) {
-    if (history[index]?.turnId === checkpoint.anchorTurnId) {
-      anchorIndex = index;
-      break;
-    }
+  if (!sessionTurnIds.has(validation.checkpoint.anchorTurnId)) {
+    return { checkpoint: null, issue: 'CONTEXT_CHECKPOINT_ANCHOR_INVALID' };
   }
-  if (anchorIndex < 0) {
-    return { checkpoint: null, history, issue: 'CONTEXT_CHECKPOINT_ANCHOR_INVALID' };
-  }
-  return {
-    checkpoint,
-    history: history.slice(anchorIndex + 1),
-    issue: null,
-  };
+  return validation;
 }

--- a/src/backend/ai/agentHost/managedFileResolver.ts
+++ b/src/backend/ai/agentHost/managedFileResolver.ts
@@ -4,7 +4,6 @@ import {
   imageUriToDataUrl,
   readFileUriBytes,
 } from '@/backend/services/file/fileStorage';
-import type { AgentMessageView } from '@/shared/contracts/agent';
 import type { FileEntry, FileEntryId } from '@/shared/data/types/file';
 import { FileEntryIdSchema } from '@/shared/data/types/file';
 
@@ -16,7 +15,7 @@ export type ManagedFileFact = {
 };
 
 export type TurnResourceLedger = {
-  /** Managed ids explicitly referenced by the current input or visible history. */
+  /** Managed ids explicitly referenced by the current input or Session transcript. */
   fileEntryIds: ReadonlySet<string>;
   /** Current input facts validated before the message reservation. */
   inputFiles: ReadonlyMap<string, ManagedFileFact>;
@@ -115,20 +114,15 @@ export function createManagedFileResolver(
 
 export function createTurnResourceLedger(
   inputFiles: ReadonlyMap<string, ManagedFileFact>,
-  history: readonly AgentMessageView[],
+  authorizedFileEntryIds: readonly string[],
   availableFiles: ReadonlyMap<string, ManagedFileFact> = inputFiles,
 ): TurnResourceLedger {
   const fileEntryIds = new Set<string>(inputFiles.keys());
 
-  for (const message of history) {
-    for (const part of message.parts) {
-      if (part.type !== 'file') {
-        continue;
-      }
-      const parsed = FileEntryIdSchema.safeParse(part.fileEntryId);
-      if (parsed.success) {
-        fileEntryIds.add(parsed.data);
-      }
+  for (const fileEntryId of authorizedFileEntryIds) {
+    const parsed = FileEntryIdSchema.safeParse(fileEntryId);
+    if (parsed.success) {
+      fileEntryIds.add(parsed.data);
     }
   }
 

--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -153,6 +153,9 @@ export class AgentSessionChatClient {
 
         entry.observation = observation;
         this.installSnapshot(entry, observation.snapshot);
+        // A fresh Host snapshot can reflect terminal events missed while this
+        // session had no observers. Refresh the durable transcript projection.
+        this.options.onTranscriptChanged?.(sessionId);
         isSnapshotInstalled = true;
         for (const event of queuedEvents) {
           this.applyEvent(entry, event);

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -116,6 +116,19 @@ describe('AgentSessionChatClient', () => {
     });
   });
 
+  test('invalidates the durable transcript after installing a fresh observation snapshot', async () => {
+    const protocol = protocolWithObservation(async () => ({
+      snapshot: snapshot(),
+      unsubscribe: jest.fn(),
+    }));
+    const onTranscriptChanged = jest.fn();
+    const client = new AgentSessionChatClient(protocol, { onTranscriptChanged });
+
+    await client.observe('session-1');
+
+    expect(onTranscriptChanged).toHaveBeenCalledWith('session-1');
+  });
+
   test('cancels the active turn with the correlated session and turn ids', async () => {
     let listener: ((event: AgentEvent) => void) | undefined;
     const protocol = protocolWithObservation(async (_sessionId, nextListener) => {


### PR DESCRIPTION
## Summary

- Refresh the durable transcript whenever a fresh Host observation snapshot is installed, covering terminal events missed while a session was unobserved.
- Make submission admission, attachment reads, and automatic naming lifecycle-cancellable, and drain admissions before Runtime shutdown.
- Open the Runtime session before reserving transcript rows, retry terminal persistence with the same semantic outcome, and fail the Host generation closed on a persistent write failure.
- Load checkpoint replay tails directly in AgentSessionStore while projecting full-transcript turn and file authorization indexes separately from model-visible attachment content.
- Update architecture documentation and add focused regression coverage for the changed invariants.

## Validation

- pnpm format
- Changed-file oxlint and ESLint checks pass.
- pnpm lint: oxlint passes; expo lint cannot resolve the unbuilt local @cherrystudio/ai-core workspace package in eight pre-existing/base files.
- Tests, typecheck, and builds were not run per repository verification policy.