### PR TITLE
feat(chat-input): persist web search per session

### DIFF
--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -26,8 +26,9 @@ record for mobile-originated Agent Sessions only.
 
 Out of scope: branching columns, background turns, Mobile Skill configuration/loading, and broader
 Pi provider coverage. The Host projects Agent-specific MCP bindings into each Runtime snapshot.
-System capabilities are resolved independently and require no Agent persistence; the composer
-carries web-search and image-generation selection only on the current submission.
+System capabilities are resolved independently and require no Agent persistence. The frontend cache
+owns the Session-scoped web-search composer selection; image generation remains selected only by
+the current submission.
 
 ## Current limitations
 
@@ -130,8 +131,8 @@ unavailability without deleting or retargeting the row. Runtime projection is de
 
 The physical table and typed Data API retain the `builtin` variant to read existing databases
 without a destructive migration. Those rows are legacy compatibility data: the Host ignores them,
-and the Agent editor omits them when replacing bindings. Shared system capabilities and temporary
-composer selections are never persisted here.
+and the Agent editor omits them when replacing bindings. Shared system capabilities and composer
+selections are never persisted here.
 
 Skill configuration remains deferred. Pi reads neither tool nor Skill persistence directly.
 

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -60,9 +60,10 @@ protocol values.
 application (instructions, model, and MCP extensions). That configuration is live: before each
 turn, the Host resolves its current state and builds the Runtime execution request from it, so an
 application-level edit applies from the next turn. Shared system capabilities are not Agent
-configuration. The client may activate web search or image generation only for the submission that
-needs it. Configuration never selects a different local engine: `local` always means Pi. The client
-does not duplicate configuration or select an implementation.
+configuration. The frontend selects web search per Session and snapshots that selection into each
+submission, while image generation is selected by the submission that needs it. Configuration
+never selects a different local engine: `local` always means Pi. The client does not duplicate
+configuration or select an implementation.
 
 ### Turn
 
@@ -313,9 +314,10 @@ default instead of the Agent's configured effort.
 
 `temporaryCapabilities` is also turn-local and is never written to Agent configuration. The Host
 uses `web-search` to admit `web_search` and `web_fetch`, and `image-generation` to admit
-`generate_image` when its other system gates pass. Omitting the array admits neither temporary
-capability. The assistant's inference snapshot records the concrete tools that were frozen for the
-turn, so history does not depend on reconstructing composer state.
+`generate_image` when its other system gates pass. The frontend may retain web-search selection per
+Session and includes `web-search` on every submission while enabled. Omitting the array admits
+neither temporary capability. The assistant's inference snapshot records the concrete tools frozen
+for the turn, so history does not depend on reconstructing composer state.
 
 `observeSession` registers the listener and captures the snapshot as one Host operation, so an
 event cannot fall into a snapshot/subscription gap. Calling it again replaces stale frontend state;

--- a/docs/references/agent/agent-tools-and-resources.md
+++ b/docs/references/agent/agent-tools-and-resources.md
@@ -5,10 +5,11 @@
 The system catalog ships device calendar and reminders, health, location, web search and fetch,
 image generation, and `write_file`, all using the settled `ToolRef` and `{ value, artifacts }`
 contracts. For each turn the Host resolves that catalog against model tool support, platform, OS
-permission, app configuration, and composer-selected temporary capabilities, then combines it with
-the Agent's persisted executable MCP bindings. Calendar, reminders, health, location, and
-`write_file` are available to every Agent when their system gates pass. Web search and image
-generation enter only the turn whose composer selected them; they are never Agent configuration.
+permission, app configuration, and composer-selected turn capabilities, then combines it with the
+Agent's persisted executable MCP bindings. Calendar, reminders, health, location, and `write_file`
+are available to every Agent when their system gates pass. The frontend keeps web-search selection
+per Session and snapshots it into each turn; image generation enters only the turn whose draft
+selected it. Neither is Agent configuration.
 Office generation, inspection, and editing are not implemented. Sections that a shipped tool still
 diverges from carry an **As-built** note.
 
@@ -70,10 +71,10 @@ own platform, permission, application-configuration, approval, and optional temp
 gates. The Agent editor neither reads nor overrides it.
 
 `web_search` and `web_fetch` require the turn-local `web-search` capability. `generate_image`
