### PR TITLE
refactor(ai-provider): move the Pi language binding behind the Runtime seam

### DIFF
--- a/docs/references/ai/provider-serving-boundaries.md
+++ b/docs/references/ai/provider-serving-boundaries.md
@@ -1,6 +1,7 @@
 # Provider Serving Boundaries
 
-Status: **Phase 1 landed; Phases 2 and 3 started**.
+Status: **Phases 1 and 2 landed (Phase 2 reshaped by the
+[target architecture](./target-architecture.md)); Phase 3 started**.
 
 This reference defines how Cherry Mobile shares Provider connection facts without turning image,
 language, embedding, rerank, audio, or video execution into one universal adapter. It complements
@@ -70,11 +71,12 @@ Language support is protocol-oriented, not Provider-id-oriented. Standard Provid
 usable by declaring a supported endpoint and adapter family in the registry; adding a Provider must
 not require another entry in a Pi-specific Provider table.
 
-`resolveLanguageServingPlan()` is the shared language control-plane result. It contains the resolved
-connection, declared authentication facts, shared language transport policy, and a typed Pi
-compatibility result. AI SDK language configuration consumes the same plan but keeps its broader
-authentication and Provider projection inside the AI SDK binding. Image models bypass this plan and
-consume only `ResolvedProviderConnection`.
+The provider layer owns the runtime-agnostic language control plane: `ResolvedProviderConnection`
+plus the shared language transport policy. The typed Pi compatibility decision
+(`resolvePiLanguageBinding`) lives with the Pi binding and consumes those facts; the provider layer
+never sees the decision. System model support asks the bound Runtime through
+`LanguageServingSupport`, so replacing the Runtime replaces that answer with it. AI SDK language
+configuration and image models consume the connection facts directly.
 
 The Pi binding owns only Pi mechanics:
 
@@ -143,12 +145,14 @@ must prove tool calls, reasoning, images, usage, cancellation, and error parity 
 model id, and common request headers consumed by Pi and AI SDK request construction. Existing
 credential selection and capability executors remain unchanged.
 
-### Phase 2: language serving materialization — started
+### Phase 2: language serving materialization — landed, reshaped
 
-`LanguageServingPlan` now classifies declared auth behavior and returns a typed supported or
-unsupported Pi binding before credential selection or network execution. Pi compatibility failures
-carry stable codes while preserving the existing user-facing messages. Pi and non-image AI SDK
-configuration consume this plan; their native model/config projections remain client-specific.
+The typed supported-or-unsupported Pi binding is classified before credential selection or network
+execution, with stable compatibility codes and unchanged user-facing messages. The plan wrapper was
+later dissolved by the target architecture: the decision (`resolvePiLanguageBinding`) moved into
+the Pi adapter, the provider layer keeps only runtime-agnostic facts, and system model support
+reaches the decision through the Runtime binding (`LanguageServingSupport`). Native model/config
+projections remain client-specific.
 
 Credential selection and its non-secret receipt still belong to the binding that materializes the
 credential because AI SDK supports IAM paths that Pi cannot execute. A later slice may share an

--- a/src/backend/ai/README.md
+++ b/src/backend/ai/README.md
@@ -20,10 +20,10 @@ owns the mobile platform and application-service boundaries around that package.
   transcript persistence, managed turn resources, executable Agent capabilities, and the mobile
   provider/model adaptation required to construct Pi.
 - `provider/` resolves credential-selection-free connection facts shared by Pi and AI SDK request
-  construction, materializes the shared language serving plan and typed compatibility result, owns
-  shared Provider HTTP transport policies, injects Expo environment values and app headers, then
-  builds AI SDK provider configuration from mobile data services. Image execution consumes shared
-  connection facts but bypasses the language plan.
+  construction, owns shared Provider HTTP transport policies and the runtime-agnostic system model
+  support factory, injects Expo environment values and app headers, then builds AI SDK provider
+  configuration from mobile data services. The Pi language compatibility decision lives in
+  `agent/piAdapter/`, behind the Runtime binding.
 - `mcp/` owns the mobile Streamable HTTP transport, connection lifecycle, server status, and tool
   discovery used by MCP settings.
 - `devBench/` owns development-only provider fixtures and benchmark request helpers.

