### PR TITLE
refactor(messages): centralize message layout ownership

### DIFF
--- a/.rnstorybook/stories/messages/MessagesStoryFrame.tsx
+++ b/.rnstorybook/stories/messages/MessagesStoryFrame.tsx
@@ -22,8 +22,8 @@ export function MessagesStoryFrame({
           contentInsetAdjustmentBehavior="automatic"
         >
           {examples.map(({ label, message }) => (
-            <View key={message.id}>
-              <Text className="px-4 font-medium text-foreground-tertiary text-sm">{label}</Text>
+            <View className="gap-2 px-4" key={message.id}>
+              <Text className="font-medium text-foreground-tertiary text-sm">{label}</Text>
               {message.role === 'user' ? (
                 <UserMessage message={message} />
               ) : (

--- a/docs/guides/ui-development.md
+++ b/docs/guides/ui-development.md
@@ -43,11 +43,38 @@ Apply this rule prospectively. Do not migrate an untouched `forwardRef` componen
 Render callbacks remain appropriate when a parent must supply item data, such as a virtualized
 list's `renderItem`.
 
+## Own Layout At The Container Boundary
+
+A container owns the placement of its immediate children: flow, alignment, external spacing,
+content insets, and constraints imposed by the available region. A child owns its intrinsic
+content, internal spacing, surface, typography, and interactions. Natural child-size changes still
+participate in layout; a child must not reach outward with margins, offsets, or parent-specific
+positioning to arrange its siblings.
+
+- Put sibling spacing on their common container with `gap` or container padding. Do not distribute
+  half of a gap across child margins.
+- Keep reusable content components free of screen and list gutters. The screen, list, grid, or row
+  frame that places them owns those external insets.
+- Do not repeat a child's private padding or internal dimensions as a magic number in its parent.
+  When parent behavior genuinely needs child geometry, prefer measured size; otherwise expose the
+  smallest explicit layout contract from the child owner and derive the parent value from it.
+- A composition component owns the ordering and spacing of the parts it combines. Individual parts
+  own only their internal presentation and interaction unless their public API explicitly states a
+  layout role.
+- In a virtualized list, keep viewport and content insets at the list boundary, row placement in a
+  list-owned row frame, and rendered item content below that frame. Size estimates and anchoring
+  must include the row frame without teaching item content about virtualization.
+
+This complements the single-owner spacing rule in [`DESIGN.md`](../../DESIGN.md#shape-and-spacing):
+the visual specification defines how spacing is chosen, while this guide defines which component
+owns it.
+
 ## Acceptance
 
 - Shared controls retain accessible labels, states, scalable text, and usable platform fallbacks.
 - Competing gestures have one documented winner and cancelled interactions do not fire on release.
 - Feature components keep business state and translations outside CherryUI.
+- Containers own external placement and reusable children do not carry screen-specific gutters.
 - Visual changes are inspected in light and dark themes on a device.
 - iOS device work in parallel worktrees follows
   [Parallel Device Testing](./parallel-device-testing.md).

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -11,14 +11,14 @@ import { usePreference } from '@/frontend/data/hooks';
 import { emitLayoutBenchProbe } from '@/shared/devBench/layoutBenchProbe';
 
 import {
-  ANCHOR_MAX_TEXT_LINES,
   ANCHOR_TOP_GAP,
   getAnchoredUserMessageIndex,
   getMessageRowType,
   MAINTAIN_VISIBLE_CONTENT_POSITION,
   messageKeyExtractor,
-  USER_MESSAGE_VERTICAL_PADDING,
+  resolveUserMessageAnchorMaxSize,
 } from './list/messageListLayout';
+import { MessageListRow } from './list/MessageListRow';
 import { useMessageListAnchorPin } from './list/useMessageListAnchorPin';
 import {
   emitProgrammaticScroll,
@@ -77,7 +77,9 @@ export function MessageList({
   const anchorIndex = getAnchoredUserMessageIndex(messages);
   const listHeader = useMemo(() => <View style={{ height: contentTopInset }} />, [contentTopInset]);
   const renderMessageRow = useCallback(
-    ({ item }: LegendListRenderItemProps<MessageListItem>) => renderMessage(item),
+    ({ item }: LegendListRenderItemProps<MessageListItem>) => (
+      <MessageListRow message={item} renderMessage={renderMessage} />
+    ),
     [renderMessage],
   );
   const handleStartReached = useCallback(() => {
@@ -93,14 +95,13 @@ export function MessageList({
   const anchorHasFile = anchorMessage?.data.parts?.some((part) => part.type === 'file') ?? false;
   const anchorMaxSize = anchorHasFile
     ? undefined
-    : ANCHOR_MAX_TEXT_LINES * resolveTypographyScale(fontSizeStep).base.lineHeight +
-      USER_MESSAGE_VERTICAL_PADDING;
+    : resolveUserMessageAnchorMaxSize(resolveTypographyScale(fontSizeStep).base.lineHeight);
   const { freeze, scrollMessageToEnd } = useKeyboardScrollToEnd({ listRef });
   // 被锚定用户消息的固定落点：距内容区顶部（导航栏/安全区之下）ANCHOR_TOP_GAP。
   // anchoredEndSpace 与钉顶滚动共用同一偏移，保证「预留空白算出的位置」和「滚动落点」一致。
   const anchorOffset = contentTopInset + ANCHOR_TOP_GAP;
   const contentContainerStyle = useMemo(
-    () => ({ paddingBottom: contentBottomInset, paddingTop: 12 }),
+    () => ({ paddingBottom: contentBottomInset, paddingTop: ANCHOR_TOP_GAP }),
     [contentBottomInset],
   );
 

--- a/src/frontend/components/messages/README.md
+++ b/src/frontend/components/messages/README.md
@@ -12,12 +12,12 @@ history, message rows and parts, live-turn anchoring, and entry motion.
 - `MessageListProps` accepts layout measurements plus optional pagination, readiness, entry-motion,
   bottom-accessory inputs, the feature renderer, and optional `extraData` for rendered state that is
   not carried by message items. Single-turn workspaces can opt into animating their first anchor.
-- `AssistantMessage` owns the standard assistant row: pending placeholder, structured parts, and
-  entry motion. Its `children` render after the message body, so a feature composes its own accessory
-  (a toolbar, for example) into an otherwise standard message instead of teaching this module about
-  that feature's state. The slot is unconditional, including while the placeholder is up; an
-  accessory holds the message and decides for itself when to appear.
-- `UserMessage` owns the standard user row, including managed attachments and the text bubble.
+- `AssistantMessage` owns standard assistant content: the pending placeholder, structured parts,
+  and entry motion. Its `children` render after the message body, so a feature composes its own
+  accessory (a toolbar, for example) without teaching this module about that feature's state. The
+  slot is unconditional, including while the placeholder is up; an accessory holds the message and
+  decides for itself when to appear.
+- `UserMessage` owns standard user content, including managed attachments and the text bubble.
 - `getBuiltInToolDisplay` exposes the shared title and platform-specific icon used by
   feature-owned tool approval UI.
 
@@ -39,12 +39,50 @@ The module accepts only visible `user` and `assistant` messages. A feature that 
 roles must explicitly filter or adapt them before crossing this interface. Feature runtime,
 persistence entities, composer state, and tool-approval orchestration remain with their owners.
 
+### Composition And Layout Contract
+
+The screen composes the message history and composer as sibling regions. Within the history, layout
+ownership flows from the list toward intrinsic content:
+
+```text
+ChatScreen or PaintingComposer
+├── message workspace
+│   └── MessageList
+│       └── list-owned row frame
+│           └── feature role renderer
+│               └── UserMessage or AssistantMessage
+│                   └── MessageParts
+│                       └── individual part renderers
+└── Composer.Dock
+```
+
+- The screen owns whether the message list and composer exist and passes their measured top and
+  bottom insets across the list API.
+- `MessageList` owns scrolling, content insets, row gutters, role-level row spacing, anchoring, and
+  the placement of every rendered message. The feature renderer supplies content; it does not
+  recreate list spacing.
+- `UserMessage` and `AssistantMessage` own role presentation inside the row frame. They may define
+  intrinsic width, internal grouping, bubbles, surfaces, and entry motion, but do not add list or
+  screen gutters.
+- `MessageParts` owns part order and spacing. Each part renderer owns only its internal visual and
+  interaction contract; it does not position sibling parts or reach into the row frame.
+- Feature-owned accessories, such as the assistant toolbar, compose after the message body. Their
+  spacing from the body belongs to the assistant composition, not to an individual part.
+- Parent layout must not copy private child padding. The latest-user text cap is the one current
+  cross-layer geometry requirement: the user-message owner exposes its content-height contract,
+  and the list derives the final capped row height by adding its own row padding. Messages with
+  file parts continue to use their full measured height.
+
+Exact spacing values live in code, not this document. Changing a list gutter or row inset must have
+one list-owned source; changing intrinsic message padding must update the content owner's explicit
+geometry contract when anchoring depends on it.
+
 ## List Behavior
 
 `MessageList` owns its `LegendList` ref, role-based recycling types, latest-user anchor derivation,
-keyboard lift, at-bottom shared value, entry-animation provider, and the business wiring for the
-optional CherryUI scroll-to-bottom button. Callers provide stable message item references and
-only the layout insets and callbacks they own.
+keyboard lift, at-bottom shared value, row frames, entry-animation provider, and the business wiring
+for the optional CherryUI scroll-to-bottom button. Callers provide stable message item references
+and only the layout insets and callbacks they own.
 
 The latest user message is anchored below the content header. Text anchors use a two-line height
 cap; messages containing files use their full measured height. Initial Session entry and sending a
@@ -69,12 +107,12 @@ and anchoring.
 ## Organization
 
 - `MessageList.tsx` is the wiring layer. `list/` owns its layout policy, anchor pinning, readiness
-  gate, interaction lock, and dev-only instrumentation.
-- `rows/` owns the standard user and assistant row layouts.
+  gate, role-level row frame, interaction lock, and dev-only instrumentation.
+- `rows/` owns the intrinsic user and assistant presentation inside the list-owned row frame.
 - `motion/` carries the private slide-in provider shared by the list and rows.
-- `parts/` adapts Cherry message schema parts into CherryUI primitives. `parts/tools/` owns tool
-  dispatch and tool-specific adapters; `parts/tools/metaTool/` composes explicit search, inspect,
-  invoke, and exec variants.
+- `parts/` owns ordered part composition and adapts Cherry message schema parts into CherryUI
+  primitives. `parts/tools/` owns tool dispatch and tool-specific adapters;
+  `parts/tools/metaTool/` composes explicit search, inspect, invoke, and exec variants.
 - `parts/tools/builtInTool/` owns shared built-in tool labels. Only its `builtInToolIcon/` family is
   platform-specific.
 

--- a/src/frontend/components/messages/list/MessageListRow.tsx
+++ b/src/frontend/components/messages/list/MessageListRow.tsx
@@ -1,0 +1,30 @@
+import { StyleSheet, type StyleProp, View, type ViewStyle } from 'react-native';
+
+import type { MessageListItem, MessageRenderer } from '../types';
+import { MESSAGE_ROW_HORIZONTAL_PADDING, MESSAGE_ROW_VERTICAL_PADDING } from './messageListLayout';
+
+type MessageListRowProps = {
+  message: MessageListItem;
+  renderMessage: MessageRenderer;
+};
+
+export function MessageListRow({ message, renderMessage }: MessageListRowProps) {
+  return <View style={messageRowStyles[message.role]}>{renderMessage(message)}</View>;
+}
+
+const styles = StyleSheet.create({
+  assistant: {
+    paddingVertical: MESSAGE_ROW_VERTICAL_PADDING.assistant,
+  },
+  root: {
+    paddingHorizontal: MESSAGE_ROW_HORIZONTAL_PADDING,
+  },
+  user: {
+    paddingVertical: MESSAGE_ROW_VERTICAL_PADDING.user,
+  },
+});
+
+const messageRowStyles = {
+  assistant: [styles.root, styles.assistant],
+  user: [styles.root, styles.user],
+} satisfies Record<MessageListItem['role'], StyleProp<ViewStyle>>;

--- a/src/frontend/components/messages/list/messageListLayout.ts
+++ b/src/frontend/components/messages/list/messageListLayout.ts
@@ -1,9 +1,19 @@
+import { resolveUserMessageContentAnchorMaxSize } from '../rows/userMessageLayout';
 import type { MessageListItem } from '../types';
 
 // 被锚定的用户消息距内容区顶部（顶部安全区/导航栏之下）的视觉间距。
 export const ANCHOR_TOP_GAP = 12;
-export const ANCHOR_MAX_TEXT_LINES = 2;
-export const USER_MESSAGE_VERTICAL_PADDING = 32;
+export const MESSAGE_ROW_HORIZONTAL_PADDING = 16;
+export const MESSAGE_ROW_VERTICAL_PADDING = {
+  assistant: 12,
+  user: 8,
+} as const satisfies Record<MessageListItem['role'], number>;
+
+export function resolveUserMessageAnchorMaxSize(bodyLineHeight: number) {
+  return (
+    resolveUserMessageContentAnchorMaxSize(bodyLineHeight) + MESSAGE_ROW_VERTICAL_PADDING.user * 2
+  );
+}
 
 // 流式助手消息高度持续变化，不能成为 MVCP 的锚点，否则它会把已钉顶的用户消息向下推。
 function shouldRestoreMessagePosition(item: MessageListItem): boolean {

--- a/src/frontend/components/messages/parts/MessageParts.tsx
+++ b/src/frontend/components/messages/parts/MessageParts.tsx
@@ -1,3 +1,5 @@
+import { View } from 'react-native';
+
 import type { MessageListItem } from '../types';
 import { resolveMessageCitationText } from './citations';
 import { MessagePartRenderer } from './MessagePartRenderer';
@@ -26,16 +28,20 @@ export function MessageParts({ message, renderMode = 'markdown' }: MessagePartsP
 
   const citationText = resolveMessageCitationText(parts);
 
-  return parts.map((part, index) => {
-    const resolvedText = citationText.get(index);
-    return (
-      <MessagePartRenderer
-        isStreaming={message.status === 'pending'}
-        key={getMessagePartKey(message, part, index)}
-        part={part}
-        renderMode={renderMode}
-        resolvedText={resolvedText}
-      />
-    );
-  });
+  return (
+    <View className="gap-2">
+      {parts.map((part, index) => {
+        const resolvedText = citationText.get(index);
+        return (
+          <MessagePartRenderer
+            isStreaming={message.status === 'pending'}
+            key={getMessagePartKey(message, part, index)}
+            part={part}
+            renderMode={renderMode}
+            resolvedText={resolvedText}
+          />
+        );
+      })}
+    </View>
+  );
 }

--- a/src/frontend/components/messages/rows/AssistantMessage.tsx
+++ b/src/frontend/components/messages/rows/AssistantMessage.tsx
@@ -41,7 +41,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   const slideInStyle = useAssistantMessageSlideInStyle(message.id);
 
   return (
-    <Animated.View className="w-full gap-2 px-4 py-3" style={slideInStyle}>
+    <Animated.View className="w-full gap-2" style={slideInStyle}>
       <AssistantMessageBody message={message} />
       {children}
     </Animated.View>

--- a/src/frontend/components/messages/rows/UserMessage.tsx
+++ b/src/frontend/components/messages/rows/UserMessage.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { useUserMessageSlideInStyle } from '../motion/useUserMessageSlideInStyle';
@@ -7,6 +7,7 @@ import { MessageParts } from '../parts/MessageParts';
 import type { MessageListItem } from '../types';
 import { partitionUserMessageParts } from './partitionUserMessageParts';
 import { UserMessageAttachments } from './UserMessageAttachments';
+import { USER_MESSAGE_BUBBLE_PADDING } from './userMessageLayout';
 
 type UserMessageProps = {
   message: MessageListItem;
@@ -17,14 +18,14 @@ export const UserMessage = memo(function UserMessage({ message }: UserMessagePro
   const { attachments, bodyMessage } = useMemo(() => partitionUserMessageParts(message), [message]);
 
   return (
-    <Animated.View className="w-full items-end px-4 py-2" style={slideInStyle}>
+    <Animated.View className="w-full items-end" style={slideInStyle}>
       <View className="max-w-[86%]">
         <View className="items-end gap-2">
           {attachments.length > 0 ? (
             <UserMessageAttachments attachments={attachments} messageId={message.id} />
           ) : null}
           {bodyMessage ? (
-            <View className="self-end rounded-xl bg-chat-user p-2">
+            <View className="self-end rounded-xl bg-chat-user" style={styles.bubble}>
               <MessageParts message={bodyMessage} renderMode="plainText" />
             </View>
           ) : null}
@@ -32,4 +33,10 @@ export const UserMessage = memo(function UserMessage({ message }: UserMessagePro
       </View>
     </Animated.View>
   );
+});
+
+const styles = StyleSheet.create({
+  bubble: {
+    padding: USER_MESSAGE_BUBBLE_PADDING,
+  },
 });

--- a/src/frontend/components/messages/rows/userMessageLayout.ts
+++ b/src/frontend/components/messages/rows/userMessageLayout.ts
@@ -1,0 +1,12 @@
+const USER_MESSAGE_ANCHOR_TEXT_LINES = 2;
+
+export const USER_MESSAGE_BUBBLE_PADDING = 8;
+
+/**
+ * The user-message content height that may participate in the latest-message anchor.
+ * The list adds its own row padding separately, so this contract stays owned by the
+ * user-message presentation instead of duplicating its bubble geometry in the list.
+ */
+export function resolveUserMessageContentAnchorMaxSize(bodyLineHeight: number) {
+  return USER_MESSAGE_ANCHOR_TEXT_LINES * bodyLineHeight + USER_MESSAGE_BUBBLE_PADDING * 2;
+}

--- a/src/frontend/features/paintings/components/PaintingAssistantMessage.tsx
+++ b/src/frontend/features/paintings/components/PaintingAssistantMessage.tsx
@@ -93,7 +93,7 @@ export function PaintingAssistantMessage({
   const failureMessage = error?.message ?? interruption?.message;
   if (status !== 'generating' && (error || interruption)) {
     return (
-      <View className="w-full px-4 py-3">
+      <View className="w-full">
         <View className="flex-row items-start gap-2 rounded-md border border-border bg-card p-3">
           <CircleAlertIcon className="mt-0.5 size-5 text-destructive" />
           <View className="min-w-0 flex-1 gap-0.5">
@@ -163,7 +163,7 @@ export function PaintingAssistantMessage({
   });
 
   return (
-    <View className="w-full px-4 py-3">
+    <View className="w-full">
       <View className="relative w-full" onLayout={handlePreviewLayout}>
         {showLoader ? (
           previewWidth > 0 ? (


### PR DESCRIPTION
## Summary

- add a list-owned row frame for message gutters and role-level spacing
- keep intrinsic padding with message content and derive the latest-user anchor cap from an explicit content layout contract
- make MessageParts own part spacing and document container/content ownership in the UI guide and message module

## Verification

- pnpm format:check: passed
- targeted oxlint and Expo lint for changed TypeScript files: passed
- pnpm lint: blocked by 8 existing unresolved @cherrystudio/ai-core import errors outside the changed files
- tests, typecheck, and device verification: not run per workspace verification policy