### PR TITLE
refactor(agent): notify the background reply at the event-loop exit

### DIFF
--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -132,6 +132,19 @@ const NOOP_BACKGROUND_REPLY_TURN: BackgroundReplyTurn = {
   update: () => {},
 };
 
+/**
+ * Runtime events after which the background-reply surface must re-read the
+ * assistant message. Declaring the set here rather than notifying inside each
+ * branch means a newly handled event cannot silently stop refreshing the live
+ * notification — a drift no test would catch.
+ */
+const MESSAGE_SURFACE_EVENTS: ReadonlySet<RuntimeEvent['type']> = new Set([
+  'approval.resolved',
+  'part.add',
+  'part.replace',
+  'text.delta',
+]);
+
 const TERMINAL_PERSISTENCE_RETRY_DELAYS_MS = [0, 50, 200] as const;
 
 type MobileAgentHostOverrides = {
@@ -614,6 +627,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       });
       for await (const event of events) {
         const isTerminal = await this.handleRuntimeEvent(sessionId, state, event);
+        if (MESSAGE_SURFACE_EVENTS.has(event.type)) {
+          state.backgroundReply.update(state.assistantMessage);
+        }
         if (isTerminal) {
           return;
         }
@@ -687,7 +703,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           messageId: state.assistantMessage.id,
           delta: { op: 'part.add', index: event.index, part },
         });
-        state.backgroundReply.update(state.assistantMessage);
         return false;
       }
       case 'text.delta': {
@@ -700,7 +715,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           messageId: state.assistantMessage.id,
           delta: { op: 'text.append', partId: event.partId, text: event.text },
         });
-        state.backgroundReply.update(state.assistantMessage);
         return false;
       }
       case 'part.replace': {
@@ -714,7 +728,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           messageId: state.assistantMessage.id,
           delta: { op: 'part.replace', part },
         });
-        state.backgroundReply.update(state.assistantMessage);
         return false;
       }
       case 'approval.requested': {
@@ -738,7 +751,6 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           state.turn = { ...state.turn, status: 'running' };
           this.publish(sessionId, { type: 'turn.updated', turn: state.turn });
         }
-        state.backgroundReply.update(state.assistantMessage);
         this.publish(sessionId, { type: 'approval.resolved', approval });
         return false;
       }

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -312,7 +312,15 @@ describe('MobileAgentHost', () => {
       sessionId: session.id,
       sessionTitle: '',
     });
-    expect(backgroundReplyTurn.update).toHaveBeenCalled();
+    // One notification per message-changing event (part.add, two text.delta,
+    // part.replace) — a handled event that stops notifying would show up here.
+    expect(backgroundReplyTurn.update).toHaveBeenCalledTimes(4);
+    expect(backgroundReplyTurn.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: submitted.assistantMessageId,
+        parts: [{ id: 'text-1', type: 'text', text: 'Hi', state: 'done' }],
+      }),
+    );
     expect(backgroundReplyTurn.finish).toHaveBeenCalledWith('completed', {
       waitFor: expect.any(Promise),
     });
@@ -1427,6 +1435,11 @@ describe('MobileAgentHost', () => {
     expect(statuses).toEqual(['running', 'awaiting-approval', 'running', 'completed']);
     expect(events.some((event) => event.type === 'approval.resolved')).toBe(true);
     assertJsonRoundTrip(events);
+
+    // Awaiting approval is its own background-reply state, not a content
+    // refresh; resolving it goes back through the ordinary update path.
+    expect(backgroundReplyTurn.awaitApproval).toHaveBeenCalledTimes(1);
+    expect(backgroundReplyTurn.update).toHaveBeenCalled();
 
     const transcript = await store.listMessages(session.id);
     const toolPart = transcript[1]?.parts[0];


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Phase 2 of the `backend/ai` architecture redesign (target state: #697), merged bottom-up:
>
> 1. #711 split the Host mappings by direction
> 2. #712 notify the background reply at the event-loop exit
> 3. #713 record the landed Phase 2 shape in the target-architecture reference

### What this PR does

Before this PR: `state.backgroundReply.update(state.assistantMessage)` appeared in four branches of `handleRuntimeEvent` — `part.add`, `text.delta`, `part.replace`, and `approval.resolved`. Every branch that mutates the assistant message had to remember to repeat it.

After this PR: the run loop notifies once, driven by an explicit `MESSAGE_SURFACE_EVENTS` set:

```ts
for await (const event of events) {
  const isTerminal = await this.handleRuntimeEvent(sessionId, state, event);
  if (MESSAGE_SURFACE_EVENTS.has(event.type)) {
    state.backgroundReply.update(state.assistantMessage);
  }
  if (isTerminal) return;
}
```

`awaitApproval` stays in the `approval.requested` branch — it is a distinct surface state with a single call site, not a content refresh.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. The agent protocol, the event stream, and the mobile UI are unchanged.

### Why we need it and why it was done in this way

This was a silent-failure shape. Adding a new handled event that mutates the assistant message, and forgetting the notification line, stops the Live Activity from refreshing — with no test failure and no error. The knowledge "which events change what the notification shows" was spread across four branches instead of being stated once.

The following tradeoffs were made:

- The set must still be updated when a new message-changing event type is handled. That is strictly better than the previous state: the set is one reviewable list with a comment explaining its contract, and the Host tests now fail when an entry is missing.
- `approval.resolved` now notifies after its `publish` rather than before. Both are synchronous and independent (one feeds the protocol event stream, the other the system notification), so ordering is not observable.

The following alternatives were considered:

- Returning a `{terminal, notify}` result from `handleRuntimeEvent`. Rejected — that just moves the per-branch repetition from a call to a return field; forgetting it stays equally silent.
- Converging naming, usage, and background reply behind a single turn-observer interface (the original Phase 2 sketch). Rejected after reading the code: naming has three call sites with different timings whose ordering is itself an invariant (`finalize` passes `waitFor: Promise.allSettled(namingPromises)`), and usage has only `record`/`drain`. A shared interface would be five methods with one call site each — the Host would shrink while understanding a turn would require reading an extra indirection layer.

### Breaking changes

None. Identical notifications, emitted from one place instead of four.

### Special notes for your reviewer

The pre-existing assertion was `expect(backgroundReplyTurn.update).toHaveBeenCalled()`, which passes both before and after this change and therefore protects nothing. It is now an exact count plus the message carried by the last call, and the approval test asserts that `awaitApproval` and `update` stay distinct.

Verified with a positive control: removing `'part.replace'` from the set fails the suite with `Expected number of calls: 4, Received number of calls: 3`. The entry was then restored.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
