### PR TITLE
fix(agent-runtime): downgrade unsupported image history

### DIFF
--- a/packages/ai-runtime/src/messages/__tests__/messageCapabilities.test.ts
+++ b/packages/ai-runtime/src/messages/__tests__/messageCapabilities.test.ts
@@ -2,7 +2,11 @@ import { MODALITY } from '@cherrystudio/provider-registry';
 import type { Model } from '@cherrystudio/universal/data/types/model';
 import type { UIMessage } from 'ai';
 
-import { resolveMediaCapabilities, stripUnsupportedMedia } from '../messageCapabilities';
+import {
+  resolveMediaCapabilities,
+  stripUnsupportedMedia,
+  unsupportedMediaNote,
+} from '../messageCapabilities';
 
 const model = (inputModalities: string[]): Model =>
   ({ capabilities: [], inputModalities }) as unknown as Model;
@@ -31,6 +35,13 @@ describe('resolveMediaCapabilities', () => {
 
 describe('stripUnsupportedMedia', () => {
   const noVision = { image: false, video: true, audio: true };
+
+  it('exposes the same omission note to non-UIMessage adapters', () => {
+    expect(unsupportedMediaNote('image/png', noVision)).toBe(
+      '[image attachment omitted: this model does not accept image input]',
+    );
+    expect(unsupportedMediaNote('image/png', { ...noVision, image: true })).toBeUndefined();
+  });
 
   it('replaces an image file part with a note when the model has no vision', () => {
     const [out] = stripUnsupportedMedia([fileMsg('image/png')], noVision);

--- a/packages/ai-runtime/src/messages/messageCapabilities.ts
+++ b/packages/ai-runtime/src/messages/messageCapabilities.ts
@@ -40,6 +40,17 @@ function gatedModality(mediaType: string): GatedModality | undefined {
   return undefined;
 }
 
+/** Return the provider-visible note for an unsupported media type. */
+export function unsupportedMediaNote(
+  mediaType: string,
+  caps: MediaCapabilities,
+): string | undefined {
+  const modality = gatedModality(mediaType);
+  return modality && caps[modality] === false
+    ? `[${modality} attachment omitted: this model does not accept ${modality} input]`
+    : undefined;
+}
+
 /**
  * Replace `file` parts whose modality the model can't accept with a text note.
  *
@@ -57,13 +68,10 @@ export function stripUnsupportedMedia<T extends UIMessage = UIMessage>(
     let changed = false;
     const parts = message.parts.map((part) => {
       if (part.type !== 'file') return part;
-      const modality = gatedModality(part.mediaType);
-      if (!modality || caps[modality] !== false) return part;
+      const note = unsupportedMediaNote(part.mediaType, caps);
+      if (!note) return part;
       changed = true;
-      return {
-        type: 'text',
-        text: `[${modality} attachment omitted: this model does not accept ${modality} input]`,
-      };
+      return { type: 'text', text: note };
     });
     return changed ? ({ ...message, parts } as T) : message;
   });

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -27,6 +27,8 @@
  *     stays private to the Host.
  */
 
+import { unsupportedMediaNote } from '@cherrystudio/ai-runtime/messages';
+
 import type { AiService } from '@/backend/ai/AiService';
 import type { McpRuntimeService } from '@/backend/ai/mcp';
 import {
@@ -150,6 +152,7 @@ const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
 };
 
 const TERMINAL_PERSISTENCE_RETRY_DELAYS_MS = [0, 50, 200] as const;
+const NO_IMAGE_MEDIA_CAPABILITIES = { image: false, video: true, audio: true } as const;
 
 type MobileAgentHostOverrides = {
   agents: AgentDefinitionSource;
@@ -627,6 +630,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         parts,
         runtimeContextCheckpoint,
         runtimeTextAttachments,
+        modelPreflight,
         tools,
       );
       this.runningTurns.add(run);
@@ -731,16 +735,35 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     inputParts: AgentInputPart[],
     storedContextCheckpoint: RuntimeContextCheckpoint | null,
     runtimeTextAttachments: RuntimeAttachmentContents,
+    modelPreflight: RuntimeModelPreflight,
     tools: readonly RuntimeTool[],
   ): Promise<void> {
     try {
       const runtimeAttachments = new Map(runtimeTextAttachments);
-      const runtimeImages = await this.resolveRuntimeImages(
-        state.resources,
-        state.abortController.signal,
-      );
-      for (const [fileEntryId, image] of runtimeImages) {
-        runtimeAttachments.set(fileEntryId, image);
+      if (modelPreflight.inputModalities.includes('image')) {
+        const runtimeImages = await this.resolveRuntimeImages(
+          state.resources,
+          state.abortController.signal,
+        );
+        for (const [fileEntryId, image] of runtimeImages) {
+          runtimeAttachments.set(fileEntryId, image);
+        }
+      } else {
+        const omitImage = (fileEntryId: string, mediaType: string) => {
+          const text = unsupportedMediaNote(mediaType, NO_IMAGE_MEDIA_CAPABILITIES);
+          if (text) runtimeAttachments.set(fileEntryId, { type: 'text', text });
+        };
+        for (const part of inputParts) {
+          if (part.type === 'file') omitImage(part.fileEntryId, part.mediaType);
+        }
+        for (const message of history) {
+          if (message.role !== 'user') continue;
+          for (const part of message.parts) {
+            if (part.type === 'file' && part.purpose === 'input-attachment') {
+              omitImage(part.fileEntryId, part.mediaType);
+            }
+          }
+        }
       }
       state.abortController.signal.throwIfAborted();
       const events = state.runtimeSession.execute({
@@ -1181,7 +1204,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       return;
     }
     if (!model.inputModalities.includes('image')) {
-      fail('CAPABILITY_UNSUPPORTED', 'The selected model does not support image input.');
+      // runTurn replaces these references with text notes without reading image bytes.
+      return;
     }
 
     const limit = findImageAttachmentLimit(images, model);

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -1585,43 +1585,121 @@ describe('MobileAgentHost', () => {
     await expect(store.listMessages(session.id)).resolves.toEqual([]);
   });
 
-  test('rejects unsupported models and endpoints before reserving image messages', async () => {
+  test('replaces current and historical images after switching to a text-only model', async () => {
+    const firstFact = {
+      fileEntryId: FILE_ENTRY_ID,
+      mediaType: 'image/png',
+      name: 'first.png',
+      size: 128,
+    };
+    const secondFact = {
+      fileEntryId: SECOND_FILE_ENTRY_ID,
+      mediaType: 'image/png',
+      name: 'second.png',
+      size: 128,
+    };
+    const facts = new Map([
+      [FILE_ENTRY_ID, firstFact],
+      [SECOND_FILE_ENTRY_ID, secondFact],
+    ]);
+    const requests: RuntimeExecutionRequest[] = [];
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR })
+      .script((controller) => {
+        requests.push(controller.request);
+        controller.emit({ type: 'completed' });
+      })
+      .script((controller) => {
+        requests.push(controller.request);
+        controller.emit({ type: 'completed' });
+      });
+    jest
+      .spyOn(runtime, 'preflightModel')
+      .mockResolvedValueOnce({
+        contextWindow: 128_000,
+        inputModalities: ['text', 'image'],
+        maxInputTokens: 120_000,
+        maxOutputTokens: 8_000,
+        supportsTools: true,
+      })
+      .mockResolvedValueOnce({
+        contextWindow: 128_000,
+        inputModalities: ['text'],
+        maxInputTokens: 120_000,
+        maxOutputTokens: 8_000,
+        supportsTools: true,
+      });
+    const readAsDataUrl = jest.fn(async () => 'data:image/png;base64,AAAA');
+    const files: ManagedFileResolver = {
+      readAsBytes: async () => undefined,
+      readAsDataUrl,
+      resolveAvailable: async (ids) =>
+        new Map([...facts].filter(([fileEntryId]) => ids.includes(fileEntryId))),
+    };
+    const host = createHost(runtime, noOpNaming, files);
+    const session = await host.createSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+    });
+    const events: AgentEvent[] = [];
+    await host.observeSession(session.id, (event) => events.push(event));
+
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [{ type: 'file', fileEntryId: FILE_ENTRY_ID, mediaType: 'image/png' }],
+    });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the image turn');
+    events.length = 0;
+    await host.submitMessage({
+      sessionId: session.id,
+      parts: [
+        { type: 'text', text: 'Continue.' },
+        { type: 'file', fileEntryId: SECOND_FILE_ENTRY_ID, mediaType: 'image/png' },
+      ],
+    });
+    await waitFor(() => terminalTurnEvent(events) !== undefined, 'the text-only follow-up turn');
+
+    const replayedUser = requests[1]?.history
+      .flatMap((turn) => turn.messages)
+      .find((message) => message.role === 'user');
+    expect(replayedUser?.parts).toEqual([
+      {
+        type: 'text',
+        text: '[image attachment omitted: this model does not accept image input]',
+      },
+    ]);
+    expect(requests[1]?.input).toEqual([
+      { type: 'text', text: 'Continue.' },
+      {
+        type: 'text',
+        text: '[image attachment omitted: this model does not accept image input]',
+      },
+    ]);
+    expect(readAsDataUrl).toHaveBeenCalledTimes(1);
+    const transcript = await store.listMessages(session.id);
+    expect(transcript[0]?.parts[0]).toMatchObject({
+      type: 'file',
+      fileEntryId: FILE_ENTRY_ID,
+      purpose: 'input-attachment',
+    });
+    expect(transcript[2]?.parts[1]).toMatchObject({
+      type: 'file',
+      fileEntryId: SECOND_FILE_ENTRY_ID,
+      purpose: 'input-attachment',
+    });
+  });
+
+  test('rejects an unavailable model endpoint before reserving image messages', async () => {
     const fact = {
       fileEntryId: FILE_ENTRY_ID,
       mediaType: 'image/png',
       name: 'managed.png',
       size: 128,
     };
-    const textOnlyRuntime = new FakeRuntime({
-      descriptor: FAKE_DESCRIPTOR,
-      modelPreflight: {
-        contextWindow: 128_000,
-        inputModalities: ['text'],
-        maxInputTokens: 120_000,
-        maxOutputTokens: 8_000,
-        supportsTools: true,
-      },
-    });
     const files: ManagedFileResolver = {
       readAsBytes: async () => undefined,
       readAsDataUrl: jest.fn(async () => 'data:image/png;base64,AAAA'),
       resolveAvailable: async () => new Map([[FILE_ENTRY_ID, fact]]),
     };
-    const host = createHost(textOnlyRuntime, noOpNaming, files);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
-
-    await expect(
-      host.submitMessage({
-        sessionId: session.id,
-        parts: [{ type: 'file', fileEntryId: FILE_ENTRY_ID, mediaType: 'image/png' }],
-      }),
-    ).rejects.toMatchObject({ view: { code: 'CAPABILITY_UNSUPPORTED' } });
-    expect(await store.listMessages(session.id)).toEqual([]);
-    expect(files.readAsDataUrl).not.toHaveBeenCalled();
-
     const unsupportedEndpointRuntime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR });
     jest
       .spyOn(unsupportedEndpointRuntime, 'preflightModel')

--- a/src/backend/ai/agent/runtime/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntime.ts
@@ -653,24 +653,6 @@ class PiRuntimeSession implements AgentRuntimeSession {
         });
         return;
       }
-      if (
-        (request.input.some((part) => part.type === 'file') ||
-          request.history.some((turn) =>
-            turn.messages.some((message) => message.parts.some((part) => part.type === 'file')),
-          )) &&
-        !resolution.model.input.includes('image')
-      ) {
-        this.emit(turn, {
-          type: 'failed',
-          error: {
-            code: 'unsupported_input',
-            message: 'The selected model does not support image input.',
-            retryable: false,
-          },
-        });
-        return;
-      }
-
       const conversation = toPiConversation(request, resolution.model);
       // Compose the turn signal into every provider call: cancellation must
       // reach the HTTP transport directly, not only through pi's own loop

--- a/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
@@ -950,6 +950,43 @@ describe('PiRuntime mapping', () => {
     await session.close();
   });
 
+  test('replaces current and historical images when the model accepts only text', async () => {
+    const runtime = createTestRuntime();
+    let prompt: PiMessage | undefined;
+    const arranged = arrange(runtime, async (context) => {
+      prompt = context.prompt;
+      await emitText(context, 'Continued without images.');
+    });
+    const session = await runtime.open();
+    const image = {
+      type: 'file' as const,
+      mediaType: 'image/png',
+      name: 'image.png',
+      uri: 'data:image/png;base64,AAAA',
+    };
+    const omitted = '[image attachment omitted: this model does not accept image input]';
+
+    const events = await collect(
+      session.execute(
+        baseRequest('turn-text-only-images', {
+          history: [{ turnId: 'turn-with-image', messages: [{ role: 'user', parts: [image] }] }],
+          input: [{ type: 'text', text: 'Continue.' }, image],
+        }),
+      ),
+    );
+
+    expect(events.at(-1)).toEqual({ type: 'completed' });
+    expect(arranged.lastOptions?.initialState?.messages).toEqual([
+      { role: 'user', content: omitted, timestamp: expect.any(Number) },
+    ]);
+    expect(prompt).toEqual({
+      role: 'user',
+      content: `Continue.\n${omitted}`,
+      timestamp: expect.any(Number),
+    });
+    await session.close();
+  });
+
   test('preflights and maps current and historical inline images without retaining data URLs', async () => {
     const runtime = createTestRuntime();
     const holder = holders.get(runtime);

--- a/src/backend/ai/agent/runtime/pi/modelMessages.ts
+++ b/src/backend/ai/agent/runtime/pi/modelMessages.ts
@@ -1,3 +1,4 @@
+import { unsupportedMediaNote } from '@cherrystudio/ai-runtime/messages';
 import type {
   Api as PiApi,
   AssistantMessage,
@@ -50,6 +51,11 @@ export function toPiConversation(
   const historyTurns: PiHistoryTurn[] = [];
   const systemParts = request.instructions.length > 0 ? [request.instructions] : [];
   const providerNamesByCallId = collectProviderNames(request);
+  const mediaCapabilities = {
+    image: model.input.includes('image'),
+    video: false,
+    audio: false,
+  };
 
   for (const turn of request.history) {
     const historyTurn: PiHistoryTurn = { turnId: turn.turnId, messages: [] };
@@ -62,7 +68,7 @@ export function toPiConversation(
       if (message.role === 'user') {
         historyTurn.messages.push({
           role: 'user',
-          content: collectUserContent(message.parts),
+          content: collectUserContent(message.parts, mediaCapabilities),
           timestamp: Date.now(),
         });
         continue;
@@ -81,12 +87,19 @@ export function toPiConversation(
   return {
     history: historyTurns.flatMap((turn) => turn.messages),
     historyTurns,
-    prompt: { role: 'user', content: collectUserContent(request.input), timestamp: Date.now() },
+    prompt: {
+      role: 'user',
+      content: collectUserContent(request.input, mediaCapabilities),
+      timestamp: Date.now(),
+    },
     systemPrompt: systemParts.join('\n\n'),
   };
 }
 
-function collectUserContent(parts: readonly RuntimeMessagePart[]): UserMessage['content'] {
+function collectUserContent(
+  parts: readonly RuntimeMessagePart[],
+  mediaCapabilities: { image: boolean; video: boolean; audio: boolean },
+): UserMessage['content'] {
   const content = parts.flatMap<TextContent | ImageContent>((part) => {
     if (part.type === 'text') {
       return [{ type: 'text' as const, text: part.text }];
@@ -95,6 +108,8 @@ function collectUserContent(parts: readonly RuntimeMessagePart[]): UserMessage['
       return [toPiTextAttachment(part)];
     }
     if (part.type === 'file') {
+      const note = unsupportedMediaNote(part.mediaType, mediaCapabilities);
+      if (note) return [{ type: 'text' as const, text: note }];
       return [toPiImage(part)];
     }
     return [];


### PR DESCRIPTION
## Summary

- expose the shared unsupported-media omission note for non-`UIMessage` adapters
- replace current and historical image attachments with text notes when the selected model is text-only
- avoid reading managed image bytes when they will be omitted, while preserving the original persisted attachment references
- retain Pi-side defensive shaping and existing validation for malformed attachments and unavailable model endpoints

## Validation

- `pnpm packages:build` — passed
- `pnpm format:check` — passed
- `pnpm typecheck` — passed
- targeted `oxlint` and Expo lint for changed files — passed
- pre-commit `oxfmt` hook — passed
- tests — not run per workspace verification policy
- `pnpm lint` — repository-wide gate remains blocked by 8 unrelated `import/no-unresolved` errors for `@cherrystudio/ai-core`; changed-file lint passes
- desktop sync audit — blocked by the pre-existing disagreement between the root AI runtime manifest and the delegated sync map; this PR does not modify sync classifications
