### PR TITLE
refactor(agent-tools): inject app services into the built-in catalog

### DIFF
--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -255,8 +255,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
    */
   constructor(
     private readonly store: AgentSessionStore,
-    aiService: AiService,
-    preferenceService: PreferenceService,
+    private readonly aiService: AiService,
+    private readonly preferenceService: PreferenceService,
     private readonly backgroundReply: BackgroundReplyLifecycle,
     mcpRuntime: McpRuntimeService,
     private readonly webSearchService: WebSearchService,
@@ -295,6 +295,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     return (
       this.overrides.tools ??
       (this.lazySystemCapabilities ??= createSystemCapabilitySource({
+        ai: this.aiService,
+        preference: this.preferenceService,
         webSearch: this.webSearchService,
       }))
     );

--- a/src/backend/ai/agent/tools/__tests__/builtInToolSource.test.ts
+++ b/src/backend/ai/agent/tools/__tests__/builtInToolSource.test.ts
@@ -11,6 +11,7 @@ import type { TurnToolResources } from '../../resources/managedFileResolver';
 import type { RuntimeModel, RuntimeTool } from '../../runtime';
 import {
   createSystemCapabilitySource,
+  type SystemCapabilityServices,
   type SystemCapabilitySourceDependencies,
 } from '../builtInToolSource';
 import type { ConfiguredPaintingModel } from '../painting';
@@ -138,7 +139,7 @@ describe('createSystemCapabilitySource', () => {
     jest.spyOn(fileContent, 'createTextEntry').mockResolvedValueOnce(entry);
     const grantFile = jest.fn();
     const resources: TurnToolResources = { fileEntryIds: new Set(), grantFile };
-    const source = createSystemCapabilitySource(dependencies({}));
+    const source = createSystemCapabilitySource(SERVICES, dependencies({}));
     const tools = await source.getTools({
       model: MODEL,
       resources,
@@ -172,7 +173,7 @@ async function resolve(
   scenario: Scenario,
   options: { platform?: string } = {},
 ): Promise<readonly RuntimeTool[]> {
-  const source = createSystemCapabilitySource({
+  const source = createSystemCapabilitySource(SERVICES, {
     ...dependencies(scenario),
     platform: options.platform ?? 'ios',
   });
@@ -182,6 +183,14 @@ async function resolve(
     temporaryCapabilities: new Set(scenario.temporaryCapabilities ?? []),
   });
 }
+
+// Every test supplies the full painting/webSearch overrides below, so these
+// services only satisfy the required parameter; the overrides win.
+const SERVICES: SystemCapabilityServices = {
+  ai: { generateImage: jest.fn() },
+  preference: { get: jest.fn() },
+  webSearch: { fetchUrls: jest.fn(), searchKeywords: jest.fn() },
+} as unknown as SystemCapabilityServices;
 
 function dependencies(scenario: Scenario): Partial<SystemCapabilitySourceDependencies> {
   return {

--- a/src/backend/ai/agent/tools/builtInToolSource.ts
+++ b/src/backend/ai/agent/tools/builtInToolSource.ts
@@ -16,7 +16,6 @@
 import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 import { Platform } from 'react-native';
 
-import { application } from '@/backend/core/application/Application';
 import { modelService } from '@/backend/data/services/ModelService';
 import { providerRegistryService } from '@/backend/data/services/ProviderRegistryService';
 import { fileContent } from '@/backend/services/file/fileContent';
@@ -92,12 +91,25 @@ export type SystemCapabilitySourceDependencies = DeviceToolDependencies &
     supportsToolCalling(model: RuntimeModel): Promise<boolean>;
   };
 
+/**
+ * The app services this catalog needs, supplied by whoever constructs it. The
+ * module owns its own storage and registry access, but a lifecycle-managed
+ * service is passed in: the container replaces instances across host
+ * generations, so reaching for one here would capture a stale binding.
+ */
+export type SystemCapabilityServices = {
+  ai: PaintingToolDependencies['ai'];
+  preference: PaintingToolDependencies['preference'];
+  webSearch: WebSearchToolDependencies['webSearch'];
+};
+
 export function createSystemCapabilitySource(
+  services: SystemCapabilityServices,
   overrides: Partial<SystemCapabilitySourceDependencies> = {},
 ): SystemCapabilitySource {
   return {
     async getTools({ model, resources, temporaryCapabilities }) {
-      const deps = resolveDependencies(overrides);
+      const deps = resolveDependencies(services, overrides);
       if (!(await deps.supportsToolCalling(model))) {
         // Handing tools to a model that cannot call them fails the whole turn.
         return [];
@@ -237,30 +249,30 @@ async function resolveDeviceAccess(
 }
 
 function resolveDependencies(
+  services: SystemCapabilityServices,
   overrides: Partial<SystemCapabilitySourceDependencies>,
 ): SystemCapabilitySourceDependencies {
   return {
     devicePermissions: overrides.devicePermissions ?? devicePermissions,
-    painting: overrides.painting ?? productionPaintingDependencies(),
+    painting: overrides.painting ?? productionPaintingDependencies(services),
     platform: overrides.platform ?? Platform.OS,
     supportsToolCalling: overrides.supportsToolCalling ?? supportsToolCalling,
-    // Resolved per turn rather than captured: the container replaces service
-    // instances across host generations.
-    webSearch: overrides.webSearch ?? application.get('WebSearchService'),
+    webSearch: overrides.webSearch ?? services.webSearch,
   };
 }
 
-function productionPaintingDependencies(): PaintingToolDependencies {
-  const ai = application.get('AiService');
+function productionPaintingDependencies(
+  services: SystemCapabilityServices,
+): PaintingToolDependencies {
   return {
-    ai: { generateImage: (request) => ai.generateImage(request) },
+    ai: services.ai,
     files: {
       createInternalEntry: paintingFileStorage.createInternalEntry,
       discard: paintingFileStorage.discard,
       readDataUrl: paintingFileStorage.readDataUrl,
       resolve: fileContent.resolve,
     },
-    preference: application.get('PreferenceService'),
+    preference: services.preference,
     providerRegistry: providerRegistryService,
   };
 }


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

> ### Stack
>
> Phase 3 of the `backend/ai` architecture redesign (target state: #697), merged bottom-up:
>
> 1. #715 make the AI SDK path private to `AiService`
> 2. #716 inject app services into the built-in tool catalog
> 3. #717 reposition `packages/ai-runtime` and drop unconsumed exports

### What this PR does

Before this PR: `builtInToolSource.ts` reached for three lifecycle-managed services through the service locator — `application.get('WebSearchService')`, `application.get('AiService')`, and `application.get('PreferenceService')`.

After this PR: they arrive as a required `SystemCapabilityServices` parameter, supplied by the Host, which already receives all three in its constructor. `application` is no longer imported by the module.

### Screenshots or videos

N/A — internal refactor with no user-facing surface. Generation behavior, the agent protocol, and the mobile UI are unchanged.

### Why we need it and why it was done in this way

The module looked dependency-free at its signature while quietly depending on three services, so its true requirements were invisible to callers and to the type checker. The Host was already handed every one of them — it just did not pass them down.

The following tradeoffs were made:

- `createSystemCapabilitySource` gains a required first parameter, so the four call sites (Host plus three in tests) had to be updated. That is the point: the requirement is now stated rather than discovered at runtime.
- The original reason for locating per turn — the container replaces service instances across host generations, so a captured binding could go stale — still holds. It now lives in the type's doc comment, and it is satisfied because the Host itself is recreated with fresh services each generation.

The following alternatives were considered: keeping `application.get` as a fallback behind optional overrides. Rejected — an optional injection point that defaults to the locator leaves the hidden dependency in place and adds a second code path that production never takes.

### Breaking changes

None. Same services, resolved through the constructor instead of the locator.

### Special notes for your reviewer

`application.get` remains in `agentDefinitions.ts` for `DbService`. That is the repository's established pattern for database access (documented in the `backendCoreLayer` rule comment in `eslint.config.js`) and is out of scope here.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
