### PR TITLE
refactor(agent-runtime): bind the Runtime at the composition root

### DIFF
--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -43,8 +43,9 @@ injected Pi Runtime remains stable for the Host lifetime.
 
 ## Production Pi binding
 
-The production Host binds `local` directly to Pi and injects provider/model resolution through an
-application adapter. The Runtime itself imports neither Expo transport nor application data
+The composition root binds the `AgentRuntime` registration to Pi and injects it into the Host;
+provider/model resolution enters through an application adapter. The Host never constructs a
+Runtime. The Runtime itself imports neither Expo transport nor application data
 services. Current provider coverage includes API-key-authenticated Anthropic Messages, Google
 Generate Content, OpenAI Chat Completions, and OpenAI Responses endpoints. Unsupported endpoint,
 non-standard adapter family, or authentication types fail before partial execution.

--- a/src/backend/ai/README.md
+++ b/src/backend/ai/README.md
@@ -14,7 +14,8 @@ owns the mobile platform and application-service boundaries around that package.
   import application protocol types, persistence, React, or Expo modules (ESLint-enforced).
 - `agent/host/` owns the Mobile Agent Host, the only adapter between the Agent Protocol
   (`@/shared/contracts/agent`) and the Runtime contract, plus Agent definition and protocol
-  projection policy. Version 1 binds `local` directly to Pi without a Runtime registry.
+  projection policy. The concrete Runtime enters through the composition root's `AgentRuntime`
+  registration; the Host never constructs one.
 - `agent/sessionStore/`, `agent/resources/`, `agent/tools/`, and `agent/piAdapter/` respectively own
   transcript persistence, managed turn resources, executable Agent capabilities, and the mobile
   provider/model adaptation required to construct Pi.

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -76,7 +76,6 @@ import {
 } from '@/shared/contracts/agent';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 
