### PR TITLE
refactor(message-parts): unify disclosure layers

### DIFF
--- a/.rnstorybook/index.ts
+++ b/.rnstorybook/index.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { registerRootComponent } from 'expo';
+import * as SplashScreen from 'expo-splash-screen';
 
 import { view } from './storybook.requires';
 
@@ -9,6 +10,8 @@ const StorybookUIRoot = view.getStorybookUI({
     setItem: AsyncStorage.setItem,
   },
 });
+
+void SplashScreen.hideAsync().catch(() => {});
 
 registerRootComponent(StorybookUIRoot);
 

--- a/.rnstorybook/stories/messages/PaintingStoryFrame.tsx
+++ b/.rnstorybook/stories/messages/PaintingStoryFrame.tsx
@@ -1,0 +1,136 @@
+import { Image, ScrollView, Text, View } from 'react-native';
+import { ScopedTheme } from 'uniwind';
+
+import type { MessageListItem } from '@/frontend/components/messages';
+import {
+  PaintingMessage,
+  type PaintingMessageState,
+} from '@/frontend/features/paintings/components/PaintingMessage';
+
+import { STORY_FILE_ENTRY_ID } from './messageFixtures';
+import { MessagesStoryProviders } from './MessagesStoryProviders';
+
+export type PaintingExample = {
+  label: string;
+  message: MessageListItem;
+  state: PaintingMessageState;
+};
+
+const firstOutputUri = Image.resolveAssetSource(
+  require('../../../assets/paintings/templates/cherry-twilight.png'),
+).uri;
+const secondOutputUri = Image.resolveAssetSource(
+  require('../../../assets/paintings/templates/cyber-rabbit-character.webp'),
+).uri;
+
+const baseState = {
+  aspectRatio: 1,
+  error: null,
+  interruption: null,
+  outputs: [],
+  resolution: '1024 × 1024',
+  status: 'idle',
+} as const satisfies PaintingMessageState;
+
+const paintingUserMessage: MessageListItem = {
+  data: {
+    parts: [
+      {
+        filename: 'reference.png',
+        mediaType: 'image/png',
+        providerMetadata: { cherry: { fileEntryId: STORY_FILE_ENTRY_ID } },
+        type: 'file',
+        url: 'file:///storybook/reference.png',
+      },
+      {
+        state: 'done',
+        text: 'Create a cinematic cherry-red city at twilight.',
+        type: 'text',
+      },
+    ],
+  },
+  id: 'painting-user',
+  role: 'user',
+  status: 'success',
+};
+
+function assistantMessage(id: string, status: MessageListItem['status']): MessageListItem {
+  return { data: { parts: [] }, id, role: 'assistant', status };
+}
+
+export const paintingExamples: readonly PaintingExample[] = [
+  {
+    label: 'Painting user prompt and reference',
+    message: paintingUserMessage,
+    state: baseState,
+  },
+  {
+    label: 'Generating',
+    message: assistantMessage('painting-generating', 'pending'),
+    state: { ...baseState, status: 'generating' },
+  },
+  {
+    label: 'Single result',
+    message: assistantMessage('painting-single-result', 'success'),
+    state: {
+      ...baseState,
+      outputs: [{ fileEntryId: 'painting-output-1', uri: firstOutputUri }],
+    },
+  },
+  {
+    label: 'Multiple results',
+    message: assistantMessage('painting-multiple-results', 'success'),
+    state: {
+      ...baseState,
+      outputs: [
+        { fileEntryId: 'painting-output-2', uri: firstOutputUri },
+        { fileEntryId: 'painting-output-3', uri: secondOutputUri },
+      ],
+    },
+  },
+  {
+    label: 'Failed',
+    message: assistantMessage('painting-failed', 'error'),
+    state: { ...baseState, error: new Error('The image provider rejected the request.') },
+  },
+  {
+    label: 'Interrupted',
+    message: assistantMessage('painting-interrupted', 'error'),
+    state: {
+      ...baseState,
+      interruption: { message: 'Generation stopped before an image was produced.' },
+    },
+  },
+  {
+    label: 'Idle without output (renders no assistant content)',
+    message: assistantMessage('painting-empty', 'success'),
+    state: baseState,
+  },
+];
+
+export function PaintingStoryFrame({
+  examples,
+  theme,
+}: {
+  examples: readonly PaintingExample[];
+  theme: 'dark' | 'light';
+}) {
+  return (
+    <ScopedTheme theme={theme}>
+      <MessagesStoryProviders>
+        <ScrollView
+          className="flex-1 bg-background"
+          contentContainerClassName="gap-5 py-4"
+          contentInsetAdjustmentBehavior="automatic"
+        >
+          {examples.map(({ label, message, state }) => (
+            <View className="gap-2 px-4" key={message.id}>
+              <Text className="font-medium text-foreground-tertiary text-sm">{label}</Text>
+              <PaintingMessage message={message} state={state} />
+            </View>
+          ))}
+        </ScrollView>
+      </MessagesStoryProviders>
+    </ScopedTheme>
+  );
+}

