### PR TITLE
fix(chat-input): keep composer in parent layout flow

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -378,10 +378,11 @@ callers never need grouping views. `Composer.Action` is the button shell every t
 owns the circle, the 44pt slop, and the tint, so the row stays one size and one material no matter
 who contributed a button to it.
 
-`Composer.Dock` floats a composed input above screen content, applies horizontal and safe-area
-insets, follows the keyboard, and reports its measured height. Pair it with
-`useComposerDockLayout()` when content above the dock needs the reserved inset, keyboard offset, or
-shared live height used by another floating control:
+`Composer.Dock` applies horizontal and safe-area insets and follows the keyboard. It floats above
+screen content by default. Use `layoutMode="flow"` when the parent should reserve its space through
+normal flex layout; this avoids measuring the dock back into React state. Pair the floating mode
+with `useComposerDockLayout()` when content behind the dock needs the reserved inset, keyboard
+offset, or shared live height used by another floating control:
 
 ```tsx
 const dock = useComposerDockLayout();

--- a/packages/ui/src/components/composer/__tests__/composer-dock.test.tsx
+++ b/packages/ui/src/components/composer/__tests__/composer-dock.test.tsx
@@ -127,4 +127,18 @@ describe('Composer.Dock', () => {
       opened: 0,
     });
   });
+
+  it('can participate in parent flow without measuring its animated height', () => {
+    act(() => {
+      renderer = create(
+        <ComposerDock layoutMode="flow">
+          <View />
+        </ComposerDock>,
+      );
+    });
+
+    const container = renderer!.root.findByProps({ pointerEvents: 'box-none' });
+    expect(container.props.className).toBe('z-10 shrink-0');
+    expect(container.props.onLayout).toBeUndefined();
+  });
 });

--- a/packages/ui/src/components/composer/components/composer-dock.tsx
+++ b/packages/ui/src/components/composer/components/composer-dock.tsx
@@ -11,15 +11,18 @@ import {
 
 export type ComposerDockProps = PropsWithChildren<{
   containerRef?: RefObject<View | null>;
+  /** Uses normal parent layout instead of overlaying sibling content. */
+  layoutMode?: 'floating' | 'flow';
   /** Stops following keyboard coordinates while another surface owns input. */
   keyboardTrackingEnabled?: boolean;
-  onHeightChange: (height: number) => void;
+  onHeightChange?: (height: number) => void;
   onLayout?: (event: LayoutChangeEvent) => void;
 }>;
 
 export function ComposerDock({
   children,
   containerRef,
+  layoutMode = 'floating',
   keyboardTrackingEnabled = true,
   onHeightChange,
   onLayout,
@@ -28,7 +31,7 @@ export function ComposerDock({
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      onHeightChange(event.nativeEvent.layout.height);
+      onHeightChange?.(event.nativeEvent.layout.height);
       onLayout?.(event);
     },
     [onHeightChange, onLayout],
@@ -37,8 +40,8 @@ export function ComposerDock({
   return (
     <View
       ref={containerRef}
-      className="absolute right-0 bottom-0 left-0 z-10"
-      onLayout={handleLayout}
+      className={layoutMode === 'flow' ? 'z-10 shrink-0' : 'absolute right-0 bottom-0 left-0 z-10'}
+      onLayout={onHeightChange || onLayout ? handleLayout : undefined}
       pointerEvents="box-none"
       style={{
         paddingBottom: Math.max(bottom, composerMinBottomPadding),

--- a/packages/ui/src/components/composer/index.ts
+++ b/packages/ui/src/components/composer/index.ts
@@ -18,3 +18,4 @@ export type {
   ComposerToolbarProps,
 } from './composer.types';
 export { useComposerDockLayout } from './hooks/use-composer-dock-layout';
+export { composerContentGap, getComposerKeyboardStickyOffset } from './utils/composer-dock-layout';

--- a/packages/ui/src/components/scroll-to-bottom-button/__tests__/scroll-to-bottom-button.test.tsx
+++ b/packages/ui/src/components/scroll-to-bottom-button/__tests__/scroll-to-bottom-button.test.tsx
@@ -19,7 +19,9 @@ jest.mock('../../surface', () => {
 
 jest.mock('@cherrystudio/app-icons/icons/arrow-down', () => {
   const React = jest.requireActual('react');
-  return (props: object) => React.createElement('ArrowDownIcon', props);
+  return function MockArrowDownIcon(props: object) {
+    return React.createElement('ArrowDownIcon', props);
+  };
 });
 
 jest.mock('uniwind', () => ({
@@ -121,5 +123,23 @@ describe('ScrollToBottomButton', () => {
       pointerEvents: 'none',
       style: [{ transform: [{ scale: 0.8 }] }, { opacity: 0 }],
     });
+  });
+
+  it('uses the list edge when there is no floating accessory', () => {
+    act(() => {
+      renderer = create(
+        <ScrollToBottomButton
+          accessibilityLabel="Scroll to bottom"
+          gap={5}
+          isAtBottom={false}
+          onPress={jest.fn()}
+        />,
+      );
+    });
+
+    expect(renderer!.root.findAllByType('AnimatedView')[0].props.style).toEqual([
+      { alignItems: 'center', left: 0, position: 'absolute', right: 0 },
+      { bottom: 5 },
+    ]);
   });
 });

--- a/packages/ui/src/components/scroll-to-bottom-button/components/scroll-to-bottom-button.tsx
+++ b/packages/ui/src/components/scroll-to-bottom-button/components/scroll-to-bottom-button.tsx
@@ -12,7 +12,7 @@ const visibilityMotion = { duration: duration.fast, easing: easing.settle } as c
 
 export type ScrollToBottomButtonProps = {
   accessibilityLabel: string;
-  bottomAccessoryHeight: SharedValue<number>;
+  bottomAccessoryHeight?: SharedValue<number>;
   gap: number;
   isAtBottom: boolean;
   onPress: () => void;
@@ -33,7 +33,10 @@ export function ScrollToBottomButton({
     { borderColor: surfaceTokens.borderColor, borderWidth: surfaceTokens.borderWidth },
   ];
 
-  const wrapStyle = useAnimatedStyle(() => ({ bottom: bottomAccessoryHeight.get() + gap }));
+  const wrapStyle = useAnimatedStyle(
+    () => ({ bottom: (bottomAccessoryHeight?.get() ?? 0) + gap }),
+    [bottomAccessoryHeight, gap],
+  );
   const containerStyle = useAnimatedStyle(
     () => ({ transform: [{ scale: withTiming(isAtBottom ? 0.8 : 1, visibilityMotion) }] }),
     [isAtBottom],

--- a/src/frontend/components/composer/README.md
+++ b/src/frontend/components/composer/README.md
@@ -58,8 +58,8 @@ plus `allowEmptySend` and `isSendEnabled` — see `canSend` below.
   it; caller-owned replacement buttons, such as painting settings, use the
   same action.
 - `ComposerDock` — connects that input-context state to CherryUI's
-  `Composer.Dock`. `useComposerDockLayout` remains CherryUI's measurement and
-  content-inset primitive.
+  `Composer.Dock`. Chat keeps it in normal parent flow; floating surfaces can pair it with
+  CherryUI's `useComposerDockLayout` measurement and content-inset primitive.
 - `utils/composerAttachments` is deep-imported on purpose (see `index.ts`).
 
 ## What is deliberately *not* pluggable

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -255,7 +255,7 @@ export function MessageList({
             className="flex-1"
           />
         </ScrollShadow>
-        {bottomAccessoryHeight && messages.length > 0 ? (
+        {messages.length > 0 ? (
           <ScrollToBottomButton
             accessibilityLabel={t('chat.message.scrollToBottom')}
             bottomAccessoryHeight={bottomAccessoryHeight}

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -78,7 +78,7 @@ let mockSlideInFlight: MessageSlideInFlight | undefined;
 let mockScrollButtonProps:
   | {
       accessibilityLabel: string;
-      bottomAccessoryHeight: SharedValue<number>;
+      bottomAccessoryHeight?: SharedValue<number>;
       gap: number;
       isAtBottom: boolean;
       onPress: () => void;
@@ -132,7 +132,7 @@ jest.mock('@legendapp/list/keyboard', () => {
 jest.mock('@cherrystudio/ui/components', () => ({
   ScrollToBottomButton: (props: {
     accessibilityLabel: string;
-    bottomAccessoryHeight: SharedValue<number>;
+    bottomAccessoryHeight?: SharedValue<number>;
     gap: number;
     isAtBottom: boolean;
     onPress: () => void;
@@ -399,7 +399,7 @@ describe('MessageList anchoring and manual scrolling', () => {
     expect(mockLatestListProps?.onStartReached).toBeUndefined();
   });
 
-  test('owns the entering-message provider and optional scroll button', () => {
+  test('owns the entering-message provider and positions the scroll button above its accessory', () => {
     const bottomAccessoryHeight = {
       get: jest.fn(() => 88),
       set: jest.fn(),
@@ -430,7 +430,11 @@ describe('MessageList anchoring and manual scrolling', () => {
     mockScrollButtonProps = undefined;
     act(() => renderer?.update(<MessageList {...listProps(props.messages)} />));
 
-    expect(mockScrollButtonProps).toBeUndefined();
+    expect(mockScrollButtonProps).toMatchObject({
+      accessibilityLabel: 'translated:chat.message.scrollToBottom',
+      gap: 5,
+    });
+    expect(mockScrollButtonProps?.bottomAccessoryHeight).toBeUndefined();
     // 入场 id 落地后刻意不清：待发消息落库常在飞行中途，清掉会让行当帧跳回落点。
     expect(mockSlideInFlight?.activeMessageId.get()).toBe('user-1');
   });

--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -1,6 +1,7 @@
-import { useComposerDockLayout } from '@cherrystudio/ui/components';
+import { composerContentGap, getComposerKeyboardStickyOffset } from '@cherrystudio/ui/components';
 import { useIsPreview, useLocalSearchParams } from 'expo-router';
 import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ComposerDock, ComposerSessionProvider } from '@/frontend/components/composer';
 import { MainHeader } from '@/frontend/components/headers';
@@ -33,10 +34,9 @@ export function ChatScreen() {
     !sessionId && Boolean(agentId) && !agent.error && (agent.isLoading || Boolean(agent.agent));
   const hasComposer =
     !isPreview && Boolean(agent.agent) && (isSessionAvailable || isNewAgentAvailable);
-  const composerDockLayout = useComposerDockLayout();
-  const contentBottomInset = hasComposer
-    ? composerDockLayout.contentBottomInset
-    : PREVIEW_CONTENT_BOTTOM_INSET;
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const contentBottomInset = hasComposer ? composerContentGap : PREVIEW_CONTENT_BOTTOM_INSET;
+  const keyboardOffset = hasComposer ? getComposerKeyboardStickyOffset(bottomInset) : 0;
 
   return (
     <>
@@ -47,9 +47,8 @@ export function ChatScreen() {
             assistantAvatarUri={agent.agent?.avatarUri}
             assistantName={agent.agent?.name}
             isAssistantToolbarEnabled={!isPreview}
-            bottomAccessoryHeight={hasComposer ? composerDockLayout.inputHeightShared : undefined}
             contentBottomInset={contentBottomInset}
-            keyboardOffset={hasComposer ? composerDockLayout.keyboardOffset : 0}
+            keyboardOffset={keyboardOffset}
             messageWindow={messageWindow}
             renderGateKey={sessionId}
             sessionId={sessionId}
@@ -59,7 +58,7 @@ export function ChatScreen() {
         )}
         {hasComposer ? (
           <ComposerSessionProvider>
-            <ComposerDock onHeightChange={composerDockLayout.handleInputHeightChange}>
+            <ComposerDock layoutMode="flow">
               <ChatInput
                 agentId={resolvedAgentId}
                 dismissKeyboardOnSend={false}

--- a/src/frontend/features/chat/README.md
+++ b/src/frontend/features/chat/README.md
@@ -10,9 +10,9 @@ behavior. Structured message rendering is shared with painting through
 
 ## Organization
 
-- `ChatScreen.tsx` is header + swappable body + docked composer session. With a Session the body is
-  the conversation; selecting an Agent without one shows the empty state and creates the Session on
-  first send.
+- `ChatScreen.tsx` is header + swappable body + composer session in normal parent flow. With a
+  Session the body is the conversation; selecting an Agent without one shows the empty state and
+  creates the Session on first send.
 - `input/` owns the narrow Agent Protocol wrapper around the shared composer. Agent settings are
   edited on the Agent screen; image attachment admission failures restore the managed draft and
   surface a user-facing reason.

--- a/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
+++ b/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
@@ -2,8 +2,6 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { ChatScreen } from '../ChatScreen';
 
-const mockHandleInputHeightChange = jest.fn();
-const mockInputHeightShared = { value: 122 };
 let chatInputProps: Record<string, unknown> | undefined;
 let chatWorkspaceProps: Record<string, unknown> | undefined;
 let dockProps: Record<string, unknown> | undefined;
@@ -11,13 +9,12 @@ let mockSessionData: { agentId: string; id: string } | undefined;
 let mockSessionIsLoading: boolean;
 
 jest.mock('@cherrystudio/ui/components', () => ({
-  useComposerDockLayout: () => ({
-    contentBottomInset: 130,
-    handleInputHeightChange: mockHandleInputHeightChange,
-    inputHeight: 122,
-    inputHeightShared: mockInputHeightShared,
-    keyboardOffset: 26,
-  }),
+  composerContentGap: 8,
+  getComposerKeyboardStickyOffset: () => 26,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 0 }),
 }));
 
 jest.mock('@/frontend/components/composer', () => ({
@@ -84,19 +81,19 @@ describe('ChatScreen composer dock wiring', () => {
     renderer = undefined;
   });
 
-  it('shares CherryUI dock measurements with the workspace and composer', () => {
+  it('keeps the composer in normal flow and shares only keyboard geometry', () => {
     act(() => {
       renderer = create(<ChatScreen />);
     });
 
     expect(chatWorkspaceProps).toMatchObject({
-      bottomAccessoryHeight: mockInputHeightShared,
-      contentBottomInset: 130,
+      contentBottomInset: 8,
       keyboardOffset: 26,
     });
     expect(dockProps).toMatchObject({
-      onHeightChange: mockHandleInputHeightChange,
+      layoutMode: 'flow',
     });
+    expect(dockProps?.onHeightChange).toBeUndefined();
     expect(chatInputProps).toMatchObject({
       agentId: 'agent-1',
       dismissKeyboardOnSend: false,

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -3,7 +3,6 @@ import { useHeaderHeight } from 'expo-router/react-navigation';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
 
 import { MessageList, type MessageListItem } from '@/frontend/components/messages';
 import { resolveHeaderContentInset } from '@/frontend/components/navigation';
@@ -33,7 +32,6 @@ type ChatWorkspaceProps = {
   assistantAvatarUri?: null | string;
   assistantName?: string;
   isAssistantToolbarEnabled: boolean;
-  bottomAccessoryHeight?: SharedValue<number>;
   contentBottomInset: number;
   keyboardOffset: number;
   messageWindow: AgentMessageHistoryWindow;
@@ -44,7 +42,6 @@ type ChatWorkspaceProps = {
 export function ChatWorkspace({
   assistantAvatarUri,
   assistantName,
-  bottomAccessoryHeight,
   contentBottomInset,
   keyboardOffset,
   messageWindow,
@@ -149,7 +146,6 @@ export function ChatWorkspace({
       >
         <MessageList
           key={listRenderKey}
-          bottomAccessoryHeight={bottomAccessoryHeight}
           contentBottomInset={contentBottomInset}
           contentTopInset={contentTopInset}
           enteringMessageId={live.enteringUserMessageId}

--- a/src/frontend/features/chat/workspace/README.md
+++ b/src/frontend/features/chat/workspace/README.md
@@ -8,9 +8,9 @@ and message rendering live in `@/frontend/components/messages`.
 
 - `ChatWorkspace` is exported from `index.ts` for Agent Session screens.
 - Internal workspace pieces should be imported through relative paths inside this module.
-- The docking itself (`ComposerDock`, `useComposerDockLayout`) is not here — the shared app
-  composer owns input-context transitions, while CherryUI owns reusable keyboard, safe-area, and
-  measurement behavior. This module only connects those values to Chat.
+- The composer placement itself is not here — `ChatScreen` keeps the shared composer in normal
+  parent flow, while CherryUI owns reusable keyboard and safe-area behavior. This module only
+  connects the remaining list geometry to Chat.
 
 ## Organization
 

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import type { SharedValue } from 'react-native-reanimated';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import type { MessageListItem, MessageListProps } from '@/frontend/components/messages';
@@ -7,11 +6,6 @@ import type { AgentMessageView } from '@/shared/contracts/agent';
 
 import { ChatWorkspace } from '../ChatWorkspace';
 
-const mockInputHeightShared = {
-  get: jest.fn(() => 80),
-  set: jest.fn(),
-  value: 80,
-} as unknown as SharedValue<number>;
 const mockLoadOlder = jest.fn(async () => undefined);
 const mockRetry = jest.fn(async () => undefined);
 const mockRespondApproval = jest.fn(async () => undefined);
@@ -182,7 +176,6 @@ function createWorkspaceElement(
 ) {
   return (
     <ChatWorkspace
-      bottomAccessoryHeight={isPreview ? undefined : mockInputHeightShared}
       contentBottomInset={isPreview ? 12 : 96}
       isAssistantToolbarEnabled={!isPreview}
       keyboardOffset={isPreview ? 0 : 26}
@@ -230,7 +223,7 @@ describe('ChatWorkspace message rendering integration', () => {
     requestAnimationFrameSpy.mockRestore();
   });
 
-  test('merges live rows with displayable history and passes dock layout', () => {
+  test('merges live rows with displayable history and passes list layout', () => {
     const pendingUserMessage = createMessage('user-pending', 'user', 'pending');
     const messages = [
       createMessage('system-1', 'system'),
@@ -251,7 +244,6 @@ describe('ChatWorkspace message rendering integration', () => {
       'user-pending',
     ]);
     expect(mockMessageListProps?.enteringMessageId).toBe('user-pending');
-    expect(mockMessageListProps?.bottomAccessoryHeight).toBe(mockInputHeightShared);
     expect(mockMessageListProps?.contentBottomInset).toBe(96);
     expect(mockMessageListProps?.keyboardOffset).toBe(26);
     expect(mockMessageListProps?.onLoadOlder).toBe(mockLoadOlder);
@@ -285,10 +277,9 @@ describe('ChatWorkspace message rendering integration', () => {
     expect(mockAlertShow).not.toHaveBeenCalled();
   });
 
-  test('omits the internal scroll button accessory in preview', () => {
+  test('uses preview insets and hides assistant actions in preview', () => {
     renderer = renderWorkspace(true, [createMessage('assistant-1', 'assistant')]);
 
-    expect(mockMessageListProps?.bottomAccessoryHeight).toBeUndefined();
     expect(mockMessageListProps?.contentBottomInset).toBe(12);
     expect(mockMessageListProps?.keyboardOffset).toBe(0);
     expect(renderer.root.findAllByProps({ testID: 'assistant-message-toolbar' })).toHaveLength(0);


### PR DESCRIPTION
### What this PR does

Before this PR:

- The chat composer was absolutely positioned over the message list.
- Every animated composer height change flowed through `onLayout`, React state, `ChatScreen`, `ChatWorkspace`, and `MessageList` while the keyboard animation was also running.

After this PR:

- The chat composer participates in normal parent flex layout, so the parent reserves its space directly.
- Composer height animation remains local to `ChatInput`; the screen no longer measures that animation back into React state.
- Keyboard-following motion and chat-list lifting remain handled by the existing UI-thread keyboard primitives.
- The scroll-to-bottom control can anchor to the list edge when there is no floating accessory.

### Screenshots or videos

Not included. Manual device verification was intentionally not run as part of this task.

### Why we need it and why it was done in this way

The previous floating layout coupled a local composer animation to full-screen React renders. Keeping the composer in normal flow removes that feedback path while preserving the input's intended focus morph and the existing keyboard/list synchronization.

The following tradeoffs were made:

- `Composer.Dock` keeps floating mode as its default so painting and other existing callers are unchanged.
- Chat opts into `layoutMode="flow"` and uses only the shared content-gap and keyboard-offset geometry.
- Existing `KeyboardStickyView` and `KeyboardAwareLegendList` behavior remains unchanged.

The following alternatives were considered:

- Removing the input height morph was rejected because it is local presentation behavior, not keyboard avoidance.
- Replacing the chat-list keyboard integration with a screen-wide keyboard avoiding view was rejected because it would duplicate or remove the list's existing end-position behavior.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm format`: passed.
- Targeted `oxlint` and Expo lint for changed files: passed.
- Full `pnpm lint`: blocked by 8 existing unresolved `@cherrystudio/ai-core` imports in unrelated backend files.
- Tests, typecheck, and manual device verification were not run per the repository's user-owned verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: I have left the code cleaner than I found it
- [x] Upgrade: The impact of this change on upgrade flows was considered and no upgrade change is required
- [x] Documentation: Internal component and feature documentation was updated; no user-guide change is required
- [x] Self-review: I reviewed the final diff before requesting review

### Release note

```release-note
Improved the responsiveness of chat composer and keyboard transitions.
```
