### PR TITLE
runtime request mapping

### DIFF
--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -113,11 +113,10 @@ import {
   toAgentErrorView,
   toAgentMessagePart,
   toAgentUsageView,
-  toRuntimeHistory,
-  toRuntimeInputParts,
-} from './mapping';
+} from './runtimeProjection';
 import { materializeRuntimeAttachments } from './turnAttachments';
 import { prepareTurn, type TurnPlan, type TurnPreparationDependencies } from './turnPreparation';
+import { toRuntimeHistory, toRuntimeInputParts } from './turnRuntimeInput';
 
 const logger = loggerService.withContext('MobileAgentHost');
 

--- a/src/backend/ai/agent/host/__tests__/runtimeProjection.test.ts
+++ b/src/backend/ai/agent/host/__tests__/runtimeProjection.test.ts
@@ -1,0 +1,36 @@
+import { toAgentErrorView } from '../runtimeProjection';
+
+describe('Runtime output projection', () => {
+  test('preserves provider identity behind the closed protocol error code', () => {
+    expect(
+      toAgentErrorView({
+        code: 'access_denied',
+        message: 'OpenAI API error (403): access denied',
+        retryable: false,
+        origin: 'provider',
+        name: 'AI_APICallError',
+        context: {
+          statusCode: 403,
+          providerId: 'openai',
+          modelId: 'gpt-test',
+          responseBody: '{"error":"access_denied"}',
+        },
+      }),
+    ).toEqual({
+      code: 'EXECUTION_FAILED',
+      message: 'OpenAI API error (403): access denied',
+      retryable: false,
+      failure: {
+        version: 1,
+        reasonCode: 'permission',
+        source: { layer: 'provider', name: 'AI_APICallError', code: 'access_denied' },
+        context: {
+          statusCode: 403,
+          providerId: 'openai',
+          modelId: 'gpt-test',
+          responseBody: '{"error":"access_denied"}',
+        },
+      },
+    });
+  });
+});

--- a/src/backend/ai/agent/host/__tests__/turnRuntimeInput.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnRuntimeInput.test.ts
@@ -1,44 +1,11 @@
 import type { AgentMessageView, JsonValue } from '@/shared/contracts/agent';
 
-import { toAgentErrorView, toRuntimeHistory, toRuntimeInputParts } from '../mapping';
+import { toRuntimeHistory, toRuntimeInputParts } from '../turnRuntimeInput';
 
 const TIMESTAMP = '2026-08-25T00:00:00.000Z';
 const TOOL_REF = { source: 'mcp', serverId: 'server-1', rawToolName: 'delete_file' } as const;
 
