### PR TITLE
refactor(agent-data): remove unused inference settings

### DIFF
--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -38,8 +38,6 @@ The Agent Data API, `Backend.agent`, and frontend surfaces share these current c
   or clearing its model can therefore make its existing Sessions unavailable through the public
   Host API even though their rows remain durable. The Data API's static Session and transcript
   reads remain available without resolving an executable Agent definition.
-- Concurrent partial updates to one Agent's settings are last-writer-wins and can lose independently
-  updated fields because the read/merge happens before the serialized write transaction.
 - Batch reorder callers must provide unique Agent ids. Duplicate ids can currently be reported as
   `NOT_FOUND`, despite the underlying ordering helper otherwise using the last move for an id.
 - Agent deletion is soft so historical Sessions retain their definition and avatar reference.
@@ -53,7 +51,7 @@ protocol values or application data ([Agent Runtime](./agent-runtime.md), protoc
 Mobile Agent has one execution target and one engine: `local → Pi` in this mobile app. Application
 composition injects Pi directly into the Host, so there is no implementation choice to persist.
 Cloud and LAN desktop control are separate domains and must not reuse Mobile Agent definitions,
-Sessions, settings, or execution-target values.
+Sessions, or execution-target values.
 `contextCheckpoint` does not change this decision: it is a versioned, Runtime-produced content
 artifact anchored to a durable turn, not an engine id, resumable Runtime instance, provider cursor,
 or routing choice. The Host treats its payload as opaque and a process restart still interrupts an
@@ -146,7 +144,7 @@ store maps to the protocol's ISO strings at the boundary. `agent` uses UUID v4 (
 `agent_session` and `agent_session_message` use time-ordered UUID v7 (`uuidPrimaryKeyOrdered`).
 Agent updates advance `updatedAt` with `max(previous + 1, wall clock)` inside the serialized write
 transaction. The composer can therefore use it as a strict row version when reconciling optimistic
-model selection with settings edits and inactive query caches.
+model selection with Agent definition edits and inactive query caches.
 
 **Desktop divergence is documented.** Mobile shares the desktop table names and the
 `agent → agent_session → agent_session_message` shape but owns its columns, per the #568
@@ -165,7 +163,6 @@ external runtime (workspace, delivery, resume tokens) are deliberately absent, w
 | `instructions` | text | NOT NULL DEFAULT `''` | System instructions |
 | `avatar` | text | NULL | Stable file reference; NULL renders the default avatar |
 | `modelId` | text | NULL, FK → `user_model.id` ON DELETE SET NULL | `UniqueModelId` |
-| `settings` | text (json) | NOT NULL | Inference params (temperature, reasoning, max tokens) |
 | `toolApprovalMode` | text | NOT NULL DEFAULT `default` | `default` preserves tool policy; `auto` promotes effective `ask` to `auto` |
 | `orderKey` | text | NOT NULL | `orderKeyColumns` fractional index |
 | `createdAt` / `updatedAt` / `deletedAt` | integer | helper defaults | Soft delete via `deletedAt` |

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -17,7 +17,7 @@ process-local transport mechanics, not protocol data. JSON safety keeps applicat
 this document does not define a network wire protocol.
 
 Cloud control and LAN desktop control are separate product domains. They do not execute a Mobile
-Agent, reuse its Session or settings, or extend `AgentExecutionTarget` with remote variants.
+Agent, reuse its Session or definition, or extend `AgentExecutionTarget` with remote variants.
 
 The protocol does not expose provider SDK objects, Runtime-native events, SQLite rows,
 `AbortSignal`, streams, callbacks inside values, or implementation-specific Pi/provider-SDK state.
@@ -59,7 +59,7 @@ type AgentSessionView = {
 accepts only `local`, meaning this mobile app. Runtime ids and Pi/provider-SDK implementation
 details never appear in protocol values.
 
-`agentId` identifies the application-owned Agent configuration — the settings the user edits in the
+`agentId` identifies the application-owned Agent configuration — the definition the user edits in the
 application (instructions, model, tool-approval preference, and MCP extensions). That configuration
 is live: before each turn, the Host resolves its current state and builds the Runtime execution
 request from it, so an application-level edit applies from the next turn. Shared system

--- a/migrations/sqlite-drizzle/0010_remove-agent-settings.sql
+++ b/migrations/sqlite-drizzle/0010_remove-agent-settings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `agent` DROP COLUMN `settings`;

--- a/migrations/sqlite-drizzle/meta/0010_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1723 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e7e56e8b-a621-4e6c-a1ec-dab101fbb439",
+  "prevId": "5cbe9bb5-a702-4966-95e8-f191ccf00050",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_approval_mode": {
+          "name": "tool_approval_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_created_at_idx": {
+          "name": "agent_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "agent_order_key_idx": {
+          "name": "agent_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_model_id_user_model_id_fk": {
+          "name": "agent_model_id_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_tool_binding": {
+      "name": "agent_tool_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_tool_name": {
+          "name": "raw_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "approval": {
+          "name": "approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "display_name_snapshot": {
+          "name": "display_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_tool_binding_agent_id_idx": {
+          "name": "agent_tool_binding_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_tool_binding_mcp_server_id_idx": {
+          "name": "agent_tool_binding_mcp_server_id_idx",
+          "columns": ["mcp_server_id"],
+          "isUnique": false
+        },
+        "agent_tool_binding_builtin_uniq": {
+          "name": "agent_tool_binding_builtin_uniq",
+          "columns": ["agent_id", "capability_id"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'builtin'"
+        },
+        "agent_tool_binding_mcp_server_default_uniq": {
+          "name": "agent_tool_binding_mcp_server_default_uniq",
+          "columns": ["agent_id", "mcp_server_id"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"raw_tool_name\" IS NULL"
+        },
+        "agent_tool_binding_mcp_tool_uniq": {
+          "name": "agent_tool_binding_mcp_tool_uniq",
+          "columns": ["agent_id", "mcp_server_id", "raw_tool_name"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"raw_tool_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_binding_agent_id_agent_id_fk": {
+          "name": "agent_tool_binding_agent_id_agent_id_fk",
+          "tableFrom": "agent_tool_binding",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_tool_binding_identity_check": {
+          "name": "agent_tool_binding_identity_check",
+          "value": "(\n        (\"agent_tool_binding\".\"source\" = 'builtin' AND \"agent_tool_binding\".\"capability_id\" IS NOT NULL AND length(\"agent_tool_binding\".\"capability_id\") > 0 AND \"agent_tool_binding\".\"mcp_server_id\" IS NULL AND \"agent_tool_binding\".\"raw_tool_name\" IS NULL)\n        OR\n        (\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"capability_id\" IS NULL AND \"agent_tool_binding\".\"mcp_server_id\" IS NOT NULL AND length(\"agent_tool_binding\".\"mcp_server_id\") > 0 AND (\"agent_tool_binding\".\"raw_tool_name\" IS NULL OR length(\"agent_tool_binding\".\"raw_tool_name\") > 0))\n      )"
+        },
+        "agent_tool_binding_approval_check": {
+          "name": "agent_tool_binding_approval_check",
+          "value": "\"agent_tool_binding\".\"approval\" IN ('auto', 'ask', 'deny')"
+        }
+      }
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title_is_manual": {
+          "name": "title_is_manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"kind\":\"local\"}'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_agent_id_idx": {
+          "name": "agent_session_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_session_last_activity_at_idx": {
+          "name": "agent_session_last_activity_at_idx",
+          "columns": ["last_activity_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_checkpoint": {
+          "name": "context_checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_snapshot": {
+          "name": "message_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_created_idx": {
+          "name": "agent_session_message_session_created_idx",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        },
+        "agent_session_message_turn_id_idx": {
+          "name": "agent_session_message_turn_id_idx",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "agent_session_message_status_idx": {
+          "name": "agent_session_message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agent_session_message_active_turn_uniq": {
+          "name": "agent_session_message_active_turn_uniq",
+          "columns": ["session_id"],
+          "isUnique": true,
+          "where": "\"agent_session_message\".\"role\" = 'assistant' and \"agent_session_message\".\"status\" in ('pending', 'streaming')"
+        },
+        "agent_session_message_fts_rowid_uniq": {
+          "name": "agent_session_message_fts_rowid_uniq",
+          "columns": ["fts_rowid"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_message_model_id_user_model_id_fk": {
+          "name": "agent_session_message_model_id_user_model_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_session_message_role_check": {
+          "name": "agent_session_message_role_check",
+          "value": "\"agent_session_message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "agent_session_message_status_check": {
+          "name": "agent_session_message_status_check",
+          "value": "\"agent_session_message\".\"status\" IN ('pending', 'streaming', 'success', 'error', 'cancelled', 'interrupted')"
+        }
+      }
+    },
+    "ai_usage_record": {
+      "name": "ai_usage_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_kind": {
+          "name": "record_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_icon": {
+          "name": "source_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_label": {
+          "name": "api_key_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_masked": {
+          "name": "api_key_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_attribution": {
+          "name": "api_key_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_cache_tokens": {
+          "name": "no_cache_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_snapshot": {
+          "name": "pricing_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_first_token_ms": {
+          "name": "time_first_token_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_completion_ms": {
+          "name": "time_completion_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_thinking_ms": {
+          "name": "time_thinking_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usage_record_request_id_idx": {
+          "name": "ai_usage_record_request_id_idx",
+          "columns": ["request_id"],
+          "isUnique": true
+        },
+        "ai_usage_record_created_at_idx": {
+          "name": "ai_usage_record_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_message_created_idx": {
+          "name": "ai_usage_record_message_created_idx",
+          "columns": ["message_kind", "message_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_provider_created_idx": {
+          "name": "ai_usage_record_provider_created_idx",
+          "columns": ["provider_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_model_created_idx": {
+          "name": "ai_usage_record_model_created_idx",
+          "columns": ["model_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_api_key_created_idx": {
+          "name": "ai_usage_record_api_key_created_idx",
+          "columns": ["api_key_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_source_created_idx": {
+          "name": "ai_usage_record_source_created_idx",
+          "columns": ["source_type", "source_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_usage_record_record_kind_check": {
+          "name": "ai_usage_record_record_kind_check",
+          "value": "\"ai_usage_record\".\"record_kind\" IN ('invocation', 'legacy-aggregate')"
+        },
+        "ai_usage_record_message_kind_check": {
+          "name": "ai_usage_record_message_kind_check",
+          "value": "\"ai_usage_record\".\"message_kind\" IN ('chat', 'agent-session')"
+        },
+        "ai_usage_record_source_type_check": {
+          "name": "ai_usage_record_source_type_check",
+          "value": "\"ai_usage_record\".\"source_type\" IN ('assistant', 'agent')"
+        },
+        "ai_usage_record_modality_check": {
+          "name": "ai_usage_record_modality_check",
+          "value": "\"ai_usage_record\".\"modality\" IN ('language', 'embedding', 'image', 'rerank')"
+        },
+        "ai_usage_record_attribution_check": {
+          "name": "ai_usage_record_attribution_check",
+          "value": "\"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched', 'auth', 'unknown')"
+        },
+        "ai_usage_record_auth_method_check": {
+          "name": "ai_usage_record_auth_method_check",
+          "value": "\"ai_usage_record\".\"auth_method\" IN ('oauth', 'external-cli', 'iam-aws', 'api-key-aws', 'iam-gcp', 'iam-azure')"
+        },
+        "ai_usage_record_cost_source_check": {
+          "name": "ai_usage_record_cost_source_check",
+          "value": "\"ai_usage_record\".\"cost_source\" IN ('provider', 'computed')"
+        },
+        "ai_usage_record_cost_currency_check": {
+          "name": "ai_usage_record_cost_currency_check",
+          "value": "\"ai_usage_record\".\"cost_currency\" IN ('USD', 'CNY')"
+        },
+        "ai_usage_record_kind_identity_check": {
+          "name": "ai_usage_record_kind_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"record_kind\" = 'invocation'\n        AND \"ai_usage_record\".\"request_count\" = 1\n        AND \"ai_usage_record\".\"provider_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"model_id\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"record_kind\" = 'legacy-aggregate'\n        AND \"ai_usage_record\".\"request_count\" >= 1\n        AND \"ai_usage_record\".\"message_kind\" IS NOT NULL\n        AND \"ai_usage_record\".\"message_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_message_identity_check": {
+          "name": "ai_usage_record_message_identity_check",
+          "value": "(\"ai_usage_record\".\"message_kind\" IS NULL AND \"ai_usage_record\".\"message_id\" IS NULL)\n        OR (\"ai_usage_record\".\"message_kind\" IS NOT NULL AND \"ai_usage_record\".\"message_id\" IS NOT NULL)"
+        },
+        "ai_usage_record_source_identity_check": {
+          "name": "ai_usage_record_source_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"source_type\" IS NULL\n        AND \"ai_usage_record\".\"source_id\" IS NULL\n        AND \"ai_usage_record\".\"source_name\" IS NULL\n        AND \"ai_usage_record\".\"source_icon\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"source_type\" IS NOT NULL\n        AND \"ai_usage_record\".\"source_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_api_key_identity_check": {
+          "name": "ai_usage_record_api_key_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched')\n        AND \"ai_usage_record\".\"api_key_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'auth'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'unknown'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      )"
+        },
+        "ai_usage_record_cost_tuple_check": {
+          "name": "ai_usage_record_cost_tuple_check",
+          "value": "(\n        \"ai_usage_record\".\"cost\" IS NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NULL\n        AND \"ai_usage_record\".\"cost_breakdown\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"cost\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_image_count_check": {
+          "name": "ai_usage_record_image_count_check",
+          "value": "(\n        \"ai_usage_record\".\"modality\" = 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NOT NULL\n        AND \"ai_usage_record\".\"image_count\" >= 0\n      ) OR (\n        \"ai_usage_record\".\"modality\" <> 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NULL\n      )"
+        },
+        "ai_usage_record_nonnegative_check": {
+          "name": "ai_usage_record_nonnegative_check",
+          "value": "\n        (\"ai_usage_record\".\"input_tokens\" IS NULL OR \"ai_usage_record\".\"input_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR \"ai_usage_record\".\"output_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR \"ai_usage_record\".\"total_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR \"ai_usage_record\".\"reasoning_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR \"ai_usage_record\".\"no_cache_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR \"ai_usage_record\".\"cache_read_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR \"ai_usage_record\".\"cache_write_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" >= 0)\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR \"ai_usage_record\".\"time_first_token_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR \"ai_usage_record\".\"time_completion_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR \"ai_usage_record\".\"time_thinking_ms\" >= 0)\n      "
+        },
+        "ai_usage_record_integer_check": {
+          "name": "ai_usage_record_integer_check",
+          "value": "\n        typeof(\"ai_usage_record\".\"request_count\") = 'integer'\n        AND (\"ai_usage_record\".\"input_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"input_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"output_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"total_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"reasoning_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"no_cache_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_read_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_write_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"image_count\" IS NULL OR typeof(\"ai_usage_record\".\"image_count\") = 'integer')\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_first_token_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_completion_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_thinking_ms\") = 'integer')\n        AND typeof(\"ai_usage_record\".\"created_at\") = 'integer'\n      "
+        },
+        "ai_usage_record_finite_cost_check": {
+          "name": "ai_usage_record_finite_cost_check",
+          "value": "\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" <= 1.7976931348623157e308"
+        }
+      }
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_url": {
+          "name": "endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_is_enabled_idx": {
+          "name": "mcp_server_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "painting": {
+      "name": "painting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"input\":[],\"output\":[]}'"
+        }
+      },
+      "indexes": {
+        "painting_order_key_idx": {
+          "name": "painting_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "user_model_custom_config_check": {
+          "name": "user_model_custom_config_check",
+          "value": "\"user_model\".\"preset_model_id\" IS NOT NULL OR (\"user_model\".\"name\" IS NOT NULL AND \"user_model\".\"capabilities\" IS NOT NULL AND \"user_model\".\"supports_streaming\" IS NOT NULL)"
+        }
+      }
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787834308152,
       "tag": "0009_agent-tool-approval-mode",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1787895004379,
+      "tag": "0010_remove-agent-settings",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/ai/agent/host/__tests__/agentDefinitions.integration.test.ts
+++ b/src/backend/ai/agent/host/__tests__/agentDefinitions.integration.test.ts
@@ -35,7 +35,6 @@ describe('agent-table definition source', () => {
       instructions: 'Be terse.',
       modelId: 'openai::gpt-4',
       name: 'Researcher',
-      settings: { maxOutputTokens: 2048, reasoningEffort: 'high', temperature: 0.4 },
       toolApprovalMode: 'auto',
     });
 
@@ -44,7 +43,7 @@ describe('agent-table definition source', () => {
       instructions: 'Be terse.',
       model: { modelId: 'gpt-4', providerId: 'openai' },
       name: 'Researcher',
-      options: { maxOutputTokens: 2048, reasoningEffort: 'high', temperature: 0.4 },
+      options: {},
       toolApprovalMode: 'auto',
     });
 

--- a/src/backend/ai/agent/host/agentDefinitions.ts
+++ b/src/backend/ai/agent/host/agentDefinitions.ts
@@ -2,8 +2,8 @@
  * Minimal Agent configuration source.
  *
  * Tool bindings and the fixed built-in catalog are resolved separately from the
- * definition. Agent lookup stays limited to id/name/model/instructions,
- * inference options, and the interactive tool-approval preference.
+ * definition. Agent lookup stays limited to id/name/model/instructions and the
+ * interactive tool-approval preference.
  */
 
 import { and, eq, isNull } from 'drizzle-orm';
@@ -49,17 +49,7 @@ export function createAgentTableDefinitionSource(): AgentDefinitionSource {
         name: agent.name,
         instructions: agent.instructions,
         model: { providerId, modelId },
-        options: {
-          ...(agent.settings.maxOutputTokens !== undefined
-            ? { maxOutputTokens: agent.settings.maxOutputTokens }
-            : {}),
-          ...(agent.settings.reasoningEffort !== undefined
-            ? { reasoningEffort: agent.settings.reasoningEffort }
-            : {}),
-          ...(agent.settings.temperature !== undefined
-            ? { temperature: agent.settings.temperature }
-            : {}),
-        },
+        options: {},
         toolApprovalMode: agent.toolApprovalMode,
       };
     },

--- a/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
@@ -130,9 +130,9 @@ function makeSqliteHarness(): StoreHarness {
         .run(MODEL_ID);
       sqlite
         .prepare(
-          'INSERT INTO agent (id, name, settings, order_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+          'INSERT INTO agent (id, name, order_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
         )
-        .run(id, 'Agent', '{}', 'a0', Date.now(), Date.now());
+        .run(id, 'Agent', 'a0', Date.now(), Date.now());
       return id;
     },
     raw: sqlite,

--- a/src/backend/data/db/__tests__/migrations.test.ts
+++ b/src/backend/data/db/__tests__/migrations.test.ts
@@ -104,7 +104,6 @@ describe('bundled SQLite migrations', () => {
         'instructions',
         'avatar',
         'model_id',
-        'settings',
         'order_key',
         'created_at',
         'updated_at',
@@ -234,8 +233,8 @@ describe('bundled SQLite migrations', () => {
       );
 
       database.exec(`
-        INSERT INTO agent (id, name, settings, order_key, created_at, updated_at)
-        VALUES ('agent-1', 'Agent', '{}', 'a0', 1, 1);
+        INSERT INTO agent (id, name, order_key, created_at, updated_at)
+        VALUES ('agent-1', 'Agent', 'a0', 1, 1);
         INSERT INTO agent_tool_binding (
           id, agent_id, source, capability_id, enabled, approval, created_at, updated_at
         ) VALUES ('binding-builtin', 'agent-1', 'builtin', 'calendar.read', 1, 'auto', 1, 1);

--- a/src/backend/data/db/migrations.ts
+++ b/src/backend/data/db/migrations.ts
@@ -8,6 +8,7 @@ import m0006 from '../../../../migrations/sqlite-drizzle/0006_natural_blur.sql';
 import m0007 from '../../../../migrations/sqlite-drizzle/0007_agent-tool-bindings.sql';
 import m0008 from '../../../../migrations/sqlite-drizzle/0008_context-checkpoint.sql';
 import m0009 from '../../../../migrations/sqlite-drizzle/0009_agent-tool-approval-mode.sql';
+import m0010 from '../../../../migrations/sqlite-drizzle/0010_remove-agent-settings.sql';
 import journal from '../../../../migrations/sqlite-drizzle/meta/_journal.json';
 
 // Expo SQLite migrations must be bundled into JS; unlike the desktop main
@@ -27,5 +28,6 @@ export const migrations = {
     m0007,
     m0008,
     m0009,
+    m0010,
   },
 };

--- a/src/backend/data/db/schemas/agent.ts
+++ b/src/backend/data/db/schemas/agent.ts
@@ -1,6 +1,6 @@
 import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
-import type { AgentSettings, AgentToolApprovalMode } from '@/shared/data/types/agent';
+import type { AgentToolApprovalMode } from '@/shared/data/types/agent';
 
 import {
   createUpdateDeleteTimestamps,
@@ -34,8 +34,6 @@ export const agentTable = sqliteTable(
     // Default model: FK to user_model(id) — UniqueModelId "providerId::modelId"
     // Legitimately nullable: NULL = "no model selected yet"
     modelId: text().references(() => userModelTable.id, { onDelete: 'set null' }),
-    // JSON blob: inference params; creation supplies the product default
-    settings: text({ mode: 'json' }).$type<AgentSettings>().notNull(),
     // Per-Agent interactive approval preference. This does not enable tools.
     toolApprovalMode: text({ enum: ['default', 'auto'] })
       .$type<AgentToolApprovalMode>()

--- a/src/backend/data/services/AgentService.ts
+++ b/src/backend/data/services/AgentService.ts
@@ -17,11 +17,7 @@ import {
 } from '@/shared/data/api/schemas/agents';
 import type { OrderRequest } from '@/shared/data/api/schemas/endpointHelpers';
 import type { OffsetPaginationResponse } from '@/shared/data/api/types';
-import {
-  type Agent,
-  DEFAULT_AGENT_SETTINGS,
-  DEFAULT_AGENT_TOOL_APPROVAL_MODE,
-} from '@/shared/data/types/agent';
+import { type Agent, DEFAULT_AGENT_TOOL_APPROVAL_MODE } from '@/shared/data/types/agent';
 import type { UniqueModelId } from '@/shared/data/types/model';
 
 import { modelService } from './ModelService';
@@ -46,7 +42,6 @@ function rowToAgent(row: AgentRow, modelName: null | string = null): Agent {
     modelName,
     name: row.name,
     orderKey: row.orderKey,
-    settings: row.settings,
     toolApprovalMode: row.toolApprovalMode,
     updatedAt: timestampToISO(row.updatedAt),
   };
@@ -158,7 +153,6 @@ export class AgentService {
         {
           ...dto,
           modelId,
-          settings: dto.settings ?? DEFAULT_AGENT_SETTINGS,
           toolApprovalMode: dto.toolApprovalMode ?? DEFAULT_AGENT_TOOL_APPROVAL_MODE,
         },
         { pkColumn: agentTable.id, scope: isNull(agentTable.deletedAt) },
@@ -175,14 +169,9 @@ export class AgentService {
       this.validateName(dto.name);
     }
 
-    const { settings: settingsPatch, ...columnFields } = dto;
     const updates = Object.fromEntries(
-      Object.entries(columnFields).filter(([, value]) => value !== undefined),
+      Object.entries(dto).filter(([, value]) => value !== undefined),
     ) as Partial<typeof agentTable.$inferInsert>;
-
-    if (settingsPatch !== undefined) {
-      updates.settings = { ...current.settings, ...settingsPatch };
-    }
 
     if (Object.keys(updates).length === 0) {
       return current;

--- a/src/backend/data/services/__tests__/AgentService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentService.integration.test.ts
@@ -68,7 +68,7 @@ describe('AgentService persistence', () => {
     sqlite.close();
   });
 
-  it('creates with default settings and inherits the default-model preference', async () => {
+  it('creates with definition defaults and inherits the default-model preference', async () => {
     insertUserModel(sqlite, 'openai', 'gpt-4');
     preferenceGet.mockResolvedValue('openai::gpt-4');
 
@@ -79,7 +79,6 @@ describe('AgentService persistence', () => {
       instructions: '',
       modelId: 'openai::gpt-4',
       name: 'Researcher',
-      settings: {},
       toolApprovalMode: 'default',
     });
   });
@@ -115,23 +114,6 @@ describe('AgentService persistence', () => {
     ).rejects.toBeDefined();
   });
 
-  it('merges settings updates over the stored blob instead of replacing it', async () => {
-    const agent = await agentService.create({
-      name: 'Researcher',
-      settings: { futureSetting: true, temperature: 0.2 },
-    });
-
-    const updated = await agentService.update(agent.id, {
-      settings: { reasoningEffort: 'high' },
-    });
-
-    expect(updated.settings).toEqual({
-      futureSetting: true,
-      reasoningEffort: 'high',
-      temperature: 0.2,
-    });
-  });
-
   it('advances the Agent version when updates share one wall-clock millisecond', async () => {
     jest.spyOn(Date, 'now').mockReturnValue(1_000);
     const agent = await agentService.create({ name: 'Researcher' });
@@ -141,21 +123,6 @@ describe('AgentService persistence', () => {
 
     expect(Date.parse(firstUpdate.updatedAt)).toBeGreaterThan(Date.parse(agent.updatedAt));
     expect(Date.parse(secondUpdate.updatedAt)).toBeGreaterThan(Date.parse(firstUpdate.updatedAt));
-  });
-
-  it('clears a stored setting when the patch carries the key as explicit undefined', async () => {
-    const agent = await agentService.create({
-      name: 'Researcher',
-      settings: { futureSetting: true, temperature: 0.2 },
-    });
-
-    const updated = await agentService.update(agent.id, {
-      settings: { temperature: undefined },
-    });
-
-    expect(updated.settings).toEqual({ futureSetting: true });
-    // The JSON column must not resurrect the key on a fresh read.
-    expect((await agentService.getById(agent.id)).settings).toEqual({ futureSetting: true });
   });
 
   it('filters by search and persists explicit ordering changes', async () => {

--- a/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
@@ -15,8 +15,8 @@ describe('AgentSessionMessageService persistence', () => {
     await installTestHost({ DbService: testDb.dbService });
     sqlite
       .prepare(
-        `INSERT INTO agent (id, name, settings, order_key, created_at, updated_at)
-         VALUES ('agent-1', 'Agent', '{}', 'a0', 1, 1)`,
+        `INSERT INTO agent (id, name, order_key, created_at, updated_at)
+         VALUES ('agent-1', 'Agent', 'a0', 1, 1)`,
       )
       .run();
     insertSession(sqlite, 'session-1');

--- a/src/backend/data/services/__tests__/AgentSessionService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionService.integration.test.ts
@@ -64,8 +64,8 @@ describe('AgentSessionService persistence', () => {
 function insertAgent(database: DatabaseSync, id: string): void {
   database
     .prepare(
-      `INSERT INTO agent (id, name, settings, order_key, created_at, updated_at)
-       VALUES (?, ?, '{}', ?, 1, 1)`,
+      `INSERT INTO agent (id, name, order_key, created_at, updated_at)
+       VALUES (?, ?, ?, 1, 1)`,
     )
     .run(id, id, id);
 }

--- a/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
+++ b/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
@@ -93,9 +93,9 @@ describe('auxiliary Data API integration', () => {
     const assistantMessageId = mockRandomUUID();
     sqlite
       .prepare(
-        'INSERT INTO agent (id, name, settings, order_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+        'INSERT INTO agent (id, name, order_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
       )
-      .run(agentId, 'Needle Agent', '{}', 'a0', now, now);
+      .run(agentId, 'Needle Agent', 'a0', now, now);
     sqlite
       .prepare(
         'INSERT INTO agent_session (id, agent_id, title, title_is_manual, last_activity_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',

--- a/src/frontend/features/agents/__tests__/agentForm.test.ts
+++ b/src/frontend/features/agents/__tests__/agentForm.test.ts
@@ -12,7 +12,6 @@ describe('createAgentFormState', () => {
       instructions: 'sys',
       modelId: 'openai::gpt-5',
       name: 'Researcher',
-      settings: { temperature: 0.4 },
       toolApprovalMode: 'auto',
     } as unknown as Agent);
 

--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -95,11 +95,7 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
   const selectedModelLabel = selectedModel?.name;
   const reasoningEfforts = useChatInputReasoningEfforts(selectedModel);
   const { isReasoningEffortSelected, reasoningEffort, selectReasoningEffort } =
-    useChatInputReasoningEffortSelection(
-      reasoningEfforts,
-      agent?.settings.reasoningEffort,
-      agentId,
-    );
+    useChatInputReasoningEffortSelection(reasoningEfforts, agentId);
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
   const [isInputActive, setIsInputActive] = useState(false);
   const isInputActiveRef = useRef(false);
@@ -209,7 +205,6 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
               reasoningEffort: getChatInputReasoningEffortSnapshot(
                 reasoningEffort,
                 isReasoningEffortSelected,
-                agent?.settings.reasoningEffort,
                 reasoningEfforts,
               ),
             }
@@ -222,7 +217,6 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
       });
     },
     [
-      agent?.settings.reasoningEffort,
       isReasoningEffortSelected,
       reasoningEffort,
       reasoningEfforts,

--- a/src/frontend/features/chat/input/hooks/__tests__/useChatInputReasoningEffortSelection.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useChatInputReasoningEffortSelection.test.tsx
@@ -1,4 +1,3 @@
-import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
@@ -8,13 +7,12 @@ import { useChatInputReasoningEffortSelection } from '../useChatInputReasoningEf
 type Snapshot = ReturnType<typeof useChatInputReasoningEffortSelection>;
 
 describe('useChatInputReasoningEffortSelection', () => {
-  test('shows the Agent effort without turning it into a local override', async () => {
+  test('uses the model default without turning it into a local override', async () => {
     let snapshot: Snapshot | undefined;
 
     await act(async () => {
       create(
         <Harness
-          agentEffort="high"
           availableEfforts={['default', 'low', 'high']}
           onSnapshot={(value) => {
             snapshot = value;
@@ -25,16 +23,15 @@ describe('useChatInputReasoningEffortSelection', () => {
 
     expect(snapshot).toMatchObject({
       isReasoningEffortSelected: false,
-      reasoningEffort: 'high',
+      reasoningEffort: 'default',
     });
   });
 
-  test('keeps a composer selection when the Agent value refreshes', async () => {
+  test('keeps a composer selection across a rerender', async () => {
     let snapshot: Snapshot | undefined;
     let renderer: ReactTestRenderer | undefined;
-    const renderHarness = (agentEffort: ReasoningEffortOption) => (
+    const renderHarness = () => (
       <Harness
-        agentEffort={agentEffort}
         availableEfforts={['default', 'low', 'high']}
         onSnapshot={(value) => {
           snapshot = value;
@@ -43,10 +40,10 @@ describe('useChatInputReasoningEffortSelection', () => {
     );
 
     await act(async () => {
-      renderer = create(renderHarness('low'));
+      renderer = create(renderHarness());
     });
     await act(async () => snapshot?.selectReasoningEffort('high'));
-    await act(async () => renderer?.update(renderHarness('low')));
+    await act(async () => renderer?.update(renderHarness()));
 
     expect(snapshot).toMatchObject({
       isReasoningEffortSelected: true,
@@ -57,9 +54,8 @@ describe('useChatInputReasoningEffortSelection', () => {
   test('clears a composer selection when the Agent changes', async () => {
     let snapshot: Snapshot | undefined;
     let renderer: ReactTestRenderer | undefined;
-    const renderHarness = (agentId: string, agentEffort: ReasoningEffortOption) => (
+    const renderHarness = (agentId: string) => (
       <Harness
-        agentEffort={agentEffort}
         agentId={agentId}
         availableEfforts={['default', 'low', 'high']}
         onSnapshot={(value) => {
@@ -69,30 +65,28 @@ describe('useChatInputReasoningEffortSelection', () => {
     );
 
     await act(async () => {
-      renderer = create(renderHarness('agent-a', 'low'));
+      renderer = create(renderHarness('agent-a'));
     });
     await act(async () => snapshot?.selectReasoningEffort('high'));
-    await act(async () => renderer?.update(renderHarness('agent-b', 'low')));
+    await act(async () => renderer?.update(renderHarness('agent-b')));
 
     expect(snapshot).toMatchObject({
       isReasoningEffortSelected: false,
-      reasoningEffort: 'low',
+      reasoningEffort: 'default',
     });
   });
 });
 
 function Harness({
-  agentEffort,
   agentId,
   availableEfforts,
   onSnapshot,
 }: {
-  agentEffort: ReasoningEffortOption;
   agentId?: string;
   availableEfforts: readonly ChatInputReasoningEffort[];
   onSnapshot: (snapshot: Snapshot) => void;
 }) {
-  const snapshot = useChatInputReasoningEffortSelection(availableEfforts, agentEffort, agentId);
+  const snapshot = useChatInputReasoningEffortSelection(availableEfforts, agentId);
 
   useEffect(() => onSnapshot(snapshot), [onSnapshot, snapshot]);
   return null;

--- a/src/frontend/features/chat/input/hooks/useChatInputReasoningEffortSelection.ts
+++ b/src/frontend/features/chat/input/hooks/useChatInputReasoningEffortSelection.ts
@@ -1,4 +1,3 @@
-import type { ReasoningEffortOption } from '@cherrystudio/universal/types/aiSdk';
 import { useCallback, useState } from 'react';
 
 import {
@@ -13,12 +12,11 @@ type ReasoningEffortOverride = {
 };
 
 /**
- * Owns the composer's per-turn reasoning selection. Agent configuration is an
- * inherited fallback only and is never mutated by this state.
+ * Owns the composer's per-turn reasoning selection. Without a local override,
+ * the selected model's default reasoning mode is used.
  */
 export function useChatInputReasoningEffortSelection(
   reasoningEfforts: readonly ChatInputReasoningEffort[],
-  agentReasoningEffort: ReasoningEffortOption = CHAT_INPUT_DEFAULT_REASONING_EFFORT,
   agentId?: string | null,
 ) {
   const [override, setOverride] = useState<ReasoningEffortOverride | null>(null);
@@ -42,7 +40,7 @@ export function useChatInputReasoningEffortSelection(
   return {
     isReasoningEffortSelected: activeOverride !== null,
     reasoningEffort: resolveAvailableChatInputReasoningEffort(
-      activeOverride?.reasoningEffort ?? agentReasoningEffort,
+      activeOverride?.reasoningEffort ?? CHAT_INPUT_DEFAULT_REASONING_EFFORT,
       reasoningEfforts,
     ),
     selectReasoningEffort,

--- a/src/frontend/features/chat/input/utils/__tests__/chatInputReasoning.test.ts
+++ b/src/frontend/features/chat/input/utils/__tests__/chatInputReasoning.test.ts
@@ -61,16 +61,15 @@ describe('chat input reasoning', () => {
     ]);
   });
 
-  test('snapshots the assistant effort until the user selects a request override', () => {
+  test('snapshots the model default until the user selects a request override', () => {
     expect(getChatInputReasoningEffortSnapshot('high', false)).toBe('default');
-    expect(
-      getChatInputReasoningEffortSnapshot('default', false, 'high', ['default', 'low', 'high']),
-    ).toBe('high');
-    expect(
-      getChatInputReasoningEffortSnapshot('high', false, 'max', ['default', 'low', 'high']),
-    ).toBe('high');
+    expect(getChatInputReasoningEffortSnapshot('high', false, ['default', 'low', 'high'])).toBe(
+      'default',
+    );
     expect(getChatInputReasoningEffortSnapshot('high', true)).toBe('high');
-    expect(getChatInputReasoningEffortSnapshot('low', true, 'high')).toBe('low');
+    expect(getChatInputReasoningEffortSnapshot('low', true, ['default', 'low', 'high'])).toBe(
+      'low',
+    );
   });
 });
 

--- a/src/frontend/features/chat/input/utils/chatInputReasoning.ts
+++ b/src/frontend/features/chat/input/utils/chatInputReasoning.ts
@@ -112,12 +112,11 @@ export function resolveAvailableChatInputReasoningEffort(
 export function getChatInputReasoningEffortSnapshot(
   reasoningEffort: ChatInputReasoningEffort,
   isReasoningEffortSelected: boolean,
-  assistantReasoningEffort?: ReasoningEffortOption,
   availableEfforts: readonly ChatInputReasoningEffort[] = [],
 ): ReasoningEffortOption {
   if (isReasoningEffortSelected) return reasoningEffort;
   return resolveAvailableChatInputReasoningEffort(
-    assistantReasoningEffort ?? CHAT_INPUT_DEFAULT_REASONING_EFFORT,
+    CHAT_INPUT_DEFAULT_REASONING_EFFORT,
     availableEfforts,
   );
 }

--- a/src/shared/data/api/schemas/__tests__/agents.test.ts
+++ b/src/shared/data/api/schemas/__tests__/agents.test.ts
@@ -16,12 +16,6 @@ describe('agent api schemas', () => {
     },
   );
 
-  test('accepts partial settings updates without requiring the full settings object', () => {
-    expect(UpdateAgentSchema.safeParse({ settings: { reasoningEffort: 'high' } }).success).toBe(
-      true,
-    );
-  });
-
   test.each([CreateAgentSchema, UpdateAgentSchema])(
     'accepts only supported tool approval modes',
     (schema) => {
@@ -33,22 +27,17 @@ describe('agent api schemas', () => {
     },
   );
 
-  test('keeps unknown settings fields in update payloads', () => {
-    expect(
-      UpdateAgentSchema.parse({
-        settings: { futureSetting: { enabled: true }, temperature: 0.5 },
-      }),
-    ).toEqual({
-      settings: { futureSetting: { enabled: true }, temperature: 0.5 },
-    });
-  });
-
-  test('preserves explicit-undefined settings keys so a patch can clear them', () => {
-    const parsed = UpdateAgentSchema.parse({ settings: { temperature: undefined } });
-
-    expect(parsed.settings).toBeDefined();
-    expect(Object.keys(parsed.settings ?? {})).toContain('temperature');
-  });
+  test.each([CreateAgentSchema, UpdateAgentSchema])(
+    'rejects removed per-Agent inference settings',
+    (schema) => {
+      expect(
+        schema.safeParse({
+          name: 'Agent',
+          settings: { maxOutputTokens: 2048, reasoningEffort: 'high', temperature: 0.5 },
+        }).success,
+      ).toBe(false);
+    },
+  );
 
   test.each([CreateAgentSchema, UpdateAgentSchema])(
     'rejects avatar writes — the avatar workflow owns that column',

--- a/src/shared/data/api/schemas/agents.ts
+++ b/src/shared/data/api/schemas/agents.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import type { OffsetPaginationResponse } from '@/shared/data/api/types';
-import { type Agent, AgentSchema, AgentSettingsSchema } from '@/shared/data/types/agent';
+import { type Agent, AgentSchema } from '@/shared/data/types/agent';
 
 import { type OrderEndpoints } from './endpointHelpers';
 
@@ -14,7 +14,6 @@ const AGENT_MUTABLE_FIELDS = {
   instructions: true,
   modelId: true,
   name: true,
-  settings: true,
   toolApprovalMode: true,
 } as const;
 
@@ -24,12 +23,7 @@ export const CreateAgentSchema = AgentSchema.pick(AGENT_MUTABLE_FIELDS)
   .strict();
 export type CreateAgentDto = z.infer<typeof CreateAgentSchema>;
 
-export const UpdateAgentSchema = AgentSchema.pick(AGENT_MUTABLE_FIELDS)
-  .partial()
-  .extend({
-    settings: AgentSettingsSchema.partial().optional(),
-  })
-  .strict();
+export const UpdateAgentSchema = AgentSchema.pick(AGENT_MUTABLE_FIELDS).partial().strict();
 export type UpdateAgentDto = z.infer<typeof UpdateAgentSchema>;
 
 /**

--- a/src/shared/data/types/agent.ts
+++ b/src/shared/data/types/agent.ts
@@ -2,25 +2,6 @@ import * as z from 'zod';
 
 import { UniqueModelIdSchema } from '@/shared/data/types/model';
 
-/**
- * Inference parameters for an Agent.
- *
- * Loose (passthrough) on purpose: the column is a JSON blob that outlives app
- * versions, so unknown keys written by a newer or older build must survive a
- * read-modify-write round trip instead of being silently dropped. Capability
- * toggles are deliberately absent — capabilities are tools, not agent booleans
- * (docs/references/agent/agent-persistence.md).
- */
-export const AgentSettingsSchema = z.looseObject({
-  temperature: z.number().min(0).max(2).optional(),
-  maxOutputTokens: z.number().int().positive().optional(),
-  reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
-});
-export type AgentSettings = z.infer<typeof AgentSettingsSchema>;
-
-/** Creation default: every parameter unset means "use the model's defaults". */
-export const DEFAULT_AGENT_SETTINGS: AgentSettings = {};
-
 /** Controls only interactive tool approval; it never grants tool availability or resource access. */
 export const AgentToolApprovalModeSchema = z.enum(['default', 'auto']);
 export type AgentToolApprovalMode = z.infer<typeof AgentToolApprovalModeSchema>;
@@ -47,7 +28,6 @@ export const AgentSchema = z.strictObject({
   modelName: z.string().nullable(),
   name: z.string().min(1),
   orderKey: z.string(),
-  settings: AgentSettingsSchema,
   toolApprovalMode: AgentToolApprovalModeSchema,
   updatedAt: z.iso.datetime(),
 });


### PR DESCRIPTION
## Summary

- remove the unused `agent.settings` JSON column and its `temperature`, `maxOutputTokens`, and `reasoningEffort` fields from persistence and Data API contracts
- use the selected model default for Agent chat reasoning unless the user chooses a per-turn override
- append migration `0010_remove-agent-settings`, update the bundled migration registry, and align documentation and test fixtures

## Data migration

Existing values in `agent.settings` are intentionally discarded. The product had no normal write path for these settings; Agent creation stored an empty object, and reasoning selection remains a per-turn composer choice.

Historical inference snapshots and runtime request parameter types remain unchanged because they record or carry actual execution parameters rather than Agent configuration.

## Validation

- `pnpm format:check`
- targeted Oxlint and Expo lint for changed TypeScript files
- `git diff --check`
- commit hook `oxfmt`

Not run per repository instructions: tests, typecheck, and device verification.

Full `pnpm lint` reached Expo lint but is currently blocked by eight existing unresolved imports for the unbuilt `@cherrystudio/ai-core` package; Oxlint completed with warnings only. The desktop AI sync audit is also blocked by a pre-existing exclusion mismatch for `src/main/ai/messages/fileProcessor.ts`.