### PR TITLE
fix(agent): type the naming model id as UniqueModelId

### DIFF
--- a/src/backend/ai/agent/host/AgentSessionNaming.ts
+++ b/src/backend/ai/agent/host/AgentSessionNaming.ts
@@ -10,7 +10,7 @@ import type { ModelService } from '@/backend/data/services/ModelService';
 import type { ProviderService } from '@/backend/data/services/ProviderService';
 import type { AgentInputPart, AgentMessagePart, AgentSessionView } from '@/shared/contracts/agent';
 import { loggerService } from '@/shared/core/logger/LoggerService';
-import { isUniqueModelId, parseUniqueModelId } from '@/shared/data/types/model';
+import { isUniqueModelId, parseUniqueModelId, type UniqueModelId } from '@/shared/data/types/model';
 
 import type { AgentSessionStore } from '../sessionStore/AgentSessionStore';
 
@@ -159,7 +159,7 @@ export class AgentSessionNaming {
     }
   }
 
-  private async resolveNamingModelId(): Promise<string | null> {
+  private async resolveNamingModelId(): Promise<UniqueModelId | null> {
     const [configured, defaultModelId] = await Promise.all([
       this.dependencies.preference.get('agent.session_naming.model_id'),
       this.dependencies.preference.get('agent.default_model_id'),


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: `pnpm typecheck` fails on `v0.2`.

```
src/backend/ai/agent/host/AgentSessionNaming.ts(136,9): error TS2322:
Type 'string' is not assignable to type '`${string}::${string}`'.
```

`AiService.generateText` takes a `UniqueModelId` (the `${providerId}::${modelId}` template literal), but `AgentSessionNaming.resolveNamingModelId` still declared its return type as `string | null`.

After this PR: the return type says `UniqueModelId | null`, which is what the function already produces — every candidate passes through the `isUniqueModelId` guard before it is returned.

### Screenshots or videos

N/A — a type annotation fix with no runtime behavior change.

### Why we need it and why it was done in this way

`v0.2` does not currently typecheck, so every PR based on it inherits a red `typecheck` job.

The following tradeoffs were made: none — the annotation is narrowed to what the guard already guarantees, so no cast, no runtime check, and no behavior change.

The following alternatives were considered: asserting at the call site (`uniqueModelId as UniqueModelId`). Rejected — that hides the fact that the function is already correct and moves the claim away from where the guard lives.

### Breaking changes

None.

### Special notes for your reviewer

Found while rebasing the `backend/ai` architecture stack (#699) onto current `v0.2`; the stack cannot go green until this lands. `AgentSessionNaming.test.ts` passes unchanged.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: Not applicable — explained above
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```