-import { createPiModelResolver } from '../piAdapter/piModelResolver';
 import {
   managedFileResolver,
   type ManagedFileResolver,
@@ -89,7 +88,7 @@ import type {
   RuntimeEvent,
   RuntimeUsageReport,
 } from '../runtime';
-import { PiRuntime, raceAbort } from '../runtime';
+import { raceAbort } from '../runtime';
 import type { AgentSessionStore } from '../sessionStore/AgentSessionStore';
 import { interruptNonTerminalToolParts } from '../sessionStore/messageSettlement';
 import {
@@ -212,6 +211,7 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
   'BackgroundReplyRuntime',
   'McpRuntimeService',
   'WebSearchService',
+  'AgentRuntime',
 ])
 @AppStatePolicy('continue')
 export class MobileAgentHost extends BaseService implements AgentProtocol {
@@ -234,8 +234,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private acceptingSubmissions = true;
 
   /**
-   * Lifecycle composition supplies the selected store adapter. Production
-   * binds `local` directly to Pi; tests may replace the Runtime and Agent ports.
+   * Lifecycle composition supplies the selected store adapter and the Runtime
+   * bound at the composition root (`AgentRuntime` registration); tests may
+   * replace the Runtime and Agent ports.
    */
   constructor(
     private readonly store: AgentSessionStore,
@@ -244,7 +245,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     private readonly backgroundReply: BackgroundReplyLifecycle,
     mcpRuntime: McpRuntimeService,
     private readonly webSearchService: WebSearchService,
-    private readonly runtime: AgentRuntime = new PiRuntime(createPiModelResolver()),
+    private readonly runtime: AgentRuntime,
     private readonly overrides: Partial<MobileAgentHostOverrides> = {},
   ) {
     super();

--- a/src/backend/ai/agent/runtime/pi/PiRuntimeService.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntimeService.ts
@@ -1,0 +1,37 @@
+import { BaseService, Injectable, Phase, ServicePhase } from '@/backend/core/lifecycle';
+
+import { createPiModelResolver } from '../../piAdapter/piModelResolver';
+import type {
+  AgentRuntime,
+  AgentRuntimeSession,
+  RuntimeDescriptor,
+  RuntimeModel,
+  RuntimeModelPreflight,
+} from '../types';
+import { PiRuntime } from './PiRuntime';
+
+/**
+ * The composition-root binding of the Agent Runtime contract to Pi.
+ *
+ * This service is the only place that names a concrete Runtime. Replacing the
+ * Runtime means adding an implementation directory and re-pointing the
+ * `AgentRuntime` registration; consumers depend on the `AgentRuntime` contract
+ * and never construct a Runtime themselves.
+ */
+@Injectable('AgentRuntime')
+@ServicePhase(Phase.PostReady)
+export class PiRuntimeService extends BaseService implements AgentRuntime {
+  private readonly runtime: AgentRuntime = new PiRuntime(createPiModelResolver());
+
+  get descriptor(): RuntimeDescriptor {
+    return this.runtime.descriptor;
+  }
+
+  preflightModel(model: RuntimeModel): Promise<RuntimeModelPreflight> {
+    return this.runtime.preflightModel(model);
+  }
+
+  open(): Promise<AgentRuntimeSession> {
+    return this.runtime.open();
+  }
+}

--- a/src/backend/core/application/serviceRegistry.ts
+++ b/src/backend/core/application/serviceRegistry.ts
@@ -1,4 +1,5 @@
 import { MobileAgentHost } from '@/backend/ai/agent/host/MobileAgentHost';
+import { PiRuntimeService } from '@/backend/ai/agent/runtime/pi/PiRuntimeService';
 import { SqliteAgentSessionStore } from '@/backend/ai/agent/sessionStore/SqliteAgentSessionStore';
 import { AiService } from '@/backend/ai/AiService';
 import { McpRuntimeService } from '@/backend/ai/mcp';
@@ -44,6 +45,7 @@ export const services = {
   McpRuntimeService,
   AiService,
   AgentSessionStore: SqliteAgentSessionStore,
+  AgentRuntime: PiRuntimeService,
   MobileAgentHost,
   JobHandlerRegistry,
   JobRuntime,


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Part of the `backend/ai` architecture redesign (stack #699), merged bottom-up:
>
> 1. #697 target architecture reference (docs only)
> 2. #698 retire the desktop-sync trust workflow
> 3. #702 bind the Runtime at the composition root
> 4. #703 move the Pi language binding behind the Runtime seam
> 5. #704 remove the contract's port-package dependency
> 6. #705 enforce Pi isolation with lint
>
> Together these complete Phase 0 and Phase 1 of the plan recorded in #697.

### What this PR does

Before this PR: `MobileAgentHost` defaulted its seventh constructor parameter to `new PiRuntime(createPiModelResolver())`. The Host — the layer that is supposed to know only the `AgentRuntime` contract — named the concrete Runtime, and no registry entry existed for it.

After this PR: `PiRuntimeService` (`@Injectable('AgentRuntime')`, `@ServicePhase(Phase.PostReady)`) is registered in `serviceRegistry.ts` and injected into the Host through `@DependsOn`. The default parameter and the `PiRuntime`/`createPiModelResolver` imports are gone from the Host.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. The mobile UI, the Data API shape, and the agent protocol are all unchanged.

### Why we need it and why it was done in this way

Success criterion 3 in #697: replacing the Runtime should mean adding an implementation directory and re-pointing one line at the composition root. A defaulted constructor argument is a second binding point that no lint rule or type can see.

The following tradeoffs were made:

- One more class in the tree (`PiRuntimeService` delegates `descriptor`/`preflightModel`/`open` to a `PiRuntime` field) in exchange for a single, greppable binding point that participates in lifecycle phase ordering.

The following alternatives were considered: constructing `PiRuntime` directly in `createBackendServices`. Rejected — the lifecycle DI container is the existing framework for backend services, and only registration gets `Phase.PostReady` ordering and container-level test overrides.

### Breaking changes

None. Behavior is identical; only the construction site moves.

### Special notes for your reviewer

`createAppBootstrapRuntime.test.ts` now overrides the `AgentRuntime` token. Without the override the test constructs the real `PiRuntimeService`, which is why it failed before that change was added.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