--- a/src/backend/ai/agent/piAdapter/__tests__/piApiAdapters.test.ts
+++ b/src/backend/ai/agent/piAdapter/__tests__/piApiAdapters.test.ts
@@ -2,9 +2,8 @@ import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
 import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type { Context, FetchFunction, Model as PiModel } from '@earendil-works/pi-ai';
 
-import type { PiLanguageEndpointType } from '@/backend/ai/provider/languageServingPlan';
-
 import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from '../piApiAdapters';
+import type { PiLanguageEndpointType } from '../piLanguageBinding';
 
 const mockAnthropicStreamSimple = jest.fn();
 const mockGoogleStreamSimple = jest.fn();

--- a/src/backend/ai/agent/piAdapter/__tests__/piLanguageBinding.test.ts
+++ b/src/backend/ai/agent/piAdapter/__tests__/piLanguageBinding.test.ts
@@ -1,31 +1,34 @@
 import { ENDPOINT_TYPE, type EndpointType } from '@cherrystudio/provider-registry';
 
+import { resolveProviderConnection } from '@/backend/ai/provider/providerConnection';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
 
 import {
   LanguageServingCompatibilityError,
   requirePiLanguageBinding,
-  resolveLanguageServingPlan,
-} from '../languageServingPlan';
+  resolvePiLanguageBinding,
+  supportsPiLanguageModel,
+} from '../piLanguageBinding';
 
