### PR TITLE
docs(architecture): record the landed Phase 2 shape

### DIFF
--- a/docs/references/ai/target-architecture.md
+++ b/docs/references/ai/target-architecture.md
@@ -43,11 +43,16 @@ src/backend/ai/
 │   │                    terminal persistence, restart reconciliation. Protocol invariants only.
 │   │                    Turn preparation (turnPreparation.ts) and attachment materialization
 │   │                    (turnAttachments.ts) stay write-free and testable without a Host.
-│   │                    Side effects (naming, usage, background reply) converge behind one
-│   │                    explicitly ordered turn-observer seam.
+│   │                    The two adaptation directions are separate: turnRuntimeInput.ts
+│   │                    assembles the Runtime request, runtimeProjection.ts projects Runtime
+│   │                    output onto the protocol. Side effects (naming, usage, background
+│   │                    reply) keep explicit call sites; per-event notification is driven
+│   │                    from the run loop, not repeated in each branch.
 │   ├── runtime/
 │   │   ├── types.ts     The seam contract. No imports from packages/* ports. Neutral usage
-│   │   │                shape. Model preflight and static capability queries live here.
+│   │   │                shape. Model preflight lives here; the language-serving question
+│   │   │                needs app entities, so it is a separate interface the Runtime
+│   │   │                implementation answers (see Seam Rule 4).
 │   │   ├── FakeRuntime.ts  Conformance double; updated with every contract change.
 │   │   └── pi/          Everything Pi-specific: PiRuntime, the current piAdapter/ content
 │   │                    (model resolution, API adapters, stream binding), the Pi language
@@ -75,9 +80,14 @@ New module and directory names are chosen at implementation time following
 3. **One binding point.** The composition root creates and registers the Runtime. Replacing the
    Runtime means adding one implementation directory and changing one composition line. The Host
    never constructs a Runtime.
-4. **Capability questions go through the contract.** "Can this model serve?" is answered by the
-   Runtime's preflight and static capability surface, not by importing a specific runtime's binding
-   logic. Image-generation support stays an AI SDK concern and is not routed through the seam.
+4. **Capability questions go through the bound Runtime.** "Can this model serve?" is answered by
+   the Runtime, never by importing a specific runtime's binding logic. Per-turn questions use the
+   contract's `preflightModel`. The settings-level question needs the full `Provider` and `Model`
+   records — which the contract may not import (Rule 2) and which a `RuntimeModel` id cannot
+   recover, since remote provider model lists are not persisted. It is therefore declared as
+   `LanguageServingSupport` in the provider layer and implemented by the Runtime service, so
+   re-pointing the `AgentRuntime` registration swaps both answers together. Image-generation
+   support stays an AI SDK concern and is not routed through the seam.
 5. **Normalized history is the seam currency.** The Host side maps protocol transcripts into the
    normalized Runtime shape; each Runtime maps that shape into its own messages. Neither side
    imports the other's mapping.
@@ -99,7 +109,7 @@ New module and directory names are chosen at implementation time following
 | --- | --- | --- |
 | 0 | This document; retire the `ai-runtime` desktop-sync trust workflow | Landed |
 | 1 | Seal the seam: Runtime binding at the composition root, split the Pi language binding out of `provider/`, neutral usage shape in the contract, language capability query behind `LanguageServingSupport`, Pi-isolation lint rule | Landed |
-| 2 | Host decomposition | Partially landed (#696: `turnPreparation.ts`, `turnAttachments.ts`, Pi lifecycle phases). Remaining: converge naming/usage/background-reply behind the turn-observer seam |
+| 2 | Host decomposition | Landed (#696: `turnPreparation.ts`, `turnAttachments.ts`, Pi lifecycle phases; then the mapping split into `turnRuntimeInput.ts`/`runtimeProjection.ts` and the run-loop background-reply notification) |
 | 3 | Fold `generation/` into `AiService`, shrink provider config to its AI SDK consumers, inline the consumed `packages/ai-runtime` symbols, delete the package | Pending |
 
 Phase 1 precedes 2 and 3; the contract shape must settle before code moves against it. Phases 2

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -10,8 +10,11 @@
  *
  * The write-free stretch between admission and the first durable row lives in
  * `./turnPreparation` (gates and the frozen `TurnPlan`); attachment admission
- * and materialization live in `./turnAttachments`. This class keeps admission,
- * reservation, execution, and terminal settlement.
+ * and materialization live in `./turnAttachments`. The two adaptation
+ * directions are separate modules: `./turnRuntimeInput` assembles the Runtime
+ * request, `./runtimeProjection` projects Runtime output back onto the
+ * protocol. This class keeps admission, reservation, execution, and terminal
+ * settlement.
  *
  * Protocol invariants implemented here (agent-protocol.md):
  * 1.  one active turn per Session (synchronous admission guard);


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Phase 2 of the `backend/ai` architecture redesign (target state: #697), merged bottom-up:
>
> 1. #711 split the Host mappings by direction
> 2. #712 notify the background reply at the event-loop exit
> 3. #713 record the landed Phase 2 shape in the target-architecture reference

### What this PR does

Before this PR: `docs/references/ai/target-architecture.md` described three things that differ from what actually landed.

After this PR:

- **Seam Rule 4** states the real shape: per-turn questions use the contract's `preflightModel`, while the settings-level question is `LanguageServingSupport` in the provider layer, implemented by the Runtime service. The rule now explains *why* it cannot live on the contract — it needs the full `Provider`/`Model` records, which Rule 2 forbids the contract from importing, and which a `RuntimeModel` id cannot recover because remote provider model lists are not persisted.
- The **host/ entry** names the two adaptation directions (`turnRuntimeInput.ts`, `runtimeProjection.ts`) and states that side-effect collaborators keep explicit call sites, with per-event notification driven from the run loop.
- **Migration Status** moves Phase 2 to landed.

### Screenshots or videos

N/A — documentation only.

### Why we need it and why it was done in this way

The Migration Status table is what makes this document safe to trust; a target-state reference that quietly diverges from the code is worse than none. Two of these three corrections are places where implementation proved the original plan wrong, so the reasoning belongs in the document rather than in a merged PR description.

The following tradeoffs were made: none — the alternative is leaving the reference describing a design that was not built.

The following alternatives were considered: reshaping the code to match the document instead. For Seam Rule 4 that is not possible without breaking contract purity (Rule 2); for the observer seam it was considered and rejected on its merits, with the reasoning recorded in #712.

### Breaking changes

None. Documentation only.

### Special notes for your reviewer

Phase 3 (fold `generation/` into `AiService`, shrink provider config, inline and delete `packages/ai-runtime`) remains pending. Note that #707 removed the provider transport policy mechanism entirely, so that part of the Phase 3 scope is already gone.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
