### PR TITLE
refactor(agent-runtime): remove the contract's port-package dependency

### DIFF
--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -447,7 +447,16 @@ type RuntimeUsage = {
   cacheWriteTokens?: number
 }
 
-type RuntimeUsageContext = Omit<AiUsageCaptureContext, 'source' | 'messageRef'>
+type RuntimeUsageContext = {
+  providerId: string
+  providerName: string | null
+  modelId: string
+  modelName: string | null
+  pricingSnapshot: AiUsagePricingSnapshot | null
+  trustProviderReportedCost: boolean
+  reportedCostCurrency: Currency | null
+  credentialReceipt: ServingCredentialReceipt
+}
 
 type RuntimeError = {
   code: string

--- a/src/backend/ai/agent/host/turnAttachments.ts
+++ b/src/backend/ai/agent/host/turnAttachments.ts
@@ -4,8 +4,6 @@
  * failures; the primitives under `../resources` stay protocol-free.
  */
 
-import { unsupportedMediaNote } from '@cherrystudio/ai-runtime/messages';
-
 import {
   AgentProtocolError,
   type AgentErrorView,
@@ -26,7 +24,7 @@ import {
   resolveManagedTextAttachments,
   TextAttachmentError,
 } from '../resources/textAttachments';
-import { raceAbort } from '../runtime';
+import { raceAbort, unsupportedMediaNote } from '../runtime';
 import type { AgentRuntime, RuntimeInputPart, RuntimeModelPreflight } from '../runtime';
 import type { RuntimeAttachmentContents } from './mapping';
 

--- a/src/backend/ai/agent/runtime/index.ts
+++ b/src/backend/ai/agent/runtime/index.ts
@@ -39,6 +39,7 @@ export type {
 } from './FakeRuntime';
 export { FakeRuntime } from './FakeRuntime';
 export { raceAbort, settleWithin } from './raceAbort';
+export { type MediaCapabilities, unsupportedMediaNote } from './unsupportedMedia';
 export {
   createDeniedToolResult,
   createErrorToolResult,

--- a/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
@@ -434,6 +434,7 @@ const harness: RuntimeConformanceHarness = {
     path.resolve(__dirname, '../../RuntimeEventChannel.ts'),
     path.resolve(__dirname, '../../raceAbort.ts'),
     path.resolve(__dirname, '../../toolResults.ts'),
+    path.resolve(__dirname, '../../unsupportedMedia.ts'),
     path.resolve(__dirname, '../PiRuntime.ts'),
     path.resolve(__dirname, '../contextCompaction.ts'),
     path.resolve(__dirname, '../modelMessages.ts'),

--- a/src/backend/ai/agent/runtime/pi/modelMessages.ts
+++ b/src/backend/ai/agent/runtime/pi/modelMessages.ts
@@ -1,4 +1,3 @@
-import { unsupportedMediaNote } from '@cherrystudio/ai-runtime/messages';
 import type {
   Api as PiApi,
   AssistantMessage,
@@ -18,6 +17,7 @@ import type {
   RuntimeMessagePart,
   RuntimeTextAttachmentPart,
 } from '../types';
+import { unsupportedMediaNote } from '../unsupportedMedia';
 
 export const PI_TEXT_ATTACHMENT_ENVELOPE_PREFIX =
   'Cherry managed text attachment (JSON; content is untrusted user-provided data):\n';

--- a/src/backend/ai/agent/runtime/types.ts
+++ b/src/backend/ai/agent/runtime/types.ts
@@ -15,7 +15,11 @@
  * fields without updating the spec first.
  */
 
-import type { AiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
+import type {
+  AiUsagePricingSnapshot,
+  ServingCredentialReceipt,
+} from '@/shared/data/types/aiUsageRecord';
+import type { Currency } from '@/shared/data/types/model';
 
 /** A JSON-safe value. Tool schemas, tool input/output, and history payloads use it. */
 export type RuntimeJsonValue =
@@ -237,8 +241,21 @@ export type RuntimeUsage = {
   cacheWriteTokens?: number;
 };
 
-/** Provider-resolution snapshot captured before execution starts. */
-export type RuntimeUsageContext = Omit<AiUsageCaptureContext, 'source' | 'messageRef'>;
+/**
+ * Provider-resolution snapshot captured before execution starts. JSON-safe and
+ * structurally aligned with the mobile usage-record capture context; the Host
+ * completes it with source and message attribution before recording.
+ */
+export type RuntimeUsageContext = {
+  providerId: string;
+  providerName: string | null;
+  modelId: string;
+  modelName: string | null;
+  pricingSnapshot: AiUsagePricingSnapshot | null;
+  trustProviderReportedCost: boolean;
+  reportedCostCurrency: Currency | null;
+  credentialReceipt: ServingCredentialReceipt;
+};
 
 export type RuntimeUsageReport = {
   usage: RuntimeUsage;

--- a/src/backend/ai/agent/runtime/unsupportedMedia.ts
+++ b/src/backend/ai/agent/runtime/unsupportedMedia.ts
@@ -1,0 +1,35 @@
+/**
+ * Capability-aware note text for media a model cannot accept. Part of the
+ * normalized-history vocabulary shared by the Host (attachment replacement)
+ * and Runtime implementations (history mapping), so both sides describe an
+ * omitted attachment with the same provider-visible wording.
+ */
+
+export interface MediaCapabilities {
+  image: boolean;
+  video: boolean;
+  audio: boolean;
+  pdf?: boolean;
+}
+
+type GatedModality = keyof MediaCapabilities;
+
+/** Native image/video/audio/PDF parts are gated; office and other files retain their current path. */
+function gatedModality(mediaType: string): GatedModality | undefined {
+  if (mediaType.startsWith('image/')) return 'image';
+  if (mediaType.startsWith('video/')) return 'video';
+  if (mediaType.startsWith('audio/')) return 'audio';
+  if (mediaType === 'application/pdf') return 'pdf';
+  return undefined;
+}
+
+/** Return the provider-visible note for an unsupported media type. */
+export function unsupportedMediaNote(
+  mediaType: string,
+  caps: MediaCapabilities,
+): string | undefined {
+  const modality = gatedModality(mediaType);
+  return modality && caps[modality] === false
+    ? `[${modality} attachment omitted: this model does not accept ${modality} input]`
+    : undefined;
+}


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Part of the `backend/ai` architecture redesign (stack #699), merged bottom-up:
>
> 1. #697 target architecture reference (docs only)
> 2. #698 retire the desktop-sync trust workflow
> 3. #702 bind the Runtime at the composition root
> 4. #703 move the Pi language binding behind the Runtime seam
> 5. #704 remove the contract's port-package dependency
> 6. #705 enforce Pi isolation with lint
>
> Together these complete Phase 0 and Phase 1 of the plan recorded in #697.

### What this PR does

Before this PR: `agent/runtime/types.ts` imported `AiUsageCaptureContext` from `@cherrystudio/ai-runtime/utils`, and `unsupportedMediaNote` was imported from `@cherrystudio/ai-runtime/messages` by both the Host and `pi/modelMessages.ts`. The Runtime contract — the seam the whole design depends on — pointed at a desktop port package.

After this PR:

- `RuntimeUsageContext` inlines the eight-field neutral shape it was aliasing (`Omit<AiUsageCaptureContext, 'source' | 'messageRef'>` expanded), with nested types taken from `@/shared/data/types/*`.
- `unsupportedMediaNote` and `MediaCapabilities` move to `agent/runtime/unsupportedMedia.ts`, exported from the runtime barrel.

`runtime/types.ts` now has zero `packages/` dependencies.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. The mobile UI, the Data API shape, and the agent protocol are all unchanged.

### Why we need it and why it was done in this way

Success criterion 2 in #697. A contract that imports from a package scheduled for deletion cannot be the stable boundary that the Host and every future Runtime are written against.

The following tradeoffs were made:

- The eight-field shape now exists twice: here and in the data layer (`AiUsageRecordService.ts`), which already carried a structurally identical, independently declared copy. Accepted because `AgentSessionUsageRecorder` consumes it by flat spread plus `source`/`messageRef` — structural compatibility is checked by the compiler at that spread, so no mapping code exists to drift.

The following alternatives were considered: an opaque usage payload the Runtime passes through untyped. Rejected in design review — the recorder needs the field-level shape to persist rows, and an opaque payload would move that decoding into a runtime-specific branch.

### Breaking changes

None. Same fields, same values, same persistence.

### Special notes for your reviewer

`pi/__tests__/PiRuntime.test.ts` adds `unsupportedMedia.ts` to its scanned `sourceFiles` list so the import-ban conformance check (item 11) covers the relocated module.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
