### PR TITLE
refactor(agent): make turn policy and lifecycle explicit

### DIFF
--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -74,6 +74,7 @@ import {
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import { FileEntryIdSchema } from '@/shared/data/types/file';
 import { parseUniqueModelId } from '@/shared/data/types/model';
+import { applyToolApprovalMode } from '@/shared/utils/agentToolApproval';
 import { isAiSupportedImageMediaType } from '@/shared/utils/imageFileTypes';
 
 import { createPiModelResolver } from '../piAdapter/piModelResolver';
@@ -1446,21 +1447,17 @@ function applyTurnOverrides(
 }
 
 /**
- * Applies only the Agent's interactive approval preference. Tool availability,
- * hard denies, system permission, and callback-level resource checks are left
- * untouched and continue to fail closed.
+ * Applies only the Agent's interactive approval preference; the value-level
+ * rule lives in the shared policy module next to the MCP approval floor.
  */
 function applyAgentToolApprovalMode(
   tools: readonly RuntimeTool[],
   mode: AgentDefinition['toolApprovalMode'],
 ): RuntimeTool[] {
-  if (mode === 'default') {
-    return [...tools];
-  }
-
-  return tools.map((tool) =>
-    tool.approval === 'ask' ? { ...tool, approval: 'auto' as const } : tool,
-  );
+  return tools.map((tool) => {
+    const approval = applyToolApprovalMode(tool.approval, mode);
+    return approval === tool.approval ? tool : { ...tool, approval };
+  });
 }
 
 function imageAttachmentLimitMessage(limit: ImageAttachmentLimit): string {

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -8,6 +8,11 @@
  * lifecycle service (one per ApplicationHost generation):
  * route unmount only unsubscribes; disposal cancels and awaits active turns.
  *
+ * The write-free stretch between admission and the first durable row lives in
+ * `./turnPreparation` (gates and the frozen `TurnPlan`); attachment admission
+ * and materialization live in `./turnAttachments`. This class keeps admission,
+ * reservation, execution, and terminal settlement.
+ *
  * Protocol invariants implemented here (agent-protocol.md):
  * 1.  one active turn per Session (synchronous admission guard);
  * 2.  reservation of user message + assistant placeholder commits atomically
@@ -26,8 +31,6 @@
  * 10. clients supply an execution target and Agent id; the local Pi binding
  *     stays private to the Host.
  */
-
-import { unsupportedMediaNote } from '@cherrystudio/ai-runtime/messages';
 
 import type { AiService } from '@/backend/ai/AiService';
 import type { McpRuntimeService } from '@/backend/ai/mcp';
@@ -72,33 +75,18 @@ import {
   type AgentTurnView,
 } from '@/shared/contracts/agent';
 import { loggerService } from '@/shared/core/logger/LoggerService';
-import { FileEntryIdSchema } from '@/shared/data/types/file';
-import { parseUniqueModelId } from '@/shared/data/types/model';
-import { applyToolApprovalMode } from '@/shared/utils/agentToolApproval';
-import { isAiSupportedImageMediaType } from '@/shared/utils/imageFileTypes';
 
 import { createPiModelResolver } from '../piAdapter/piModelResolver';
-import { findImageAttachmentLimit, type ImageAttachmentLimit } from '../resources/imageAttachments';
 import {
-  createTurnResourceLedger,
   managedFileResolver,
-  type ManagedFileFact,
   type ManagedFileResolver,
   type TurnResourceLedger,
 } from '../resources/managedFileResolver';
-import {
-  isSupportedTextAttachment,
-  resolveManagedTextAttachments,
-  TextAttachmentError,
-} from '../resources/textAttachments';
 import type {
   AgentRuntime,
   AgentRuntimeSession,
   RuntimeContextCheckpoint,
   RuntimeEvent,
-  RuntimeInputPart,
-  RuntimeModelPreflight,
-  RuntimeTool,
   RuntimeUsageReport,
 } from '../runtime';
 import { PiRuntime, raceAbort } from '../runtime';
@@ -119,15 +107,8 @@ import {
 } from './agentDefinitions';
 import { AgentSessionNaming } from './AgentSessionNaming';
 import { AgentSessionUsageRecorder } from './AgentSessionUsageRecorder';
-import {
-  validateRuntimeContextCheckpoint,
-  validateRuntimeContextCheckpointCandidate,
-} from './contextCheckpoints';
-import {
-  createAgentInferenceSnapshot,
-  type AgentInferenceModelResolver,
-  resolveAgentInferenceModel,
-} from './inferenceSnapshot';
+import { validateRuntimeContextCheckpoint } from './contextCheckpoints';
+import { type AgentInferenceModelResolver, resolveAgentInferenceModel } from './inferenceSnapshot';
 import {
   toAgentApprovalView,
   toAgentErrorView,
@@ -135,8 +116,9 @@ import {
   toAgentUsageView,
   toRuntimeHistory,
   toRuntimeInputParts,
-  type RuntimeAttachmentContents,
 } from './mapping';
+import { materializeRuntimeAttachments } from './turnAttachments';
+import { prepareTurn, type TurnPlan, type TurnPreparationDependencies } from './turnPreparation';
 
 const logger = loggerService.withContext('MobileAgentHost');
 
@@ -153,7 +135,6 @@ const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
 };
 
 const TERMINAL_PERSISTENCE_RETRY_DELAYS_MS = [0, 50, 200] as const;
-const NO_IMAGE_MEDIA_CAPABILITIES = { image: false, video: true, audio: true } as const;
 
 type MobileAgentHostOverrides = {
   agents: AgentDefinitionSource;
@@ -305,6 +286,19 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
 
   private lazySystemCapabilities: SystemCapabilitySource | undefined;
 
+  /** Ports for the write-free preparation stage; accessors keep test overrides live. */
+  private get turnPreparation(): TurnPreparationDependencies {
+    return {
+      agents: this.agents,
+      files: this.files,
+      inferenceModel: this.inferenceModel,
+      routeExecutionTarget: (target) => this.routeExecutionTarget(target),
+      runtimeTools: this.runtimeTools,
+      store: this.store,
+      systemCapabilities: this.systemCapabilities,
+    };
+  }
+
   /** Reconcile any unfinished state available from the selected store. */
   protected override async onInit(): Promise<void> {
     await this.reconcileInterruptedTurns();
@@ -441,146 +435,21 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       completion: completion.promise,
     });
     try {
-      const session = await raceAbort(this.store.getSession(sessionId), signal);
-      if (!session) {
-        fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
-      }
-      const configuredAgent = await raceAbort(this.requireAgent(session.agentId), signal);
-      const agent = applyTurnOverrides(configuredAgent, parsed);
-      const runtime = this.routeExecutionTarget(session.executionTarget);
-      if (
-        !runtime.descriptor.capabilities.attachments &&
-        parsed.parts.some((part) => part.type === 'file')
-      ) {
-        fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
-      }
-
-      const storedContextCandidate = await raceAbort(
-        this.store.getLatestContextCheckpoint(sessionId),
-        signal,
-      );
-      const checkpointValidation = storedContextCandidate
-        ? validateRuntimeContextCheckpointCandidate(storedContextCandidate.checkpoint)
-        : null;
-      const requestedCheckpoint = checkpointValidation?.checkpoint ?? null;
-      const storedTurnContext = await raceAbort(
-        this.store.loadRuntimeTurnContext(sessionId, requestedCheckpoint?.anchorTurnId ?? null),
-        signal,
-      );
-      const runtimeContextCheckpoint =
-        requestedCheckpoint && storedTurnContext.anchorFound ? requestedCheckpoint : null;
-      const runtimeContextIssue =
-        checkpointValidation?.issue ??
-        (requestedCheckpoint && !storedTurnContext.anchorFound
-          ? 'CONTEXT_CHECKPOINT_ANCHOR_INVALID'
-          : null);
-      if (runtimeContextIssue) {
-        logger.warn('Agent context checkpoint rejected; replaying full history', {
-          code: runtimeContextIssue,
-          checkpointMessageId: storedContextCandidate?.assistantMessageId,
-          sessionId,
-        });
-      }
-      const { availableFiles, inputFiles, parts } = await this.resolveManagedInput(
-        parsed.parts,
-        storedTurnContext.history,
-        signal,
-      );
-      const resources = createTurnResourceLedger(
-        inputFiles,
-        storedTurnContext.referencedFileEntryIds,
-        availableFiles,
-      );
-
-      // Freeze system capabilities and configured MCP tools for the turn so mid-turn changes
-      // cannot alter the active catalog. The catalog closes over this turn's
-      // resource ledger, never a global file surface. System capability
-      // resolution remains optional; configured MCP binding resolution fails closed.
-      let systemTools: readonly RuntimeTool[] = [];
-      let configuredTools: readonly RuntimeTool[] = [];
-      if (runtime.descriptor.capabilities.tools) {
-        try {
-          systemTools = await raceAbort(
-            this.systemCapabilities.getTools({
-              model: agent.model,
-              resources,
-              temporaryCapabilities: new Set(parsed.temporaryCapabilities ?? []),
-            }),
-            signal,
-          );
-        } catch (error) {
-          signal.throwIfAborted();
-          logger.warn(
-            'Failed to resolve system capabilities; continuing without them',
-            error as Error,
-          );
-        }
-        try {
-          configuredTools = await raceAbort(this.runtimeTools.resolve(agent.id), signal);
-        } catch {
-          signal.throwIfAborted();
-          fail('EXECUTION_UNAVAILABLE', 'The configured Agent tools are unavailable.');
-        }
-      }
-      const tools = applyAgentToolApprovalMode(
-        [...systemTools, ...configuredTools],
-        agent.toolApprovalMode,
-      );
-      let inferenceModel: Awaited<ReturnType<AgentInferenceModelResolver>>;
-      try {
-        inferenceModel = await raceAbort(this.inferenceModel(agent.model), signal);
-      } catch {
-        signal.throwIfAborted();
-        fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.');
-      }
-      const modelPreflight = await this.preflightModel(runtime, agent, signal);
-      if (tools.length > 0 && !modelPreflight.supportsTools) {
-        fail('CAPABILITY_UNSUPPORTED', 'The selected model does not support native tool calling.');
-      }
-      const inferenceSnapshot = createAgentInferenceSnapshot({
-        model: inferenceModel,
-        options: agent.options,
-        tools,
-      });
-
-      this.assertAttachmentRequestSupported(
-        runtime,
-        parts,
-        storedTurnContext.history,
-        resources,
-        modelPreflight,
-      );
-      const runtimeTextAttachments = await this.resolveRuntimeTextAttachments(
-        parts,
-        storedTurnContext.history,
-        resources,
-        signal,
-      );
+      // Every gate between admission and the first durable write lives in the
+      // preparation stage; a failure there leaves nothing to reconcile.
+      const plan = await prepareTurn(this.turnPreparation, parsed, signal);
 
       // Open the Runtime before creating durable pending rows. A failed open
       // must leave no reservation that startup reconciliation has to repair.
-      const runtimeSession = await this.getRuntimeSession(sessionId, runtime, signal);
+      const runtimeSession = await this.getRuntimeSession(sessionId, plan.runtime, signal);
       signal.throwIfAborted();
-
-      const userParts: AgentMessagePart[] = parts.map((part, index) =>
-        part.type === 'text'
-          ? { id: `input-${index}`, type: 'text', text: part.text, state: 'done' }
-          : {
-              id: `input-${index}`,
-              type: 'file',
-              fileEntryId: part.fileEntryId,
-              mediaType: part.mediaType,
-              ...(part.name !== undefined ? { name: part.name } : {}),
-              purpose: 'input-attachment',
-            },
-      );
 
       // Invariant 2: reservation commits before execution starts.
       const reserved = await this.store.reserveSubmission({
         sessionId,
-        userParts,
-        modelId: inferenceSnapshot.model.uniqueModelId,
-        inferenceSnapshot,
+        userParts: plan.userParts,
+        modelId: plan.inferenceSnapshot.model.uniqueModelId,
+        inferenceSnapshot: plan.inferenceSnapshot,
       });
 
       // The Turn projection starts here: reservation time is the turn start.
@@ -594,22 +463,22 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         endedAt: null,
       };
       const state: ActiveTurnState = {
-        agent,
+        agent: plan.agent,
         abortController,
         turn,
         assistantMessage: reserved.assistantMessage,
         autoNamePromise: null,
-        autoNameUserParts: storedTurnContext.hasMessages ? null : parts,
+        autoNameUserParts: plan.hasMessages ? null : plan.inputParts,
         backgroundReply: this.startBackgroundReply({
-          agentId: agent.id,
-          agentName: agent.name,
+          agentId: plan.agent.id,
+          agentName: plan.agent.name,
           sessionId,
-          sessionTitle: session.title,
+          sessionTitle: plan.session.title,
         }),
         pendingApprovals: new Map(),
         pendingContextCheckpoint: null,
-        resources,
-        sessionTurnIds: new Set([...storedTurnContext.sessionTurnIds, reserved.turnId]),
+        resources: plan.resources,
+        sessionTurnIds: new Set([...plan.sessionTurnIds, reserved.turnId]),
         usage: null,
         runtimeSession,
       };
@@ -626,17 +495,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         this.publishSessionRename(state.autoNamePromise);
       }
 
-      const run = this.runTurn(
-        sessionId,
-        agent,
-        state,
-        storedTurnContext.history,
-        parts,
-        runtimeContextCheckpoint,
-        runtimeTextAttachments,
-        modelPreflight,
-        tools,
-      );
+      const run = this.runTurn(sessionId, plan, state);
       this.runningTurns.add(run);
       this.runningTurnsBySession.set(sessionId, run);
       void run.finally(() => {
@@ -731,54 +590,27 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
 
   // ── Execution ──
 
-  private async runTurn(
-    sessionId: string,
-    agent: AgentDefinition,
-    state: ActiveTurnState,
-    history: AgentMessageView[],
-    inputParts: AgentInputPart[],
-    storedContextCheckpoint: RuntimeContextCheckpoint | null,
-    runtimeTextAttachments: RuntimeAttachmentContents,
-    modelPreflight: RuntimeModelPreflight,
-    tools: readonly RuntimeTool[],
-  ): Promise<void> {
+  private async runTurn(sessionId: string, plan: TurnPlan, state: ActiveTurnState): Promise<void> {
     try {
-      const runtimeAttachments = new Map(runtimeTextAttachments);
-      if (modelPreflight.inputModalities.includes('image')) {
-        const runtimeImages = await this.resolveRuntimeImages(
-          state.resources,
-          state.abortController.signal,
-        );
-        for (const [fileEntryId, image] of runtimeImages) {
-          runtimeAttachments.set(fileEntryId, image);
-        }
-      } else {
-        const omitImage = (fileEntryId: string, mediaType: string) => {
-          const text = unsupportedMediaNote(mediaType, NO_IMAGE_MEDIA_CAPABILITIES);
-          if (text) runtimeAttachments.set(fileEntryId, { type: 'text', text });
-        };
-        for (const part of inputParts) {
-          if (part.type === 'file') omitImage(part.fileEntryId, part.mediaType);
-        }
-        for (const message of history) {
-          if (message.role !== 'user') continue;
-          for (const part of message.parts) {
-            if (part.type === 'file' && part.purpose === 'input-attachment') {
-              omitImage(part.fileEntryId, part.mediaType);
-            }
-          }
-        }
-      }
+      const runtimeAttachments = await materializeRuntimeAttachments({
+        files: this.files,
+        history: plan.history,
+        inputParts: plan.inputParts,
+        modelPreflight: plan.modelPreflight,
+        resources: state.resources,
+        signal: state.abortController.signal,
+        textAttachments: plan.runtimeTextAttachments,
+      });
       state.abortController.signal.throwIfAborted();
       const events = state.runtimeSession.execute({
         turnId: state.turn.id,
-        instructions: agent.instructions,
-        model: agent.model,
-        history: toRuntimeHistory(history, runtimeAttachments),
-        contextCheckpoint: storedContextCheckpoint,
-        input: toRuntimeInputParts(inputParts, state.resources, runtimeAttachments),
-        tools: [...tools],
-        options: agent.options,
+        instructions: plan.agent.instructions,
+        model: plan.agent.model,
+        history: toRuntimeHistory(plan.history, runtimeAttachments),
+        contextCheckpoint: plan.runtimeContextCheckpoint,
+        input: toRuntimeInputParts(plan.inputParts, state.resources, runtimeAttachments),
+        tools: [...plan.tools],
+        options: plan.agent.options,
       });
       for await (const event of events) {
         const isTerminal = await this.handleRuntimeEvent(sessionId, state, event);
@@ -1071,229 +903,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
 
   // ── Helpers ──
 
-  private async resolveManagedInput(
-    parts: AgentInputPart[],
-    history: AgentMessageView[],
-    signal: AbortSignal,
-  ) {
-    const fileEntryIds = parts.flatMap((part) => {
-      if (part.type !== 'file') {
-        return [];
-      }
-      const parsed = FileEntryIdSchema.safeParse(part.fileEntryId);
-      if (!parsed.success) {
-        fail('ATTACHMENT_UNAVAILABLE', 'An attached file is no longer available.');
-      }
-      return [parsed.data];
-    });
-
-    const historicalFileEntryIds = history.flatMap((message) =>
-      message.parts.flatMap((part) => {
-        if (part.type !== 'file' || part.purpose !== 'input-attachment') {
-          return [];
-        }
-        const parsed = FileEntryIdSchema.safeParse(part.fileEntryId);
-        return parsed.success ? [parsed.data] : [];
-      }),
-    );
-    let availableFiles: Awaited<ReturnType<ManagedFileResolver['resolveAvailable']>> = new Map();
-    if (fileEntryIds.length > 0 || historicalFileEntryIds.length > 0) {
-      try {
-        availableFiles = await raceAbort(
-          this.files.resolveAvailable([...fileEntryIds, ...historicalFileEntryIds]),
-          signal,
-        );
-      } catch {
-        signal.throwIfAborted();
-        fail('ATTACHMENT_UNAVAILABLE', 'An attached file could not be verified.');
-      }
-    }
-
-    const inputFiles = new Map(
-      fileEntryIds.flatMap((fileEntryId) => {
-        const fact = availableFiles.get(fileEntryId);
-        return fact ? [[fileEntryId, fact] as const] : [];
-      }),
-    );
-
-    const canonicalParts = parts.map((part): AgentInputPart => {
-      if (part.type !== 'file') {
-        return part;
-      }
-      const fact = inputFiles.get(part.fileEntryId);
-      if (!fact) {
-        fail('ATTACHMENT_UNAVAILABLE', 'An attached file is no longer available.');
-      }
-      if (
-        part.mediaType !== fact.mediaType ||
-        (part.name !== undefined && part.name !== fact.name)
-      ) {
-        fail('ATTACHMENT_METADATA_MISMATCH', 'Attached file metadata could not be verified.');
-      }
-      return {
-        type: 'file',
-        fileEntryId: fact.fileEntryId,
-        mediaType: fact.mediaType,
-        name: fact.name,
-      };
-    });
-
-    return { availableFiles, inputFiles, parts: canonicalParts };
-  }
-
-  private async preflightModel(
-    runtime: AgentRuntime,
-    agent: AgentDefinition,
-    signal: AbortSignal,
-  ): Promise<RuntimeModelPreflight> {
-    try {
-      return await raceAbort(runtime.preflightModel(agent.model), signal);
-    } catch {
-      signal.throwIfAborted();
-      fail(
-        'CAPABILITY_UNSUPPORTED',
-        'The selected model or provider endpoint cannot execute this turn.',
-      );
-    }
-  }
-
-  private assertAttachmentRequestSupported(
-    runtime: AgentRuntime,
-    input: AgentInputPart[],
-    history: AgentMessageView[],
-    resources: TurnResourceLedger,
-    model: RuntimeModelPreflight,
-  ): void {
-    let hasAttachments = false;
-    const images = input.flatMap((part) => {
-      if (part.type !== 'file') {
-        return [];
-      }
-      const fact = resources.inputFiles.get(part.fileEntryId);
-      if (!fact) {
-        fail('ATTACHMENT_UNAVAILABLE', 'An attached file is no longer available.');
-      }
-      hasAttachments = true;
-      if (isAiSupportedImageMediaType(fact.mediaType)) {
-        return [fact];
-      }
-      if (isSupportedTextAttachment(fact)) {
-        return [];
-      }
-      fail('ATTACHMENT_INVALID', unsupportedAttachmentMessage(fact));
-    });
-
-    for (const message of history) {
-      for (const part of message.parts) {
-        if (part.type !== 'file' || part.purpose !== 'input-attachment') {
-          continue;
-        }
-        const fact = resources.availableFiles.get(part.fileEntryId);
-        if (fact && isAiSupportedImageMediaType(fact.mediaType)) {
-          hasAttachments = true;
-          images.push(fact);
-        } else if (fact && isSupportedTextAttachment(fact)) {
-          hasAttachments = true;
-        }
-      }
-    }
-
-    if (!hasAttachments) {
-      return;
-    }
-    if (!runtime.descriptor.capabilities.attachments) {
-      fail('CAPABILITY_UNSUPPORTED', 'The selected runtime does not support file attachments.');
-    }
-    if (images.length === 0) {
-      return;
-    }
-    if (!model.inputModalities.includes('image')) {
-      // runTurn replaces these references with text notes without reading image bytes.
-      return;
-    }
-
-    const limit = findImageAttachmentLimit(images, model);
-    if (limit) {
-      fail('CAPABILITY_UNSUPPORTED', imageAttachmentLimitMessage(limit));
-    }
-  }
-
-  private async resolveRuntimeTextAttachments(
-    input: AgentInputPart[],
-    history: AgentMessageView[],
-    resources: TurnResourceLedger,
-    signal: AbortSignal,
-  ): Promise<RuntimeAttachmentContents> {
-    const currentFileEntryIds = input.flatMap((part) =>
-      part.type === 'file' ? [part.fileEntryId] : [],
-    );
-    const historicalFileEntryIds: string[] = [];
-    for (let messageIndex = history.length - 1; messageIndex >= 0; messageIndex -= 1) {
-      const parts = history[messageIndex]?.parts ?? [];
-      for (let partIndex = parts.length - 1; partIndex >= 0; partIndex -= 1) {
-        const part = parts[partIndex];
-        if (part?.type === 'file' && part.purpose === 'input-attachment') {
-          historicalFileEntryIds.push(part.fileEntryId);
-        }
-      }
-    }
-
-    try {
-      return await resolveManagedTextAttachments({
-        availableFiles: resources.availableFiles,
-        currentFileEntryIds,
-        historicalFileEntryIds,
-        readBytes: (file, signal) => this.files.readAsBytes(file, signal),
-        signal,
-      });
-    } catch (error) {
-      signal.throwIfAborted();
-      if (error instanceof TextAttachmentError) {
-        fail(
-          error.failure === 'unavailable' ? 'ATTACHMENT_UNAVAILABLE' : 'ATTACHMENT_INVALID',
-          error.message,
-        );
-      }
-      fail('ATTACHMENT_UNAVAILABLE', 'An attached text file could not be resolved.');
-    }
-  }
-
-  private async resolveRuntimeImages(
-    resources: TurnResourceLedger,
-    signal: AbortSignal,
-  ): Promise<RuntimeAttachmentContents> {
-    const files = new Map<string, Extract<RuntimeInputPart, { type: 'file' }>>();
-    for (const fact of resources.availableFiles.values()) {
-      if (!isAiSupportedImageMediaType(fact.mediaType)) {
-        continue;
-      }
-      try {
-        const uri = await this.files.readAsDataUrl(fact, signal);
-        signal.throwIfAborted();
-        if (!uri || !uri.startsWith(`data:${fact.mediaType};base64,`)) {
-          if (resources.inputFiles.has(fact.fileEntryId)) {
-            throw new Error('A current managed image became unavailable.');
-          }
-          continue;
-        }
-        files.set(fact.fileEntryId, {
-          type: 'file',
-          mediaType: fact.mediaType,
-          name: fact.name,
-          uri,
-        });
-      } catch {
-        if (signal.aborted) {
-          throw signal.reason ?? new Error('Managed image resolution was aborted.');
-        }
-        if (resources.inputFiles.has(fact.fileEntryId)) {
-          throw new Error('A current managed image could not be read.');
-        }
-      }
-    }
-    return files;
-  }
-
   private assertIdle(sessionId: string): void {
     if (!this.acceptingSubmissions) {
       fail('EXECUTION_UNAVAILABLE', 'The Agent Host is stopping.');
@@ -1418,61 +1027,4 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         logger.warn('Agent Session auto-naming failed', error as Error);
       });
   }
-}
-
-function applyTurnOverrides(
-  agent: AgentDefinition,
-  input: Pick<AgentSubmitMessageInput, 'modelId' | 'reasoningEffort'>,
-): AgentDefinition {
-  if (input.modelId === undefined && input.reasoningEffort === undefined) {
-    return agent;
-  }
-
-  const options = { ...agent.options };
-  if (input.reasoningEffort !== undefined) {
-    if (input.reasoningEffort === 'default' || input.reasoningEffort === 'auto') {
-      // Pi resolves an absent effort to the selected model's default. Removing
-      // the Agent setting here makes an explicit composer "default" win.
-      delete options.reasoningEffort;
-    } else {
-      options.reasoningEffort = input.reasoningEffort === 'none' ? 'off' : input.reasoningEffort;
-    }
-  }
-
-  return {
-    ...agent,
-    ...(input.modelId ? { model: parseUniqueModelId(input.modelId) } : {}),
-    options,
-  };
-}
-
-/**
- * Applies only the Agent's interactive approval preference; the value-level
- * rule lives in the shared policy module next to the MCP approval floor.
- */
-function applyAgentToolApprovalMode(
-  tools: readonly RuntimeTool[],
-  mode: AgentDefinition['toolApprovalMode'],
-): RuntimeTool[] {
-  return tools.map((tool) => {
-    const approval = applyToolApprovalMode(tool.approval, mode);
-    return approval === tool.approval ? tool : { ...tool, approval };
-  });
-}
-
-function imageAttachmentLimitMessage(limit: ImageAttachmentLimit): string {
-  switch (limit) {
-    case 'count':
-      return 'Too many images are attached to this request.';
-    case 'file-bytes':
-      return 'An attached image exceeds the per-file size limit.';
-    case 'total-bytes':
-      return 'The attached images exceed the total request size limit.';
-    case 'context':
-      return 'The attached images exceed the selected model context budget.';
-  }
-}
-
-function unsupportedAttachmentMessage(file: ManagedFileFact): string {
-  return `Attachment ${JSON.stringify(file.name)} has unsupported media type ${JSON.stringify(file.mediaType)}.`;
 }

--- a/src/backend/ai/agent/host/__tests__/turnAttachments.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnAttachments.test.ts
@@ -1,0 +1,291 @@
+import {
+  AgentProtocolError,
+  type AgentInputPart,
+  type AgentMessageView,
+} from '@/shared/contracts/agent';
+import { FileEntryIdSchema, type FileEntryId } from '@/shared/data/types/file';
+
+import {
+  createTurnResourceLedger,
+  type ManagedFileFact,
+  type ManagedFileResolver,
+} from '../../resources/managedFileResolver';
+import { FakeRuntime, type RuntimeModelPreflight } from '../../runtime';
+import {
+  assertAttachmentRequestSupported,
+  materializeRuntimeAttachments,
+  resolveManagedInput,
+  resolveRuntimeTextAttachments,
+} from '../turnAttachments';
+
+const FIRST_ID = FileEntryIdSchema.parse('00000000-0000-7000-8000-000000000001');
+const SECOND_ID = FileEntryIdSchema.parse('00000000-0000-7000-8000-000000000002');
+const NOW = '2026-01-01T00:00:00.000Z';
+
+const IMAGE_MODEL: RuntimeModelPreflight = {
+  contextWindow: 128_000,
+  inputModalities: ['text', 'image'],
+  maxInputTokens: 120_000,
+  maxOutputTokens: 8_000,
+  supportsTools: true,
+};
+
+const TEXT_MODEL: RuntimeModelPreflight = {
+  ...IMAGE_MODEL,
+  inputModalities: ['text'],
+};
+
+describe('turn attachments', () => {
+  test('resolves current and historical managed facts while canonicalizing current input', async () => {
+    const current = fact(FIRST_ID, 'managed.png', 'image/png');
+    const historical = fact(SECOND_ID, 'history.txt', 'text/plain');
+    const facts = new Map([
+      [FIRST_ID, current],
+      [SECOND_ID, historical],
+    ]);
+    const files = resolver(facts);
+    const input: AgentInputPart[] = [
+      { type: 'text', text: 'Inspect this.' },
+      { type: 'file', fileEntryId: FIRST_ID, mediaType: 'image/png' },
+    ];
+
+    const resolved = await resolveManagedInput(
+      files,
+      input,
+      [messageWithFile(historical)],
+      new AbortController().signal,
+    );
+
+    expect(files.resolveAvailable).toHaveBeenCalledWith([FIRST_ID, SECOND_ID]);
+    expect(resolved.availableFiles).toEqual(facts);
+    expect(resolved.inputFiles).toEqual(new Map([[FIRST_ID, current]]));
+    expect(resolved.parts).toEqual([
+      { type: 'text', text: 'Inspect this.' },
+      {
+        type: 'file',
+        fileEntryId: FIRST_ID,
+        mediaType: 'image/png',
+        name: 'managed.png',
+      },
+    ]);
+    expect(input[1]).not.toHaveProperty('name');
+  });
+
+  test('rejects forged current metadata with a protocol-safe error', async () => {
+    const files = resolver(new Map([[FIRST_ID, fact(FIRST_ID, 'managed.png', 'image/png')]]));
+
+    await expect(
+      resolveManagedInput(
+        files,
+        [
+          {
+            type: 'file',
+            fileEntryId: FIRST_ID,
+            mediaType: 'image/jpeg',
+            name: 'forged.jpg',
+          },
+        ],
+        [],
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({
+      view: {
+        code: 'ATTACHMENT_METADATA_MISMATCH',
+        message: 'Attached file metadata could not be verified.',
+        retryable: false,
+      },
+    });
+  });
+
+  test('projects attachment capability and media admission failures at the Host boundary', () => {
+    const historicalText = fact(FIRST_ID, 'history.txt', 'text/plain');
+    const historicalResources = createTurnResourceLedger(
+      new Map(),
+      [FIRST_ID],
+      new Map([[FIRST_ID, historicalText]]),
+    );
+    const runtimeWithoutAttachments = new FakeRuntime({
+      descriptor: {
+        id: 'text-only',
+        name: 'Text-only Runtime',
+        capabilities: {
+          approvals: true,
+          attachments: false,
+          reasoning: true,
+          tools: true,
+        },
+      },
+    });
+
+    expect(
+      captureProtocolError(() =>
+        assertAttachmentRequestSupported(
+          runtimeWithoutAttachments,
+          [],
+          [messageWithFile(historicalText)],
+          historicalResources,
+          TEXT_MODEL,
+        ),
+      ),
+    ).toMatchObject({ view: { code: 'CAPABILITY_UNSUPPORTED' } });
+
+    const unsupported = fact(SECOND_ID, 'report.pdf', 'application/pdf');
+    const unsupportedResources = createTurnResourceLedger(new Map([[SECOND_ID, unsupported]]), []);
+    expect(
+      captureProtocolError(() =>
+        assertAttachmentRequestSupported(
+          new FakeRuntime(),
+          [
+            {
+              type: 'file',
+              fileEntryId: SECOND_ID,
+              mediaType: unsupported.mediaType,
+              name: unsupported.name,
+            },
+          ],
+          [],
+          unsupportedResources,
+          IMAGE_MODEL,
+        ),
+      ),
+    ).toMatchObject({ view: { code: 'ATTACHMENT_INVALID' } });
+  });
+
+  test('projects invalid current text content to an attachment protocol error', async () => {
+    const text = fact(FIRST_ID, 'spoofed.txt', 'text/plain', 3);
+    const files = resolver(new Map([[FIRST_ID, text]]), {
+      readAsBytes: async () => Uint8Array.from([65, 0, 66]),
+    });
+    const input: AgentInputPart[] = [
+      {
+        type: 'file',
+        fileEntryId: FIRST_ID,
+        mediaType: text.mediaType,
+        name: text.name,
+      },
+    ];
+
+    await expect(
+      resolveRuntimeTextAttachments(
+        files,
+        input,
+        [],
+        createTurnResourceLedger(new Map([[FIRST_ID, text]]), []),
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({
+      view: {
+        code: 'ATTACHMENT_INVALID',
+        message: expect.stringContaining('contains NUL bytes'),
+      },
+    });
+  });
+
+  test('replaces current and historical images with notes without reading bytes for a text model', async () => {
+    const current = fact(FIRST_ID, 'current.png', 'image/png');
+    const historical = fact(SECOND_ID, 'historical.png', 'image/png');
+    const files = resolver(
+      new Map([
+        [FIRST_ID, current],
+        [SECOND_ID, historical],
+      ]),
+    );
+    const resources = createTurnResourceLedger(
+      new Map([[FIRST_ID, current]]),
+      [SECOND_ID],
+      new Map([
+        [FIRST_ID, current],
+        [SECOND_ID, historical],
+      ]),
+    );
+
+    const attachments = await materializeRuntimeAttachments({
+      files,
+      history: [messageWithFile(historical)],
+      inputParts: [
+        {
+          type: 'file',
+          fileEntryId: FIRST_ID,
+          mediaType: current.mediaType,
+          name: current.name,
+        },
+      ],
+      modelPreflight: TEXT_MODEL,
+      resources,
+      signal: new AbortController().signal,
+      textAttachments: new Map(),
+    });
+
+    const omitted = {
+      type: 'text',
+      text: '[image attachment omitted: this model does not accept image input]',
+    };
+    expect(attachments).toEqual(
+      new Map([
+        [FIRST_ID, omitted],
+        [SECOND_ID, omitted],
+      ]),
+    );
+    expect(files.readAsDataUrl).not.toHaveBeenCalled();
+  });
+});
+
+function fact(
+  fileEntryId: FileEntryId,
+  name: string,
+  mediaType: string,
+  size = 128,
+): ManagedFileFact {
+  return { fileEntryId, mediaType, name, size };
+}
+
+function messageWithFile(file: ManagedFileFact): AgentMessageView {
+  return {
+    id: `message-${file.fileEntryId}`,
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    role: 'user',
+    status: 'success',
+    parts: [
+      {
+        id: `part-${file.fileEntryId}`,
+        type: 'file',
+        fileEntryId: file.fileEntryId,
+        mediaType: file.mediaType,
+        name: file.name,
+        purpose: 'input-attachment',
+      },
+    ],
+    usage: null,
+    modelId: null,
+    inferenceSnapshot: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function resolver(
+  facts: ReadonlyMap<string, ManagedFileFact>,
+  overrides: Partial<Pick<ManagedFileResolver, 'readAsBytes' | 'readAsDataUrl'>> = {},
+): ManagedFileResolver {
+  return {
+    resolveAvailable: jest.fn(
+      async (fileEntryIds: readonly FileEntryId[]) =>
+        new Map([...facts].filter(([fileEntryId]) => fileEntryIds.includes(fileEntryId))),
+    ),
+    readAsBytes: jest.fn(overrides.readAsBytes ?? (async () => undefined)),
+    readAsDataUrl: jest.fn(overrides.readAsDataUrl ?? (async () => undefined)),
+  };
+}
+
+function captureProtocolError(action: () => void): AgentProtocolError {
+  try {
+    action();
+  } catch (error) {
+    if (error instanceof AgentProtocolError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error('Expected an Agent protocol error.');
+}

--- a/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
@@ -1,0 +1,304 @@
+import type {
+  AgentMessageView,
+  AgentSessionView,
+  AgentSubmitMessageInput,
+} from '@/shared/contracts/agent';
+import { FileEntryIdSchema, type FileEntryId } from '@/shared/data/types/file';
+import { createUniqueModelId } from '@/shared/data/types/model';
+
+import type { ManagedFileFact, ManagedFileResolver } from '../../resources/managedFileResolver';
+import { FakeRuntime, type RuntimeModel, type RuntimeTool } from '../../runtime';
+import type {
+  StoredRuntimeContextCheckpoint,
+  StoredRuntimeTurnContext,
+} from '../../sessionStore/AgentSessionStore';
+import type { AgentDefinition } from '../agentDefinitions';
+import type { AgentInferenceModelSnapshot } from '../inferenceSnapshot';
+import { prepareTurn, type TurnPreparationDependencies } from '../turnPreparation';
+
+const AGENT_ID = 'agent-1';
+const SESSION_ID = 'session-1';
+const FILE_ENTRY_ID = FileEntryIdSchema.parse('00000000-0000-7000-8000-000000000001');
+const NOW = '2026-01-01T00:00:00.000Z';
+
+const BASE_MODEL: RuntimeModel = { providerId: 'provider-1', modelId: 'model-1' };
+const OVERRIDE_MODEL: RuntimeModel = { providerId: 'provider-2', modelId: 'model-2' };
+
+const SESSION: AgentSessionView = {
+  id: SESSION_ID,
+  agentId: AGENT_ID,
+  executionTarget: { kind: 'local' },
+  title: '',
+  titleIsManual: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const AGENT: AgentDefinition = {
+  id: AGENT_ID,
+  name: 'Planner Agent',
+  instructions: 'Plan carefully.',
+  model: BASE_MODEL,
+  options: { maxOutputTokens: 512, reasoningEffort: 'low', temperature: 0.2 },
+  toolApprovalMode: 'auto',
+};
+
+const EMPTY_CONTEXT: StoredRuntimeTurnContext = {
+  anchorFound: true,
+  hasMessages: false,
+  history: [],
+  referencedFileEntryIds: [],
+  sessionTurnIds: [],
+};
+
+describe('turn preparation', () => {
+  test('builds a canonical turn plan from frozen model, tool, and attachment facts', async () => {
+    const harness = createHarness();
+    const input: AgentSubmitMessageInput = {
+      sessionId: SESSION_ID,
+      parts: [
+        { type: 'text', text: 'Review this file.' },
+        {
+          type: 'file',
+          fileEntryId: FILE_ENTRY_ID,
+          mediaType: 'text/plain',
+        },
+      ],
+      modelId: createUniqueModelId(OVERRIDE_MODEL.providerId, OVERRIDE_MODEL.modelId),
+      reasoningEffort: 'default',
+      temporaryCapabilities: ['web-search'],
+    };
+
+    const plan = await prepareTurn(harness.dependencies, input, new AbortController().signal);
+
+    expect(harness.routeExecutionTarget).toHaveBeenCalledWith(SESSION.executionTarget);
+    expect(harness.getSystemTools).toHaveBeenCalledWith({
+      model: OVERRIDE_MODEL,
+      resources: plan.resources,
+      temporaryCapabilities: new Set(['web-search']),
+    });
+    expect(harness.resolveRuntimeTools).toHaveBeenCalledWith(AGENT_ID);
+    expect(harness.resolveInferenceModel).toHaveBeenCalledWith(OVERRIDE_MODEL);
+    expect(harness.preflightModel).toHaveBeenCalledWith(OVERRIDE_MODEL);
+
+    expect(plan.agent).toEqual({
+      ...AGENT,
+      model: OVERRIDE_MODEL,
+      options: { maxOutputTokens: 512, temperature: 0.2 },
+    });
+    expect(plan.inputParts).toEqual([
+      { type: 'text', text: 'Review this file.' },
+      {
+        type: 'file',
+        fileEntryId: FILE_ENTRY_ID,
+        mediaType: 'text/plain',
+        name: 'notes.txt',
+      },
+    ]);
+    expect(plan.userParts).toEqual([
+      { id: 'input-0', type: 'text', text: 'Review this file.', state: 'done' },
+      {
+        id: 'input-1',
+        type: 'file',
+        fileEntryId: FILE_ENTRY_ID,
+        mediaType: 'text/plain',
+        name: 'notes.txt',
+        purpose: 'input-attachment',
+      },
+    ]);
+    expect(plan.runtimeTextAttachments.get(FILE_ENTRY_ID)).toEqual({
+      type: 'text-attachment',
+      mediaType: 'text/plain',
+      name: 'notes.txt',
+      text: 'trusted only as user input',
+      truncated: false,
+      trust: 'untrusted-user-content',
+    });
+    expect(plan.tools.map((tool) => tool.approval)).toEqual(['auto', 'deny']);
+    expect(harness.systemTool.approval).toBe('ask');
+    expect(harness.configuredTool.approval).toBe('deny');
+    expect(plan.inferenceSnapshot).toMatchObject({
+      version: 1,
+      model: {
+        uniqueModelId: createUniqueModelId(OVERRIDE_MODEL.providerId, OVERRIDE_MODEL.modelId),
+      },
+      parameters: { maxOutputTokens: 512, temperature: 0.2 },
+      tools: [{ approval: 'auto' }, { approval: 'deny' }],
+    });
+    expect(plan.hasMessages).toBe(false);
+    expect(plan.runtimeContextCheckpoint).toBeNull();
+    expect(plan.sessionTurnIds).toEqual([]);
+  });
+
+  test('stops at session admission when the session does not exist', async () => {
+    const harness = createHarness();
+    harness.getSession.mockResolvedValueOnce(null);
+
+    await expect(
+      prepareTurn(harness.dependencies, textInput(), new AbortController().signal),
+    ).rejects.toMatchObject({ view: { code: 'SESSION_NOT_FOUND' } });
+
+    expect(harness.getAgent).not.toHaveBeenCalled();
+    expect(harness.routeExecutionTarget).not.toHaveBeenCalled();
+    expect(harness.getLatestContextCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when configured tool bindings cannot be resolved', async () => {
+    const harness = createHarness();
+    harness.resolveRuntimeTools.mockRejectedValueOnce(new Error('private MCP failure'));
+
+    await expect(
+      prepareTurn(harness.dependencies, textInput(), new AbortController().signal),
+    ).rejects.toMatchObject({
+      view: {
+        code: 'EXECUTION_UNAVAILABLE',
+        message: 'The configured Agent tools are unavailable.',
+      },
+    });
+
+    expect(harness.resolveInferenceModel).not.toHaveBeenCalled();
+    expect(harness.preflightModel).not.toHaveBeenCalled();
+  });
+
+  test('replays full history when a valid checkpoint anchor is no longer present', async () => {
+    const harness = createHarness();
+    const checkpoint = {
+      version: 1 as const,
+      anchorTurnId: 'turn-anchor',
+      payload: { summary: 'Earlier context.' },
+    };
+    const history = [textMessage('message-after-anchor', 'turn-later')];
+    harness.getLatestContextCheckpoint.mockResolvedValueOnce({
+      assistantMessageId: 'assistant-anchor',
+      checkpoint,
+    });
+    harness.loadRuntimeTurnContext.mockResolvedValueOnce({
+      anchorFound: false,
+      hasMessages: true,
+      history,
+      referencedFileEntryIds: [],
+      sessionTurnIds: ['turn-later'],
+    });
+
+    const plan = await prepareTurn(harness.dependencies, textInput(), new AbortController().signal);
+
+    expect(harness.loadRuntimeTurnContext).toHaveBeenCalledWith(SESSION_ID, 'turn-anchor');
+    expect(plan.runtimeContextCheckpoint).toBeNull();
+    expect(plan.history).toEqual(history);
+    expect(plan.hasMessages).toBe(true);
+    expect(plan.sessionTurnIds).toEqual(['turn-later']);
+  });
+});
+
+function createHarness() {
+  const textFact = fact(FILE_ENTRY_ID, 'notes.txt', 'text/plain', 26);
+  const getSession = jest.fn(
+    async (_sessionId: string): Promise<AgentSessionView | null> => SESSION,
+  );
+  const getAgent = jest.fn(async (_agentId: string): Promise<AgentDefinition | null> => AGENT);
+  const getLatestContextCheckpoint = jest.fn(
+    async (_sessionId: string): Promise<StoredRuntimeContextCheckpoint | null> => null,
+  );
+  const loadRuntimeTurnContext = jest.fn(
+    async (_sessionId: string, _anchorTurnId: string | null): Promise<StoredRuntimeTurnContext> =>
+      EMPTY_CONTEXT,
+  );
+  const resolveAvailable = jest.fn(async (fileEntryIds: readonly FileEntryId[]) =>
+    fileEntryIds.includes(FILE_ENTRY_ID) ? new Map([[FILE_ENTRY_ID, textFact]]) : new Map(),
+  );
+  const readAsBytes = jest.fn(async () => new TextEncoder().encode('trusted only as user input'));
+  const files: ManagedFileResolver = {
+    resolveAvailable,
+    readAsBytes,
+    readAsDataUrl: jest.fn(async () => undefined),
+  };
+  const systemTool = tool('system_tool', 'ask');
+  const configuredTool = tool('configured_tool', 'deny');
+  const getSystemTools = jest.fn(async () => [systemTool]);
+  const resolveRuntimeTools = jest.fn(async (_agentId: string) => [configuredTool]);
+  const resolveInferenceModel = jest.fn(
+    async (model: RuntimeModel): Promise<AgentInferenceModelSnapshot> => ({
+      uniqueModelId: createUniqueModelId(model.providerId, model.modelId),
+      providerId: model.providerId,
+      modelId: model.modelId,
+      apiModelId: `${model.modelId}-api`,
+      name: 'Selected Model',
+    }),
+  );
+  const runtime = new FakeRuntime({
+    modelPreflight: {
+      contextWindow: 128_000,
+      inputModalities: ['text', 'image'],
+      maxInputTokens: 120_000,
+      maxOutputTokens: 8_000,
+      supportsTools: true,
+    },
+  });
+  const preflightModel = jest.spyOn(runtime, 'preflightModel');
+  const routeExecutionTarget = jest.fn(() => runtime);
+  const dependencies: TurnPreparationDependencies = {
+    agents: { getAgent },
+    files,
+    inferenceModel: resolveInferenceModel,
+    routeExecutionTarget,
+    runtimeTools: { resolve: resolveRuntimeTools },
+    store: { getLatestContextCheckpoint, getSession, loadRuntimeTurnContext },
+    systemCapabilities: { getTools: getSystemTools },
+  };
+
+  return {
+    configuredTool,
+    dependencies,
+    getAgent,
+    getLatestContextCheckpoint,
+    getSession,
+    getSystemTools,
+    loadRuntimeTurnContext,
+    preflightModel,
+    resolveInferenceModel,
+    resolveRuntimeTools,
+    routeExecutionTarget,
+    systemTool,
+  };
+}
+
+function textInput(): AgentSubmitMessageInput {
+  return { sessionId: SESSION_ID, parts: [{ type: 'text', text: 'Continue.' }] };
+}
+
+function fact(
+  fileEntryId: FileEntryId,
+  name: string,
+  mediaType: string,
+  size: number,
+): ManagedFileFact {
+  return { fileEntryId, mediaType, name, size };
+}
+
+function tool(providerName: string, approval: RuntimeTool['approval']): RuntimeTool {
+  return {
+    ref: { source: 'builtin', capabilityId: providerName },
+    providerName,
+    displayName: providerName,
+    description: `${providerName} description`,
+    inputSchema: { type: 'object' },
+    approval,
+    execute: async () => ({ value: null, artifacts: [] }),
+  };
+}
+
+function textMessage(id: string, turnId: string): AgentMessageView {
+  return {
+    id,
+    sessionId: SESSION_ID,
+    turnId,
+    role: 'user',
+    status: 'success',
+    parts: [{ id: `${id}-part`, type: 'text', text: 'Later message.', state: 'done' }],
+    usage: null,
+    modelId: null,
+    inferenceSnapshot: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}

--- a/src/backend/ai/agent/host/turnAttachments.ts
+++ b/src/backend/ai/agent/host/turnAttachments.ts
@@ -1,0 +1,321 @@
+/**
+ * Turn-level attachment admission and materialization for the Mobile Agent
+ * Host. This module owns the protocol-error projection of attachment
+ * failures; the primitives under `../resources` stay protocol-free.
+ */
+
+import { unsupportedMediaNote } from '@cherrystudio/ai-runtime/messages';
+
+import {
+  AgentProtocolError,
+  type AgentErrorView,
+  type AgentInputPart,
+  type AgentMessageView,
+} from '@/shared/contracts/agent';
+import { FileEntryIdSchema } from '@/shared/data/types/file';
+import { isAiSupportedImageMediaType } from '@/shared/utils/imageFileTypes';
+
+import { findImageAttachmentLimit, type ImageAttachmentLimit } from '../resources/imageAttachments';
+import type {
+  ManagedFileFact,
+  ManagedFileResolver,
+  TurnResourceLedger,
+} from '../resources/managedFileResolver';
+import {
+  isSupportedTextAttachment,
+  resolveManagedTextAttachments,
+  TextAttachmentError,
+} from '../resources/textAttachments';
+import { raceAbort } from '../runtime';
+import type { AgentRuntime, RuntimeInputPart, RuntimeModelPreflight } from '../runtime';
+import type { RuntimeAttachmentContents } from './mapping';
+
+const NO_IMAGE_MEDIA_CAPABILITIES = { image: false, video: true, audio: true } as const;
+
+function fail(code: AgentErrorView['code'], message: string, retryable = false): never {
+  throw new AgentProtocolError({ code, message, retryable });
+}
+
+export type ResolvedManagedInput = {
+  availableFiles: ReadonlyMap<string, ManagedFileFact>;
+  inputFiles: ReadonlyMap<string, ManagedFileFact>;
+  parts: AgentInputPart[];
+};
+
+/**
+ * Verifies every referenced managed file against the resolver and rewrites the
+ * input parts to the canonical file facts. Arbitrary paths and mismatched
+ * metadata fail closed before any durable row exists.
+ */
+export async function resolveManagedInput(
+  files: ManagedFileResolver,
+  parts: AgentInputPart[],
+  history: AgentMessageView[],
+  signal: AbortSignal,
+): Promise<ResolvedManagedInput> {
+  const fileEntryIds = parts.flatMap((part) => {
+    if (part.type !== 'file') {
+      return [];
+    }
+    const parsed = FileEntryIdSchema.safeParse(part.fileEntryId);
+    if (!parsed.success) {
+      fail('ATTACHMENT_UNAVAILABLE', 'An attached file is no longer available.');
+    }
+    return [parsed.data];
+  });
+
+  const historicalFileEntryIds = history.flatMap((message) =>
+    message.parts.flatMap((part) => {
+      if (part.type !== 'file' || part.purpose !== 'input-attachment') {
+        return [];
+      }
+      const parsed = FileEntryIdSchema.safeParse(part.fileEntryId);
+      return parsed.success ? [parsed.data] : [];
+    }),
+  );
+  let availableFiles: Awaited<ReturnType<ManagedFileResolver['resolveAvailable']>> = new Map();
+  if (fileEntryIds.length > 0 || historicalFileEntryIds.length > 0) {
+    try {
+      availableFiles = await raceAbort(
+        files.resolveAvailable([...fileEntryIds, ...historicalFileEntryIds]),
+        signal,
+      );
+    } catch {
+      signal.throwIfAborted();
+      fail('ATTACHMENT_UNAVAILABLE', 'An attached file could not be verified.');
+    }
+  }
+
+  const inputFiles = new Map(
+    fileEntryIds.flatMap((fileEntryId) => {
+      const fact = availableFiles.get(fileEntryId);
+      return fact ? [[fileEntryId, fact] as const] : [];
+    }),
+  );
+
+  const canonicalParts = parts.map((part): AgentInputPart => {
+    if (part.type !== 'file') {
+      return part;
+    }
+    const fact = inputFiles.get(part.fileEntryId);
+    if (!fact) {
+      fail('ATTACHMENT_UNAVAILABLE', 'An attached file is no longer available.');
+    }
+    if (part.mediaType !== fact.mediaType || (part.name !== undefined && part.name !== fact.name)) {
+      fail('ATTACHMENT_METADATA_MISMATCH', 'Attached file metadata could not be verified.');
+    }
+    return {
+      type: 'file',
+      fileEntryId: fact.fileEntryId,
+      mediaType: fact.mediaType,
+      name: fact.name,
+    };
+  });
+
+  return { availableFiles, inputFiles, parts: canonicalParts };
+}
+
+/**
+ * Request-level attachment gate: runtime capability, media admissibility, and
+ * image limits — all before any network call. A model without image input
+ * passes here; execution replaces those references with text notes.
+ */
+export function assertAttachmentRequestSupported(
+  runtime: AgentRuntime,
+  input: AgentInputPart[],
+  history: AgentMessageView[],
+  resources: TurnResourceLedger,
+  model: RuntimeModelPreflight,
+): void {
+  let hasAttachments = false;
+  const images = input.flatMap((part) => {
+    if (part.type !== 'file') {
+      return [];
+    }
+    const fact = resources.inputFiles.get(part.fileEntryId);
+    if (!fact) {
+      fail('ATTACHMENT_UNAVAILABLE', 'An attached file is no longer available.');
+    }
+    hasAttachments = true;
+    if (isAiSupportedImageMediaType(fact.mediaType)) {
+      return [fact];
+    }
+    if (isSupportedTextAttachment(fact)) {
+      return [];
+    }
+    fail('ATTACHMENT_INVALID', unsupportedAttachmentMessage(fact));
+  });
+
+  for (const message of history) {
+    for (const part of message.parts) {
+      if (part.type !== 'file' || part.purpose !== 'input-attachment') {
+        continue;
+      }
+      const fact = resources.availableFiles.get(part.fileEntryId);
+      if (fact && isAiSupportedImageMediaType(fact.mediaType)) {
+        hasAttachments = true;
+        images.push(fact);
+      } else if (fact && isSupportedTextAttachment(fact)) {
+        hasAttachments = true;
+      }
+    }
+  }
+
+  if (!hasAttachments) {
+    return;
+  }
+  if (!runtime.descriptor.capabilities.attachments) {
+    fail('CAPABILITY_UNSUPPORTED', 'The selected runtime does not support file attachments.');
+  }
+  if (images.length === 0) {
+    return;
+  }
+  if (!model.inputModalities.includes('image')) {
+    // materializeRuntimeAttachments replaces these references with text notes
+    // without reading image bytes.
+    return;
+  }
+
+  const limit = findImageAttachmentLimit(images, model);
+  if (limit) {
+    fail('CAPABILITY_UNSUPPORTED', imageAttachmentLimitMessage(limit));
+  }
+}
+
+/** Resolves bounded text attachment bodies, projecting failures to protocol errors. */
+export async function resolveRuntimeTextAttachments(
+  files: ManagedFileResolver,
+  input: AgentInputPart[],
+  history: AgentMessageView[],
+  resources: TurnResourceLedger,
+  signal: AbortSignal,
+): Promise<RuntimeAttachmentContents> {
+  const currentFileEntryIds = input.flatMap((part) =>
+    part.type === 'file' ? [part.fileEntryId] : [],
+  );
+  const historicalFileEntryIds: string[] = [];
+  for (let messageIndex = history.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const parts = history[messageIndex]?.parts ?? [];
+    for (let partIndex = parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const part = parts[partIndex];
+      if (part?.type === 'file' && part.purpose === 'input-attachment') {
+        historicalFileEntryIds.push(part.fileEntryId);
+      }
+    }
+  }
+
+  try {
+    return await resolveManagedTextAttachments({
+      availableFiles: resources.availableFiles,
+      currentFileEntryIds,
+      historicalFileEntryIds,
+      readBytes: (file, readSignal) => files.readAsBytes(file, readSignal),
+      signal,
+    });
+  } catch (error) {
+    signal.throwIfAborted();
+    if (error instanceof TextAttachmentError) {
+      fail(
+        error.failure === 'unavailable' ? 'ATTACHMENT_UNAVAILABLE' : 'ATTACHMENT_INVALID',
+        error.message,
+      );
+    }
+    fail('ATTACHMENT_UNAVAILABLE', 'An attached text file could not be resolved.');
+  }
+}
+
+/**
+ * Builds the execution-time attachment payload: validated text bodies plus
+ * inline image data URLs when the model accepts images, or text omission
+ * notes when it does not (image bytes are never read in that case).
+ */
+export async function materializeRuntimeAttachments(input: {
+  files: ManagedFileResolver;
+  history: AgentMessageView[];
+  inputParts: AgentInputPart[];
+  modelPreflight: RuntimeModelPreflight;
+  resources: TurnResourceLedger;
+  signal: AbortSignal;
+  textAttachments: RuntimeAttachmentContents;
+}): Promise<RuntimeAttachmentContents> {
+  const { files, history, inputParts, modelPreflight, resources, signal, textAttachments } = input;
+  const attachments = new Map(textAttachments);
+  if (modelPreflight.inputModalities.includes('image')) {
+    const images = await resolveRuntimeImages(files, resources, signal);
+    for (const [fileEntryId, image] of images) {
+      attachments.set(fileEntryId, image);
+    }
+    return attachments;
+  }
+
+  const omitImage = (fileEntryId: string, mediaType: string) => {
+    const text = unsupportedMediaNote(mediaType, NO_IMAGE_MEDIA_CAPABILITIES);
+    if (text) attachments.set(fileEntryId, { type: 'text', text });
+  };
+  for (const part of inputParts) {
+    if (part.type === 'file') omitImage(part.fileEntryId, part.mediaType);
+  }
+  for (const message of history) {
+    if (message.role !== 'user') continue;
+    for (const part of message.parts) {
+      if (part.type === 'file' && part.purpose === 'input-attachment') {
+        omitImage(part.fileEntryId, part.mediaType);
+      }
+    }
+  }
+  return attachments;
+}
+
+async function resolveRuntimeImages(
+  files: ManagedFileResolver,
+  resources: TurnResourceLedger,
+  signal: AbortSignal,
+): Promise<RuntimeAttachmentContents> {
+  const images = new Map<string, Extract<RuntimeInputPart, { type: 'file' }>>();
+  for (const fact of resources.availableFiles.values()) {
+    if (!isAiSupportedImageMediaType(fact.mediaType)) {
+      continue;
+    }
+    try {
+      const uri = await files.readAsDataUrl(fact, signal);
+      signal.throwIfAborted();
+      if (!uri || !uri.startsWith(`data:${fact.mediaType};base64,`)) {
+        if (resources.inputFiles.has(fact.fileEntryId)) {
+          throw new Error('A current managed image became unavailable.');
+        }
+        continue;
+      }
+      images.set(fact.fileEntryId, {
+        type: 'file',
+        mediaType: fact.mediaType,
+        name: fact.name,
+        uri,
+      });
+    } catch {
+      if (signal.aborted) {
+        throw signal.reason ?? new Error('Managed image resolution was aborted.');
+      }
+      if (resources.inputFiles.has(fact.fileEntryId)) {
+        throw new Error('A current managed image could not be read.');
+      }
+    }
+  }
+  return images;
+}
+
+function imageAttachmentLimitMessage(limit: ImageAttachmentLimit): string {
+  switch (limit) {
+    case 'count':
+      return 'Too many images are attached to this request.';
+    case 'file-bytes':
+      return 'An attached image exceeds the per-file size limit.';
+    case 'total-bytes':
+      return 'The attached images exceed the total request size limit.';
+    case 'context':
+      return 'The attached images exceed the selected model context budget.';
+  }
+}
+
+function unsupportedAttachmentMessage(file: ManagedFileFact): string {
+  return `Attachment ${JSON.stringify(file.name)} has unsupported media type ${JSON.stringify(file.mediaType)}.`;
+}

--- a/src/backend/ai/agent/host/turnPreparation.ts
+++ b/src/backend/ai/agent/host/turnPreparation.ts
@@ -1,0 +1,296 @@
+/**
+ * Turn preparation for the Mobile Agent Host: everything between admission
+ * and the first durable write. `prepareTurn` is a standalone planning stage
+ * over explicit ports — it loads the Session, Agent definition, checkpoint,
+ * and history, admits attachments, freezes the tool snapshot, preflights the
+ * model, and returns one immutable `TurnPlan`. It performs no writes and
+ * publishes no events, so every gate can fail here with zero side effects
+ * and the stage is testable without a Host instance.
+ */
+
+import {
+  AgentProtocolError,
+  type AgentErrorView,
+  type AgentExecutionTarget,
+  type AgentInputPart,
+  type AgentMessagePart,
+  type AgentMessageView,
+  type AgentSessionView,
+  type AgentSubmitMessageInput,
+} from '@/shared/contracts/agent';
+import { loggerService } from '@/shared/core/logger/LoggerService';
+import { parseUniqueModelId } from '@/shared/data/types/model';
+import { applyToolApprovalMode } from '@/shared/utils/agentToolApproval';
+
+import {
+  createTurnResourceLedger,
+  type ManagedFileResolver,
+  type TurnResourceLedger,
+} from '../resources/managedFileResolver';
+import { raceAbort } from '../runtime';
+import type {
+  AgentRuntime,
+  RuntimeContextCheckpoint,
+  RuntimeModelPreflight,
+  RuntimeTool,
+} from '../runtime';
+import type { AgentSessionStore } from '../sessionStore/AgentSessionStore';
+import type { SystemCapabilitySource } from '../tools/builtInToolSource';
+import type { AgentRuntimeToolResolver } from '../tools/runtimeTools';
+import type { AgentDefinition, AgentDefinitionSource } from './agentDefinitions';
+import { validateRuntimeContextCheckpointCandidate } from './contextCheckpoints';
+import {
+  createAgentInferenceSnapshot,
+  type AgentInferenceModelResolver,
+} from './inferenceSnapshot';
+import type { RuntimeAttachmentContents } from './mapping';
+import {
+  assertAttachmentRequestSupported,
+  resolveManagedInput,
+  resolveRuntimeTextAttachments,
+} from './turnAttachments';
+
+const logger = loggerService.withContext('AgentTurnPreparation');
+
+function fail(code: AgentErrorView['code'], message: string, retryable = false): never {
+  throw new AgentProtocolError({ code, message, retryable });
+}
+
+export type TurnPreparationDependencies = {
+  agents: AgentDefinitionSource;
+  files: ManagedFileResolver;
+  inferenceModel: AgentInferenceModelResolver;
+  /** The Host keeps the engine binding; preparation only consumes the routed Runtime. */
+  routeExecutionTarget(target: AgentExecutionTarget): AgentRuntime;
+  runtimeTools: AgentRuntimeToolResolver;
+  store: Pick<
+    AgentSessionStore,
+    'getLatestContextCheckpoint' | 'getSession' | 'loadRuntimeTurnContext'
+  >;
+  systemCapabilities: SystemCapabilitySource;
+};
+
+/** Everything the Host needs to reserve and execute a turn, frozen before the first write. */
+export type TurnPlan = {
+  agent: AgentDefinition;
+  /** False only for a truly empty Session; drives first-message auto-naming. */
+  hasMessages: boolean;
+  history: AgentMessageView[];
+  inferenceSnapshot: ReturnType<typeof createAgentInferenceSnapshot>;
+  /** Canonicalized input parts: file parts rewritten to verified managed facts. */
+  inputParts: AgentInputPart[];
+  modelPreflight: RuntimeModelPreflight;
+  resources: TurnResourceLedger;
+  runtime: AgentRuntime;
+  runtimeContextCheckpoint: RuntimeContextCheckpoint | null;
+  runtimeTextAttachments: RuntimeAttachmentContents;
+  session: AgentSessionView;
+  sessionTurnIds: readonly string[];
+  tools: readonly RuntimeTool[];
+  /** The user message parts to reserve, projected from the canonical input. */
+  userParts: AgentMessagePart[];
+};
+
+export async function prepareTurn(
+  dependencies: TurnPreparationDependencies,
+  parsed: AgentSubmitMessageInput,
+  signal: AbortSignal,
+): Promise<TurnPlan> {
+  const { sessionId } = parsed;
+  const session = await raceAbort(dependencies.store.getSession(sessionId), signal);
+  if (!session) {
+    fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
+  }
+  const configuredAgent = await raceAbort(dependencies.agents.getAgent(session.agentId), signal);
+  if (!configuredAgent) {
+    fail('AGENT_NOT_FOUND', `Agent does not exist: ${session.agentId}`);
+  }
+  const agent = applyTurnOverrides(configuredAgent, parsed);
+  const runtime = dependencies.routeExecutionTarget(session.executionTarget);
+  if (
+    !runtime.descriptor.capabilities.attachments &&
+    parsed.parts.some((part) => part.type === 'file')
+  ) {
+    fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
+  }
+
+  const storedContextCandidate = await raceAbort(
+    dependencies.store.getLatestContextCheckpoint(sessionId),
+    signal,
+  );
+  const checkpointValidation = storedContextCandidate
+    ? validateRuntimeContextCheckpointCandidate(storedContextCandidate.checkpoint)
+    : null;
+  const requestedCheckpoint = checkpointValidation?.checkpoint ?? null;
+  const storedTurnContext = await raceAbort(
+    dependencies.store.loadRuntimeTurnContext(sessionId, requestedCheckpoint?.anchorTurnId ?? null),
+    signal,
+  );
+  const runtimeContextCheckpoint =
+    requestedCheckpoint && storedTurnContext.anchorFound ? requestedCheckpoint : null;
+  const runtimeContextIssue =
+    checkpointValidation?.issue ??
+    (requestedCheckpoint && !storedTurnContext.anchorFound
+      ? 'CONTEXT_CHECKPOINT_ANCHOR_INVALID'
+      : null);
+  if (runtimeContextIssue) {
+    logger.warn('Agent context checkpoint rejected; replaying full history', {
+      code: runtimeContextIssue,
+      checkpointMessageId: storedContextCandidate?.assistantMessageId,
+      sessionId,
+    });
+  }
+  const { availableFiles, inputFiles, parts } = await resolveManagedInput(
+    dependencies.files,
+    parsed.parts,
+    storedTurnContext.history,
+    signal,
+  );
+  const resources = createTurnResourceLedger(
+    inputFiles,
+    storedTurnContext.referencedFileEntryIds,
+    availableFiles,
+  );
+
+  // Freeze system capabilities and configured MCP tools for the turn so
+  // mid-turn changes cannot alter the active catalog. The catalog closes over
+  // this turn's resource ledger, never a global file surface. System capability
+  // resolution remains optional; configured MCP binding resolution fails closed.
+  let systemTools: readonly RuntimeTool[] = [];
+  let configuredTools: readonly RuntimeTool[] = [];
+  if (runtime.descriptor.capabilities.tools) {
+    try {
+      systemTools = await raceAbort(
+        dependencies.systemCapabilities.getTools({
+          model: agent.model,
+          resources,
+          temporaryCapabilities: new Set(parsed.temporaryCapabilities ?? []),
+        }),
+        signal,
+      );
+    } catch (error) {
+      signal.throwIfAborted();
+      logger.warn('Failed to resolve system capabilities; continuing without them', error as Error);
+    }
+    try {
+      configuredTools = await raceAbort(dependencies.runtimeTools.resolve(agent.id), signal);
+    } catch {
+      signal.throwIfAborted();
+      fail('EXECUTION_UNAVAILABLE', 'The configured Agent tools are unavailable.');
+    }
+  }
+  const tools = applyAgentToolApprovalMode(
+    [...systemTools, ...configuredTools],
+    agent.toolApprovalMode,
+  );
+  let inferenceModel: Awaited<ReturnType<AgentInferenceModelResolver>>;
+  try {
+    inferenceModel = await raceAbort(dependencies.inferenceModel(agent.model), signal);
+  } catch {
+    signal.throwIfAborted();
+    fail('EXECUTION_UNAVAILABLE', 'The selected model is unavailable.');
+  }
+  let modelPreflight: RuntimeModelPreflight;
+  try {
+    modelPreflight = await raceAbort(runtime.preflightModel(agent.model), signal);
+  } catch {
+    signal.throwIfAborted();
+    fail(
+      'CAPABILITY_UNSUPPORTED',
+      'The selected model or provider endpoint cannot execute this turn.',
+    );
+  }
+  if (tools.length > 0 && !modelPreflight.supportsTools) {
+    fail('CAPABILITY_UNSUPPORTED', 'The selected model does not support native tool calling.');
+  }
+  const inferenceSnapshot = createAgentInferenceSnapshot({
+    model: inferenceModel,
+    options: agent.options,
+    tools,
+  });
+
+  assertAttachmentRequestSupported(
+    runtime,
+    parts,
+    storedTurnContext.history,
+    resources,
+    modelPreflight,
+  );
+  const runtimeTextAttachments = await resolveRuntimeTextAttachments(
+    dependencies.files,
+    parts,
+    storedTurnContext.history,
+    resources,
+    signal,
+  );
+
+  const userParts: AgentMessagePart[] = parts.map((part, index) =>
+    part.type === 'text'
+      ? { id: `input-${index}`, type: 'text', text: part.text, state: 'done' }
+      : {
+          id: `input-${index}`,
+          type: 'file',
+          fileEntryId: part.fileEntryId,
+          mediaType: part.mediaType,
+          ...(part.name !== undefined ? { name: part.name } : {}),
+          purpose: 'input-attachment',
+        },
+  );
+
+  return {
+    agent,
+    hasMessages: storedTurnContext.hasMessages,
+    history: storedTurnContext.history,
+    inferenceSnapshot,
+    inputParts: parts,
+    modelPreflight,
+    resources,
+    runtime,
+    runtimeContextCheckpoint,
+    runtimeTextAttachments,
+    session,
+    sessionTurnIds: storedTurnContext.sessionTurnIds,
+    tools,
+    userParts,
+  };
+}
+
+function applyTurnOverrides(
+  agent: AgentDefinition,
+  input: Pick<AgentSubmitMessageInput, 'modelId' | 'reasoningEffort'>,
+): AgentDefinition {
+  if (input.modelId === undefined && input.reasoningEffort === undefined) {
+    return agent;
+  }
+
+  const options = { ...agent.options };
+  if (input.reasoningEffort !== undefined) {
+    if (input.reasoningEffort === 'default' || input.reasoningEffort === 'auto') {
+      // Pi resolves an absent effort to the selected model's default. Removing
+      // the Agent setting here makes an explicit composer "default" win.
+      delete options.reasoningEffort;
+    } else {
+      options.reasoningEffort = input.reasoningEffort === 'none' ? 'off' : input.reasoningEffort;
+    }
+  }
+
+  return {
+    ...agent,
+    ...(input.modelId ? { model: parseUniqueModelId(input.modelId) } : {}),
+    options,
+  };
+}
+
+/**
+ * Applies only the Agent's interactive approval preference; the value-level
+ * rule lives in the shared policy module next to the MCP approval floor.
+ */
+function applyAgentToolApprovalMode(
+  tools: readonly RuntimeTool[],
+  mode: AgentDefinition['toolApprovalMode'],
+): RuntimeTool[] {
+  return tools.map((tool) => {
+    const approval = applyToolApprovalMode(tool.approval, mode);
+    return approval === tool.approval ? tool : { ...tool, approval };
+  });
+}

--- a/src/backend/ai/agent/runtime/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntime.ts
@@ -165,9 +165,12 @@ type ToolPartBase = {
 };
 
 /**
- * Turn lifecycle. The first transition out of `running` wins — a later cancel
- * cannot retarget a timeout outcome and vice versa — and only the terminal
- * fence in `emit()` reaches `terminated`.
+ * Turn lifecycle. The first transition out of `running` wins the phase — it is
+ * never retargeted — and only the terminal fence in `emit()` reaches
+ * `terminated`. The published terminal event is a separate concern: during
+ * `timing-out` the run loop's timeout failure still races the unconditional
+ * `cancelled` from `cancel()`/`close()`, and the fence keeps whichever lands
+ * first.
  */
 type TurnPhase = 'running' | 'cancelling' | 'timing-out' | 'terminated';
 

--- a/src/backend/ai/agent/runtime/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntime.ts
@@ -164,22 +164,27 @@ type ToolPartBase = {
   toolRef: RuntimeTool['ref'];
 };
 
+/**
+ * Turn lifecycle. The first transition out of `running` wins — a later cancel
+ * cannot retarget a timeout outcome and vice versa — and only the terminal
+ * fence in `emit()` reaches `terminated`.
+ */
+type TurnPhase = 'running' | 'cancelling' | 'timing-out' | 'terminated';
+
 type ActiveTurn = {
   abortController: AbortController;
   agent?: PiRuntimeAgent;
   approvalWaiters: Map<string, ApprovalWaiter>;
   channel: RuntimeEventChannel;
-  cancelRequested: boolean;
   currentMessageOrdinal?: number;
   failedToolCalls: Set<string>;
   hasUsage: boolean;
   limitError?: RuntimeError;
   nextMessageOrdinal: number;
   nextPartIndex: number;
+  phase: TurnPhase;
   settledToolCalls: Set<string>;
   terminalMessage?: AssistantMessage;
-  terminated: boolean;
-  timedOut: boolean;
   timeoutHandle?: ReturnType<typeof setTimeout>;
   toolCallCount: number;
   toolParts: Map<string, ToolPartBase>;
@@ -563,15 +568,13 @@ class PiRuntimeSession implements AgentRuntimeSession {
     const turn: ActiveTurn = {
       abortController: new AbortController(),
       approvalWaiters: new Map(),
-      cancelRequested: false,
       channel,
       failedToolCalls: new Set(),
       hasUsage: false,
       nextMessageOrdinal: 0,
       nextPartIndex: 0,
+      phase: 'running',
       settledToolCalls: new Set(),
-      terminated: false,
-      timedOut: false,
       toolCallCount: 0,
       toolParts: new Map(),
       toolStepCount: 0,
@@ -596,7 +599,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
   async cancel(turnId: string): Promise<void> {
     const turn = this.activeTurn;
     if (!turn || turn.turnId !== turnId) return;
-    turn.cancelRequested = true;
+    this.advancePhase(turn, 'cancelling');
     this.abortExecution(turn, new Error('The turn was cancelled.'));
     await settleWithin(turn.agent?.waitForIdle(), PI_TURN_SETTLE_GRACE_MS);
     this.emit(turn, { type: 'cancelled' });
@@ -620,7 +623,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
     this.closed = true;
     const turn = this.activeTurn;
     if (turn) {
-      turn.cancelRequested = true;
+      this.advancePhase(turn, 'cancelling');
       this.abortExecution(turn, new Error('The session was closed.'));
       await settleWithin(turn.agent?.waitForIdle(), PI_TURN_SETTLE_GRACE_MS);
       this.emit(turn, { type: 'cancelled' });
@@ -637,11 +640,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       );
       secrets = resolution.redactionValues;
       turn.usageContext = resolution.usageContext;
-      if (turn.terminated || turn.cancelRequested) return;
-      if (turn.timedOut) {
-        this.emit(turn, { type: 'failed', error: TURN_TIMEOUT_ERROR });
-        return;
-      }
+      if (this.settleIfEnding(turn)) return;
       if (request.tools.length > 0 && !resolution.supportsTools) {
         this.emit(turn, {
           type: 'failed',
@@ -693,25 +692,16 @@ class PiRuntimeSession implements AgentRuntimeSession {
         }),
         turn.abortController.signal,
       );
-      if (turn.terminated) return;
-      if (turn.timedOut) {
-        this.emit(turn, { type: 'failed', error: TURN_TIMEOUT_ERROR });
-        return;
-      }
+      if (this.settleIfEnding(turn)) return;
       if (!contextPlan.ok) {
-        this.emit(
-          turn,
-          turn.cancelRequested
-            ? { type: 'cancelled' }
-            : {
-                type: 'failed',
-                error: {
-                  code: contextPlan.code,
-                  message: contextPlan.message,
-                  retryable: contextPlan.retryable,
-                },
-              },
-        );
+        this.emit(turn, {
+          type: 'failed',
+          error: {
+            code: contextPlan.code,
+            message: contextPlan.message,
+            retryable: contextPlan.retryable,
+          },
+        });
         return;
       }
       if (contextPlan.usage) {
@@ -738,7 +728,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
               turn.limitError = TOOL_STEP_LIMIT_ERROR;
             }
           }
-          return turn.limitError !== undefined || turn.timedOut || turn.cancelRequested;
+          return turn.limitError !== undefined || turn.phase !== 'running';
         },
         streamFn,
         toolExecution: 'parallel',
@@ -747,7 +737,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
         ? this.createAgent(agentOptions)
         : await createDefaultAgent(agentOptions);
       turn.agent = agent;
-      if (turn.terminated || turn.cancelRequested) {
+      if (this.settleIfEnding(turn)) {
         agent.abort();
         return;
       }
@@ -755,17 +745,9 @@ class PiRuntimeSession implements AgentRuntimeSession {
 
       // Consumer-side cancellation: the abort releases this wait immediately
       // rather than trusting the third-party loop to return. A late settlement
-      // is fenced by `turn.terminated` in `emit()` and `handlePiEvent()`.
+      // is fenced by the terminated phase in `emit()` and `handlePiEvent()`.
       await raceAbort(agent.prompt(conversation.prompt), turn.abortController.signal);
-      if (turn.terminated) return;
-      if (turn.timedOut) {
-        this.emit(turn, { type: 'failed', error: TURN_TIMEOUT_ERROR });
-        return;
-      }
-      if (turn.cancelRequested) {
-        this.emit(turn, { type: 'cancelled' });
-        return;
-      }
+      if (this.settleIfEnding(turn, { emitCancelled: true })) return;
 
       const terminal = turn.terminalMessage;
       if (!terminal) {
@@ -821,21 +803,14 @@ class PiRuntimeSession implements AgentRuntimeSession {
           break;
       }
     } catch (error) {
-      if (!turn.terminated) {
-        this.emit(
-          turn,
-          turn.timedOut
-            ? { type: 'failed', error: TURN_TIMEOUT_ERROR }
-            : turn.cancelRequested
-              ? { type: 'cancelled' }
-              : {
-                  type: 'failed',
-                  error: normalizeExecutionError(error, secrets, {
-                    providerId: turn.usageContext?.providerId ?? request.model.providerId,
-                    modelId: turn.usageContext?.modelId ?? request.model.modelId,
-                  }),
-                },
-        );
+      if (!this.settleIfEnding(turn, { emitCancelled: true })) {
+        this.emit(turn, {
+          type: 'failed',
+          error: normalizeExecutionError(error, secrets, {
+            providerId: turn.usageContext?.providerId ?? request.model.providerId,
+            modelId: turn.usageContext?.modelId ?? request.model.modelId,
+          }),
+        });
       }
     } finally {
       unsubscribe?.();
@@ -843,7 +818,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
   }
 
   private handlePiEvent(turn: ActiveTurn, event: PiAgentEvent): void {
-    if (turn.terminated) return;
+    if (turn.phase === 'terminated') return;
     switch (event.type) {
       case 'message_start':
         if (event.message.role === 'assistant') {
@@ -955,7 +930,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       toolRef: runtimeTool.ref,
     });
 
-    if (turn.cancelRequested || turn.terminated || signal?.aborted) {
+    if (turn.phase !== 'running' || signal?.aborted) {
       return this.interruptToolCall(turn, part);
     }
 
@@ -1029,7 +1004,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
         turn.settledToolCalls.add(toolCallId);
         return this.piToolResult(DENIED_TOOL_RESULT);
       }
-      if (turn.cancelRequested || turn.terminated || signal?.aborted) {
+      if (turn.phase !== 'running' || signal?.aborted) {
         return this.interruptToolCall(turn, part);
       }
     }
@@ -1044,7 +1019,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
         signal: callbackSignal,
         toolCallId,
       });
-      if (turn.cancelRequested || turn.terminated || turn.timedOut || callbackSignal.aborted) {
+      if (turn.phase !== 'running' || callbackSignal.aborted) {
         return this.interruptToolCall(turn, part);
       }
       this.replaceToolPart(turn, part, { state: 'output-available', output });
@@ -1053,11 +1028,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       return this.piToolResult(output);
     } catch (error) {
       const isInterrupted =
-        turn.cancelRequested ||
-        turn.terminated ||
-        turn.timedOut ||
-        turn.abortController.signal.aborted ||
-        signal?.aborted;
+        turn.phase !== 'running' || turn.abortController.signal.aborted || signal?.aborted;
       if (isInterrupted) {
         return this.interruptToolCall(turn, part);
       }
@@ -1156,7 +1127,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       // Pi may surface the rejection used to unwind an approval waiter as a
       // native error result. During cancellation the Runtime terminalizer owns
       // the outcome, so keep the part live and normalize it as interrupted.
-      if (turn.cancelRequested) continue;
+      if (turn.phase === 'cancelling') continue;
       const base = this.ensureToolPartFromProviderCall(
         turn,
         result.toolCallId,
@@ -1192,7 +1163,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
 
   private waitForApproval(turn: ActiveTurn, approvalId: string): Promise<'approve' | 'deny'> {
     return new Promise((resolve, reject) => {
-      if (turn.cancelRequested || turn.terminated) {
+      if (turn.phase !== 'running') {
         reject(new Error('The turn is no longer active.'));
         return;
       }
@@ -1211,14 +1182,45 @@ class PiRuntimeSession implements AgentRuntimeSession {
     this.rejectApprovals(turn, approvalError);
   }
 
+  /**
+   * Moves the turn out of `running` exactly once; a turn already cancelling,
+   * timing out, or terminated keeps its first outcome.
+   */
+  private advancePhase(turn: ActiveTurn, phase: 'cancelling' | 'timing-out'): boolean {
+    if (turn.phase !== 'running') return false;
+    turn.phase = phase;
+    return true;
+  }
+
+  /**
+   * The single early-exit check for the run loop: reports whether the turn is
+   * past `running` and settles the outcome that is this loop's to publish. A
+   * timeout failure is always published here; `cancelled` only where the loop
+   * owns it (`emitCancelled`) — otherwise `cancel()`/`close()` publish it
+   * after their settle grace, and the terminal fence keeps exactly one.
+   */
+  private settleIfEnding(turn: ActiveTurn, options?: { emitCancelled?: boolean }): boolean {
+    switch (turn.phase) {
+      case 'running':
+        return false;
+      case 'cancelling':
+        if (options?.emitCancelled) this.emit(turn, { type: 'cancelled' });
+        return true;
+      case 'timing-out':
+        this.emit(turn, { type: 'failed', error: TURN_TIMEOUT_ERROR });
+        return true;
+      case 'terminated':
+        return true;
+    }
+  }
+
   private timeoutTurn(turn: ActiveTurn): void {
-    if (turn.terminated || turn.timedOut) return;
-    turn.timedOut = true;
+    if (!this.advancePhase(turn, 'timing-out')) return;
     this.abortExecution(turn, new Error('The Agent turn timed out.'));
   }
 
   private emit(turn: ActiveTurn, event: RuntimeEvent): void {
-    if (turn.terminated) return;
+    if (turn.phase === 'terminated') return;
     if (event.type === 'usage') turn.usageReported = true;
     const isTerminal =
       event.type === 'completed' || event.type === 'failed' || event.type === 'cancelled';
@@ -1235,7 +1237,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
         });
       }
       this.interruptUnsettledToolParts(turn);
-      turn.terminated = true;
+      turn.phase = 'terminated';
       this.rejectApprovals(turn, new Error('The turn reached a terminal state.'));
     }
     turn.channel.push(event);

--- a/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
@@ -1819,4 +1819,51 @@ describe('PiRuntime mapping', () => {
     expect(agentSignal?.aborted).toBe(true);
     await session.close();
   });
+
+  test('interrupts a tool call arriving after the turn timeout without requesting approval', async () => {
+    const runtime = createTestRuntime({
+      maxToolCalls: 16,
+      maxToolSteps: 8,
+      turnTimeoutMs: 5,
+    });
+    const executed = jest.fn();
+    let lateCall: Promise<unknown> | undefined;
+    arrange(runtime, (context) => {
+      const piTool = context.options.initialState?.tools?.[0];
+      if (!piTool) throw new Error('Timeout program requires one tool.');
+      return new Promise((resolve) => {
+        // The synchronous abort listener reaches the Runtime while the phase
+        // is `timing-out`, before the run loop publishes the timeout failure.
+        context.signal.addEventListener(
+          'abort',
+          () => {
+            lateCall = piTool.execute('late-call', {}, new AbortController().signal);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    });
+    const session = await runtime.open();
+
+    const events = await collect(
+      session.execute(baseRequest('turn-timeout-late-tool', { tools: [askTool(executed)] })),
+    );
+
+    expect(executed).not.toHaveBeenCalled();
+    expect(events.some((event) => event.type === 'approval.requested')).toBe(false);
+    expect(
+      events.find(
+        (event) =>
+          event.type === 'part.replace' &&
+          event.part.type === 'tool' &&
+          event.part.toolCallId === 'late-call',
+      ),
+    ).toMatchObject({ part: { state: 'interrupted' } });
+    expect(events.at(-1)).toMatchObject({ type: 'failed', error: { code: 'turn_timeout' } });
+    await expect(lateCall).resolves.toMatchObject({
+      details: { value: { status: 'interrupted' } },
+    });
+    await session.close();
+  });
 });

--- a/src/backend/ai/agent/tools/runtimeTools.ts
+++ b/src/backend/ai/agent/tools/runtimeTools.ts
@@ -1,5 +1,6 @@
 import type { McpExecutableToolDescriptor, McpRuntimeToolSelection } from '@/backend/ai/mcp';
 import type { AgentToolBinding } from '@/shared/data/types/agentToolBinding';
+import { clampMcpToolApproval } from '@/shared/utils/agentToolApproval';
 
 import type { RuntimeTool } from '../runtime';
 
@@ -73,9 +74,10 @@ export function createAgentRuntimeToolResolver(input: {
           return [
             {
               descriptor,
-              // Mobile never grants third-party MCP automatic approval. Preserve
-              // an explicit deny; safely downgrade any legacy auto row to ask.
-              approval: resolved.approval === 'deny' ? 'deny' : 'ask',
+              // An MCP row on its own is never auto: the shared policy keeps an
+              // explicit deny and clamps everything else to ask. The Host may
+              // later promote ask to auto for Agents whose approval mode says so.
+              approval: clampMcpToolApproval(resolved.approval),
             },
           ];
         },

--- a/src/frontend/features/agents/agentToolSettings.ts
+++ b/src/frontend/features/agents/agentToolSettings.ts
@@ -1,6 +1,7 @@
 import type { WriteAgentToolBinding } from '@/shared/data/api/schemas/agentToolBindings';
 import type { AgentToolBinding } from '@/shared/data/types/agentToolBinding';
 import type { McpServer } from '@/shared/data/types/mcpServer';
+import { clampMcpToolApproval } from '@/shared/utils/agentToolApproval';
 
 export type McpToolBindingDraft = Extract<WriteAgentToolBinding, { source: 'mcp' }>;
 
@@ -44,7 +45,7 @@ export function createAgentToolBindingDraft(
     binding.source === 'mcp'
       ? [
           {
-            approval: binding.approval === 'deny' ? 'deny' : 'ask',
+            approval: clampMcpToolApproval(binding.approval),
             displayNameSnapshot: binding.displayNameSnapshot,
             enabled: binding.enabled,
             ...(binding.rawToolName ? { rawToolName: binding.rawToolName } : {}),
@@ -110,7 +111,7 @@ export function setAgentMcpServerEnabled(
 
   const restored = option.binding ?? option.originalBinding;
   const nextBinding: McpToolBindingDraft = restored
-    ? { ...restored, approval: restored.approval === 'deny' ? 'deny' : 'ask', enabled: true }
+    ? { ...restored, approval: clampMcpToolApproval(restored.approval), enabled: true }
     : {
         approval: 'ask',
         displayNameSnapshot: option.server?.name ?? option.displayName,

--- a/src/shared/utils/__tests__/agentToolApproval.test.ts
+++ b/src/shared/utils/__tests__/agentToolApproval.test.ts
@@ -1,0 +1,38 @@
+import { applyToolApprovalMode, clampMcpToolApproval } from '../agentToolApproval';
+
+describe('clampMcpToolApproval', () => {
+  test('preserves an explicit deny', () => {
+    expect(clampMcpToolApproval('deny')).toBe('deny');
+  });
+
+  test('clamps ask and legacy auto rows to ask', () => {
+    expect(clampMcpToolApproval('ask')).toBe('ask');
+    expect(clampMcpToolApproval('auto')).toBe('ask');
+  });
+});
+
+describe('applyToolApprovalMode', () => {
+  test('default mode keeps every approval unchanged', () => {
+    expect(applyToolApprovalMode('auto', 'default')).toBe('auto');
+    expect(applyToolApprovalMode('ask', 'default')).toBe('ask');
+    expect(applyToolApprovalMode('deny', 'default')).toBe('deny');
+  });
+
+  test('auto mode promotes only ask', () => {
+    expect(applyToolApprovalMode('ask', 'auto')).toBe('auto');
+    expect(applyToolApprovalMode('auto', 'auto')).toBe('auto');
+    expect(applyToolApprovalMode('deny', 'auto')).toBe('deny');
+  });
+});
+
+describe('composed MCP policy', () => {
+  test('the only path to auto for an MCP tool is the confirmed Agent mode', () => {
+    expect(applyToolApprovalMode(clampMcpToolApproval('auto'), 'default')).toBe('ask');
+    expect(applyToolApprovalMode(clampMcpToolApproval('ask'), 'auto')).toBe('auto');
+  });
+
+  test('an explicit deny survives both stages in every mode', () => {
+    expect(applyToolApprovalMode(clampMcpToolApproval('deny'), 'default')).toBe('deny');
+    expect(applyToolApprovalMode(clampMcpToolApproval('deny'), 'auto')).toBe('deny');
+  });
+});

--- a/src/shared/utils/agentToolApproval.ts
+++ b/src/shared/utils/agentToolApproval.ts
@@ -1,0 +1,36 @@
+import type { AgentToolApprovalMode } from '@/shared/data/types/agent';
+import type { AgentToolApproval } from '@/shared/data/types/agentToolBinding';
+
+/**
+ * The single statement of mobile's interactive tool-approval policy. Every
+ * layer that clamps an MCP row or applies the Agent-level approval mode calls
+ * these two functions; the composed behavior is:
+ *
+ *   persisted row -> clampMcpToolApproval -> applyToolApprovalMode -> snapshot
+ *
+ * so on its own a third-party MCP tool is never `auto`, and the only sanctioned
+ * promotion from `ask` to `auto` is the Agent's explicitly confirmed mode.
+ */
+
+export type McpInteractiveApproval = Extract<AgentToolApproval, 'ask' | 'deny'>;
+
+/**
+ * Approval floor for third-party MCP tools: an explicit deny is preserved and
+ * everything else — including a legacy `auto` row — is clamped to ask.
+ */
+export function clampMcpToolApproval(approval: AgentToolApproval): McpInteractiveApproval {
+  return approval === 'deny' ? 'deny' : 'ask';
+}
+
+/**
+ * Applies an Agent's approval mode to one resolved tool approval. `default`
+ * keeps the tool's own value; `auto` promotes only `ask`. Tool availability,
+ * explicit denies, OS permissions, and callback-level resource checks are
+ * untouched and continue to fail closed.
+ */
+export function applyToolApprovalMode(
+  approval: AgentToolApproval,
+  mode: AgentToolApprovalMode,
+): AgentToolApproval {
+  return mode === 'auto' && approval === 'ask' ? 'auto' : approval;
+}


### PR DESCRIPTION
## Summary

- centralize the mobile Agent tool-approval policy so backend resolution, Host planning, and frontend drafts share one rule
- model the Pi Runtime turn lifecycle as one explicit phase and close late tool calls immediately after timeout
- extract attachment handling and the write-free turn preparation stage from `MobileAgentHost`
- add direct regression coverage for attachment admission, turn planning, and post-timeout tool calls

## Validation

- `pnpm lint` (passes with pre-existing warnings)
- `pnpm format:check`
- `pnpm typecheck`

Jest suites were not run in this workspace, following the repository instruction that test execution is user-owned.