--- a/.rnstorybook/stories/messages/painting.stories.tsx
+++ b/.rnstorybook/stories/messages/painting.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-native';
+
+import { PaintingAssistantMessage } from '@/frontend/features/paintings/components/PaintingAssistantMessage';
+
+import { paintingExamples, PaintingStoryFrame } from './PaintingStoryFrame';
+
+const meta = {
+  title: 'Messages/Painting',
+  component: PaintingAssistantMessage,
+  args: {
+    aspectRatio: 1,
+    error: null,
+    interruption: null,
+    outputs: [],
+    resolution: '1024 × 1024',
+    status: 'idle',
+  },
+  parameters: { controls: { disable: true } },
+} satisfies Meta<typeof PaintingAssistantMessage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Light: Story = {
+  render: () => <PaintingStoryFrame examples={paintingExamples} theme="light" />,
+};
+
+export const Dark: Story = {
+  render: () => <PaintingStoryFrame examples={paintingExamples} theme="dark" />,
+};
+
+export const Generating: Story = {
+  render: () => <PaintingStoryFrame examples={[paintingExamples[1]!]} theme="light" />,
+};
+
+export const SingleResult: Story = {
+  render: () => <PaintingStoryFrame examples={[paintingExamples[2]!]} theme="light" />,
+};
+
+export const MultipleResults: Story = {
+  render: () => <PaintingStoryFrame examples={[paintingExamples[3]!]} theme="light" />,
+};
+
+export const Failed: Story = {
+  render: () => <PaintingStoryFrame examples={[paintingExamples[4]!]} theme="light" />,
+};
+
+export const Interrupted: Story = {
+  render: () => <PaintingStoryFrame examples={[paintingExamples[5]!]} theme="light" />,
+};

--- a/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
@@ -15,7 +15,9 @@ import { BottomSheet } from '../../bottom-sheet';
 import { Image } from '../../image';
 import { PrismSweep } from '../../loading';
 import type {
+  MessagePartDetailProps,
   MessagePartReasoningProps,
+  MessagePartSummaryProps,
   MessagePartTone,
   MessagePartToolProps,
 } from '../message-part.types';
