### PR TITLE
refactor(ai-backend): simplify Pi runtime message flow

### DIFF
--- a/src/backend/ai/agent/FakeRuntime.ts
+++ b/src/backend/ai/agent/FakeRuntime.ts
@@ -63,12 +63,6 @@ const DEFAULT_DESCRIPTOR: RuntimeDescriptor = {
   },
 };
 
-const TERMINAL_TYPES = new Set<RuntimeEvent['type']>(['completed', 'failed', 'cancelled']);
-
-function isTerminal(event: RuntimeEvent): boolean {
-  return TERMINAL_TYPES.has(event.type);
-}
-
 /**
  * Normalize an unknown thrown value into a {@link RuntimeError} that carries no
  * credentials or stack trace (conformance item 10). Native messages are
@@ -149,15 +143,14 @@ function validateRequest(
     };
   }
   if (!capabilities.attachments) {
-    const inputHasAttachment = request.input.some(
-      (part) => part.type === 'file' || part.type === 'text-attachment',
-    );
-    const historyHasAttachment = request.history.some((turn) =>
-      turn.messages.some((message) =>
-        message.parts.some((part) => part.type === 'file' || part.type === 'text-attachment'),
-      ),
-    );
-    if (inputHasAttachment || historyHasAttachment) {
+    if (
+      request.input.some((part) => part.type === 'file' || part.type === 'text-attachment') ||
+      request.history.some((turn) =>
+        turn.messages.some((message) =>
+          message.parts.some((part) => part.type === 'file' || part.type === 'text-attachment'),
+        ),
+      )
+    ) {
       return {
         code: 'unsupported_input',
         message: 'This runtime does not support file attachments.',
@@ -179,7 +172,6 @@ type ActiveTurn = {
   abortController: AbortController;
   approvalWaiters: Map<string, ApprovalWaiter>;
   toolParts: Map<string, Extract<RuntimeOutputPart, { type: 'tool' }>>;
-  terminated: boolean;
 };
 
 class FakeRuntimeSession implements AgentRuntimeSession {
@@ -215,7 +207,6 @@ class FakeRuntimeSession implements AgentRuntimeSession {
       abortController: new AbortController(),
       approvalWaiters: new Map(),
       toolParts: new Map(),
-      terminated: false,
     };
     this.activeTurn = turn;
 
@@ -244,7 +235,7 @@ class FakeRuntimeSession implements AgentRuntimeSession {
 
   async cancel(turnId: string): Promise<void> {
     const turn = this.activeTurn;
-    if (!turn || turn.turnId !== turnId || turn.terminated) {
+    if (!turn || turn.turnId !== turnId) {
       return; // idempotent no-op
     }
     turn.abortController.abort();
@@ -258,7 +249,7 @@ class FakeRuntimeSession implements AgentRuntimeSession {
     decision: 'approve' | 'deny';
   }): Promise<void> {
     const turn = this.activeTurn;
-    if (!turn || turn.turnId !== input.turnId || turn.terminated) {
+    if (!turn || turn.turnId !== input.turnId) {
       return;
     }
     const waiter = turn.approvalWaiters.get(input.approvalId);
@@ -275,21 +266,22 @@ class FakeRuntimeSession implements AgentRuntimeSession {
     }
     this.closed = true;
     const turn = this.activeTurn;
-    if (turn && !turn.terminated) {
+    if (turn) {
       turn.abortController.abort();
       this.rejectApprovals(turn, new Error('The session was closed.'));
       this.emitFor(turn, { type: 'cancelled' });
     }
-    this.activeTurn = undefined;
     // Release scripted resources.
     this.programs.length = 0;
   }
 
   private emitFor(turn: ActiveTurn, event: RuntimeEvent): void {
-    if (turn.terminated) {
+    if (this.activeTurn !== turn) {
       return; // no output may follow a terminal event
     }
-    if (isTerminal(event)) {
+    const isTerminal =
+      event.type === 'completed' || event.type === 'failed' || event.type === 'cancelled';
+    if (isTerminal) {
       this.interruptUnsettledToolParts(turn);
     } else if (
       (event.type === 'part.add' || event.type === 'part.replace') &&
@@ -298,13 +290,10 @@ class FakeRuntimeSession implements AgentRuntimeSession {
       turn.toolParts.set(event.part.toolCallId, event.part);
     }
     turn.channel.push(event);
-    if (isTerminal(event)) {
-      turn.terminated = true;
+    if (isTerminal) {
       turn.channel.end();
       this.rejectApprovals(turn, new Error('The turn ended.'));
-      if (this.activeTurn === turn) {
-        this.activeTurn = undefined;
-      }
+      this.activeTurn = undefined;
     }
   }
 
@@ -331,7 +320,7 @@ class FakeRuntimeSession implements AgentRuntimeSession {
 
   private waitForApproval(turn: ActiveTurn, approvalId: string): Promise<'approve' | 'deny'> {
     return new Promise<'approve' | 'deny'>((resolve, reject) => {
-      if (turn.terminated) {
+      if (this.activeTurn !== turn) {
         reject(new Error('The turn has already ended.'));
         return;
       }

--- a/src/backend/ai/agent/index.ts
+++ b/src/backend/ai/agent/index.ts
@@ -46,11 +46,5 @@ export {
   TOOL_EXECUTION_ERROR,
 } from './toolResults';
 
-export type {
-  PiModelResolution,
-  PiRuntimeAgent,
-  PiRuntimeAgentFactory,
-  PiRuntimeContextOptions,
-  PiRuntimeDependencies,
-} from './pi/PiRuntime';
+export type { PiModelResolution, PiRuntimeDependencies } from './pi/PiRuntime';
 export { PiRuntime } from './pi/PiRuntime';

--- a/src/backend/ai/agent/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/pi/PiRuntime.ts
@@ -136,7 +136,6 @@ const DEFAULT_EXECUTION_ERROR_MESSAGE = 'The model provider call failed.';
 const MAX_EXECUTION_ERROR_MESSAGE_CHARS = 4_000;
 const REDACTED_SECRET = '[REDACTED]';
 
-const TERMINAL_TYPES = new Set<RuntimeEvent['type']>(['completed', 'failed', 'cancelled']);
 const TERMINAL_ERROR_DIAGNOSTIC_TYPES = new Set([
   'pi_messages_response_failure',
   'provider_response_failure',
@@ -434,10 +433,6 @@ function normalizeToolExecutionError(error: unknown): RuntimeError {
   };
 }
 
-function sensitiveValues(resolution: PiModelResolution): string[] {
-  return [...resolution.redactionValues];
-}
-
 function redactCompactionSummary(summary: string, sensitiveValues: readonly string[]): string {
   let redacted = summary.replace(
     /data:[^;,\s]+;base64,[a-z0-9+/=]+/gi,
@@ -600,11 +595,9 @@ class PiRuntimeSession implements AgentRuntimeSession {
 
   async cancel(turnId: string): Promise<void> {
     const turn = this.activeTurn;
-    if (!turn || turn.turnId !== turnId || turn.terminated) return;
+    if (!turn || turn.turnId !== turnId) return;
     turn.cancelRequested = true;
-    turn.abortController.abort();
-    turn.agent?.abort();
-    this.rejectApprovals(turn, new Error('The turn was cancelled.'));
+    this.abortExecution(turn, new Error('The turn was cancelled.'));
     await settleWithin(turn.agent?.waitForIdle(), PI_TURN_SETTLE_GRACE_MS);
     this.emit(turn, { type: 'cancelled' });
   }
@@ -615,7 +608,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
     decision: 'approve' | 'deny';
   }): Promise<void> {
     const turn = this.activeTurn;
-    if (!turn || turn.turnId !== input.turnId || turn.terminated) return;
+    if (!turn || turn.turnId !== input.turnId) return;
     const waiter = turn.approvalWaiters.get(input.approvalId);
     if (!waiter) return;
     turn.approvalWaiters.delete(input.approvalId);
@@ -626,15 +619,12 @@ class PiRuntimeSession implements AgentRuntimeSession {
     if (this.closed) return;
     this.closed = true;
     const turn = this.activeTurn;
-    if (turn && !turn.terminated) {
+    if (turn) {
       turn.cancelRequested = true;
-      turn.abortController.abort();
-      turn.agent?.abort();
-      this.rejectApprovals(turn, new Error('The session was closed.'));
+      this.abortExecution(turn, new Error('The session was closed.'));
       await settleWithin(turn.agent?.waitForIdle(), PI_TURN_SETTLE_GRACE_MS);
       this.emit(turn, { type: 'cancelled' });
     }
-    this.activeTurn = undefined;
   }
 
   private async run(request: RuntimeExecutionRequest, turn: ActiveTurn): Promise<void> {
@@ -645,7 +635,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
         this.dependencies.resolveModel(request.model, request.options),
         turn.abortController.signal,
       );
-      secrets = sensitiveValues(resolution);
+      secrets = resolution.redactionValues;
       turn.usageContext = resolution.usageContext;
       if (turn.terminated || turn.cancelRequested) return;
       if (turn.timedOut) {
@@ -1233,18 +1223,23 @@ class PiRuntimeSession implements AgentRuntimeSession {
     turn.approvalWaiters.clear();
   }
 
+  private abortExecution(turn: ActiveTurn, approvalError: Error): void {
+    turn.abortController.abort();
+    turn.agent?.abort();
+    this.rejectApprovals(turn, approvalError);
+  }
+
   private timeoutTurn(turn: ActiveTurn): void {
     if (turn.terminated || turn.timedOut) return;
     turn.timedOut = true;
-    turn.abortController.abort();
-    turn.agent?.abort();
-    this.rejectApprovals(turn, new Error('The Agent turn timed out.'));
+    this.abortExecution(turn, new Error('The Agent turn timed out.'));
   }
 
   private emit(turn: ActiveTurn, event: RuntimeEvent): void {
     if (turn.terminated) return;
     if (event.type === 'usage') turn.usageReported = true;
-    const isTerminal = TERMINAL_TYPES.has(event.type);
+    const isTerminal =
+      event.type === 'completed' || event.type === 'failed' || event.type === 'cancelled';
     if (isTerminal) {
       if (turn.timeoutHandle) clearTimeout(turn.timeoutHandle);
       turn.abortController.abort();

--- a/src/backend/ai/agent/pi/contextCompaction.ts
+++ b/src/backend/ai/agent/pi/contextCompaction.ts
@@ -99,10 +99,9 @@ export function estimatePiContextFixedCosts(input: {
     (total, tool) => total + estimateTextTokens(serializeTool(tool)),
     0,
   );
-  const imageCount = [...input.conversation.history, input.conversation.prompt].reduce(
-    (total, message) => total + countImages(message),
-    0,
-  );
+  const imageCount =
+    input.conversation.history.reduce((total, message) => total + countImages(message), 0) +
+    countImages(input.conversation.prompt);
   const attachmentTokens =
     imageCount * Math.max(0, PI_IMAGE_CONTEXT_TOKEN_RESERVE - PI_ESTIMATED_IMAGE_TOKENS);
   const outputReserveTokens = Math.max(0, input.outputReserveTokens);
@@ -321,7 +320,8 @@ function createCheckpoint(
     const value = metadata.get(message as object);
     return value ? [value] : [];
   });
-  let anchorTurnId = summarizedMetadata.at(-1)?.turnId ?? previous?.anchorTurnId ?? null;
+  const lastSummarized = summarizedMetadata.at(-1);
+  let anchorTurnId = lastSummarized?.turnId ?? previous?.anchorTurnId ?? null;
   let resume: PiCheckpointPayload['resume'];
 
   if (preparation.isSplitTurn) {
@@ -339,7 +339,7 @@ function createCheckpoint(
     anchorTurnId = previousTurn?.turnId ?? previous?.anchorTurnId ?? null;
     if (!anchorTurnId) return null;
     resume = { turnId: splitTurn.turnId, messageOffset: splitTurn.messageOffset };
-  } else if (summarizedMetadata.at(-1)?.turnId === null) {
+  } else if (lastSummarized?.turnId === null) {
     return null;
   }
 

--- a/src/backend/ai/agent/pi/modelMessages.ts
+++ b/src/backend/ai/agent/pi/modelMessages.ts
@@ -153,12 +153,12 @@ function appendAssistantHistory(
   model: PiModel<PiApi>,
   usage: RuntimeExecutionRequest['history'][number]['messages'][number]['usage'],
 ): void {
-  const startIndex = history.length;
   let content: AssistantMessage['content'] = [];
+  let lastAssistant: AssistantMessage | undefined;
   const flushAssistant = () => {
     if (content.length === 0) return;
     const stopReason = content.some((part) => part.type === 'toolCall') ? 'toolUse' : 'stop';
-    history.push({
+    lastAssistant = {
       api: model.api,
       content,
       model: model.id,
@@ -167,7 +167,8 @@ function appendAssistantHistory(
       stopReason,
       timestamp: Date.now(),
       usage: EMPTY_PI_USAGE,
-    });
+    };
+    history.push(lastAssistant);
     content = [];
   };
 
@@ -209,12 +210,7 @@ function appendAssistantHistory(
 
   flushAssistant();
 
-  if (usage) {
-    const lastAssistant = history
-      .slice(startIndex)
-      .findLast((message): message is AssistantMessage => message.role === 'assistant');
-    if (lastAssistant) lastAssistant.usage = toPiUsage(usage);
-  }
+  if (usage && lastAssistant) lastAssistant.usage = toPiUsage(usage);
 }
 
 function toPiUsage(usage: NonNullable<RuntimeMessage['usage']>): PiUsage {

--- a/src/backend/ai/agentHost/AgentSessionNaming.ts
+++ b/src/backend/ai/agentHost/AgentSessionNaming.ts
@@ -29,13 +29,7 @@ type AgentSessionNamingDependencies = {
   store: AgentSessionStore;
 };
 
-function extractInputText(parts: readonly AgentInputPart[]): string {
-  return parts
-    .flatMap((part) => (part.type === 'text' && part.text.trim() ? [part.text.trim()] : []))
-    .join('\n\n');
-}
-
-function extractAssistantText(parts: readonly AgentMessagePart[]): string {
+function extractText(parts: readonly (AgentInputPart | AgentMessagePart)[]): string {
   return parts
     .flatMap((part) => (part.type === 'text' && part.text.trim() ? [part.text.trim()] : []))
     .join('\n\n');
@@ -73,7 +67,7 @@ export class AgentSessionNaming {
   }
 
   async drain(): Promise<void> {
-    await Promise.allSettled([...this.inFlightWrites]);
+    await Promise.allSettled(this.inFlightWrites);
   }
 
   private track(run: () => Promise<AgentSessionView | null>): Promise<AgentSessionView | null> {
@@ -93,7 +87,7 @@ export class AgentSessionNaming {
     parts: readonly AgentInputPart[],
   ): Promise<AgentSessionView | null> {
     this.dependencies.signal?.throwIfAborted();
-    const userText = extractInputText(parts);
+    const userText = extractText(parts);
     const nextTitle = buildFirstUserMessageTitle(userText).slice(0, 255);
     if (!nextTitle) return null;
 
@@ -119,8 +113,8 @@ export class AgentSessionNaming {
       this.dependencies.signal?.throwIfAborted();
       if (!enabled) return null;
 
-      const userText = extractInputText(input.userParts);
-      const assistantText = extractAssistantText(input.assistantParts);
+      const userText = extractText(input.userParts);
+      const assistantText = extractText(input.assistantParts);
       if (!userText || !assistantText) return null;
 
       const session = await this.dependencies.store.getSession(sessionId);

--- a/src/backend/ai/agentHost/AgentSessionUsageRecorder.ts
+++ b/src/backend/ai/agentHost/AgentSessionUsageRecorder.ts
@@ -41,7 +41,7 @@ export class AgentSessionUsageRecorder {
   }
 
   async drain(): Promise<void> {
-    await Promise.allSettled([...this.inFlight]);
+    await Promise.allSettled(this.inFlight);
   }
 
   private async recordNow(input: RecordAgentSessionUsageInput): Promise<void> {

--- a/src/backend/ai/agentHost/MobileAgentHost.ts
+++ b/src/backend/ai/agentHost/MobileAgentHost.ts
@@ -101,9 +101,7 @@ import { findImageAttachmentLimit, type ImageAttachmentLimit } from './imageAtta
 import {
   createAgentInferenceSnapshot,
   type AgentInferenceModelResolver,
-  type AgentModelToolSupportResolver,
   resolveAgentInferenceModel,
-  resolveAgentModelToolSupport,
 } from './inferenceSnapshot';
 import {
   createTurnResourceLedger,
@@ -158,7 +156,6 @@ type MobileAgentHostOverrides = {
     AgentSessionNaming,
     'drain' | 'maybeRenameFromConversationSummary' | 'maybeRenameFromFirstUserMessage'
   >;
-  modelSupportsTools: AgentModelToolSupportResolver;
   runtimeTools: AgentRuntimeToolResolver;
   usage: Pick<AgentSessionUsageRecorder, 'drain' | 'record'>;
   tools: SystemCapabilitySource;
@@ -244,7 +241,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly naming: MobileAgentHostOverrides['naming'];
   private readonly usage: MobileAgentHostOverrides['usage'];
   private readonly inferenceModel: MobileAgentHostOverrides['inferenceModel'];
-  private readonly modelSupportsTools: MobileAgentHostOverrides['modelSupportsTools'];
   private readonly runtimeTools: MobileAgentHostOverrides['runtimeTools'];
   private readonly lifecycleAbortController = new AbortController();
   private acceptingSubmissions = true;
@@ -277,7 +273,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       });
     this.usage = overrides.usage ?? new AgentSessionUsageRecorder();
     this.inferenceModel = overrides.inferenceModel ?? resolveAgentInferenceModel;
-    this.modelSupportsTools = overrides.modelSupportsTools ?? resolveAgentModelToolSupport;
     this.runtimeTools =
       overrides.runtimeTools ??
       createAgentRuntimeToolResolver({
@@ -341,7 +336,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     );
     this.runtimeSessions.clear();
     await Promise.allSettled(closing);
-    await Promise.allSettled([...this.runningTurns]);
+    await Promise.allSettled(this.runningTurns);
     await this.naming.drain();
     await this.usage.drain();
   }
@@ -528,19 +523,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         signal.throwIfAborted();
         fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.');
       }
-      if (tools.length > 0) {
-        let supportsTools = false;
-        try {
-          supportsTools = await raceAbort(this.modelSupportsTools(agent.model), signal);
-        } catch {
-          signal.throwIfAborted();
-        }
-        if (!supportsTools) {
-          fail(
-            'CAPABILITY_UNSUPPORTED',
-            'The selected model does not support native tool calling.',
-          );
-        }
+      const modelPreflight = await this.preflightModel(runtime, agent, signal);
+      if (tools.length > 0 && !modelPreflight.supportsTools) {
+        fail('CAPABILITY_UNSUPPORTED', 'The selected model does not support native tool calling.');
       }
       const inferenceSnapshot = createAgentInferenceSnapshot({
         model: inferenceModel,
@@ -548,7 +533,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         tools,
       });
 
-      const modelPreflight = await this.preflightModel(runtime, agent, signal);
       this.assertAttachmentRequestSupported(
         runtime,
         parts,

--- a/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agentHost/__tests__/MobileAgentHost.test.ts
@@ -127,7 +127,6 @@ const stubTool: RuntimeTool = {
 };
 
 type HostToolOverrides = {
-  modelSupportsTools?: () => Promise<boolean>;
   resolveRuntimeTools?: () => Promise<RuntimeTool[]>;
 };
 
@@ -151,7 +150,6 @@ function createHost(
       agents,
       files,
       inferenceModel: resolveInferenceModel,
-      modelSupportsTools: toolOverrides.modelSupportsTools ?? (async () => true),
       naming,
       runtimeTools: {
         resolve: toolOverrides.resolveRuntimeTools ?? (async () => []),
@@ -831,9 +829,17 @@ describe('MobileAgentHost', () => {
   });
 
   test('rejects configured tools for an unsupported model before reserving messages', async () => {
-    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR });
+    const runtime = new FakeRuntime({
+      descriptor: FAKE_DESCRIPTOR,
+      modelPreflight: {
+        contextWindow: 128_000,
+        inputModalities: ['text', 'image'],
+        maxInputTokens: 120_000,
+        maxOutputTokens: 8_000,
+        supportsTools: false,
+      },
+    });
     const host = createHost(runtime, noOpNaming, noFiles, noOpTools, inferenceModel, {
-      modelSupportsTools: async () => false,
       resolveRuntimeTools: async () => [
         {
           approval: 'ask',

--- a/src/backend/ai/agentHost/imageAttachments.ts
+++ b/src/backend/ai/agentHost/imageAttachments.ts
@@ -25,10 +25,14 @@ export function findImageAttachmentLimit(
   if (files.length > MAX_IMAGE_ATTACHMENT_COUNT) {
     return 'count';
   }
-  if (files.some((file) => file.size > MAX_IMAGE_ATTACHMENT_BYTES)) {
-    return 'file-bytes';
+  let totalBytes = 0;
+  for (const file of files) {
+    if (file.size > MAX_IMAGE_ATTACHMENT_BYTES) {
+      return 'file-bytes';
+    }
+    totalBytes += file.size;
   }
-  if (files.reduce((total, file) => total + file.size, 0) > MAX_IMAGE_ATTACHMENT_TOTAL_BYTES) {
+  if (totalBytes > MAX_IMAGE_ATTACHMENT_TOTAL_BYTES) {
     return 'total-bytes';
   }
   if (

--- a/src/backend/ai/agentHost/inferenceSnapshot.ts
+++ b/src/backend/ai/agentHost/inferenceSnapshot.ts
@@ -1,8 +1,5 @@
-import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
-
 import type { RuntimeModel, RuntimeOptions, RuntimeTool } from '@/backend/ai/agent';
 import { modelService } from '@/backend/data/services/ModelService';
-import { providerService } from '@/backend/data/services/ProviderService';
 import {
   AgentInferenceSnapshotV1Schema,
   type AgentInferenceSnapshotV1,
@@ -13,15 +10,11 @@ export type AgentInferenceModelSnapshot = AgentInferenceSnapshotV1['model'];
 export type AgentInferenceModelResolver = (
   model: RuntimeModel,
 ) => Promise<AgentInferenceModelSnapshot>;
-export type AgentModelToolSupportResolver = (model: RuntimeModel) => Promise<boolean>;
 
 /** Resolves public model facts only; provider credentials never cross this boundary. */
 export const resolveAgentInferenceModel: AgentInferenceModelResolver = async (runtimeModel) => {
   const uniqueModelId = createUniqueModelId(runtimeModel.providerId, runtimeModel.modelId);
-  const [model] = await Promise.all([
-    modelService.getById(uniqueModelId),
-    providerService.getByProviderId(runtimeModel.providerId),
-  ]);
+  const model = await modelService.getById(uniqueModelId);
   if (!model) {
     throw new Error('The selected model is unavailable.');
   }
@@ -33,14 +26,6 @@ export const resolveAgentInferenceModel: AgentInferenceModelResolver = async (ru
     ...(model.apiModelId !== undefined ? { apiModelId: model.apiModelId } : {}),
     name: model.name,
   };
-};
-
-/** Admission-time public capability check; no credentials are resolved here. */
-export const resolveAgentModelToolSupport: AgentModelToolSupportResolver = async (runtimeModel) => {
-  const model = await modelService.getById(
-    createUniqueModelId(runtimeModel.providerId, runtimeModel.modelId),
-  );
-  return model?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ?? false;
 };
 
 /**

--- a/src/backend/ai/agentHost/piModelResolver.ts
+++ b/src/backend/ai/agentHost/piModelResolver.ts
@@ -42,8 +42,9 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       return (await resolveConfiguredPiModel(runtimeModel)).preflight;
     },
     async resolveModel(runtimeModel, runtimeOptions): Promise<PiModelResolution> {
-      const { adapter, configuredBaseUrl, connection, model, preflight, provider, servingPlan } =
+      const { adapter, model, preflight, provider, servingPlan } =
         await resolveConfiguredPiModel(runtimeModel);
+      const { connection } = servingPlan;
 
       const selectedApiKey = await providerService.resolveApiKey(provider.id);
       if (!selectedApiKey.value.trim()) {
@@ -59,7 +60,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       const providerFetch = servingPlan.transportPolicy?.wrapFetch(baseFetch) ?? baseFetch;
       const piModel: PiModel<SupportedPiApi> = {
         api: adapter.api,
-        baseUrl: adapter.formatBaseUrl(configuredBaseUrl),
+        baseUrl: adapter.formatBaseUrl(connection.baseUrl.trim()),
         ...(adapter.api === 'openai-completions' || adapter.api === 'openai-responses'
           ? { compat: { supportsDeveloperRole: false } }
           : {}),
@@ -126,15 +127,11 @@ async function resolveConfiguredPiModel(runtimeModel: RuntimeModel) {
   if (!model) throw new Error(`Model is not configured: ${uniqueModelId}`);
 
   const servingPlan = resolveLanguageServingPlan(provider, model);
-  const connection = servingPlan.connection;
   const piBinding = requirePiLanguageBinding(servingPlan);
   const adapter = resolvePiApiAdapter(piBinding.endpointType);
-  const configuredBaseUrl = connection.baseUrl.trim();
 
   return {
     adapter,
-    configuredBaseUrl,
-    connection,
     model,
     preflight: toPiModelPreflight(model),
     provider,

--- a/src/backend/ai/agentHost/tools/painting/generateImage.ts
+++ b/src/backend/ai/agentHost/tools/painting/generateImage.ts
@@ -199,21 +199,14 @@ function extractParamValues(
   }
 
   const parsed = buildParamsSchema(support, mode).parse(candidate);
-  const regularEntries = Object.entries(supports).flatMap(([key, spec]) => {
+  const paramValues: Record<string, unknown> = {};
+  for (const [key, spec] of Object.entries(supports)) {
     const value = parsed[key];
-    if (value === undefined || (spec.type === 'size' && spec.pairedEnumKey)) {
-      return [];
+    if (value !== undefined) {
+      paramValues[spec.type === 'size' && spec.pairedEnumKey ? spec.pairedEnumKey : key] = value;
     }
-    return [[key, value]];
-  });
-  const pairedSizeEntries = Object.entries(supports).flatMap(([key, spec]) => {
-    const value = parsed[key];
-    if (value === undefined || spec.type !== 'size' || !spec.pairedEnumKey) {
-      return [];
-    }
-    return [[spec.pairedEnumKey, value]];
-  });
-  return Object.fromEntries([...regularEntries, ...pairedSizeEntries]);
+  }
+  return paramValues as ParamValues;
 }
 
 async function resolveInputImages(

--- a/src/backend/ai/mcp/mcpRuntimeAdapter.ts
+++ b/src/backend/ai/mcp/mcpRuntimeAdapter.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeToolCall,
   RuntimeToolRef,
 } from '@/backend/ai/agent';
+import { raceAbort } from '@/backend/ai/agent/raceAbort';
 
 export const MCP_TOOL_CALL_TIMEOUT_MS = 60 * 1000;
 export const MCP_TOOL_RESULT_MAX_BYTES = 256 * 1024;
@@ -17,6 +18,7 @@ const MCP_RESULT_PREVIEW_MAX_BYTES = 8 * 1024;
 const MCP_RESULT_PREVIEW_MAX_DEPTH = 5;
 const MCP_RESULT_PREVIEW_MAX_ENTRIES = 12;
 const MCP_RESULT_PREVIEW_MAX_STRING_BYTES = 512;
+const UTF8_ENCODER = new TextEncoder();
 
 export type McpExecutableToolDescriptor = {
   serverId: string;
@@ -200,7 +202,7 @@ async function executeMcpRuntimeTool(input: {
 
   const bound = createBoundedSignal(MCP_TOOL_CALL_TIMEOUT_MS, call.signal);
   try {
-    const remoteResult = await settleOrAbort(
+    const remoteResult = await raceAbort(
       input.invoke(input.ref, call.input, bound.signal, input.endpointUrl, input.generation),
       bound.signal,
     );
@@ -316,7 +318,7 @@ function truncateUtf8(value: string, maxBytes: number): string {
 }
 
 function utf8Size(value: string): number {
-  return new TextEncoder().encode(value).byteLength;
+  return UTF8_ENCODER.encode(value).byteLength;
 }
 
 function isRuntimeJsonValue(value: unknown): value is RuntimeJsonValue {
@@ -383,26 +385,4 @@ export function createBoundedSignal(
         ? timeoutController.signal
         : AbortSignal.any([timeoutController.signal, ...upstream]),
   };
-}
-
-function settleOrAbort<TValue>(promise: Promise<TValue>, signal: AbortSignal): Promise<TValue> {
-  return new Promise<TValue>((resolve, reject) => {
-    const abort = () => reject(new Error('MCP invocation aborted'));
-    if (signal.aborted) {
-      abort();
-    } else {
-      signal.addEventListener('abort', abort, { once: true });
-    }
-
-    promise.then(
-      (value) => {
-        signal.removeEventListener('abort', abort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener('abort', abort);
-        reject(error);
-      },
-    );
-  });
 }

--- a/src/backend/ai/provider/__tests__/languageServingPlan.test.ts
+++ b/src/backend/ai/provider/__tests__/languageServingPlan.test.ts
@@ -10,12 +10,11 @@ import {
 } from '../languageServingPlan';
 
 describe('resolveLanguageServingPlan', () => {
-  it('classifies shared auth and Pi protocol facts without selecting credentials', () => {
+  it('classifies Pi protocol facts without selecting credentials', () => {
     const provider = createProvider();
     const plan = resolveLanguageServingPlan(provider, createModel(ENDPOINT_TYPE.OPENAI_RESPONSES));
 
     expect(plan).toMatchObject({
-      auth: { declaredMethods: ['api-key'], type: 'api-key' },
       bindings: {
         pi: { endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES, status: 'supported' },
       },

--- a/src/backend/ai/provider/languageServingPlan.ts
+++ b/src/backend/ai/provider/languageServingPlan.ts
@@ -9,7 +9,7 @@ import {
   type ProviderLanguageTransportPolicy,
 } from '@/backend/ai/provider/providerTransport';
 import type { Model } from '@/shared/data/types/model';
-import type { AuthType, Provider, ProviderAuthMethod } from '@/shared/data/types/provider';
+import type { Provider } from '@/shared/data/types/provider';
 
 const PI_LANGUAGE_ENDPOINT_TYPES = [
   ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
@@ -53,10 +53,6 @@ export type PiLanguageBinding =
     };
 
 export interface LanguageServingPlan {
-  auth: {
-    declaredMethods: readonly ProviderAuthMethod[] | undefined;
-    type: AuthType;
-  };
   bindings: {
     pi: PiLanguageBinding;
   };
@@ -83,10 +79,6 @@ export function resolveLanguageServingPlan(
   const connection = options.resolvedConnection ?? resolveProviderConnection(provider, model);
 
   return {
-    auth: {
-      declaredMethods: provider.authMethods ? [...provider.authMethods] : undefined,
-      type: provider.authType,
-    },
     bindings: {
       pi: resolvePiLanguageBinding(provider, connection),
     },

--- a/src/backend/ai/provider/providerTransport.ts
+++ b/src/backend/ai/provider/providerTransport.ts
@@ -8,11 +8,6 @@ export interface ProviderLanguageTransportPolicy {
   wrapFetch(baseFetch: ProviderFetch): ProviderFetch;
 }
 
-interface ProviderLanguageTransportPolicyRegistration {
-  matches(provider: Provider): boolean;
-  policy: ProviderLanguageTransportPolicy;
-}
-
 const CHERRY_AI_LANGUAGE_TRANSPORT_POLICY: ProviderLanguageTransportPolicy = {
   wrapFetch: (baseFetch) => async (input, init) => {
     const signature = generateSignature({
@@ -28,22 +23,17 @@ const CHERRY_AI_LANGUAGE_TRANSPORT_POLICY: ProviderLanguageTransportPolicy = {
   },
 };
 
-const PROVIDER_LANGUAGE_TRANSPORT_POLICIES: readonly ProviderLanguageTransportPolicyRegistration[] =
-  [
-    {
-      matches: (provider) =>
-        isManagedCherryAiProviderId(provider.id) ||
-        isManagedCherryAiProviderId(provider.presetProviderId ?? ''),
-      policy: CHERRY_AI_LANGUAGE_TRANSPORT_POLICY,
-    },
-  ];
-
 /** Resolve shared Provider-specific language HTTP behavior without selecting user credentials. */
 export function resolveProviderLanguageTransportPolicy(
   provider: Provider,
 ): ProviderLanguageTransportPolicy | undefined {
-  return PROVIDER_LANGUAGE_TRANSPORT_POLICIES.find((registration) => registration.matches(provider))
-    ?.policy;
+  if (
+    isManagedCherryAiProviderId(provider.id) ||
+    isManagedCherryAiProviderId(provider.presetProviderId ?? '')
+  ) {
+    return CHERRY_AI_LANGUAGE_TRANSPORT_POLICY;
+  }
+  return undefined;
 }
 
 function getJsonBody(body: BodyInit | null | undefined): Record<string, unknown> | undefined {


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: Pi and shared AI backend paths retained duplicate terminal and capability state, provider policy indirection, and repeated scans or allocations.

After this PR: Pi runtime and host lifecycle decisions use existing sources of truth, model preflight owns tool capability, and MCP, provider, attachment, naming, and image parameter paths reuse direct shared logic.

### Screenshots or videos

N/A: internal refactor with no visible UI changes.

### Why we need it and why it was done in this way

Behavior-preserving cleanup removes 95 net lines while retaining protocol, cancellation, provider signing, attachment, and persistence contracts.

The following tradeoffs were made: public contracts and module boundaries stay intact; the CherryAI transport condition remains direct until another transport policy justifies a registry.

The following alternatives were considered: broader provider and agent architecture changes were deferred because they would expand behavior and review scope.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validated with the complete `src/backend/ai` Jest scope (43 suites, 890 tests, 7 snapshots), `pnpm lint`, `pnpm format:check`, and `pnpm typecheck`.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and is not applicable
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