-describe('Agent Host mappings', () => {
-  test('preserves provider identity behind the closed protocol error code', () => {
-    expect(
-      toAgentErrorView({
-        code: 'access_denied',
-        message: 'OpenAI API error (403): access denied',
-        retryable: false,
-        origin: 'provider',
-        name: 'AI_APICallError',
-        context: {
-          statusCode: 403,
-          providerId: 'openai',
-          modelId: 'gpt-test',
-          responseBody: '{"error":"access_denied"}',
-        },
-      }),
-    ).toEqual({
-      code: 'EXECUTION_FAILED',
-      message: 'OpenAI API error (403): access denied',
-      retryable: false,
-      failure: {
-        version: 1,
-        reasonCode: 'permission',
-        source: { layer: 'provider', name: 'AI_APICallError', code: 'access_denied' },
-        context: {
-          statusCode: 403,
-          providerId: 'openai',
-          modelId: 'gpt-test',
-          responseBody: '{"error":"access_denied"}',
-        },
-      },
-    });
-  });
-
+describe('Turn Runtime input assembly', () => {
   test('projects only ledger-authorized managed image content into Runtime input', () => {
     const fileEntryId = '00000000-0000-7000-8000-000000000001';
     const image = {

--- a/src/backend/ai/agent/host/runtimeProjection.ts
+++ b/src/backend/ai/agent/host/runtimeProjection.ts
@@ -1,36 +1,21 @@
 /**
- * Pure mappings between the Agent Runtime contract and the Agent Protocol.
- * The Host is the only adapter between the two; neither side's shape leaks
- * through the other.
+ * Runtime output projected onto the Agent Protocol. The Host is the only
+ * adapter between the two; neither side's shape leaks through the other.
+ * `turnRuntimeInput.ts` owns the opposite direction.
  */
 
 import {
   AgentFailureSnapshotSchema,
   AgentApprovalViewSchema,
   AgentMessagePartSchema,
-  AgentToolResultSchema,
   type AgentApprovalView,
   type AgentErrorView,
-  type AgentInputPart,
   type AgentMessagePart,
-  type AgentMessageView,
   type AgentUsageView,
 } from '@/shared/contracts/agent';
 import { classifyAgentFailureReason } from '@/shared/utils/agentFailure';
 
-import type { TurnResourceLedger } from '../resources/managedFileResolver';
-import {
-  type RuntimeApproval,
-  type RuntimeError,
-  type RuntimeHistoryTurn,
-  type RuntimeInputPart,
-  type RuntimeMessage,
-  type RuntimeMessagePart,
-  type RuntimeOutputPart,
-  type RuntimeUsage,
-} from '../runtime';
-
-export type RuntimeAttachmentContents = ReadonlyMap<string, RuntimeInputPart>;
+import type { RuntimeApproval, RuntimeError, RuntimeOutputPart, RuntimeUsage } from '../runtime';
 
 const MAX_ERROR_CODE_CHARS = 128;
 const MAX_ERROR_MESSAGE_CHARS = 4_000;
@@ -155,103 +140,4 @@ export function toAgentUsageView(usage: RuntimeUsage): AgentUsageView {
     ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
     ...(usage.totalTokens !== undefined ? { totalTokens: usage.totalTokens } : {}),
   };
-}
-
-export function toRuntimeInputParts(
-  parts: AgentInputPart[],
-  resources?: Pick<TurnResourceLedger, 'fileEntryIds'>,
-  attachments?: RuntimeAttachmentContents,
-): RuntimeInputPart[] {
-  return parts.flatMap((part): RuntimeInputPart[] => {
-    if (part.type === 'file') {
-      if (!resources?.fileEntryIds.has(part.fileEntryId)) {
-        throw new Error('Managed file input is outside the turn resource ledger.');
-      }
-      const attachment = attachments?.get(part.fileEntryId);
-      if (!attachment) {
-        throw new Error('Managed file input has no resolved Runtime content.');
-      }
-      return [attachment];
-    }
-    return [{ type: 'text', text: part.text }];
-  });
-}
-
-/**
- * Persisted protocol transcript to normalized runtime history. Tool parts
- * expand into `tool-call` + `tool-result` pairs; protocol `error` parts stay
- * behind the boundary (they describe the turn, not model-visible content).
- */
-export function toRuntimeHistory(
-  messages: AgentMessageView[],
-  attachments: RuntimeAttachmentContents = new Map(),
-): RuntimeHistoryTurn[] {
-  const history: RuntimeHistoryTurn[] = [];
-  for (const message of messages) {
-    const parts: RuntimeMessagePart[] = [];
-    for (const part of message.parts) {
-      switch (part.type) {
-        case 'text':
-        case 'reasoning':
-          parts.push({ type: part.type, text: part.text });
-          break;
-        case 'file':
-          if (message.role === 'user' && part.purpose === 'input-attachment') {
-            const attachment = attachments.get(part.fileEntryId);
-            if (attachment) {
-              parts.push(attachment);
-            }
-          }
-          // Missing historical input content is omitted. Assistant artifacts
-          // never become implicit model attachments.
-          break;
-        case 'tool': {
-          const validPart = AgentMessagePartSchema.safeParse(part);
-          const output = AgentToolResultSchema.safeParse(part.output);
-          if (
-            validPart.success &&
-            (part.state === 'output-available' ||
-              part.state === 'denied' ||
-              part.state === 'error' ||
-              part.state === 'interrupted') &&
-            output.success
-          ) {
-            parts.push({
-              type: 'tool-call',
-              toolCallId: part.toolCallId,
-              toolRef: part.toolRef,
-              providerName: part.providerName,
-              input: part.input ?? null,
-            });
-            parts.push({
-              type: 'tool-result',
-              toolCallId: part.toolCallId,
-              output: output.data,
-              isError: part.state === 'error' || part.state === 'interrupted',
-            });
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    }
-    const currentTurn = history.at(-1);
-    const runtimeTurn =
-      message.turnId !== null && currentTurn?.turnId === message.turnId
-        ? currentTurn
-        : { turnId: message.turnId, messages: [] };
-    if (runtimeTurn !== currentTurn) {
-      history.push(runtimeTurn);
-    }
-    if (parts.length > 0) {
-      const runtimeMessage: RuntimeMessage = {
-        role: message.role,
-        parts,
-        ...(message.role === 'assistant' && message.usage ? { usage: message.usage } : {}),
-      };
-      runtimeTurn.messages.push(runtimeMessage);
-    }
-  }
-  return history;
 }

--- a/src/backend/ai/agent/host/turnAttachments.ts
+++ b/src/backend/ai/agent/host/turnAttachments.ts
@@ -26,7 +26,7 @@ import {
 } from '../resources/textAttachments';
 import { raceAbort, unsupportedMediaNote } from '../runtime';
 import type { AgentRuntime, RuntimeInputPart, RuntimeModelPreflight } from '../runtime';
-import type { RuntimeAttachmentContents } from './mapping';
+import type { RuntimeAttachmentContents } from './turnRuntimeInput';
 
 const NO_IMAGE_MEDIA_CAPABILITIES = { image: false, video: true, audio: true } as const;
 

--- a/src/backend/ai/agent/host/turnPreparation.ts
+++ b/src/backend/ai/agent/host/turnPreparation.ts
@@ -43,12 +43,12 @@ import {
   createAgentInferenceSnapshot,
   type AgentInferenceModelResolver,
 } from './inferenceSnapshot';
-import type { RuntimeAttachmentContents } from './mapping';
 import {
   assertAttachmentRequestSupported,
   resolveManagedInput,
   resolveRuntimeTextAttachments,
 } from './turnAttachments';
+import type { RuntimeAttachmentContents } from './turnRuntimeInput';
 
 const logger = loggerService.withContext('AgentTurnPreparation');
 

--- a/src/backend/ai/agent/host/turnRuntimeInput.ts
+++ b/src/backend/ai/agent/host/turnRuntimeInput.ts
@@ -1,0 +1,122 @@
+/**
+ * Turn material assembly: the protocol transcript and the admitted input parts
+ * become the normalized Runtime request. This direction is the Host's write
+ * side; `runtimeProjection.ts` owns the read side that turns Runtime output
+ * back into protocol views.
+ */
+
+import {
+  AgentMessagePartSchema,
+  AgentToolResultSchema,
+  type AgentInputPart,
+  type AgentMessageView,
+} from '@/shared/contracts/agent';
+
+import type { TurnResourceLedger } from '../resources/managedFileResolver';
+import type {
+  RuntimeHistoryTurn,
+  RuntimeInputPart,
+  RuntimeMessage,
+  RuntimeMessagePart,
+} from '../runtime';
+
+export type RuntimeAttachmentContents = ReadonlyMap<string, RuntimeInputPart>;
+
+export function toRuntimeInputParts(
+  parts: AgentInputPart[],
+  resources?: Pick<TurnResourceLedger, 'fileEntryIds'>,
+  attachments?: RuntimeAttachmentContents,
+): RuntimeInputPart[] {
+  return parts.flatMap((part): RuntimeInputPart[] => {
+    if (part.type === 'file') {
+      if (!resources?.fileEntryIds.has(part.fileEntryId)) {
+        throw new Error('Managed file input is outside the turn resource ledger.');
+      }
+      const attachment = attachments?.get(part.fileEntryId);
+      if (!attachment) {
+        throw new Error('Managed file input has no resolved Runtime content.');
+      }
+      return [attachment];
+    }
+    return [{ type: 'text', text: part.text }];
+  });
+}
+
+/**
+ * Persisted protocol transcript to normalized runtime history. Tool parts
+ * expand into `tool-call` + `tool-result` pairs; protocol `error` parts stay
+ * behind the boundary (they describe the turn, not model-visible content).
+ */
+export function toRuntimeHistory(
+  messages: AgentMessageView[],
+  attachments: RuntimeAttachmentContents = new Map(),
+): RuntimeHistoryTurn[] {
+  const history: RuntimeHistoryTurn[] = [];
+  for (const message of messages) {
+    const parts: RuntimeMessagePart[] = [];
+    for (const part of message.parts) {
+      switch (part.type) {
+        case 'text':
+        case 'reasoning':
+          parts.push({ type: part.type, text: part.text });
+          break;
+        case 'file':
+          if (message.role === 'user' && part.purpose === 'input-attachment') {
+            const attachment = attachments.get(part.fileEntryId);
+            if (attachment) {
+              parts.push(attachment);
+            }
+          }
+          // Missing historical input content is omitted. Assistant artifacts
+          // never become implicit model attachments.
+          break;
+        case 'tool': {
+          const validPart = AgentMessagePartSchema.safeParse(part);
+          const output = AgentToolResultSchema.safeParse(part.output);
+          if (
+            validPart.success &&
+            (part.state === 'output-available' ||
+              part.state === 'denied' ||
+              part.state === 'error' ||
+              part.state === 'interrupted') &&
+            output.success
+          ) {
+            parts.push({
+              type: 'tool-call',
+              toolCallId: part.toolCallId,
+              toolRef: part.toolRef,
+              providerName: part.providerName,
+              input: part.input ?? null,
+            });
+            parts.push({
+              type: 'tool-result',
+              toolCallId: part.toolCallId,
+              output: output.data,
+              isError: part.state === 'error' || part.state === 'interrupted',
+            });
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    const currentTurn = history.at(-1);
+    const runtimeTurn =
+      message.turnId !== null && currentTurn?.turnId === message.turnId
+        ? currentTurn
+        : { turnId: message.turnId, messages: [] };
+    if (runtimeTurn !== currentTurn) {
+      history.push(runtimeTurn);
+    }
+    if (parts.length > 0) {
+      const runtimeMessage: RuntimeMessage = {
+        role: message.role,
+        parts,
+        ...(message.role === 'assistant' && message.usage ? { usage: message.usage } : {}),
+      };
+      runtimeTurn.messages.push(runtimeMessage);
+    }
+  }
+  return history;
+}


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Phase 2 of the `backend/ai` architecture redesign (target state: #697), merged bottom-up:
>
> 1. #711 split the Host mappings by direction
> 2. #712 notify the background reply at the event-loop exit
> 3. #713 record the landed Phase 2 shape in the target-architecture reference

### What this PR does

Before this PR: `host/mapping.ts` held both directions of the protocol ↔ Runtime adaptation in one file — `toAgent*` projecting Runtime output onto the protocol, and `toRuntimeHistory`/`toRuntimeInputParts` assembling the Runtime request from the protocol transcript.

After this PR:

- `turnRuntimeInput.ts` owns the write side: `toRuntimeInputParts`, `toRuntimeHistory`, and the `RuntimeAttachmentContents` type they consume (already imported by `turnPreparation.ts` and `turnAttachments.ts`).
- `runtimeProjection.ts` (the renamed `mapping.ts`) keeps the read side and its file comment now states which direction it owns.
- `__tests__/mapping.test.ts` splits the same way into `runtimeProjection.test.ts` and `turnRuntimeInput.test.ts`.

Pure moves — no logic changes.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. The agent protocol, the event stream, and the mobile UI are unchanged.

### Why we need it and why it was done in this way

The target architecture (#697) places turn material assembly with the other turn stages and keeps the orchestration core to protocol orchestration. `toRuntimeHistory` and `toRuntimeInputParts` are material assembly: they run at execution time over the frozen `TurnPlan`, alongside `turnPreparation.ts` and `turnAttachments.ts`. Grouping them by *file they used to live in* rather than by *direction they serve* made the Host's write path span two unrelated modules.

The following tradeoffs were made:

- Two files instead of one, and one more import in the Host. In exchange each file has a single direction, and the attachment-content type now lives with the functions that produce and consume it rather than in a module its other importers do not otherwise use.

The following alternatives were considered: folding the write side into `turnPreparation.ts`. Rejected — preparation is the write-free planning stage that ends at the frozen `TurnPlan`, while these two functions run later, during execution. Merging them would blur the stage boundary #696 established.

### Breaking changes

None. Pure relocation; every function keeps its behavior and signature.

### Special notes for your reviewer

`git` tracks `mapping.ts → runtimeProjection.ts` and `mapping.test.ts → turnRuntimeInput.test.ts` as renames, so the diff reads as one rename plus one extraction per pair.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