@@ -53,14 +55,13 @@ export function MessagePartReasoning({
         <ChevronRightIcon className="size-3.5 text-muted-foreground" />
       </MessagePartStatus>
       {isOpen ? (
-        <MessagePartSheet
-          contentClassName="px-4 pb-4"
+        <MessagePartDetail
           onClose={() => setIsOpen(false)}
           testID={`${testID}-detail`}
           title={detailTitle}
         >
           {children}
-        </MessagePartSheet>
+        </MessagePartDetail>
       ) : null}
     </View>
   );
@@ -68,6 +69,7 @@ export function MessagePartReasoning({
 
 export function MessagePartTool({
   children,
+  detailTitle,
   icon: Icon = WrenchIcon,
   imageSource,
   state,
@@ -77,12 +79,48 @@ export function MessagePartTool({
   title,
 }: MessagePartToolProps) {
   const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <View className="gap-1.5">
+      <MessagePartSummary
+        icon={Icon}
+        imageSource={imageSource}
+        onPress={() => setIsOpen(true)}
+        state={state}
+        statusText={statusText}
+        statusTone={statusTone}
+        testID={testID}
+        title={title}
+      />
+      {isOpen ? (
+        <MessagePartDetail
+          onClose={() => setIsOpen(false)}
+          testID={`${testID}-detail`}
+          title={detailTitle ?? title}
+        >
+          {children}
+        </MessagePartDetail>
+      ) : null}
+    </View>
+  );
+}
+
+export function MessagePartSummary({
+  icon: Icon = WrenchIcon,
+  imageSource,
+  onPress,
+  state,
+  statusText,
+  statusTone = 'default',
+  testID = 'message-part-summary',
+  title,
+}: MessagePartSummaryProps) {
   const colorClassName = toneClassName[statusTone];
   const isPulsing = state === 'running';
   const trigger = (
     <MessagePartStatus
       accessibilityLabel={statusText ? `${title}, ${statusText}` : title}
-      onPress={() => setIsOpen(true)}
+      onPress={onPress}
       testID={`${testID}-trigger`}
     >
       {imageSource ? (
@@ -107,26 +145,12 @@ export function MessagePartTool({
     </MessagePartStatus>
   );
 
-  return (
-    <View className="gap-1.5">
-      {isPulsing ? (
-        <MessagePartRunningPulse testID={`${testID}-running-trigger`}>
-          {trigger}
-        </MessagePartRunningPulse>
-      ) : (
-        trigger
-      )}
-      {isOpen ? (
-        <MessagePartSheet
-          contentClassName="gap-2.5 px-4 pb-4"
-          onClose={() => setIsOpen(false)}
-          testID={`${testID}-detail`}
-          title={title}
-        >
-          <View className="gap-2.5">{children}</View>
-        </MessagePartSheet>
-      ) : null}
-    </View>
+  return isPulsing ? (
+    <MessagePartRunningPulse testID={`${testID}-running-trigger`}>
+      {trigger}
+    </MessagePartRunningPulse>
+  ) : (
+    trigger
   );
 }
 
@@ -160,24 +184,14 @@ function MessagePartRunningPulse({ children, testID }: { children: ReactNode; te
   );
 }
 
-function MessagePartSheet({
-  children,
-  contentClassName,
-  onClose,
-  testID,
-  title,
-}: {
-  children: ReactNode;
-  contentClassName: string;
-  onClose: () => void;
-  testID: string;
-  title: string;
-}) {
+export function MessagePartDetail({ children, onClose, testID, title }: MessagePartDetailProps) {
+  // TODO(message-part-detail): Replace arbitrary children with controlled detail layouts after the
+  // visual designs for text, structured data, lists, and media are finalized.
   return (
     <BottomSheet onClose={onClose} open size="large" testID={testID} title={title}>
       <ScrollView
         className="flex-1"
-        contentContainerClassName={contentClassName}
+        contentContainerClassName="gap-2.5 px-4 pb-4"
         showsVerticalScrollIndicator={false}
       >
         {children}

--- a/packages/ui/src/components/message-part/components/message-part.tsx
+++ b/packages/ui/src/components/message-part/components/message-part.tsx
@@ -1,7 +1,12 @@
 import { View } from 'react-native';
 
 import type { MessagePartRootProps } from '../message-part.types';
-import { MessagePartReasoning, MessagePartTool } from './message-part-disclosure';
+import {
+  MessagePartDetail,
+  MessagePartReasoning,
+  MessagePartSummary,
+  MessagePartTool,
+} from './message-part-disclosure';
 import { MessagePartError } from './message-part-feedback';
 import { MessagePartPending } from './message-part-pending';
 import { MessagePartPlaceholder } from './message-part-placeholder';
@@ -24,6 +29,7 @@ function MessagePartRoot({ children, className, ...props }: MessagePartRootProps
 }
 
 export const MessagePart = Object.assign(MessagePartRoot, {
+  Detail: MessagePartDetail,
   Error: MessagePartError,
   Pending: MessagePartPending,
   Placeholder: MessagePartPlaceholder,
@@ -31,6 +37,7 @@ export const MessagePart = Object.assign(MessagePartRoot, {
   SectionTitle: MessagePartSectionTitle,
   Source: MessagePartSource,
   Status: MessagePartStatus,
+  Summary: MessagePartSummary,
   TextSection: MessagePartTextSection,
   Tool: MessagePartTool,
   Translation: MessagePartTranslation,

--- a/packages/ui/src/components/message-part/index.ts
+++ b/packages/ui/src/components/message-part/index.ts
@@ -1,5 +1,6 @@
 export { MessagePart } from './components/message-part';
 export type {
+  MessagePartDetailProps,
   MessagePartErrorProps,
   MessagePartPendingProps,
   MessagePartPlaceholderProps,
@@ -8,6 +9,7 @@ export type {
   MessagePartSectionTitleProps,
   MessagePartSourceProps,
   MessagePartStatusProps,
+  MessagePartSummaryProps,
   MessagePartTextSectionProps,
   MessagePartTone,
   MessagePartToolProps,

--- a/packages/ui/src/components/message-part/message-part.types.ts
+++ b/packages/ui/src/components/message-part/message-part.types.ts
@@ -22,6 +22,13 @@ export type MessagePartReasoningProps = {
   testID?: string;
 };
 
+export type MessagePartDetailProps = {
+  children: ReactNode;
+  onClose: () => void;
+  testID?: string;
+  title: string;
+};
+
 export type MessagePartPendingProps = {
   accessibilityLabel: string;
   testID?: string;
@@ -32,15 +39,20 @@ export type MessagePartUnknownProps = {
   testID?: string;
 };
 
-export type MessagePartToolProps = {
-  children: ReactNode;
+export type MessagePartSummaryProps = {
   icon?: ComponentType<LucideIconProps>;
   imageSource?: ImageSource | number;
+  onPress: () => void;
   state: 'complete' | 'running';
   statusText?: string;
   statusTone?: MessagePartTone;
   testID?: string;
   title: string;
+};
+
+export type MessagePartToolProps = Omit<MessagePartSummaryProps, 'onPress'> & {
+  children: ReactNode;
+  detailTitle?: string;
 };
 
 export type MessagePartErrorProps = {

--- a/src/frontend/components/messages/README.md
+++ b/src/frontend/components/messages/README.md
@@ -33,6 +33,74 @@ A tool that returns managed artifacts already has them in the message: the Host 
 as a `purpose: 'artifact'` file part that draws its own card. A per-tool renderer therefore renders
 the *call*, never the artifact, or the same file appears twice.
 
+## Message Disclosure Contract
+
+Interactive message parts separate their compact presentation, interaction state, and expanded
+content. Tool renderers must compose these layers through the shared `MessagePart` primitives
+instead of creating feature-owned rows or sheets:
+
+| Layer | Owner | Contract |
+| --- | --- | --- |
+| Summary | `MessagePart.Summary` | Renders the leading icon slot, title, status text, tone, running animation, and disclosure chevron. |
+| Interaction | `MessagePart.Tool` | Owns local open/close state and connects the summary press to its detail. Business renderers do not lift this transient state. |
+| Detail shell | `MessagePart.Detail` | Owns the `BottomSheet`, title, dismissal, scrolling, content insets, and spacing. Tool, reasoning, and source details share this shell. |
+| Detail content | The part renderer | Supplies the business-specific content inside the shell. This content remains intentionally unconstrained until its visual variants are designed. |
+
+`MessagePart.Summary` standardizes an icon *slot*, not one icon. The slot has one size, position,
+and alignment; the product adapter chooses its `icon` or `imageSource`. An image source takes
+precedence over the icon component, and the wrench is only the fallback when neither is supplied.
+The adapter also derives localized title and status text plus the semantic status tone. It must not
+recreate the shared row geometry.
+
+`MessagePart.Tool` is the required outer composition for generic, MCP, web-search, write-file, and
+Meta tool calls. Those tool renderers remain separate while their detail semantics differ. A common
+summary row is not by itself a reason to merge their business adapters. Merge adapters only when
+they have the same dispatch rules, state interpretation, and detail-content contract.
+
+Reasoning and source groups retain their domain-specific compact triggers, but their expanded views
+must use `MessagePart.Detail`. New interactive message parts may introduce a distinct compact
+trigger only when their semantics cannot be expressed by `MessagePart.Summary`; they must not
+introduce another bottom-sheet shell.
+
+### Detail Content Status
+
+Detail content currently accepts arbitrary React children. Raw text, structured values, source
+links, and media therefore keep their existing feature-owned presentation. This is an explicit
+temporary boundary, not a recommendation to create more one-off layouts.
+
+Do not add a controlled detail-layout API until the text, structured-data, list, media, empty, and
+error variants have approved visual designs. When that work begins, evolve the single
+`MessagePart.Detail` boundary rather than adding parallel shells. The matching implementation TODO
+lives beside `MessagePartDetail` in `packages/ui/src/components/message-part/components/message-part-disclosure.tsx`.
+
+### Renderer Inventory And Visual Acceptance
+
+The visible non-tool part adapters are Text, Reasoning, Code, Compact, Error, Translation, File,
+Source URL/group, and Unknown. Pending is an assistant-row state rather than a persisted part
+adapter. Video data, source-document, step-start, and provider-owned web-search parts intentionally
+render no separate message-list content.
+
+The tool content adapters are Generic, MCP, Web Search, Write File, Meta Search, Meta Inspect, Meta
+Invoke, and Meta Exec. Painting remains a feature-owned message renderer and is not a tool-detail
+variant. Count renderer families, disclosure layers, and visual states separately; combining them
+into one component total obscures ownership and does not measure duplication.
+
+Use the following Storybook stories as the visual inventory:
+
+- `Message Parts / Tools / States` covers the shared summary slot in running, complete, and error
+  states in light and dark themes.
+- `Messages / Playground / Light` and `Messages / Playground / Dark` exercise the production
+  message-part dispatch, including Generic, MCP, Web Search, Write File, and all Meta tool adapters.
+- `Messages / Painting` separates generating, single-result, multiple-result, failed, and
+  interrupted painting states.
+
+When adding or changing an interactive renderer, add a production-shaped fixture for each relevant
+state, inspect both themes on a device, open the detail, and confirm that the summary uses the shared
+slot and the expanded content uses the shared shell. Follow
+[`UI Development`](../../../../docs/guides/ui-development.md) and
+[`Parallel Device Testing`](../../../../docs/guides/parallel-device-testing.md) for the general visual
+and workspace acceptance rules.
+
 ## Ownership
 
 The module accepts only visible `user` and `assistant` messages. A feature that stores additional

--- a/src/frontend/components/messages/parts/SourceGroup.tsx
+++ b/src/frontend/components/messages/parts/SourceGroup.tsx
@@ -1,9 +1,9 @@
 import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
 import GlobeIcon from '@cherrystudio/app-icons/icons/globe';
-import { BottomSheet } from '@cherrystudio/ui/components';
+import { MessagePart } from '@cherrystudio/ui/components';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Pressable, ScrollView, Text } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
@@ -45,17 +45,8 @@ export function SourceGroup({ parts }: SourceGroupProps) {
         <ChevronRightIcon className="size-3.5 text-muted-foreground" />
       </Pressable>
       {isOpen ? (
-        <BottomSheet
-          onClose={() => setIsOpen(false)}
-          open
-          size="large"
-          title={t('chat.sources.title')}
-        >
-          <ScrollView
-            className="flex-1"
-            contentContainerClassName="gap-1 px-4 pb-4"
-            showsVerticalScrollIndicator={false}
-          >
+        <MessagePart.Detail onClose={() => setIsOpen(false)} title={t('chat.sources.title')}>
+          <View className="gap-1">
             {sources.map((source) => (
               <SourceLink
                 key={source.url}
@@ -64,8 +55,8 @@ export function SourceGroup({ parts }: SourceGroupProps) {
                 variant="listItem"
               />
             ))}
-          </ScrollView>
-        </BottomSheet>
+          </View>
+        </MessagePart.Detail>
       ) : null}
     </>
   );


### PR DESCRIPTION
## Summary

- introduce `MessagePart.Summary` as the shared replaceable icon, title, and status slot for tool rows
- promote `MessagePart.Detail` to the shared bottom-sheet shell used by tools, reasoning, and source groups
- keep tool detail children intentionally unconstrained and document the future controlled-layout boundary
- document the disclosure contract, renderer inventory, merge criteria, and visual acceptance matrix
- add production-shaped Painting Storybook stories for generating, result, failure, and interruption states
- explicitly dismiss the native splash screen from the Storybook entry

## Validation

- `pnpm lint` (passes with existing repository warnings)
- `git diff --check`
- inspected the tool summary states and generic/search detail shells in the dedicated iOS simulator
- inspected message and painting stories in light and dark themes

## Not run

- tests and typecheck were not run, following the workspace verification policy