-requires `image-generation` and a configured drawing model. The composer sends these selections on
-`submitMessage`; a successful send clears them, and they are never persisted on the Agent. System
-device and file capabilities have no Agent-specific switch. The inference snapshot records the
-tools that entered the immutable turn.
+requires `image-generation` and a configured drawing model. The composer snapshots its frontend
+Session cache for web search and its draft-local image selection on `submitMessage`. Neither is
+persisted on the Agent or Agent Session tables. System device and file capabilities have no
+Agent-specific switch. The inference snapshot records the tools that entered the immutable turn.
 
 The logical binding model is:
 

--- a/docs/references/web-search.md
+++ b/docs/references/web-search.md
@@ -12,12 +12,15 @@ Cherry Mobile retains two independent configurations:
   `WebSearchService`.
 
 `WebSearchService` reaches Agent turns through the application-owned `web_search` and `web_fetch`
-Runtime tools, never through an AI SDK tool set. Both are temporary composer capabilities: they stay
-out of the turn catalog unless that `submitMessage` carries `temporaryCapabilities: ['web-search']`.
-The selection applies to one turn and is never persisted on the Agent. The settings workflow still
-configures and checks external providers globally, and a lookup that fails because no provider is
-configured returns a terminal result telling the model to stop retrying rather than a transient
-error.
+Runtime tools, never through an AI SDK tool set. The composer stores enabled Session ids in the
+frontend MMKV cache; this state does not enter SQLite or the Agent protocol's Session model. New
+Sessions default to disabled. While enabled, every `submitMessage` carries
+`temporaryCapabilities: ['web-search']`, keeping the turn catalog immutable. The setting is never
+persisted on the Agent.
+
+The settings workflow still configures and checks external providers globally, and a lookup that
+fails because no provider is configured returns a terminal result telling the model to stop
+retrying rather than a transient error.
 
 ## External Runtime
 

--- a/src/frontend/data/__tests__/CacheService.test.ts
+++ b/src/frontend/data/__tests__/CacheService.test.ts
@@ -1,3 +1,5 @@
+import { DefaultPersistCache } from '@/shared/data/cache/cacheSchemas';
+
 import { CacheService, createInMemoryKvStorage } from '../CacheService';
 
 const MEMORY_KEY = 'internal.memory_probe.frontend' as const;
@@ -264,15 +266,16 @@ describe('CacheService getStats', () => {
       jest.advanceTimersByTime(1001);
 
       const stats = service.getStats(true);
+      const persistKeyCount = Object.keys(DefaultPersistCache).length;
       expect(stats.summary.memory.totalCount).toBe(2);
       expect(stats.summary.memory.validCount).toBe(1);
       expect(stats.summary.memory.expiredCount).toBe(1);
       expect(stats.summary.memory.withTTLCount).toBe(1);
       expect(stats.summary.memory.hookReferences).toBe(1);
-      expect(stats.summary.persist.totalCount).toBe(1);
+      expect(stats.summary.persist.totalCount).toBe(persistKeyCount);
       expect(stats.summary.total.estimatedBytes).toBeGreaterThan(0);
       expect(stats.details.memory).toHaveLength(2);
-      expect(stats.details.persist).toHaveLength(1);
+      expect(stats.details.persist).toHaveLength(persistKeyCount);
     } finally {
       jest.useRealTimers();
     }

--- a/src/frontend/features/agents/README.md
+++ b/src/frontend/features/agents/README.md
@@ -16,8 +16,8 @@ surfaces.
   plus Agent-specific MCP extensions. Inference parameters and system capabilities are not part of
   the Agent editor surface.
 - Calendar, reminders, health, location, and file capabilities are injected uniformly by the Host
-  when their system gates pass. Web search and image generation are temporary composer selections
-  for one submission; they are never saved on the Agent.
+  when their system gates pass. The frontend keeps web search as a Session-scoped composer
+  selection; image generation is selected for one submission. Neither is saved on the Agent.
 - The avatar is a managed file, not a mutable Agent field, so it has its own endpoint
   (`PUT /agents/:id/avatar`) and is written after the record lands — on create, only once the POST
   returns an id. Picking one only updates the draft; Save commits it. An avatar can be set and

--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -39,6 +39,7 @@ import { useBlurComposerOnVisibleKeyboardHide } from './hooks/useBlurComposerOnV
 import { useChatInputAgentModelSelection } from './hooks/useChatInputAgentModelSelection';
 import { useChatInputReasoningEfforts } from './hooks/useChatInputReasoningEfforts';
 import { useChatInputReasoningEffortSelection } from './hooks/useChatInputReasoningEffortSelection';
+import { useChatInputWebSearchSelection } from './hooks/useChatInputWebSearchSelection';
 import { toAgentInputParts } from './utils/agentInputParts';
 import { getChatInputTemporaryCapabilities } from './utils/chatInputCapabilities';
 import { getChatInputReasoningEffortSnapshot } from './utils/chatInputReasoning';
@@ -62,6 +63,10 @@ const focusTransitionMotion = {
 export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInputProps) {
   const { t } = useTranslation();
   const { cancel, isBusy, sendMessage } = useAgentChatControls({ agentId, sessionId });
+  const { isWebSearchEnabled, setIsWebSearchEnabled } = useChatInputWebSearchSelection({
+    agentId,
+    sessionId,
+  });
   const { agent } = useAgentApiById(agentId);
   const { updateAgent } = useAgentMutations();
   const modelPickerData = useModelPickerData({ modelType: 'text' });
@@ -97,13 +102,6 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
     );
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
   const [isInputActive, setIsInputActive] = useState(false);
-  const composerIdentity = sessionId ?? agentId ?? null;
-  const [webSearchSelection, setWebSearchSelection] = useState({
-    enabled: false,
-    identity: composerIdentity,
-  });
-  const isWebSearchEnabled =
-    webSearchSelection.identity === composerIdentity ? webSearchSelection.enabled : false;
   const isInputActiveRef = useRef(false);
   const naturalFieldHeight = useRef(restingInputHeight);
   const { inputRef } = useComposerMeta();
@@ -143,10 +141,6 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
   }));
   const closeModelPicker = useCallback(() => setIsModelPickerOpen(false), []);
   const openModelPicker = useCallback(() => setIsModelPickerOpen(true), []);