-describe('resolveLanguageServingPlan', () => {
+describe('resolvePiLanguageBinding', () => {
   it('classifies Pi protocol facts without selecting credentials', () => {
     const provider = createProvider();
-    const plan = resolveLanguageServingPlan(provider, createModel(ENDPOINT_TYPE.OPENAI_RESPONSES));
+    const model = createModel(ENDPOINT_TYPE.OPENAI_RESPONSES);
+    const connection = resolveProviderConnection(provider, model);
+    const binding = resolvePiLanguageBinding(provider, connection);
 
-    expect(plan).toMatchObject({
-      bindings: {
-        pi: { endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES, status: 'supported' },
-      },
-      connection: {
-        adapterFamily: 'openai',
-        baseUrl: 'https://api.example.com/v1',
-        endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES,
-        wireModelId: 'gpt-test',
-      },
+    expect(binding).toEqual({
+      endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      status: 'supported',
     });
-    expect(JSON.stringify(plan)).not.toContain('key-1');
+    expect(connection).toMatchObject({
+      adapterFamily: 'openai',
+      baseUrl: 'https://api.example.com/v1',
+      endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      wireModelId: 'gpt-test',
+    });
+    expect(JSON.stringify({ binding, connection })).not.toContain('key-1');
   });
 
   it.each([
@@ -83,13 +86,37 @@ describe('resolveLanguageServingPlan', () => {
       }),
     },
   ] as const)('returns a typed Pi compatibility issue for $code', ({ code, provider }) => {
-    const plan = resolveLanguageServingPlan(provider, createModel(undefined));
+    const model = createModel(undefined);
+    const binding = resolvePiLanguageBinding(provider, resolveProviderConnection(provider, model));
 
-    expect(plan.bindings.pi).toMatchObject({
+    expect(binding).toMatchObject({
       issue: { binding: 'pi', code },
       status: 'unsupported',
     });
-    expect(() => requirePiLanguageBinding(plan)).toThrow(LanguageServingCompatibilityError);
+    expect(() => requirePiLanguageBinding(binding)).toThrow(LanguageServingCompatibilityError);
+  });
+});
+
+describe('supportsPiLanguageModel', () => {
+  it('accepts a model on a Pi-compatible endpoint', () => {
+    const provider = createProvider();
+    expect(supportsPiLanguageModel(provider, createModel(ENDPOINT_TYPE.OPENAI_RESPONSES))).toBe(
+      true,
+    );
+  });
+
+  it('rejects a model whose endpoint cannot run through Pi', () => {
+    const provider = createProvider({
+      defaultChatEndpoint: ENDPOINT_TYPE.OLLAMA_CHAT,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OLLAMA_CHAT]: {
+          adapterFamily: 'ollama',
+          baseUrl: 'http://localhost:11434',
+        },
+      },
+    });
+
+    expect(supportsPiLanguageModel(provider, createModel(ENDPOINT_TYPE.OLLAMA_CHAT))).toBe(false);
   });
 });
 

--- a/src/backend/ai/agent/piAdapter/piApiAdapters.ts
+++ b/src/backend/ai/agent/piAdapter/piApiAdapters.ts
@@ -3,7 +3,7 @@ import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
 import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type { FetchFunction } from '@earendil-works/pi-ai';
 
-import type { PiLanguageEndpointType } from '@/backend/ai/provider/languageServingPlan';
+import type { PiLanguageEndpointType } from './piLanguageBinding';
 
 export type SupportedPiApi =
   | 'anthropic-messages'

--- a/src/backend/ai/agent/piAdapter/piLanguageBinding.ts
+++ b/src/backend/ai/agent/piAdapter/piLanguageBinding.ts
@@ -48,61 +48,13 @@ export type PiLanguageBinding =
       status: 'unsupported';
     };
 
-export interface LanguageServingPlan {
-  bindings: {
-    pi: PiLanguageBinding;
-  };
-  connection: ResolvedProviderConnection;
-}
-
-interface ResolveLanguageServingPlanOptions {
-  resolvedConnection?: ResolvedProviderConnection;
-}
-
 /**
- * Resolve language-serving facts before projecting them into Pi or AI SDK objects.
+ * Decide whether Pi can serve one provider connection.
  *
- * The result is intentionally credential-selection-free. It may contain sensitive
- * configured headers through `connection`, so it remains ephemeral and must not be
- * persisted or logged.
+ * This is Pi's own compatibility policy over runtime-agnostic connection
+ * facts; the provider layer supplies the facts and never sees this decision.
  */
-export function resolveLanguageServingPlan(
-  provider: Provider,
-  model: Model,
-  options: ResolveLanguageServingPlanOptions = {},
-): LanguageServingPlan {
-  const connection = options.resolvedConnection ?? resolveProviderConnection(provider, model);
-
-  return {
-    bindings: {
-      pi: resolvePiLanguageBinding(provider, connection),
-    },
-    connection,
-  };
-}
-
-export class LanguageServingCompatibilityError extends Error {
-  readonly binding: LanguageServingCompatibilityIssue['binding'];
-  readonly code: LanguageServingCompatibilityCode;
-
-  constructor(issue: LanguageServingCompatibilityIssue) {
-    super(issue.message);
-    this.name = 'LanguageServingCompatibilityError';
-    this.binding = issue.binding;
-    this.code = issue.code;
-  }
-}
-
-export function requirePiLanguageBinding(
-  plan: LanguageServingPlan,
-): Extract<PiLanguageBinding, { status: 'supported' }> {
-  if (plan.bindings.pi.status === 'unsupported') {
-    throw new LanguageServingCompatibilityError(plan.bindings.pi.issue);
-  }
-  return plan.bindings.pi;
-}
-
-function resolvePiLanguageBinding(
+export function resolvePiLanguageBinding(
   provider: Provider,
   connection: ResolvedProviderConnection,
 ): PiLanguageBinding {
@@ -150,6 +102,35 @@ function resolvePiLanguageBinding(
   }
 
   return { endpointType: connection.endpointType, status: 'supported' };
+}
+
+/** Whether Pi can serve one configured model. The language half of system model support. */
+export function supportsPiLanguageModel(provider: Provider, model: Model): boolean {
+  return (
+    resolvePiLanguageBinding(provider, resolveProviderConnection(provider, model)).status ===
+    'supported'
+  );
+}
+
+export class LanguageServingCompatibilityError extends Error {
+  readonly binding: LanguageServingCompatibilityIssue['binding'];
+  readonly code: LanguageServingCompatibilityCode;
+
+  constructor(issue: LanguageServingCompatibilityIssue) {
+    super(issue.message);
+    this.name = 'LanguageServingCompatibilityError';
+    this.binding = issue.binding;
+    this.code = issue.code;
+  }
+}
+
+export function requirePiLanguageBinding(
+  binding: PiLanguageBinding,
+): Extract<PiLanguageBinding, { status: 'supported' }> {
+  if (binding.status === 'unsupported') {
+    throw new LanguageServingCompatibilityError(binding.issue);
+  }
+  return binding;
 }
 
 function isPiLanguageEndpointType(

--- a/src/backend/ai/agent/piAdapter/piModelResolver.ts
+++ b/src/backend/ai/agent/piAdapter/piModelResolver.ts
@@ -3,10 +3,7 @@ import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import type { FetchFunction, Model as PiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
-import {
-  requirePiLanguageBinding,
-  resolveLanguageServingPlan,
-} from '@/backend/ai/provider/languageServingPlan';
+import { resolveProviderConnection } from '@/backend/ai/provider/providerConnection';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerService } from '@/backend/data/services/ProviderService';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
@@ -19,6 +16,7 @@ import type {
   RuntimeUsageContext,
 } from '../runtime';
 import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from './piApiAdapters';
+import { requirePiLanguageBinding, resolvePiLanguageBinding } from './piLanguageBinding';
 
 const DEFAULT_PI_CONTEXT_WINDOW = 128_000;
 const DEFAULT_PI_MAX_OUTPUT_TOKENS = 8_192;
@@ -42,9 +40,8 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       return (await resolveConfiguredPiModel(runtimeModel)).preflight;
     },
     async resolveModel(runtimeModel, runtimeOptions): Promise<PiModelResolution> {
-      const { adapter, model, preflight, provider, servingPlan } =
+      const { adapter, connection, model, preflight, provider } =
         await resolveConfiguredPiModel(runtimeModel);
-      const { connection } = servingPlan;
 
       const selectedApiKey = await providerService.resolveApiKey(provider.id);
       if (!selectedApiKey.value.trim()) {
@@ -124,16 +121,16 @@ async function resolveConfiguredPiModel(runtimeModel: RuntimeModel) {
   ]);
   if (!model) throw new Error(`Model is not configured: ${uniqueModelId}`);
 
-  const servingPlan = resolveLanguageServingPlan(provider, model);
-  const piBinding = requirePiLanguageBinding(servingPlan);
+  const connection = resolveProviderConnection(provider, model);
+  const piBinding = requirePiLanguageBinding(resolvePiLanguageBinding(provider, connection));
   const adapter = resolvePiApiAdapter(piBinding.endpointType);
 
   return {
     adapter,
+    connection,
     model,
     preflight: toPiModelPreflight(model),
     provider,
-    servingPlan,
   };
 }
 

--- a/src/backend/ai/agent/runtime/pi/PiRuntimeService.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntimeService.ts
@@ -1,5 +1,9 @@
+import type { LanguageServingSupport } from '@/backend/ai/provider/systemModelSupport';
 import { BaseService, Injectable, Phase, ServicePhase } from '@/backend/core/lifecycle';
+import type { Model } from '@/shared/data/types/model';
+import type { Provider } from '@/shared/data/types/provider';
 
+import { supportsPiLanguageModel } from '../../piAdapter/piLanguageBinding';
 import { createPiModelResolver } from '../../piAdapter/piModelResolver';
 import type {
   AgentRuntime,
@@ -16,11 +20,12 @@ import { PiRuntime } from './PiRuntime';
  * This service is the only place that names a concrete Runtime. Replacing the
  * Runtime means adding an implementation directory and re-pointing the
  * `AgentRuntime` registration; consumers depend on the `AgentRuntime` contract
- * and never construct a Runtime themselves.
+ * and never construct a Runtime themselves. It also answers language serving
+ * support, so system model support swaps together with the Runtime.
  */
 @Injectable('AgentRuntime')
 @ServicePhase(Phase.PostReady)
-export class PiRuntimeService extends BaseService implements AgentRuntime {
+export class PiRuntimeService extends BaseService implements AgentRuntime, LanguageServingSupport {
   private readonly runtime: AgentRuntime = new PiRuntime(createPiModelResolver());
 
   get descriptor(): RuntimeDescriptor {
@@ -33,5 +38,9 @@ export class PiRuntimeService extends BaseService implements AgentRuntime {
 
   open(): Promise<AgentRuntimeSession> {
     return this.runtime.open();
+  }
+
+  supportsLanguageModel(provider: Provider, model: Model): boolean {
+    return supportsPiLanguageModel(provider, model);
   }
 }

--- a/src/backend/ai/provider/__tests__/systemModelSupport.test.ts
+++ b/src/backend/ai/provider/__tests__/systemModelSupport.test.ts
@@ -3,33 +3,32 @@ import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
 import { DEFAULT_API_FEATURES, type Provider } from '@/shared/data/types/provider';
 
-import { isModelSupportedBySystem } from '../systemModelSupport';
+import { createSystemModelSupport, type LanguageServingSupport } from '../systemModelSupport';
 
-describe('isModelSupportedBySystem', () => {
-  it('accepts Pi-compatible text models', () => {
-    expect(isModelSupportedBySystem(createProvider(), createModel())).toBe(true);
+function supportWith(
+  supportsLanguageModel: jest.Mock,
+): ReturnType<typeof createSystemModelSupport> {
+  const language: LanguageServingSupport = { supportsLanguageModel };
+  return createSystemModelSupport(language);
+}
+
+describe('createSystemModelSupport', () => {
+  it('delegates text models to the bound language serving support', () => {
+    const supportsLanguageModel = jest.fn().mockReturnValue(true);
+    const { isModelSupportedBySystem } = supportWith(supportsLanguageModel);
+    const provider = createProvider();
+    const model = createModel();
+
+    expect(isModelSupportedBySystem(provider, model)).toBe(true);
+    expect(supportsLanguageModel).toHaveBeenCalledWith(provider, model);
+
+    supportsLanguageModel.mockReturnValue(false);
+    expect(isModelSupportedBySystem(provider, model)).toBe(false);
   });
 
-  it('rejects text models whose endpoint cannot run through Pi', () => {
-    const provider = createProvider({
-      defaultChatEndpoint: ENDPOINT_TYPE.OLLAMA_CHAT,
-      endpointConfigs: {
-        [ENDPOINT_TYPE.OLLAMA_CHAT]: {
-          adapterFamily: 'ollama',
-          baseUrl: 'http://localhost:11434',
-        },
-      },
-    });
-
-    expect(
-      isModelSupportedBySystem(
-        provider,
-        createModel({ endpointTypes: [ENDPOINT_TYPE.OLLAMA_CHAT] }),
-      ),
-    ).toBe(false);
-  });
-
-  it('accepts image models supported by the configured AI SDK adapter', () => {
+  it('accepts image models supported by the configured AI SDK adapter without consulting language serving', () => {
+    const supportsLanguageModel = jest.fn().mockReturnValue(false);
+    const { isModelSupportedBySystem } = supportWith(supportsLanguageModel);
     const provider = createProvider({
       endpointConfigs: {
         [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION]: {
@@ -44,9 +43,11 @@ describe('isModelSupportedBySystem', () => {
     });
 
     expect(isModelSupportedBySystem(provider, model)).toBe(true);
+    expect(supportsLanguageModel).not.toHaveBeenCalled();
   });
 
   it('rejects image models when the configured AI SDK adapter cannot generate images', () => {
+    const { isModelSupportedBySystem } = supportWith(jest.fn().mockReturnValue(false));
     const provider = createProvider({
       endpointConfigs: {
         [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION]: {
@@ -64,9 +65,24 @@ describe('isModelSupportedBySystem', () => {
   });
 
   it('rejects models that only serve unsupported product capabilities', () => {
+    const supportsLanguageModel = jest.fn().mockReturnValue(true);
+    const { isModelSupportedBySystem } = supportWith(supportsLanguageModel);
     const model = createModel({ capabilities: [MODEL_CAPABILITY.EMBEDDING] });
 
     expect(isModelSupportedBySystem(createProvider(), model)).toBe(false);
+    expect(supportsLanguageModel).not.toHaveBeenCalled();
+  });
+
+  it('filters out models whose provider is unknown', () => {
+    const { filterModelsSupportedBySystem } = supportWith(jest.fn().mockReturnValue(true));
+    const provider = createProvider();
+    const known = createModel();
+    const orphan = createModel({
+      id: createUniqueModelId('missing-provider', 'test-model'),
+      providerId: 'missing-provider',
+    });
+
+    expect(filterModelsSupportedBySystem([known, orphan], [provider])).toEqual([known]);
   });
 });
 

--- a/src/backend/ai/provider/config.ts
+++ b/src/backend/ai/provider/config.ts
@@ -32,7 +32,6 @@ import {
 import type { CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider';
 import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 
-import { resolveLanguageServingPlan } from '@/backend/ai/provider/languageServingPlan';
 import {
   resolveProviderConnection,
   type ResolvedProviderConnection,
@@ -179,10 +178,7 @@ export async function resolveProviderAiSdkConfig(
   const resolvedConnection =
     options?.resolvedConnection ??
     resolveProviderConnection(provider, model, { resolvedEndpoint: options?.resolvedEndpoint });
-  const languageServingPlan = isImageGenerationModel(model)
-    ? undefined
-    : resolveLanguageServingPlan(provider, model, { resolvedConnection });
-  const connection = languageServingPlan?.connection ?? resolvedConnection;
+  const connection = resolvedConnection;
   const { endpointType, baseUrl } = connection;
 
   const aiSdkProviderId = resolveConnectionAiSdkProviderId(connection);

--- a/src/backend/ai/provider/systemModelSupport.ts
+++ b/src/backend/ai/provider/systemModelSupport.ts
@@ -5,36 +5,47 @@ import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 import { isImageGenerationModel, isTextGenerationModel } from '@/shared/utils/modelPurpose';
 
-import { resolveLanguageServingPlan } from './languageServingPlan';
-
 /**
- * Whether one configured model can be executed by at least one product feature
- * currently shipped on mobile.
- *
- * Conversation support is owned by Pi. Image generation remains an independent
- * AI SDK capability, so either path is sufficient to admit the model.
+ * Conversation-serving support as answered by the bound Agent Runtime. The
+ * provider layer stays runtime-agnostic: the composition root supplies the
+ * implementation alongside the Runtime binding, so replacing the Runtime
+ * replaces this answer with it.
  */
-export function isModelSupportedBySystem(provider: Provider, model: Model): boolean {
-  if (isImageGenerationModel(model) && isImageGenerationSupported(provider, model)) {
-    return true;
-  }
-
-  return (
-    isTextGenerationModel(model) &&
-    resolveLanguageServingPlan(provider, model).bindings.pi.status === 'supported'
-  );
+export interface LanguageServingSupport {
+  supportsLanguageModel(provider: Provider, model: Model): boolean;
 }
 
-export function filterModelsSupportedBySystem(
-  models: readonly Model[],
-  providers: readonly Provider[],
-): Model[] {
-  const providersById = new Map(providers.map((provider) => [provider.id, provider]));
+export interface SystemModelSupport {
+  /**
+   * Whether one configured model can be executed by at least one product
+   * feature currently shipped on mobile. Conversation support is owned by the
+   * bound Runtime; image generation remains an independent AI SDK capability,
+   * so either path is sufficient to admit the model.
+   */
+  isModelSupportedBySystem(provider: Provider, model: Model): boolean;
+  filterModelsSupportedBySystem(models: readonly Model[], providers: readonly Provider[]): Model[];
+}
 
-  return models.filter((model) => {
-    const provider = providersById.get(model.providerId);
-    return provider ? isModelSupportedBySystem(provider, model) : false;
-  });
+export function createSystemModelSupport(language: LanguageServingSupport): SystemModelSupport {
+  const isModelSupportedBySystem = (provider: Provider, model: Model): boolean => {
+    if (isImageGenerationModel(model) && isImageGenerationSupported(provider, model)) {
+      return true;
+    }
+
+    return isTextGenerationModel(model) && language.supportsLanguageModel(provider, model);
+  };
+
+  return {
+    filterModelsSupportedBySystem: (models, providers) => {
+      const providersById = new Map(providers.map((provider) => [provider.id, provider]));
+
+      return models.filter((model) => {
+        const provider = providersById.get(model.providerId);
+        return provider ? isModelSupportedBySystem(provider, model) : false;
+      });
+    },
+    isModelSupportedBySystem,
+  };
 }
 
 function isImageGenerationSupported(provider: Provider, model: Model): boolean {

--- a/src/bootstrap/composition/createBackend.ts
+++ b/src/bootstrap/composition/createBackend.ts
@@ -1,6 +1,6 @@
 import {
-  filterModelsSupportedBySystem,
-  isModelSupportedBySystem,
+  createSystemModelSupport,
+  type LanguageServingSupport,
 } from '@/backend/ai/provider/systemModelSupport';
 import {
   createMcpServerMutations,
@@ -47,9 +47,12 @@ export type BackendComposition = {
 
 export function createBackend(
   services: BackendServices,
-  infrastructure: { dbService: DbService },
+  infrastructure: { dbService: DbService; languageServing: LanguageServingSupport },
 ): BackendComposition {
   const { dbService } = infrastructure;
+  const { filterModelsSupportedBySystem, isModelSupportedBySystem } = createSystemModelSupport(
+    infrastructure.languageServing,
+  );
   const systemModelSupport: SystemModelSupportFilter = {
     filter: async (candidateModels) =>
       filterModelsSupportedBySystem(candidateModels, await services.provider.list()),

--- a/src/bootstrap/runtime/__tests__/createAppBootstrapRuntime.test.ts
+++ b/src/bootstrap/runtime/__tests__/createAppBootstrapRuntime.test.ts
@@ -6,6 +6,7 @@ const mockDataApiDependencies = { kind: 'data-api-dependencies' };
 const mockDataApi = { kind: 'data-api' };
 const mockDataApiHandlers = { kind: 'handlers' };
 const mockAgent = { kind: 'agent' };
+const mockAgentRuntime = { kind: 'agent-runtime' };
 const mockAi = { kind: 'ai' };
 const mockCache = { kind: 'cache' };
 const mockDb = { kind: 'db' };
@@ -66,6 +67,7 @@ jest.mock('@/frontend/features/paintings/PaintingActivity/PaintingActivity', () 
  */
 const createRuntime = () =>
   createAppBootstrapRuntime({
+    AgentRuntime: mockAgentRuntime,
     AiService: mockAi,
     BackgroundActivityEnvironment: mockBackgroundActivityEnvironment,
     CacheService: mockCache,
@@ -108,7 +110,10 @@ describe('createAppBootstrapRuntime', () => {
       paintingPresenter: expect.any(Object),
       translate: expect.any(Function),
     });
-    expect(mockCreateBackend).toHaveBeenCalledWith(mockServices, { dbService: mockDb });
+    expect(mockCreateBackend).toHaveBeenCalledWith(mockServices, {
+      dbService: mockDb,
+      languageServing: mockAgentRuntime,
+    });
     expect(mockInitializeAppRuntime).toHaveBeenCalledWith(mockServices);
     expect(runtime.backend).toBe(mockBackend);
     expect(runtime.dataApi).toBe(mockDataApi);

--- a/src/bootstrap/runtime/createAppBootstrapRuntime.ts
+++ b/src/bootstrap/runtime/createAppBootstrapRuntime.ts
@@ -3,6 +3,7 @@ import { Uniwind } from 'uniwind';
 import type { MobileAgentHost } from '@/backend/ai/agent/host/MobileAgentHost';
 import type { AiService } from '@/backend/ai/AiService';
 import type { McpRuntimeService } from '@/backend/ai/mcp';
+import type { LanguageServingSupport } from '@/backend/ai/provider/systemModelSupport';
 import { application } from '@/backend/core/application/Application';
 import { ApplicationHost, type HostProfile } from '@/backend/core/application/ApplicationHost';
 import { serviceList } from '@/backend/core/application/serviceRegistry';
@@ -58,6 +59,7 @@ export function createAppBootstrapRuntime(
   const cache = host.container.get<CacheService>('CacheService');
   const dbService = host.container.get<DbService>('DbService');
   const jobRuntime = host.container.get<JobRuntime>('JobRuntime');
+  const languageServing = host.container.get<LanguageServingSupport>('AgentRuntime');
   const mcpRuntime = host.container.get<McpRuntimeService>('McpRuntimeService');
   const preference = host.container.get<PreferenceService>('PreferenceService');
   const webSearch = host.container.get<WebSearchService>('WebSearchService');
@@ -70,7 +72,7 @@ export function createAppBootstrapRuntime(
     preference,
     webSearch,
   });
-  const { backend, dataApiDependencies } = createBackend(services, { dbService });
+  const { backend, dataApiDependencies } = createBackend(services, { dbService, languageServing });
   let disposePromise: Promise<void> | undefined;
   const dataApi = new DataApiService(
     createDataApiHandlers({


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Part of the `backend/ai` architecture redesign (stack #699), merged bottom-up:
>
> 1. #697 target architecture reference (docs only)
> 2. #698 retire the desktop-sync trust workflow
> 3. #702 bind the Runtime at the composition root
> 4. #703 move the Pi language binding behind the Runtime seam
> 5. #704 remove the contract's port-package dependency
> 6. #705 enforce Pi isolation with lint
>
> Together these complete Phase 0 and Phase 1 of the plan recorded in #697.

### What this PR does

Before this PR: `provider/languageServingPlan.ts` held `PiLanguageEndpointType`, `resolvePiLanguageBinding` and `requirePiLanguageBinding` — Pi-specific decisions living in the shared provider layer. `systemModelSupport.ts` called into it directly to decide whether a text model is usable, so the settings screen's model availability was answered by Pi logic no matter which Runtime was bound.

After this PR:

- The file moves to `agent/piAdapter/piLanguageBinding.ts` (git tracks it as a rename) and gains `supportsPiLanguageModel(provider, model)`. `requirePiLanguageBinding` now takes a binding rather than a plan.
- `provider/systemModelSupport.ts` declares a `LanguageServingSupport` interface and becomes a `createSystemModelSupport(language)` factory. The image-generation branch is untouched — that is an AI SDK capability, checked through `extensionRegistry`.
- `PiRuntimeService` implements `LanguageServingSupport`; `createAppBootstrapRuntime` resolves the same `'AgentRuntime'` instance and passes it to `createBackend(services, { dbService, languageServing })`.

No frontend changes: the UI queries availability through the existing `isSystemSupported` query parameter.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. The mobile UI, the Data API shape, and the agent protocol are all unchanged.

### Why we need it and why it was done in this way

The provider layer should be a Runtime-agnostic connection-fact layer. With Pi binding decisions inside it, swapping the Runtime would leave the settings screen filtering models by the *old* Runtime's rules.

The following tradeoffs were made:

- **The capability question is declared by the provider layer, not by the `AgentRuntime` contract.** The plan of record put it on the contract next to `preflightModel`. That is not implementable: the decision needs the full `Provider` and `Model` records (provider type, API host, auth shape, model id) to resolve a Pi endpoint binding, and the contract may not import app entities — success criterion 2 and conformance item 11 both forbid it. Narrowing to the `RuntimeModel` id shape does not work either, because remote provider model lists are not persisted and cannot be resolved back from an id.
- The cost of that choice: a replacement Runtime must implement a second interface beyond `AgentRuntime`, and the requirement is expressed as an assertion at `container.get<LanguageServingSupport>('AgentRuntime')` rather than enforced by the contract. Swap semantics are unchanged — re-pointing the `'AgentRuntime'` registration swaps the availability answer with it.

The following alternatives were considered: declaring an `AgentRuntime & LanguageServingSupport` intersection type in `runtime/types.ts` for the registration site to use. Rejected — the contract file would then import app entities, which is the constraint this design works around.

### Breaking changes

None. Model availability answers are identical; only who answers them changes.

### Special notes for your reviewer

The rename carries the tests: `provider/__tests__/languageServingPlan.test.ts` becomes `piAdapter/__tests__/piLanguageBinding.test.ts` with added coverage for `supportsPiLanguageModel`. `systemModelSupport.test.ts` is rewritten against the factory with a stub implementation.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
