### PR TITLE
docs(architecture): record backend AI target architecture

### DIFF
--- a/docs/references/agent/README.md
+++ b/docs/references/agent/README.md
@@ -73,6 +73,8 @@ both sides.
 
 ## Related
 
+- [Backend AI Target Architecture](../ai/target-architecture.md) — approved target structure, seam
+  rules, and migration status for `src/backend/ai`
 - [Architecture Overview](../architecture-overview.md) — dependency direction and layer ownership
 - [Runtime Ownership](../runtime-ownership.md) — Host lifetime, observation, and shutdown
 - [Chat Streaming And Rendering](../chat/streaming-and-rendering.md) — transcript windows, live

--- a/docs/references/ai/target-architecture.md
+++ b/docs/references/ai/target-architecture.md
@@ -1,0 +1,114 @@
+# Backend AI Target Architecture
+
+Status: **target state approved 2026-08-28; migration in progress** (see
+[Migration Status](#migration-status)).
+
+This reference records the approved target structure for `src/backend/ai`, the seam rules that keep
+the conversation Runtime replaceable, and the success criteria each migration pull request is
+reviewed against. As-built behavior stays documented in [Agent Architecture](../agent/README.md),
+[AI Provider Integration](./provider-integration.md), and
+[Provider Serving Boundaries](./provider-serving-boundaries.md); this document governs where the
+implementation is heading and why.
+
+## Decisions And Constraints
+
+- **Desktop alignment is retired as an implementation constraint.** Serialized data — message part
+  JSON, the SQLite schema, checkpoint payload columns — stays desktop-aligned. Module layout, port
+  inventories, and the `packages/ai-runtime` desktop-sync trust workflow do not. Complexity that
+  exists only to mirror desktop structure is removable on sight.
+- **Drivers, ranked:** comprehension cost, then Runtime replaceability, then desktop-legacy
+  removal. When two moves conflict, the higher driver wins.
+- **Pi is the sole conversation trunk.** The AI SDK path serves non-conversation generation only:
+  `AiService` (generate text, generate image, model check, model listing) and the tools that call
+  back into it.
+- **The Runtime seam stays at `agent/runtime/types.ts`.** Replacement candidates are a future
+  remote agent service and, as insurance, a different in-process loop. Nothing is designed for the
+  remote case now: no execution-target variants, no reattach or resume structure, no topology
+  assumptions. The `local`-only note in `src/shared/contracts/agent.ts` stands until that product
+  exists.
+- **Frozen boundaries.** Above: the Agent Protocol (`src/shared/contracts/agent.ts`), its event
+  delta semantics, and the frontend projection. Below: the SQLite schema. Everything between the
+  two boundaries may be redesigned.
+- The 13 protocol invariants in [Agent Protocol](../agent/agent-protocol.md#invariants) survive
+  every phase. Terminal persistence before publication and side-effect ordering in finalization
+  remain explicit calls; an event bus would make those ordering guarantees implicit and is
+  rejected.
+
+## Target Structure
+
+```text
+src/backend/ai/
+├── agent/
+│   ├── host/            Orchestration core: admission, atomic reservation, event loop,
+│   │                    terminal persistence, restart reconciliation. Protocol invariants only.
+│   │                    Turn preparation (turnPreparation.ts) and attachment materialization
+│   │                    (turnAttachments.ts) stay write-free and testable without a Host.
+│   │                    Side effects (naming, usage, background reply) converge behind one
+│   │                    explicitly ordered turn-observer seam.
+│   ├── runtime/
+│   │   ├── types.ts     The seam contract. No imports from packages/* ports. Neutral usage
+│   │   │                shape. Model preflight and static capability queries live here.
+│   │   ├── FakeRuntime.ts  Conformance double; updated with every contract change.
+│   │   └── pi/          Everything Pi-specific: PiRuntime, the current piAdapter/ content
+│   │                    (model resolution, API adapters, stream binding), the Pi language
+│   │                    binding decision, context compaction, Pi message mapping.
+│   ├── sessionStore/    Unchanged.
+│   ├── tools/           Unchanged structure; service access via injected narrow interfaces
+│   │                    instead of application.get.
+│   └── resources/       Unchanged.
+├── provider/            Runtime-agnostic connection facts: resolved endpoints, transport
+│                        policies, model listing support. No Pi-named exports.
+├── AiService.ts         Single non-conversation facade; generation/ becomes its private
+│                        implementation.
+└── mcp/                 Unchanged.
+```
+
+New module and directory names are chosen at implementation time following
+[Naming Conventions](../naming-conventions.md); the roles above are the commitment, not the names.
+
+## Seam Rules
+
+1. **Pi isolation.** Outside `agent/runtime/pi/` (including the current `agent/piAdapter/` until it
+   moves), no file imports Pi symbols or `@earendil-works/*`. Enforced by lint, not convention.
+2. **Contract purity.** `agent/runtime/types.ts` depends on no `packages/*` port. The usage report
+   uses a neutral shape defined in the contract; the Pi resolver maps into it.
+3. **One binding point.** The composition root creates and registers the Runtime. Replacing the
+   Runtime means adding one implementation directory and changing one composition line. The Host
+   never constructs a Runtime.
+4. **Capability questions go through the contract.** "Can this model serve?" is answered by the
+   Runtime's preflight and static capability surface, not by importing a specific runtime's binding
+   logic. Image-generation support stays an AI SDK concern and is not routed through the seam.
+5. **Normalized history is the seam currency.** The Host side maps protocol transcripts into the
+   normalized Runtime shape; each Runtime maps that shape into its own messages. Neither side
+   imports the other's mapping.
+
+## Success Criteria
+
+1. Pi isolation holds repo-wide and is lint-enforced.
+2. `agent/runtime/types.ts` has no `packages/*` dependency.
+3. Swapping the Runtime touches one new directory plus one composition line.
+4. The orchestration core contains protocol orchestration and invariants only; turn preparation
+   and attachment materialization are testable without a Host instance.
+5. `packages/ai-runtime` is deleted and the desktop-sync trust workflow is retired.
+6. Existing Host and Runtime conformance suites stay green through every phase; the invariant list
+   in [Agent Protocol](../agent/agent-protocol.md#invariants) is the permanent baseline.
+
+## Migration Status
+
+| Phase | Scope | Status |
+| --- | --- | --- |
+| 0 | This document; retire the `ai-runtime` desktop-sync trust workflow | In progress |
+| 1 | Seal the seam: Runtime binding at the composition root, split the Pi language binding out of `provider/`, neutral usage shape in the contract, static capability query, Pi-isolation lint rule | Pending |
+| 2 | Host decomposition | Partially landed (#696: `turnPreparation.ts`, `turnAttachments.ts`, Pi lifecycle phases). Remaining: converge naming/usage/background-reply behind the turn-observer seam |
+| 3 | Fold `generation/` into `AiService`, shrink provider config to its AI SDK consumers, inline the consumed `packages/ai-runtime` symbols, delete the package | Pending |
+
+Phase 1 precedes 2 and 3; the contract shape must settle before code moves against it. Phases 2
+and 3 are independent of each other.
+
+## Related
+
+- [Agent Architecture](../agent/README.md) — as-built execution boundary
+- [Agent Runtime](../agent/agent-runtime.md) — as-built seam contract and conformance
+- [Provider Serving Boundaries](./provider-serving-boundaries.md) — provider control plane and
+  serving planes; Phase 1 here continues its staged ownership migration
+- [Code Organization](../code-organization.md) — placement rules for the moves above

--- a/src/backend/ai/README.md
+++ b/src/backend/ai/README.md
@@ -32,6 +32,8 @@ Pure provider implementations, request types, and parameter policies must not be
 Current execution and tool boundaries live in
 [Agent Architecture](../../../docs/references/agent/README.md) and
 [Agent Tools And Controlled Resources](../../../docs/references/agent/agent-tools-and-resources.md).
+The approved target structure and migration status for this directory live in
+[Backend AI Target Architecture](../../../docs/references/ai/target-architecture.md).
 
 ## Sync Trust
 


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Part of the `backend/ai` architecture redesign (stack #699), merged bottom-up:
>
> 1. #697 target architecture reference (docs only)
> 2. #698 retire the desktop-sync trust workflow
> 3. #702 bind the Runtime at the composition root
> 4. #703 move the Pi language binding behind the Runtime seam
> 5. #704 remove the contract's port-package dependency
> 6. #705 enforce Pi isolation with lint
>
> Together these complete Phase 0 and Phase 1 of the plan recorded in #697.

### What this PR does

Before this PR: the target state of `src/backend/ai` lived only in discussion. The as-built references ([Agent Architecture](docs/references/agent/README.md), [AI Provider Integration](docs/references/ai/provider-integration.md), [Provider Serving Boundaries](docs/references/ai/provider-serving-boundaries.md)) describe how the code works today, but nothing records where it is heading or what a migration PR is reviewed against.

After this PR: `docs/references/ai/target-architecture.md` records the approved target structure, the seam rules that keep the conversation Runtime replaceable, six success criteria, and a Migration Status table. Documentation only — no code changes.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. The mobile UI, the Data API shape, and the agent protocol are all unchanged.

### Why we need it and why it was done in this way

`src/backend/ai` works but its structure was never consolidated: the Host entangles three responsibilities, the Runtime seam leaks in three places, and `packages/ai-runtime` carries 12.9k lines of desktop port for 45 consumed symbols. Reshaping that safely needs a written target and a fixed set of acceptance criteria, otherwise every subsequent PR re-litigates the same design questions.

The following tradeoffs were made:

- A target-state document drifts from the implementation as phases land. The Migration Status table is the mitigation: every phase PR updates it, so the document states its own staleness.
- Desktop alignment is retired as an *implementation* constraint only. Serialized data — message part JSON, the SQLite schema, checkpoint payload columns — stays desktop-aligned.

The following alternatives were considered: an ADR under a separate directory. This repository consolidated its AI/agent design material into `docs/references/` in #692, so the target state follows that convention rather than starting a parallel series.

### Breaking changes

None. No code changes.

### Special notes for your reviewer

The six success criteria in this document are what the rest of the stack is reviewed against. Criteria 1, 2, 3 and part of 5 are met by the PRs above; criterion 4 (single-responsibility orchestration core) is Phase 2 work.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