-  const setWebSearchEnabled = useCallback(
-    (enabled: boolean) => setWebSearchSelection({ enabled, identity: composerIdentity }),
-    [composerIdentity],
-  );
   const handleMentionPress = useCallback(
     (mentionId: ToolMentionId) => {
       const mention = toolMentions.find((candidate) => candidate.id === mentionId);
@@ -222,9 +216,9 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
           : {}),
         ...(temporaryCapabilities.length > 0 ? { temporaryCapabilities } : {}),
       }).then(() => {
-        setWebSearchSelection((current) =>
-          current.identity === composerIdentity ? { ...current, enabled: false } : current,
-        );
+        if (!sessionId) {
+          setIsWebSearchEnabled(false);
+        }
       });
     },
     [
@@ -234,8 +228,9 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
       reasoningEfforts,
       selectedModelId,
       sendMessage,
-      composerIdentity,
       isWebSearchEnabled,
+      sessionId,
+      setIsWebSearchEnabled,
     ],
   );
   const getSendErrorLabel = useCallback(
@@ -299,7 +294,7 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
                     <ChatInputMenuItems
                       isWebSearchEnabled={isWebSearchEnabled}
                       onMentionPress={handleMentionPress}
-                      onWebSearchChange={setWebSearchEnabled}
+                      onWebSearchChange={setIsWebSearchEnabled}
                     />
                   </ComposerMenu>
                   <ComposerModelPill

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -21,8 +21,9 @@ exported through `index.ts` and receives the current `agentId` and optional `ses
   the current Agent composer and is snapshotted into each submission; it never updates Agent
   configuration. An explicit `default` selection bypasses the Agent effort for that turn and uses
   the selected model's default.
-- The composer menu owns temporary capabilities. Web search adds `web-search` to the next
-  submission; the create-image mention adds `image-generation`. Neither mutates Agent
-  configuration. A successful send clears the web selection and the sent draft; failed submission
-  preserves both for retry.
+- The composer menu stores web-search selection in the frontend persist cache, keyed by Session id.
+  New Sessions default to disabled, and the first send transfers the draft selection after lazy
+  Session creation. While enabled, every submission includes the turn-local `web-search`
+  capability. The create-image mention remains turn-local and adds `image-generation` only to the
+  draft that contains it. Neither choice mutates Agent or Agent Session persistence.
 - Follow-up queues and steering are not part of the Version 1 Agent Session composer.

--- a/src/frontend/features/chat/input/components/ChatInputMenuItems.tsx
+++ b/src/frontend/features/chat/input/components/ChatInputMenuItems.tsx
@@ -17,7 +17,7 @@ type ChatInputMenuItemsProps = {
  * composer takes them as a slot rather than knowing they exist.
  *
  * Image generation stays visible as a mention in the draft; web search is a
- * turn-only switch. Neither choice is persisted to Agent configuration.
+ * frontend Session setting. Neither choice is persisted to Agent configuration.
  */
 export function ChatInputMenuItems({
   isWebSearchEnabled,

--- a/src/frontend/features/chat/input/hooks/__tests__/useChatInputWebSearchSelection.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useChatInputWebSearchSelection.test.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { cacheService } from '@/frontend/data/CacheService';
+import {
+  SESSION_WEB_SEARCH_SELECTION_CACHE_KEY,
+  persistSessionWebSearchSelection,
+} from '@/frontend/features/chat/sessionWebSearchSelection';
+
+import { useChatInputWebSearchSelection } from '../useChatInputWebSearchSelection';
+
+type Snapshot = ReturnType<typeof useChatInputWebSearchSelection>;
+
+describe('useChatInputWebSearchSelection', () => {
+  beforeEach(() => {
+    cacheService.deletePersist(SESSION_WEB_SEARCH_SELECTION_CACHE_KEY);
+  });
+
+  test('persists the selection independently for each established Session', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          agentId="agent-1"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          sessionId="session-1"
+        />,
+      );
+    });
+    await act(async () => snapshot?.setIsWebSearchEnabled(true));
+
+    expect(snapshot?.isWebSearchEnabled).toBe(true);
+    expect(cacheService.getPersist(SESSION_WEB_SEARCH_SELECTION_CACHE_KEY)).toEqual(['session-1']);
+
+    await act(async () => {
+      renderer?.update(
+        <Harness
+          agentId="agent-1"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          sessionId="session-2"
+        />,
+      );
+    });
+    expect(snapshot?.isWebSearchEnabled).toBe(false);
+
+    await act(async () => renderer?.unmount());
+  });
+
+  test('keeps a new Session draft local until creation assigns an id', async () => {
+    let snapshot: Snapshot | undefined;
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          agentId="agent-1"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+        />,
+      );
+    });
+    await act(async () => snapshot?.setIsWebSearchEnabled(true));
+
+    expect(snapshot?.isWebSearchEnabled).toBe(true);
+    expect(cacheService.getPersist(SESSION_WEB_SEARCH_SELECTION_CACHE_KEY)).toEqual([]);
+
+    await act(async () => {
+      persistSessionWebSearchSelection('session-1', true);
+      renderer?.update(
+        <Harness
+          agentId="agent-1"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+          sessionId="session-1"
+        />,
+      );
+    });
+    expect(snapshot?.isWebSearchEnabled).toBe(true);
+
+    await act(async () => {
+      renderer?.update(
+        <Harness
+          agentId="agent-1"
+          onSnapshot={(value) => {
+            snapshot = value;
+          }}
+        />,
+      );
+    });
+    expect(snapshot?.isWebSearchEnabled).toBe(false);
+
+    await act(async () => renderer?.unmount());
+  });
+});
+
+function Harness({
+  agentId,
+  onSnapshot,
+  sessionId,
+}: {
+  agentId?: string;
+  onSnapshot: (snapshot: Snapshot) => void;
+  sessionId?: string;
+}) {
+  const snapshot = useChatInputWebSearchSelection({ agentId, sessionId });
+
+  useEffect(() => onSnapshot(snapshot), [onSnapshot, snapshot]);
+  return null;
+}

--- a/src/frontend/features/chat/input/hooks/useChatInputWebSearchSelection.ts
+++ b/src/frontend/features/chat/input/hooks/useChatInputWebSearchSelection.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+import { usePersistCache } from '@/frontend/data';
+
+import {
+  SESSION_WEB_SEARCH_SELECTION_CACHE_KEY,
+  updateSessionWebSearchSelection,
+} from '../../sessionWebSearchSelection';
+
+type DraftSelection = {
+  agentId?: string;
+  isEnabled: boolean;
+};
+
+/**
+ * Stores established Session selections in the frontend persist cache while
+ * keeping the not-yet-created Session selection local to this composer.
+ */
+export function useChatInputWebSearchSelection(input: { agentId?: string; sessionId?: string }) {
+  const { agentId, sessionId } = input;
+  const [enabledSessionIds, setEnabledSessionIds] = usePersistCache(
+    SESSION_WEB_SEARCH_SELECTION_CACHE_KEY,
+  );
+  const [draftSelection, setDraftSelection] = useState<DraftSelection>({
+    agentId,
+    isEnabled: false,
+  });
+  let activeDraftSelection = draftSelection;
+  if (
+    (sessionId && draftSelection.isEnabled) ||
+    (!sessionId && draftSelection.agentId !== agentId)
+  ) {
+    activeDraftSelection = { agentId, isEnabled: false };
+    setDraftSelection(activeDraftSelection);
+  }
+
+  const isWebSearchEnabled = sessionId
+    ? enabledSessionIds.includes(sessionId)
+    : activeDraftSelection.isEnabled;
+
+  const setIsWebSearchEnabled = (isEnabled: boolean) => {
+    if (sessionId) {
+      setEnabledSessionIds((current) =>
+        updateSessionWebSearchSelection(current, sessionId, isEnabled),
+      );
+      return;
+    }
+
+    setDraftSelection({ agentId, isEnabled });
+  };
+
+  return { isWebSearchEnabled, setIsWebSearchEnabled };
+}

--- a/src/frontend/features/chat/input/utils/chatInputActions.ts
+++ b/src/frontend/features/chat/input/utils/chatInputActions.ts
@@ -5,7 +5,7 @@ import type { ComponentType } from 'react';
 
 import { type ToolMentionId, toolMentions } from '@/frontend/utils/toolMentions';
 
-/** Web search is enabled by the composer for one submitted turn. */
+/** Web search is enabled by the composer for the current Session. */
 export const chatInputWebSearchAction = {
   icon: GlobeIcon,
   titleKey: 'chat.actions.webSearch',

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -15,6 +15,7 @@ import { AppState } from 'react-native';
 import { queryKeys, useBackendModule } from '@/frontend/data';
 import type { AgentInputPart, AgentSubmitMessageInput } from '@/shared/contracts/agent';
 
+import { persistSessionWebSearchSelection } from '../sessionWebSearchSelection';
 import { AgentSessionChatClient, type AgentSessionChatState } from './AgentSessionChatClient';
 
 type AgentChatSendInput = {
@@ -97,6 +98,10 @@ export function ChatProvider({ children }: PropsWithChildren) {
 
         const session = await client.createSession(agentId);
         targetSessionId = session.id;
+        persistSessionWebSearchSelection(
+          targetSessionId,
+          temporaryCapabilities?.includes('web-search') ?? false,
+        );
         await client.observe(targetSessionId);
         navigation.openSession(targetSessionId, agentId);
         await queryClient.invalidateQueries({ queryKey: queryKeys.agentSessions.all() });

--- a/src/frontend/features/chat/sessionWebSearchSelection.ts
+++ b/src/frontend/features/chat/sessionWebSearchSelection.ts
@@ -1,0 +1,27 @@
+import { cacheService } from '@/frontend/data/CacheService';
+
+export const SESSION_WEB_SEARCH_SELECTION_CACHE_KEY =
+  'chat.web_search.enabled_session_ids' as const;
+
+export function updateSessionWebSearchSelection(
+  enabledSessionIds: readonly string[],
+  sessionId: string,
+  isEnabled: boolean,
+): readonly string[] {
+  const alreadyEnabled = enabledSessionIds.includes(sessionId);
+  if (alreadyEnabled === isEnabled) {
+    return enabledSessionIds;
+  }
+
+  return isEnabled
+    ? [...enabledSessionIds, sessionId]
+    : enabledSessionIds.filter((candidate) => candidate !== sessionId);
+}
+
+export function persistSessionWebSearchSelection(sessionId: string, isEnabled: boolean): void {
+  const enabledSessionIds = cacheService.getPersist(SESSION_WEB_SEARCH_SELECTION_CACHE_KEY);
+  cacheService.setPersist(
+    SESSION_WEB_SEARCH_SELECTION_CACHE_KEY,
+    updateSessionWebSearchSelection(enabledSessionIds, sessionId, isEnabled),
+  );
+}

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -71,12 +71,16 @@ export type BackendCacheSchema = {
  * `undefined` — the backing store round-trips every value through JSON.
  */
 export type PersistCacheSchema = {
+  // Frontend-owned composer state. Only enabled Session ids are retained;
+  // missing ids use the product default (web search disabled).
+  'chat.web_search.enabled_session_ids': readonly string[];
   // Persist-layer self-test key: exercises the typed persist API and round-trip
   // tests for the generic mechanism, independent of any real consumer.
   'internal.persist_probe': number;
 };
 
 export const DefaultPersistCache: PersistCacheSchema = {
+  'chat.web_search.enabled_session_ids': [],
   'internal.persist_probe': 0,
 };
 


### PR DESCRIPTION
## Summary

- persist the composer web-search selection in the frontend MMKV cache, keyed by Agent Session id
- carry a new-chat draft selection into the lazily created Session and keep using the existing temporary capability payload
- document that the setting is frontend-owned and does not enter SQLite, Agent persistence, or the Agent Session protocol model

## Validation

- `pnpm lint` (passed with existing repository warnings)
- `pnpm format:check`
- Pull Request CI run 33070519846 passed: lint, typecheck, and test
- manual UI verification not run, per repository verification policy