### PR TITLE
fix(agent-chat): create sessions only after first send

### DIFF
--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -13,9 +13,9 @@ record for mobile-originated Agent Sessions only.
 
 - Four Agent-owned tables: `agent`, `agent_tool_binding`, `agent_session`,
   `agent_session_message`, plus an FTS index for message search.
-- A message-centric reshape of the `AgentSessionStore` port: the protocol's Turn becomes a Host
-  projection over the assistant message plus Host-held live state. The Agent Protocol itself does
-  not change.
+- A message-centric `AgentSessionStore` port: the protocol's Turn is a Host projection over the
+  assistant message plus Host-held live state. Starting from a Draft atomically inserts the Session
+  and its first user/assistant message pair.
 - A `SqliteAgentSessionStore` adapter that is the production `AgentSessionStore` binding;
   `InMemoryAgentSessionStore` remains as the conformance-suite reference adapter.
 - Agent CRUD plus cursor-paginated Session and transcript reads through the Data API, and an

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -285,13 +285,17 @@ Runtime identity.
 
 ```ts
 interface AgentProtocol {
-  createSession(input: {
-    agentId: string
-    executionTarget: AgentExecutionTarget
-    title?: string
-  }): Promise<AgentSessionView>
   renameSession(input: { sessionId: string; title: string }): Promise<AgentSessionView>
   deleteSession(input: { sessionId: string }): Promise<void>
+
+  startSession(input: {
+    agentId: string
+    executionTarget: AgentExecutionTarget
+    parts: AgentInputPart[]
+    modelId?: UniqueModelId
+    reasoningEffort?: ReasoningEffortOption
+    temporaryCapabilities?: Array<'web-search' | 'image-generation'>
+  }): Promise<AgentSessionView>
 
   submitMessage(input: {
     sessionId: string
@@ -322,6 +326,12 @@ type AgentSessionObservation = {
 }
 ```
 
+`startSession` is the Draft-to-Session boundary. It performs the same write-free turn preparation
+as `submitMessage`, opens the Runtime, and then atomically creates the durable Session together with
+the first user message and assistant placeholder. A failed Draft submission therefore leaves no
+empty Session. The client observes and navigates to the returned Session only after this operation
+succeeds. The chat Draft does not create a Session directly.
+
 `modelId` and `reasoningEffort` are immutable snapshots of the composer state for that submission.
 The model snapshot closes the gap while the same selection is persisted to the Agent. The reasoning
 snapshot is turn-local and is never written to Agent configuration. Omitting either field inherits
@@ -338,7 +348,9 @@ for the turn, so history does not depend on reconstructing composer state.
 `observeSession` registers the listener and captures the snapshot as one Host operation, so an
 event cannot fall into a snapshot/subscription gap. Calling it again replaces stale frontend state;
 the protocol does not need event sequence, host epoch, replay buffers, or revision counters in
-version 1.
+version 1. Observation admission is serialized with Session deletion: an observation already
+loading must finish or fail before rows are removed, and one overlapping the deletion barrier fails
+with `SESSION_BUSY` rather than returning a snapshot for a deleted Session.
 
 ## Events
 
@@ -469,6 +481,7 @@ Host boundary.
 12. Every finalized tool call is terminal and reconstructs as a paired model tool call/result.
 13. Every file part uses a managed id rather than a raw path; deleted content remains an unavailable
     historical reference, and artifact parts are not implicit model attachments.
+14. A Draft Session becomes durable in the same transaction that reserves its first message pair.
 
 ## Branching
 

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -383,13 +383,17 @@ type AgentSessionSnapshot = {
   session: AgentSessionView
   capabilities: AgentCapabilities
   activeTurn: AgentTurnView | null
+  activeUserMessage: AgentMessageView | null
+  hasHistoryBeforeActiveTurn: boolean | null
   streamingMessage: AgentMessageView | null
   pendingApprovals: AgentApprovalView[]
 }
 ```
 
 Persisted transcript pagination remains a normal data read and is not duplicated in the runtime
-snapshot. The snapshot contains only live state that must be composed over persisted messages.
+snapshot. The snapshot contains only live state that must be composed over persisted messages. An
+active turn includes its user row and whether older history precedes it, so a newly created
+Session can render its first exchange immediately without waiting behind the history-layout cover.
 
 On route remount or foreground transition, the client creates a new observation and replaces its
 live projection with the returned snapshot. On process restart, the Host reconciles unfinished

--- a/docs/references/agent/agent-tools-and-resources.md
+++ b/docs/references/agent/agent-tools-and-resources.md
@@ -74,9 +74,10 @@ approval preference only changes whether effective `ask` calls show an interacti
 
 `web_search` and `web_fetch` require the turn-local `web-search` capability. `generate_image`
 requires `image-generation` and a configured drawing model. The composer snapshots its frontend
-Session cache for web search and its draft-local image selection on `submitMessage`. Neither is
-persisted on the Agent or Agent Session tables. System device and file capabilities have no
-Agent-specific switch. The inference snapshot records the tools that entered the immutable turn.
+Session cache for web search and its draft-local image selection on either `startSession` or
+`submitMessage`. Neither is persisted on the Agent or Agent Session tables. System device and file
+capabilities have no Agent-specific switch. The inference snapshot records the tools that entered
+the immutable turn.
 
 The logical binding model is:
 

--- a/docs/references/chat/streaming-and-rendering.md
+++ b/docs/references/chat/streaming-and-rendering.md
@@ -47,7 +47,9 @@ Session id through `useSyncExternalStore`. The client:
 Selecting an Agent opens an isolated Draft composer and does not create a Session. The first send
 calls `startSession`: the Host completes write-free turn preparation, then atomically creates the
 Session and reserves its first user/assistant message pair. Only after that succeeds does the client
-establish observation and replace the Draft route with the durable Session route.
+install an observation snapshot and replace the Draft route with the durable Session route. The
+snapshot hands the first user/assistant pair directly to the message list, so the initial history
+query does not put a loading cover between send and streaming output.
 
 ## Transcript Window And Live Projection
 

--- a/docs/references/chat/streaming-and-rendering.md
+++ b/docs/references/chat/streaming-and-rendering.md
@@ -44,8 +44,10 @@ Session id through `useSyncExternalStore`. The client:
 - releases the Host observation when the final React subscriber leaves;
 - replaces observed Session state from a fresh snapshot when the app returns to the foreground.
 
-Starting a chat with an Agent does not create an empty Session. The first send creates the Session,
-establishes its observation, updates the route, and then submits the message.
+Selecting an Agent opens an isolated Draft composer and does not create a Session. The first send
+calls `startSession`: the Host completes write-free turn preparation, then atomically creates the
+Session and reserves its first user/assistant message pair. Only after that succeeds does the client
+establish observation and replace the Draft route with the durable Session route.
 
 ## Transcript Window And Live Projection
 
@@ -97,7 +99,8 @@ approvals. Stop calls `cancelTurn` only when the selected Session has a non-term
 
 ## Acceptance
 
-- A new Session is observed before its first message is submitted, so initial events are not lost.
+- A Draft creates its Session and first message pair atomically; failed admission leaves no Session.
+- The first observation snapshot recovers output produced between Session start and route subscription.
 - A fresh subscriber recovers active output and approvals from the Session snapshot.
 - Persisted and live rows merge without duplicate message ids.
 - Older transcript pages appear in chronological order.

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -180,10 +180,12 @@ type ActiveTurnState = {
   agent: AgentDefinition;
   abortController: AbortController;
   turn: AgentTurnView;
+  activeUserMessage: AgentMessageView;
   assistantMessage: AgentMessageView;
   autoNamePromise: Promise<AgentSessionView | null> | null;
   autoNameUserParts: AgentInputPart[] | null;
   backgroundReply: BackgroundReplyTurn;
+  hasHistoryBeforeActiveTurn: boolean;
   pendingApprovals: Map<string, AgentApprovalView>;
   pendingContextCheckpoint: RuntimeContextCheckpoint | null;
   resources: TurnResourceLedger;
@@ -605,6 +607,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           session,
           capabilities,
           activeTurn: active?.turn ?? null,
+          activeUserMessage: active?.activeUserMessage ?? null,
+          hasHistoryBeforeActiveTurn: active?.hasHistoryBeforeActiveTurn ?? null,
           streamingMessage: active?.assistantMessage ?? null,
           pendingApprovals: active
             ? [...active.pendingApprovals.values()].filter((entry) => entry.status === 'pending')
@@ -655,6 +659,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       agent: plan.agent,
       abortController,
       turn,
+      activeUserMessage: reserved.userMessage,
       assistantMessage: reserved.assistantMessage,
       autoNamePromise: null,
       autoNameUserParts: plan.hasMessages ? null : plan.inputParts,
@@ -664,6 +669,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         sessionId,
         sessionTitle,
       }),
+      hasHistoryBeforeActiveTurn: plan.hasMessages,
       pendingApprovals: new Map(),
       pendingContextCheckpoint: null,
       resources: plan.resources,

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -33,6 +33,8 @@
  *     published event is JSON-cloned (a non-JSON-safe value cannot survive);
  * 10. clients supply an execution target and Agent id; the local Pi binding
  *     stays private to the Host.
+ * 14. a Draft Session becomes durable in the same transaction as its first
+ *     user/assistant message reservation.
  */
 
 import type { AiService } from '@/backend/ai/AiService';
@@ -56,10 +58,10 @@ import type {
 import type { WebSearchService } from '@/backend/services/webSearch/WebSearchService';
 import {
   AgentCancelTurnInputSchema,
-  AgentCreateSessionInputSchema,
   AgentDeleteSessionInputSchema,
   AgentRenameSessionInputSchema,
   AgentRespondApprovalInputSchema,
+  AgentStartSessionInputSchema,
   AgentSubmitMessageInputSchema,
   AgentSessionSnapshotSchema,
   AgentProtocolError,
@@ -74,6 +76,7 @@ import {
   type AgentProtocol,
   type AgentSessionObservation,
   type AgentSessionView,
+  type AgentStartSessionInput,
   type AgentSubmitMessageInput,
   type AgentTurnView,
 } from '@/shared/contracts/agent';
@@ -92,7 +95,7 @@ import type {
   RuntimeUsageReport,
 } from '../runtime';
 import { raceAbort } from '../runtime';
-import type { AgentSessionStore } from '../sessionStore/AgentSessionStore';
+import type { AgentSessionStore, ReserveSubmissionResult } from '../sessionStore/AgentSessionStore';
 import { interruptNonTerminalToolParts } from '../sessionStore/messageSettlement';
 import {
   createSystemCapabilitySource,
@@ -118,7 +121,12 @@ import {
   toAgentUsageView,
 } from './runtimeProjection';
 import { materializeRuntimeAttachments } from './turnAttachments';
-import { prepareTurn, type TurnPlan, type TurnPreparationDependencies } from './turnPreparation';
+import {
+  prepareInitialTurn,
+  prepareTurn,
+  type TurnPlan,
+  type TurnPreparationDependencies,
+} from './turnPreparation';
 import { toRuntimeHistory, toRuntimeInputParts } from './turnRuntimeInput';
 
 const logger = loggerService.withContext('MobileAgentHost');
@@ -233,6 +241,8 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
   private readonly activeTurns = new Map<string, ActiveTurnState>();
   private readonly admittingSessions = new Map<string, AdmissionState>();
+  private readonly initialAdmissions = new Set<AdmissionState>();
+  private readonly observingSessions = new Map<string, Set<Promise<void>>>();
   private readonly deletingSessions = new Set<string>();
   private readonly runningTurnsBySession = new Map<string, Promise<void>>();
   private readonly runtimeSessions = new Map<
@@ -338,8 +348,13 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     for (const admission of this.admittingSessions.values()) {
       admission.abortController.abort(reason);
     }
+    for (const admission of this.initialAdmissions) {
+      admission.abortController.abort(reason);
+    }
     await Promise.allSettled(
-      [...this.admittingSessions.values()].map(({ completion }) => completion),
+      [...this.admittingSessions.values(), ...this.initialAdmissions].map(
+        ({ completion }) => completion,
+      ),
     );
     // An admission already committing its reservation may have installed a
     // turn while the first abort pass was running.
@@ -363,6 +378,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
   protected override onDestroy(): void {
     this.runningTurnsBySession.clear();
     this.listeners.clear();
+    this.observingSessions.clear();
   }
 
   async reconcileInterruptedTurns(): Promise<number> {
@@ -371,20 +387,55 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
 
   // ── Protocol operations ──
 
-  async createSession(input: {
-    agentId: string;
-    executionTarget: AgentExecutionTarget;
-    title?: string;
-  }): Promise<AgentSessionView> {
-    const parsed = AgentCreateSessionInputSchema.parse(input);
-    const agent = await this.agents.getAgent(parsed.agentId);
-    if (!agent) {
-      fail('AGENT_NOT_FOUND', `Agent does not exist: ${parsed.agentId}`);
+  async startSession(input: AgentStartSessionInput): Promise<AgentSessionView> {
+    const parsed = AgentStartSessionInputSchema.parse(input);
+    this.assertAcceptingSubmissions();
+    const completion = createCompletionSignal();
+    const abortController = new AbortController();
+    const admission = { abortController, completion: completion.promise };
+    const { signal } = abortController;
+    this.initialAdmissions.add(admission);
+    let openedRuntimeSession: AgentRuntimeSession | undefined;
+    let isRuntimeSessionInstalled = false;
+
+    try {
+      const plan = await prepareInitialTurn(this.turnPreparation, parsed, signal);
+      openedRuntimeSession = await this.openRuntimeSession(plan.runtime, signal);
+      signal.throwIfAborted();
+
+      const reserved = await this.store.reserveInitialSubmission({
+        agentId: parsed.agentId,
+        executionTarget: parsed.executionTarget,
+        userParts: plan.userParts,
+        modelId: plan.inferenceSnapshot.model.uniqueModelId,
+        inferenceSnapshot: plan.inferenceSnapshot,
+      });
+      const { session } = reserved;
+      this.runtimeSessions.set(session.id, {
+        runtimeId: plan.runtime.descriptor.id,
+        session: openedRuntimeSession,
+      });
+      isRuntimeSessionInstalled = true;
+      this.startReservedTurn(
+        session.id,
+        session.title,
+        plan,
+        reserved,
+        openedRuntimeSession,
+        abortController,
+      );
+      return session;
+    } finally {
+      if (openedRuntimeSession && !isRuntimeSessionInstalled) {
+        await openedRuntimeSession
+          .close()
+          .catch((error) =>
+            logger.warn('Failed to close an unused Runtime session', error as Error),
+          );
+      }
+      this.initialAdmissions.delete(admission);
+      completion.resolve();
     }
-    return this.store.createSession({
-      agentId: parsed.agentId,
-      title: parsed.title,
-    });
   }
 
   async renameSession(input: { sessionId: string; title: string }): Promise<AgentSessionView> {
@@ -409,6 +460,10 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     // installing its active/running state for us to cancel and drain below.
     this.deletingSessions.add(sessionId);
     try {
+      const observations = this.observingSessions.get(sessionId);
+      if (observations) {
+        await Promise.allSettled([...observations]);
+      }
       const admission = this.admittingSessions.get(sessionId);
       if (admission) {
         await admission.completion;
@@ -470,64 +525,14 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
         inferenceSnapshot: plan.inferenceSnapshot,
       });
 
-      // The Turn projection starts here: reservation time is the turn start.
-      const turn: AgentTurnView = {
-        id: reserved.turnId,
+      return this.startReservedTurn(
         sessionId,
-        status: 'running',
-        assistantMessageId: reserved.assistantMessage.id,
-        error: null,
-        startedAt: reserved.assistantMessage.createdAt,
-        endedAt: null,
-      };
-      const state: ActiveTurnState = {
-        agent: plan.agent,
-        abortController,
-        turn,
-        assistantMessage: reserved.assistantMessage,
-        autoNamePromise: null,
-        autoNameUserParts: plan.hasMessages ? null : plan.inputParts,
-        backgroundReply: this.startBackgroundReply({
-          agentId: plan.agent.id,
-          agentName: plan.agent.name,
-          sessionId,
-          sessionTitle: plan.session.title,
-        }),
-        pendingApprovals: new Map(),
-        pendingContextCheckpoint: null,
-        resources: plan.resources,
-        sessionTurnIds: new Set([...plan.sessionTurnIds, reserved.turnId]),
-        usage: null,
+        plan.sessionTitle,
+        plan,
+        reserved,
         runtimeSession,
-      };
-      this.activeTurns.set(sessionId, state);
-
-      this.publish(sessionId, { type: 'message.created', message: reserved.userMessage });
-      this.publish(sessionId, { type: 'message.created', message: reserved.assistantMessage });
-      this.publish(sessionId, { type: 'turn.updated', turn });
-      if (state.autoNameUserParts && !signal.aborted) {
-        state.autoNamePromise = this.naming.maybeRenameFromFirstUserMessage(
-          sessionId,
-          state.autoNameUserParts,
-        );
-        this.publishSessionRename(state.autoNamePromise);
-      }
-
-      const run = this.runTurn(sessionId, plan, state);
-      this.runningTurns.add(run);
-      this.runningTurnsBySession.set(sessionId, run);
-      void run.finally(() => {
-        this.runningTurns.delete(run);
-        if (this.runningTurnsBySession.get(sessionId) === run) {
-          this.runningTurnsBySession.delete(sessionId);
-        }
-      });
-
-      return {
-        turnId: reserved.turnId,
-        userMessageId: reserved.userMessage.id,
-        assistantMessageId: reserved.assistantMessage.id,
-      };
+        abortController,
+      );
     } finally {
       this.admittingSessions.delete(sessionId);
       completion.resolve();
@@ -572,37 +577,127 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     sessionId: string,
     listener: (event: AgentEvent) => void,
   ): Promise<AgentSessionObservation> {
-    const session = await this.store.getSession(sessionId);
-    if (!session) {
-      fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
+    if (this.deletingSessions.has(sessionId)) {
+      fail('SESSION_BUSY', 'The session is being deleted.');
     }
-    const agent = await this.requireAgent(session.agentId);
-    const capabilities = this.projectCapabilities(session.executionTarget);
+    const completion = createCompletionSignal();
+    const observations = this.observingSessions.get(sessionId) ?? new Set<Promise<void>>();
+    observations.add(completion.promise);
+    this.observingSessions.set(sessionId, observations);
 
-    // Snapshot capture and listener registration are one synchronous section:
-    // no event can fall into a snapshot/subscription gap (invariant 8).
-    const active = this.activeTurns.get(sessionId);
-    const snapshot = AgentSessionSnapshotSchema.parse(
-      cloneJson({
-        agent: { id: agent.id, name: agent.name },
-        session,
-        capabilities,
-        activeTurn: active?.turn ?? null,
-        streamingMessage: active?.assistantMessage ?? null,
-        pendingApprovals: active
-          ? [...active.pendingApprovals.values()].filter((entry) => entry.status === 'pending')
-          : [],
+    try {
+      const session = await this.store.getSession(sessionId);
+      if (!session) {
+        fail('SESSION_NOT_FOUND', `Session does not exist: ${sessionId}`);
+      }
+      const agent = await this.requireAgent(session.agentId);
+      const capabilities = this.projectCapabilities(session.executionTarget);
+      if (this.deletingSessions.has(sessionId)) {
+        fail('SESSION_BUSY', 'The session is being deleted.');
+      }
+
+      // Snapshot capture and listener registration are one synchronous section:
+      // no event can fall into a snapshot/subscription gap (invariant 8).
+      const active = this.activeTurns.get(sessionId);
+      const snapshot = AgentSessionSnapshotSchema.parse(
+        cloneJson({
+          agent: { id: agent.id, name: agent.name },
+          session,
+          capabilities,
+          activeTurn: active?.turn ?? null,
+          streamingMessage: active?.assistantMessage ?? null,
+          pendingApprovals: active
+            ? [...active.pendingApprovals.values()].filter((entry) => entry.status === 'pending')
+            : [],
+        }),
+      );
+      const sessionListeners = this.listeners.get(sessionId) ?? new Set();
+      this.listeners.set(sessionId, sessionListeners);
+      sessionListeners.add(listener);
+
+      return {
+        snapshot,
+        unsubscribe: () => {
+          sessionListeners.delete(listener);
+          if (sessionListeners.size === 0 && this.listeners.get(sessionId) === sessionListeners) {
+            this.listeners.delete(sessionId);
+          }
+        },
+      };
+    } finally {
+      observations.delete(completion.promise);
+      if (observations.size === 0 && this.observingSessions.get(sessionId) === observations) {
+        this.observingSessions.delete(sessionId);
+      }
+      completion.resolve();
+    }
+  }
+
+  private startReservedTurn(
+    sessionId: string,
+    sessionTitle: string,
+    plan: TurnPlan,
+    reserved: ReserveSubmissionResult,
+    runtimeSession: AgentRuntimeSession,
+    abortController: AbortController,
+  ): { turnId: string; userMessageId: string; assistantMessageId: string } {
+    // The Turn projection starts here: reservation time is the turn start.
+    const turn: AgentTurnView = {
+      id: reserved.turnId,
+      sessionId,
+      status: 'running',
+      assistantMessageId: reserved.assistantMessage.id,
+      error: null,
+      startedAt: reserved.assistantMessage.createdAt,
+      endedAt: null,
+    };
+    const state: ActiveTurnState = {
+      agent: plan.agent,
+      abortController,
+      turn,
+      assistantMessage: reserved.assistantMessage,
+      autoNamePromise: null,
+      autoNameUserParts: plan.hasMessages ? null : plan.inputParts,
+      backgroundReply: this.startBackgroundReply({
+        agentId: plan.agent.id,
+        agentName: plan.agent.name,
+        sessionId,
+        sessionTitle,
       }),
-    );
-    const sessionListeners = this.listeners.get(sessionId) ?? new Set();
-    this.listeners.set(sessionId, sessionListeners);
-    sessionListeners.add(listener);
+      pendingApprovals: new Map(),
+      pendingContextCheckpoint: null,
+      resources: plan.resources,
+      sessionTurnIds: new Set([...plan.sessionTurnIds, reserved.turnId]),
+      usage: null,
+      runtimeSession,
+    };
+    this.activeTurns.set(sessionId, state);
+
+    this.publish(sessionId, { type: 'message.created', message: reserved.userMessage });
+    this.publish(sessionId, { type: 'message.created', message: reserved.assistantMessage });
+    this.publish(sessionId, { type: 'turn.updated', turn });
+    if (state.autoNameUserParts && !abortController.signal.aborted) {
+      state.autoNamePromise = this.naming.maybeRenameFromFirstUserMessage(
+        sessionId,
+        state.autoNameUserParts,
+      );
+      this.publishSessionRename(state.autoNamePromise);
+    }
+
+    const run = this.runTurn(sessionId, plan, state);
+    this.runningTurns.add(run);
+    this.runningTurnsBySession.set(sessionId, run);
+    void run.finally(() => {
+      this.runningTurns.delete(run);
+      if (this.runningTurnsBySession.get(sessionId) === run) {
+        this.runningTurnsBySession.delete(sessionId);
+      }
+    });
 
     return {
-      snapshot,
-      unsubscribe: () => {
-        sessionListeners.delete(listener);
-      },
+      turnId: reserved.turnId,
+      userMessageId: reserved.userMessage.id,
+      assistantMessageId: reserved.assistantMessage.id,
     };
   }
 
@@ -920,10 +1015,14 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
 
   // ── Helpers ──
 
-  private assertIdle(sessionId: string): void {
+  private assertAcceptingSubmissions(): void {
     if (!this.acceptingSubmissions) {
       fail('EXECUTION_UNAVAILABLE', 'The Agent Host is stopping.');
     }
+  }
+
+  private assertIdle(sessionId: string): void {
+    this.assertAcceptingSubmissions();
     if (this.deletingSessions.has(sessionId)) {
       fail('SESSION_BUSY', 'The session is being deleted.');
     }
@@ -987,11 +1086,20 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       this.runtimeSessions.delete(sessionId);
       await raceAbort(cached.session.close(), signal);
     }
+    const session = await this.openRuntimeSession(runtime, signal);
+    this.runtimeSessions.set(sessionId, { runtimeId: runtime.descriptor.id, session });
+    return session;
+  }
+
+  private async openRuntimeSession(
+    runtime: AgentRuntime,
+    signal: AbortSignal,
+  ): Promise<AgentRuntimeSession> {
+    signal.throwIfAborted();
     const opening = runtime.open();
     try {
       const session = await raceAbort(opening, signal);
       signal.throwIfAborted();
-      this.runtimeSessions.set(sessionId, { runtimeId: runtime.descriptor.id, session });
       return session;
     } catch (error) {
       if (signal.aborted) {

--- a/src/backend/ai/agent/host/__tests__/AgentSessionNaming.test.ts
+++ b/src/backend/ai/agent/host/__tests__/AgentSessionNaming.test.ts
@@ -53,7 +53,7 @@ function createNaming(input: {
 describe('AgentSessionNaming', () => {
   test('uses the first user message as a temporary automatic title', async () => {
     const { generateText, naming, store } = createNaming({});
-    const session = await store.createSession({ agentId: 'agent-1' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
 
     const renamed = await naming.maybeRenameFromFirstUserMessage(session.id, [
       { type: 'text', text: '  A useful first message  ' },
@@ -69,7 +69,7 @@ describe('AgentSessionNaming', () => {
 
   test('replaces the temporary title with a first-exchange summary', async () => {
     const { generateText, naming, store } = createNaming({});
-    const session = await store.createSession({ agentId: 'agent-1' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
     const userParts = [{ type: 'text' as const, text: 'Explain lunar eclipses' }];
     await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
 
@@ -92,7 +92,7 @@ describe('AgentSessionNaming', () => {
 
   test('keeps the first-message title when no usable naming model is configured', async () => {
     const { generateText, naming, store } = createNaming({ defaultModelId: null });
-    const session = await store.createSession({ agentId: 'agent-1' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
     const userParts = [{ type: 'text' as const, text: 'Explain lunar eclipses' }];
     await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
 
@@ -116,7 +116,7 @@ describe('AgentSessionNaming', () => {
   test('propagates the Host lifecycle signal to summary generation', async () => {
     const controller = new AbortController();
     const { generateText, naming, store } = createNaming({ signal: controller.signal });
-    const session = await store.createSession({ agentId: 'agent-1' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
     const userParts = [{ type: 'text' as const, text: 'Explain lunar eclipses' }];
     await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
 
@@ -140,7 +140,7 @@ describe('AgentSessionNaming', () => {
         return generated.promise;
       },
     });
-    const session = await store.createSession({ agentId: 'agent-1' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
     const userParts = [{ type: 'text' as const, text: 'First question' }];
     await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
 
@@ -162,7 +162,7 @@ describe('AgentSessionNaming', () => {
 
   test('keeps the first-message title when summary naming is disabled', async () => {
     const { generateText, naming, store } = createNaming({ namingEnabled: false });
-    const session = await store.createSession({ agentId: 'agent-1' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
     const userParts = [{ type: 'text' as const, text: 'First question' }];
     await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
 

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -272,6 +272,39 @@ describe('MobileAgentHost', () => {
     ]);
   });
 
+  test('hands an active first exchange to a fresh Session observer', async () => {
+    const executionStarted = createDeferred();
+    const releaseExecution = createDeferred();
+    const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script(async (controller) => {
+      executionStarted.resolve();
+      await releaseExecution.promise;
+      controller.emit({ type: 'completed' });
+    });
+    const host = createHost(runtime);
+
+    const session = await host.startSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+      parts: [{ type: 'text', text: 'Hello.' }],
+    });
+    await executionStarted.promise;
+    const [userMessage, assistantMessage] = await store.listMessages(session.id);
+    const observation = await host.observeSession(session.id, () => undefined);
+
+    expect(observation.snapshot).toMatchObject({
+      activeUserMessage: userMessage,
+      hasHistoryBeforeActiveTurn: false,
+      streamingMessage: assistantMessage,
+    });
+
+    observation.unsubscribe();
+    releaseExecution.resolve();
+    await waitForAsync(
+      async () => (await store.listMessages(session.id))[1]?.status === 'success',
+      'the observed initial turn to settle',
+    );
+  });
+
   test('does not create a Session when a Draft submission fails preparation', async () => {
     const reserveInitialSubmission = jest.spyOn(store, 'reserveInitialSubmission');
     const host = createHost(
@@ -312,6 +345,8 @@ describe('MobileAgentHost', () => {
       attachments: true,
     });
     expect(observation.snapshot.activeTurn).toBeNull();
+    expect(observation.snapshot.activeUserMessage).toBeNull();
+    expect(observation.snapshot.hasHistoryBeforeActiveTurn).toBeNull();
 
     const submitted = await host.submitMessage({
       sessionId: session.id,

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -26,7 +26,7 @@ import {
 } from '../../runtime';
 import { InMemoryAgentSessionStore } from '../../sessionStore/InMemoryAgentSessionStore';
 import type { SystemCapabilitySource } from '../../tools/builtInToolSource';
-import type { AgentDefinitionSource } from '../agentDefinitions';
+import type { AgentDefinition, AgentDefinitionSource } from '../agentDefinitions';
 import type { AgentSessionNaming } from '../AgentSessionNaming';
 import { MAX_RUNTIME_CONTEXT_CHECKPOINT_BYTES } from '../contextCheckpoints';
 import { MobileAgentHost } from '../MobileAgentHost';
@@ -213,6 +213,16 @@ async function waitFor(predicate: () => boolean, what: string): Promise<void> {
   }
 }
 
+async function waitForAsync(predicate: () => Promise<boolean>, what: string): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (!(await predicate())) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${what}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function terminalTurnEvent(
   events: AgentEvent[],
 ): Extract<AgentEvent, { type: 'turn.updated' }> | undefined {
@@ -232,20 +242,64 @@ function assertJsonRoundTrip(events: AgentEvent[]): void {
 
 let store: InMemoryAgentSessionStore;
 
+function createStoredSession(): Promise<AgentSessionView> {
+  return store.createSession({ agentId: AGENT_ID });
+}
+
 describe('MobileAgentHost', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     store = new InMemoryAgentSessionStore();
   });
 
+  test('creates the durable Session together with an admitted first submission', async () => {
+    const host = hostWithText(['Hi']);
+
+    const session = await host.startSession({
+      agentId: AGENT_ID,
+      executionTarget: { kind: 'local' },
+      parts: [{ type: 'text', text: 'Hello.' }],
+    });
+    await waitForAsync(
+      async () => (await store.listMessages(session.id))[1]?.status === 'success',
+      'the initial turn to settle',
+    );
+
+    expect(await store.getSession(session.id)).toEqual(session);
+    expect((await store.listMessages(session.id)).map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
+  });
+
+  test('does not create a Session when a Draft submission fails preparation', async () => {
+    const reserveInitialSubmission = jest.spyOn(store, 'reserveInitialSubmission');
+    const host = createHost(
+      new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }),
+      noOpNaming,
+      noFiles,
+      noOpTools,
+      async () => {
+        throw new Error('model unavailable');
+      },
+    );
+
+    await expect(
+      host.startSession({
+        agentId: AGENT_ID,
+        executionTarget: { kind: 'local' },
+        parts: [{ type: 'text', text: 'Hello.' }],
+      }),
+    ).rejects.toMatchObject({ view: { code: 'EXECUTION_UNAVAILABLE' } });
+
+    expect(reserveInitialSubmission).not.toHaveBeenCalled();
+  });
+
   test('runs basic chat end to end: create, observe, submit, stream, record', async () => {
     const requests: RuntimeExecutionRequest[] = [];
     const host = hostWithText(['Hi', 'Ok'], requests);
 
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     expect(session.agentId).toBe(AGENT_ID);
 
     const events: AgentEvent[] = [];
@@ -388,10 +442,7 @@ describe('MobileAgentHost', () => {
         controller.emit({ type: 'completed' });
       });
     const host = createHost(runtime);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
     const completedCount = () =>
@@ -462,10 +513,7 @@ describe('MobileAgentHost', () => {
         controller.emit({ type: 'cancelled' });
       });
     const host = createHost(runtime);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
     const terminalCount = () =>
@@ -502,10 +550,7 @@ describe('MobileAgentHost', () => {
         controller.emit({ type: 'completed' });
       });
     const host = createHost(runtime);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
     const completedCount = () =>
@@ -528,10 +573,7 @@ describe('MobileAgentHost', () => {
   ])('falls back to complete history for a %s persisted checkpoint', async (_name, checkpoint) => {
     const requests: RuntimeExecutionRequest[] = [];
     const host = hostWithText(['One', 'Two'], requests);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
     const completedCount = () =>
@@ -561,10 +603,7 @@ describe('MobileAgentHost', () => {
       stubTool,
     ]);
     const host = hostWithText(['Saved.'], requests, { tools: { getTools } });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -620,10 +659,7 @@ describe('MobileAgentHost', () => {
         return [];
       },
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -646,10 +682,7 @@ describe('MobileAgentHost', () => {
         },
       },
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -670,10 +703,7 @@ describe('MobileAgentHost', () => {
       },
       tools: { getTools },
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -687,10 +717,7 @@ describe('MobileAgentHost', () => {
   test('applies composer model and reasoning snapshots to only the submitted turn', async () => {
     const requests: RuntimeExecutionRequest[] = [];
     const host = hostWithText(['One', 'Two', 'Three'], requests);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
     const completedTurnCount = () =>
@@ -769,10 +796,7 @@ describe('MobileAgentHost', () => {
     const host = createHost(runtime, noOpNaming, noFiles, noOpTools, async () => {
       throw new Error('credential-secret from provider lookup');
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
 
     await expect(
       host.submitMessage({
@@ -807,10 +831,7 @@ describe('MobileAgentHost', () => {
     const host = createHost(runtime, noOpNaming, noFiles, noOpTools, inferenceModel, {
       resolveRuntimeTools: async () => configuredTools.slice(),
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -864,10 +885,7 @@ describe('MobileAgentHost', () => {
       agents: autoAgents,
       resolveRuntimeTools: async () => tools,
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -911,10 +929,7 @@ describe('MobileAgentHost', () => {
         },
       ],
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
 
     await expect(
       host.submitMessage({
@@ -943,10 +958,7 @@ describe('MobileAgentHost', () => {
       });
     });
     const host = createHost(runtime);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -1009,10 +1021,7 @@ describe('MobileAgentHost', () => {
       }),
     };
     const host = createHost(runtime, naming);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     await host.submitMessage({
       sessionId: session.id,
       parts: [{ type: 'text', text: 'Keep working.' }],
@@ -1033,10 +1042,7 @@ describe('MobileAgentHost', () => {
     const releaseAdmission = createDeferred();
     const fake = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR });
     const host = createHost(fake);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const getSession = store.getSession.bind(store);
     jest.spyOn(store, 'getSession').mockImplementationOnce(async (sessionId) => {
       admissionStarted.resolve();
@@ -1072,10 +1078,7 @@ describe('MobileAgentHost', () => {
       });
     });
     const host = createHost(runtime);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const submitted = await host.submitMessage({
       sessionId: session.id,
       parts: [{ type: 'text', text: 'Hello.' }],
@@ -1101,10 +1104,7 @@ describe('MobileAgentHost', () => {
       maybeRenameFromConversationSummary: () => summaryName,
       maybeRenameFromFirstUserMessage: async () => null,
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
 
     await host.submitMessage({
       sessionId: session.id,
@@ -1134,10 +1134,7 @@ describe('MobileAgentHost', () => {
       maybeRenameFromConversationSummary: () => summaryName,
       maybeRenameFromFirstUserMessage: async () => null,
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     await host.submitMessage({
       sessionId: session.id,
       parts: [{ type: 'text', text: 'Hello.' }],
@@ -1200,10 +1197,7 @@ describe('MobileAgentHost', () => {
     const host = createHost(fake);
     const finalize = jest.spyOn(store, 'finalizeAssistantMessage');
     const remove = jest.spyOn(store, 'deleteSession');
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
 
     await host.submitMessage({
       sessionId: session.id,
@@ -1226,10 +1220,7 @@ describe('MobileAgentHost', () => {
       { type: 'completed' },
     ]);
     const host = createHost(fake);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const getSession = store.getSession.bind(store);
     jest.spyOn(store, 'getSession').mockImplementationOnce(async (sessionId) => {
       const result = await getSession(sessionId);
@@ -1262,6 +1253,45 @@ describe('MobileAgentHost', () => {
     expect(deletionResult.status).toBe('fulfilled');
   });
 
+  test('rejects an observation that overlaps Session deletion', async () => {
+    const lookupStarted = createDeferred();
+    let resolveAgent!: (agent: AgentDefinition | null) => void;
+    const pendingAgent = new Promise<AgentDefinition | null>((resolve) => {
+      resolveAgent = resolve;
+    });
+    let lookupCount = 0;
+    const agentSource: AgentDefinitionSource = {
+      getAgent: jest.fn(async (agentId) => {
+        lookupCount += 1;
+        if (lookupCount === 1) {
+          return agents.getAgent(agentId);
+        }
+        lookupStarted.resolve();
+        return pendingAgent;
+      }),
+    };
+    const host = createHost(
+      new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }),
+      noOpNaming,
+      noFiles,
+      noOpTools,
+      inferenceModel,
+      {
+        agents: agentSource,
+      },
+    );
+    const session = await createStoredSession();
+
+    const observation = host.observeSession(session.id, jest.fn());
+    await lookupStarted.promise;
+    const deletion = host.deleteSession({ sessionId: session.id });
+    resolveAgent(await agents.getAgent(AGENT_ID));
+
+    await expect(observation).rejects.toMatchObject({ view: { code: 'SESSION_BUSY' } });
+    await expect(deletion).resolves.toBeUndefined();
+    await expect(store.getSession(session.id)).resolves.toBeNull();
+  });
+
   test('rejects a new submission after an old turn drains while deletion is pending', async () => {
     const firstExecutionStarted = createDeferred();
     const deleteRowsStarted = createDeferred();
@@ -1280,10 +1310,7 @@ describe('MobileAgentHost', () => {
         controller.emit({ type: 'completed' });
       });
     const host = createHost(fake);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const removeSession = store.deleteSession.bind(store);
     jest.spyOn(store, 'deleteSession').mockImplementationOnce(async (sessionId) => {
       deleteRowsStarted.resolve();
@@ -1386,10 +1413,7 @@ describe('MobileAgentHost', () => {
     });
     const host = createHost(fake);
 
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
     const submitted = await host.submitMessage({
@@ -1473,10 +1497,7 @@ describe('MobileAgentHost', () => {
       readAsDataUrl,
       resolveAvailable,
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -1558,10 +1579,7 @@ describe('MobileAgentHost', () => {
       resolveAvailable: async () => new Map([[FILE_ENTRY_ID, fact]]),
     };
     const host = createHost(fake, noOpNaming, files);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -1602,10 +1620,7 @@ describe('MobileAgentHost', () => {
   test('retries the same terminal outcome when persistence fails transiently', async () => {
     const events: AgentEvent[] = [];
     const host = hostWithText(['Recovered']);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     await host.observeSession(session.id, (event) => events.push(event));
     const finalize = jest
       .spyOn(store, 'finalizeAssistantMessage')
@@ -1633,10 +1648,7 @@ describe('MobileAgentHost', () => {
     jest.spyOn(runtime, 'open').mockRejectedValueOnce(new Error('runtime unavailable'));
     const reserve = jest.spyOn(store, 'reserveSubmission');
     const host = createHost(runtime);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
 
     await expect(
       host.submitMessage({
@@ -1700,10 +1712,7 @@ describe('MobileAgentHost', () => {
         new Map([...facts].filter(([fileEntryId]) => ids.includes(fileEntryId))),
     };
     const host = createHost(runtime, noOpNaming, files);
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -1769,10 +1778,7 @@ describe('MobileAgentHost', () => {
       .spyOn(unsupportedEndpointRuntime, 'preflightModel')
       .mockRejectedValue(new Error('unsupported endpoint containing private configuration'));
     const endpointHost = createHost(unsupportedEndpointRuntime, noOpNaming, files);
-    const endpointSession = await endpointHost.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const endpointSession = await createStoredSession();
     await expect(
       endpointHost.submitMessage({
         sessionId: endpointSession.id,
@@ -1808,10 +1814,7 @@ describe('MobileAgentHost', () => {
       },
       resolveAvailable: async () => new Map([[FILE_ENTRY_ID, fact]]),
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -1870,10 +1873,7 @@ describe('MobileAgentHost', () => {
       readAsDataUrl: async () => undefined,
       resolveAvailable,
     });
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     const events: AgentEvent[] = [];
     await host.observeSession(session.id, (event) => events.push(event));
 
@@ -1963,10 +1963,7 @@ describe('MobileAgentHost', () => {
         resolveAvailable: async () => new Map([[FILE_ENTRY_ID, unsupportedFact]]),
       },
     );
-    const unsupportedSession = await unsupportedHost.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const unsupportedSession = await createStoredSession();
 
     await expect(
       unsupportedHost.submitMessage({
@@ -1992,10 +1989,7 @@ describe('MobileAgentHost', () => {
       readAsDataUrl: async () => undefined,
       resolveAvailable: async () => new Map([[FILE_ENTRY_ID, textFact]]),
     });
-    const binarySession = await binaryHost.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const binarySession = await createStoredSession();
     await expect(
       binaryHost.submitMessage({
         sessionId: binarySession.id,
@@ -2034,10 +2028,7 @@ describe('MobileAgentHost', () => {
       readAsDataUrl: async () => 'data:image/png;base64,AAAA',
       resolveAvailable: async () => facts,
     });
-    const availableSession = await availableHost.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const availableSession = await createStoredSession();
 
     await expect(
       availableHost.submitMessage({
@@ -2059,10 +2050,7 @@ describe('MobileAgentHost', () => {
       noOpNaming,
       noFiles,
     );
-    const unavailableSession = await unavailableHost.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const unavailableSession = await createStoredSession();
     await expect(
       unavailableHost.submitMessage({
         sessionId: unavailableSession.id,
@@ -2076,7 +2064,11 @@ describe('MobileAgentHost', () => {
     const host = hostWithText(['unused']);
 
     await expect(
-      host.createSession({ agentId: 'missing', executionTarget: { kind: 'local' } }),
+      host.startSession({
+        agentId: 'missing',
+        executionTarget: { kind: 'local' },
+        parts: [{ type: 'text', text: 'x' }],
+      }),
     ).rejects.toMatchObject({ view: { code: 'AGENT_NOT_FOUND' } });
     await expect(
       host.submitMessage({ sessionId: 'missing', parts: [{ type: 'text', text: 'x' }] }),
@@ -2085,10 +2077,7 @@ describe('MobileAgentHost', () => {
       view: { code: 'SESSION_NOT_FOUND' },
     });
 
-    const session = await host.createSession({
-      agentId: AGENT_ID,
-      executionTarget: { kind: 'local' },
-    });
+    const session = await createStoredSession();
     // Raw or unknown ids are rejected before any reservation.
     await expect(
       host.submitMessage({

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -243,7 +243,7 @@ function assertJsonRoundTrip(events: AgentEvent[]): void {
 let store: InMemoryAgentSessionStore;
 
 function createStoredSession(): Promise<AgentSessionView> {
-  return store.createSession({ agentId: AGENT_ID });
+  return store.createEmptySession({ agentId: AGENT_ID });
 }
 
 describe('MobileAgentHost', () => {
@@ -1185,7 +1185,7 @@ describe('MobileAgentHost', () => {
   test('reconciliation marks preloaded unfinished messages interrupted', async () => {
     // Preload the reference adapter with the state a durable adapter would
     // restore after a process death.
-    const session = await store.createSession({ agentId: AGENT_ID });
+    const session = await store.createEmptySession({ agentId: AGENT_ID });
     const reserved = await store.reserveSubmission({
       modelId: 'mock-provider::mock-model',
       inferenceSnapshot: {
@@ -1294,13 +1294,8 @@ describe('MobileAgentHost', () => {
     const pendingAgent = new Promise<AgentDefinition | null>((resolve) => {
       resolveAgent = resolve;
     });
-    let lookupCount = 0;
     const agentSource: AgentDefinitionSource = {
-      getAgent: jest.fn(async (agentId) => {
-        lookupCount += 1;
-        if (lookupCount === 1) {
-          return agents.getAgent(agentId);
-        }
+      getAgent: jest.fn(async () => {
         lookupStarted.resolve();
         return pendingAgent;
       }),

--- a/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
@@ -14,7 +14,11 @@ import type {
 } from '../../sessionStore/AgentSessionStore';
 import type { AgentDefinition } from '../agentDefinitions';
 import type { AgentInferenceModelSnapshot } from '../inferenceSnapshot';
-import { prepareTurn, type TurnPreparationDependencies } from '../turnPreparation';
+import {
+  prepareInitialTurn,
+  prepareTurn,
+  type TurnPreparationDependencies,
+} from '../turnPreparation';
 
 const AGENT_ID = 'agent-1';
 const SESSION_ID = 'session-1';
@@ -52,6 +56,27 @@ const EMPTY_CONTEXT: StoredRuntimeTurnContext = {
 };
 
 describe('turn preparation', () => {
+  test('prepares a Draft first turn without reading a durable Session', async () => {
+    const harness = createHarness();
+
+    const plan = await prepareInitialTurn(
+      harness.dependencies,
+      {
+        agentId: AGENT_ID,
+        executionTarget: { kind: 'local' },
+        parts: [{ text: 'Hello.', type: 'text' }],
+      },
+      new AbortController().signal,
+    );
+
+    expect(plan.hasMessages).toBe(false);
+    expect(plan.history).toEqual([]);
+    expect(plan.sessionTurnIds).toEqual([]);
+    expect(harness.getSession).not.toHaveBeenCalled();
+    expect(harness.getLatestContextCheckpoint).not.toHaveBeenCalled();
+    expect(harness.loadRuntimeTurnContext).not.toHaveBeenCalled();
+  });
+
   test('builds a canonical turn plan from frozen model, tool, and attachment facts', async () => {
     const harness = createHarness();
     const input: AgentSubmitMessageInput = {

--- a/src/backend/ai/agent/host/turnPreparation.ts
+++ b/src/backend/ai/agent/host/turnPreparation.ts
@@ -16,6 +16,7 @@ import {
   type AgentMessagePart,
   type AgentMessageView,
   type AgentSessionView,
+  type AgentStartSessionInput,
   type AgentSubmitMessageInput,
 } from '@/shared/contracts/agent';
 import { loggerService } from '@/shared/core/logger/LoggerService';
@@ -34,7 +35,10 @@ import type {
   RuntimeModelPreflight,
   RuntimeTool,
 } from '../runtime';
-import type { AgentSessionStore } from '../sessionStore/AgentSessionStore';
+import type {
+  AgentSessionStore,
+  StoredRuntimeTurnContext,
+} from '../sessionStore/AgentSessionStore';
 import type { SystemCapabilitySource } from '../tools/builtInToolSource';
 import type { AgentRuntimeToolResolver } from '../tools/runtimeTools';
 import type { AgentDefinition, AgentDefinitionSource } from './agentDefinitions';
@@ -84,7 +88,7 @@ export type TurnPlan = {
   runtime: AgentRuntime;
   runtimeContextCheckpoint: RuntimeContextCheckpoint | null;
   runtimeTextAttachments: RuntimeAttachmentContents;
-  session: AgentSessionView;
+  sessionTitle: string;
   sessionTurnIds: readonly string[];
   tools: readonly RuntimeTool[];
   /** The user message parts to reserve, projected from the canonical input. */
@@ -104,14 +108,6 @@ export async function prepareTurn(
   const configuredAgent = await raceAbort(dependencies.agents.getAgent(session.agentId), signal);
   if (!configuredAgent) {
     fail('AGENT_NOT_FOUND', `Agent does not exist: ${session.agentId}`);
-  }
-  const agent = applyTurnOverrides(configuredAgent, parsed);
-  const runtime = dependencies.routeExecutionTarget(session.executionTarget);
-  if (
-    !runtime.descriptor.capabilities.attachments &&
-    parsed.parts.some((part) => part.type === 'file')
-  ) {
-    fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
   }
 
   const storedContextCandidate = await raceAbort(
@@ -139,6 +135,68 @@ export async function prepareTurn(
       checkpointMessageId: storedContextCandidate?.assistantMessageId,
       sessionId,
     });
+  }
+
+  return prepareResolvedTurn(
+    dependencies,
+    parsed,
+    session,
+    configuredAgent,
+    storedTurnContext,
+    runtimeContextCheckpoint,
+    signal,
+  );
+}
+
+export async function prepareInitialTurn(
+  dependencies: TurnPreparationDependencies,
+  parsed: AgentStartSessionInput,
+  signal: AbortSignal,
+): Promise<TurnPlan> {
+  const configuredAgent = await raceAbort(dependencies.agents.getAgent(parsed.agentId), signal);
+  if (!configuredAgent) {
+    fail('AGENT_NOT_FOUND', `Agent does not exist: ${parsed.agentId}`);
+  }
+  const session = {
+    agentId: parsed.agentId,
+    executionTarget: parsed.executionTarget,
+    title: '',
+  };
+  const emptyContext: StoredRuntimeTurnContext = {
+    anchorFound: true,
+    hasMessages: false,
+    history: [],
+    referencedFileEntryIds: [],
+    sessionTurnIds: [],
+  };
+
+  return prepareResolvedTurn(
+    dependencies,
+    parsed,
+    session,
+    configuredAgent,
+    emptyContext,
+    null,
+    signal,
+  );
+}
+
+async function prepareResolvedTurn(
+  dependencies: TurnPreparationDependencies,
+  parsed: AgentSubmitMessageInput | AgentStartSessionInput,
+  session: Pick<AgentSessionView, 'agentId' | 'executionTarget' | 'title'>,
+  configuredAgent: AgentDefinition,
+  storedTurnContext: StoredRuntimeTurnContext,
+  runtimeContextCheckpoint: RuntimeContextCheckpoint | null,
+  signal: AbortSignal,
+): Promise<TurnPlan> {
+  const agent = applyTurnOverrides(configuredAgent, parsed);
+  const runtime = dependencies.routeExecutionTarget(session.executionTarget);
+  if (
+    !runtime.descriptor.capabilities.attachments &&
+    parsed.parts.some((part) => part.type === 'file')
+  ) {
+    fail('CAPABILITY_UNSUPPORTED', 'File attachments are not supported for this Agent.');
   }
   const { availableFiles, inputFiles, parts } = await resolveManagedInput(
     dependencies.files,
@@ -248,7 +306,7 @@ export async function prepareTurn(
     runtime,
     runtimeContextCheckpoint,
     runtimeTextAttachments,
-    session,
+    sessionTitle: session.title,
     sessionTurnIds: storedTurnContext.sessionTurnIds,
     tools,
     userParts,

--- a/src/backend/ai/agent/sessionStore/AgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/AgentSessionStore.ts
@@ -72,10 +72,10 @@ export type FinalizeAssistantMessageInput = {
  * The store persists messages only. The Turn is a Host projection: live turn
  * state (`running`/`awaiting-approval`/`cancelling`) and pending approvals are
  * process-local Host state by design, and terminal turn facts live on the
- * assistant message row. Multi-record operations are atomic at this boundary.
+ * assistant message row. Multi-record operations are atomic at this boundary,
+ * and the only Session creation operation reserves the first message pair with it.
  */
 export interface AgentSessionStore {
-  createSession(input: { agentId: string; title?: string }): Promise<AgentSessionView>;
   getSession(sessionId: string): Promise<AgentSessionView | null>;
   renameSession(sessionId: string, title: string): Promise<AgentSessionView | null>;
   /** Renames only when the current title still matches the caller's auto-title snapshot. */

--- a/src/backend/ai/agent/sessionStore/AgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/AgentSessionStore.ts
@@ -1,5 +1,6 @@
 import type {
   AgentErrorView,
+  AgentExecutionTarget,
   AgentInferenceSnapshotV1,
   AgentMessagePart,
   AgentMessageView,
@@ -41,6 +42,15 @@ export type ReserveSubmissionInput = {
   inferenceSnapshot: AgentInferenceSnapshotV1;
 };
 
+export type ReserveInitialSubmissionInput = Omit<ReserveSubmissionInput, 'sessionId'> & {
+  agentId: string;
+  executionTarget: AgentExecutionTarget;
+};
+
+export type ReserveInitialSubmissionResult = ReserveSubmissionResult & {
+  session: AgentSessionView;
+};
+
 export type FinalizeAssistantMessageInput = {
   assistantMessageId: string;
   status: 'success' | 'error' | 'cancelled' | 'interrupted';
@@ -76,6 +86,11 @@ export interface AgentSessionStore {
   ): Promise<AgentSessionView | null>;
   /** Deletes the Session's messages with it. */
   deleteSession(sessionId: string): Promise<boolean>;
+
+  /** Atomically creates a Session and reserves its first user/assistant message pair. */
+  reserveInitialSubmission(
+    input: ReserveInitialSubmissionInput,
+  ): Promise<ReserveInitialSubmissionResult>;
 
   /**
    * Atomically reserves the user message and assistant placeholder under a

--- a/src/backend/ai/agent/sessionStore/InMemoryAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/InMemoryAgentSessionStore.ts
@@ -12,6 +12,8 @@ import type { AgentErrorView, AgentMessageView, AgentSessionView } from '@/share
 import type {
   AgentSessionStore,
   FinalizeAssistantMessageInput,
+  ReserveInitialSubmissionInput,
+  ReserveInitialSubmissionResult,
   ReserveSubmissionInput,
   ReserveSubmissionResult,
 } from './AgentSessionStore';
@@ -34,6 +36,66 @@ type StoredMessage = {
   error: AgentErrorView | null;
   contextCheckpoint: unknown | null;
 };
+
+function createSessionView(input: {
+  agentId: string;
+  executionTarget?: AgentSessionView['executionTarget'];
+  title?: string;
+}): AgentSessionView {
+  const timestamp = nowIso();
+  return {
+    id: uuidv7(),
+    agentId: input.agentId,
+    executionTarget: input.executionTarget ?? { kind: 'local' },
+    title: input.title ?? '',
+    titleIsManual: input.title !== undefined,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function reserveInTranscript(
+  transcript: StoredMessage[],
+  input: ReserveSubmissionInput,
+): ReserveSubmissionResult {
+  // Synchronous section: both message writes commit together or not at all.
+  const timestamp = nowIso();
+  const turnId = uuidv7();
+  const userMessage: AgentMessageView = {
+    id: uuidv7(),
+    sessionId: input.sessionId,
+    turnId,
+    role: 'user',
+    status: 'success',
+    parts: cloneJson(input.userParts),
+    usage: null,
+    modelId: null,
+    inferenceSnapshot: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  const assistantMessage: AgentMessageView = {
+    id: uuidv7(),
+    sessionId: input.sessionId,
+    turnId,
+    role: 'assistant',
+    status: 'pending',
+    parts: [],
+    usage: null,
+    modelId: input.modelId,
+    inferenceSnapshot: {
+      status: 'supported',
+      snapshot: cloneJson(input.inferenceSnapshot),
+    },
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  transcript.push(
+    { view: userMessage, error: null, contextCheckpoint: null },
+    { view: assistantMessage, error: null, contextCheckpoint: null },
+  );
+  return { turnId, userMessage, assistantMessage };
+}
 
 /**
  * Process-local reference adapter for {@link AgentSessionStore}.
@@ -59,16 +121,7 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
   }
 
   async createSession(input: { agentId: string; title?: string }): Promise<AgentSessionView> {
-    const timestamp = nowIso();
-    const session: AgentSessionView = {
-      id: uuidv7(),
-      agentId: input.agentId,
-      executionTarget: { kind: 'local' },
-      title: input.title ?? '',
-      titleIsManual: input.title !== undefined,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    };
+    const session = createSessionView(input);
     this.sessions.set(session.id, session);
     this.messages.set(session.id, []);
     return cloneJson(session);
@@ -121,48 +174,31 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
     return true;
   }
 
+  async reserveInitialSubmission(
+    input: ReserveInitialSubmissionInput,
+  ): Promise<ReserveInitialSubmissionResult> {
+    const session = createSessionView({
+      agentId: input.agentId,
+      executionTarget: input.executionTarget,
+    });
+    const transcript: StoredMessage[] = [];
+    const reserved = reserveInTranscript(transcript, {
+      sessionId: session.id,
+      userParts: input.userParts,
+      modelId: input.modelId,
+      inferenceSnapshot: input.inferenceSnapshot,
+    });
+    this.sessions.set(session.id, session);
+    this.messages.set(session.id, transcript);
+    return cloneJson({ ...reserved, session });
+  }
+
   async reserveSubmission(input: ReserveSubmissionInput): Promise<ReserveSubmissionResult> {
     const transcript = this.messages.get(input.sessionId);
     if (!transcript) {
       throw new Error(`Cannot reserve a submission for an unknown session: ${input.sessionId}`);
     }
-    // Synchronous section: both message writes commit together or not at all.
-    const timestamp = nowIso();
-    const turnId = uuidv7();
-    const userMessage: AgentMessageView = {
-      id: uuidv7(),
-      sessionId: input.sessionId,
-      turnId,
-      role: 'user',
-      status: 'success',
-      parts: cloneJson(input.userParts),
-      usage: null,
-      modelId: null,
-      inferenceSnapshot: null,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    };
-    const assistantMessage: AgentMessageView = {
-      id: uuidv7(),
-      sessionId: input.sessionId,
-      turnId,
-      role: 'assistant',
-      status: 'pending',
-      parts: [],
-      usage: null,
-      modelId: input.modelId,
-      inferenceSnapshot: {
-        status: 'supported',
-        snapshot: cloneJson(input.inferenceSnapshot),
-      },
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    };
-    transcript.push(
-      { view: userMessage, error: null, contextCheckpoint: null },
-      { view: assistantMessage, error: null, contextCheckpoint: null },
-    );
-    return cloneJson({ turnId, userMessage, assistantMessage });
+    return cloneJson(reserveInTranscript(transcript, input));
   }
 
   async listMessages(sessionId: string): Promise<AgentMessageView[]> {

--- a/src/backend/ai/agent/sessionStore/InMemoryAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/InMemoryAgentSessionStore.ts
@@ -120,7 +120,8 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
     this.messages.clear();
   }
 
-  async createSession(input: { agentId: string; title?: string }): Promise<AgentSessionView> {
+  /** @internal Test and legacy-state fixture; product creation uses reserveInitialSubmission. */
+  async createEmptySession(input: { agentId: string; title?: string }): Promise<AgentSessionView> {
     const session = createSessionView(input);
     this.sessions.set(session.id, session);
     this.messages.set(session.id, []);

--- a/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
@@ -8,7 +8,7 @@ import {
   Phase,
   ServicePhase,
 } from '@/backend/core/lifecycle';
-import type { DbService } from '@/backend/data/db/DbService';
+import type { Database, DbService } from '@/backend/data/db/DbService';
 import { agentSessionMessageTable, agentSessionTable } from '@/backend/data/db/schemas';
 import { createOrderedUuid } from '@/backend/data/db/schemas/_columnHelpers';
 import {
@@ -24,6 +24,8 @@ import {
 import type {
   AgentSessionStore,
   FinalizeAssistantMessageInput,
+  ReserveInitialSubmissionInput,
+  ReserveInitialSubmissionResult,
   ReserveSubmissionInput,
   ReserveSubmissionResult,
 } from './AgentSessionStore';
@@ -117,6 +119,28 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
     });
   }
 
+  async reserveInitialSubmission(
+    input: ReserveInitialSubmissionInput,
+  ): Promise<ReserveInitialSubmissionResult> {
+    return this.dbService.withWriteTx(async (tx) => {
+      const [sessionRow] = await tx
+        .insert(agentSessionTable)
+        .values({
+          agentId: input.agentId,
+          executionTarget: input.executionTarget,
+          lastActivityAt: Date.now(),
+        })
+        .returning();
+      const reserved = await insertSubmission(tx, {
+        sessionId: sessionRow.id,
+        userParts: input.userParts,
+        modelId: input.modelId,
+        inferenceSnapshot: input.inferenceSnapshot,
+      });
+      return { ...reserved, session: toAgentSessionView(sessionRow) };
+    });
+  }
+
   async reserveSubmission(input: ReserveSubmissionInput): Promise<ReserveSubmissionResult> {
     return this.dbService.withWriteTx(async (tx) => {
       const now = Date.now();
@@ -128,34 +152,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       if (touched.length === 0) {
         throw new Error(`Cannot reserve a submission for an unknown session: ${input.sessionId}`);
       }
-      const turnId = createOrderedUuid();
-      const [userRow] = await tx
-        .insert(agentSessionMessageTable)
-        .values({
-          sessionId: input.sessionId,
-          turnId,
-          role: 'user',
-          status: 'success',
-          data: { version: 1, parts: input.userParts },
-        })
-        .returning();
-      const [assistantRow] = await tx
-        .insert(agentSessionMessageTable)
-        .values({
-          sessionId: input.sessionId,
-          turnId,
-          role: 'assistant',
-          status: 'pending',
-          data: { version: 1, parts: [] },
-          modelId: input.modelId,
-          messageSnapshot: input.inferenceSnapshot,
-        })
-        .returning();
-      return {
-        turnId,
-        userMessage: toAgentMessageView(userRow),
-        assistantMessage: toAgentMessageView(assistantRow),
-      };
+      return insertSubmission(tx, input);
     });
   }
 
@@ -328,4 +325,38 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       return assistantCount;
     });
   }
+}
+
+async function insertSubmission(
+  tx: Database,
+  input: ReserveSubmissionInput,
+): Promise<ReserveSubmissionResult> {
+  const turnId = createOrderedUuid();
+  const [userRow] = await tx
+    .insert(agentSessionMessageTable)
+    .values({
+      sessionId: input.sessionId,
+      turnId,
+      role: 'user',
+      status: 'success',
+      data: { version: 1, parts: input.userParts },
+    })
+    .returning();
+  const [assistantRow] = await tx
+    .insert(agentSessionMessageTable)
+    .values({
+      sessionId: input.sessionId,
+      turnId,
+      role: 'assistant',
+      status: 'pending',
+      data: { version: 1, parts: [] },
+      modelId: input.modelId,
+      messageSnapshot: input.inferenceSnapshot,
+    })
+    .returning();
+  return {
+    turnId,
+    userMessage: toAgentMessageView(userRow),
+    assistantMessage: toAgentMessageView(assistantRow),
+  };
 }

--- a/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
@@ -51,7 +51,8 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
     super();
   }
 
-  async createSession(input: { agentId: string; title?: string }): Promise<AgentSessionView> {
+  /** @internal Test and legacy-state fixture; product creation uses reserveInitialSubmission. */
+  async createEmptySession(input: { agentId: string; title?: string }): Promise<AgentSessionView> {
     return this.dbService.withWriteTx(async (tx) => {
       const [row] = await tx
         .insert(agentSessionTable)

--- a/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
@@ -227,6 +227,23 @@ describe.each([
     ).rejects.toThrow();
   });
 
+  test('reserveInitialSubmission atomically creates the Session and first message pair', async () => {
+    const reserved = await store.reserveInitialSubmission({
+      ...RESERVATION_FACTS,
+      agentId,
+      executionTarget: { kind: 'local' },
+      userParts: [{ id: 'input-0', type: 'text', text: 'Hello.', state: 'done' }],
+    });
+
+    expect(await store.getSession(reserved.session.id)).toEqual(reserved.session);
+    expect(await store.listMessages(reserved.session.id)).toEqual([
+      reserved.userMessage,
+      reserved.assistantMessage,
+    ]);
+    expect(reserved.userMessage.sessionId).toBe(reserved.session.id);
+    expect(reserved.assistantMessage.sessionId).toBe(reserved.session.id);
+  });
+
   test('finalizeAssistantMessage settles status, parts, usage, and turn error', async () => {
     const session = await store.createSession({ agentId });
     const reserved = await store.reserveSubmission({
@@ -441,6 +458,26 @@ describe('SqliteAgentSessionStore database guarantees', () => {
 
   afterEach(() => {
     harness.cleanup();
+  });
+
+  test('rolls back the Session when its initial message reservation fails', async () => {
+    const { store, raw } = harness;
+    if (!raw) throw new Error('sqlite harness provides raw access');
+    const agentId = await harness.makeAgentId();
+
+    await expect(
+      store.reserveInitialSubmission({
+        ...RESERVATION_FACTS,
+        agentId,
+        executionTarget: { kind: 'local' },
+        modelId: 'missing-provider::missing-model',
+        userParts: [{ id: 'input-0', type: 'text', text: 'Hello.', state: 'done' }],
+      }),
+    ).rejects.toThrow();
+
+    expect(
+      raw.prepare('SELECT COUNT(*) AS count FROM agent_session').get() as { count: number },
+    ).toEqual({ count: 0 });
   });
 
   test('the invariant-1 index rejects a second reservation while one is unsettled', async () => {

--- a/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
@@ -16,7 +16,11 @@ import { drizzle } from 'drizzle-orm/sqlite-proxy';
 import { customSqlStatements } from '@/backend/data/db/customSql';
 import type { Database, DbService } from '@/backend/data/db/DbService';
 import { schema } from '@/backend/data/db/schemas';
-import type { AgentErrorView, AgentInferenceSnapshotV1 } from '@/shared/contracts/agent';
+import type {
+  AgentErrorView,
+  AgentInferenceSnapshotV1,
+  AgentSessionView,
+} from '@/shared/contracts/agent';
 
 import type { AgentSessionStore } from '../AgentSessionStore';
 import { InMemoryAgentSessionStore } from '../InMemoryAgentSessionStore';
@@ -48,7 +52,9 @@ const RESERVATION_FACTS = { modelId: MODEL_ID, inferenceSnapshot: INFERENCE_SNAP
 
 type StoreHarness = {
   store: AgentSessionStore;
-  /** Returns an agent id valid for createSession under this adapter. */
+  /** Seeds an empty legacy Session without exposing that operation on the production port. */
+  createEmptySession: (input: { agentId: string; title?: string }) => Promise<AgentSessionView>;
+  /** Returns an agent id valid for Session creation under this adapter. */
   makeAgentId: () => Promise<string>;
   /** SQLite-only escape hatch for raw assertions; undefined for in-memory. */
   raw?: DatabaseSync;
@@ -59,6 +65,7 @@ function makeInMemoryHarness(): StoreHarness {
   const store = new InMemoryAgentSessionStore();
   return {
     store,
+    createEmptySession: (input) => store.createEmptySession(input),
     makeAgentId: async () => randomUUID(),
     cleanup: () => {},
   };
@@ -111,8 +118,10 @@ function makeSqliteHarness(): StoreHarness {
       }
     },
   } as unknown as DbService;
+  const store = new SqliteAgentSessionStore(dbService);
   return {
-    store: new SqliteAgentSessionStore(dbService),
+    store,
+    createEmptySession: (input) => store.createEmptySession(input),
     makeAgentId: async () => {
       const id = randomUUID();
       sqlite
@@ -158,8 +167,8 @@ describe.each([
     harness.cleanup();
   });
 
-  test('session lifecycle: create, get, rename, delete', async () => {
-    const created = await store.createSession({ agentId });
+  test('legacy empty Session lifecycle: seed, get, rename, delete', async () => {
+    const created = await harness.createEmptySession({ agentId });
     expect(created.agentId).toBe(agentId);
     expect(created.executionTarget).toEqual({ kind: 'local' });
     expect(created.title).toBe('');
@@ -169,7 +178,7 @@ describe.each([
     expect(await store.getSession(created.id)).toEqual(created);
     expect(await store.getSession('missing')).toBeNull();
 
-    const titled = await store.createSession({ agentId, title: 'Named' });
+    const titled = await harness.createEmptySession({ agentId, title: 'Named' });
     expect(titled.title).toBe('Named');
     expect(titled.titleIsManual).toBe(true);
 
@@ -181,7 +190,7 @@ describe.each([
     const autoNamed = await store.autoRenameSession(titled.id, 'Named', 'Summary');
     expect(autoNamed).toBeNull();
 
-    const autoTitle = await store.createSession({ agentId });
+    const autoTitle = await harness.createEmptySession({ agentId });
     const firstTitle = await store.autoRenameSession(autoTitle.id, '', 'First message');
     expect(firstTitle?.title).toBe('First message');
     expect(firstTitle?.titleIsManual).toBe(false);
@@ -193,7 +202,7 @@ describe.each([
   });
 
   test('reserveSubmission writes the correlated user/assistant pair', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -245,7 +254,7 @@ describe.each([
   });
 
   test('finalizeAssistantMessage settles status, parts, usage, and turn error', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -290,7 +299,7 @@ describe.each([
   });
 
   test('transcript accumulates across settled turns in order', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     for (const text of ['one', 'two']) {
       const reserved = await store.reserveSubmission({
         ...RESERVATION_FACTS,
@@ -327,7 +336,7 @@ describe.each([
   });
 
   test('loads a checkpoint tail separately from full-transcript authorization indexes', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const first = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -389,7 +398,7 @@ describe.each([
   });
 
   test('stores a checkpoint on the assistant terminal write and reads the newest candidate', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const first = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -417,7 +426,7 @@ describe.each([
   });
 
   test('reconcileInterrupted settles unsettled assistant placeholders once', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -437,7 +446,7 @@ describe.each([
   });
 
   test('deleteSession removes the transcript with the session', async () => {
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -483,7 +492,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
   test('the invariant-1 index rejects a second reservation while one is unsettled', async () => {
     const { store } = harness;
     const agentId = await harness.makeAgentId();
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const first = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -526,7 +535,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
     const { store, raw } = harness;
     if (!raw) throw new Error('sqlite harness provides raw access');
     const agentId = await harness.makeAgentId();
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -563,7 +572,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
     const { store, raw } = harness;
     if (!raw) throw new Error('sqlite harness provides raw access');
     const agentId = await harness.makeAgentId();
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -586,7 +595,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
     const { store, raw } = harness;
     if (!raw) throw new Error('sqlite harness provides raw access');
     const agentId = await harness.makeAgentId();
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -614,7 +623,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
     const { store, raw } = harness;
     if (!raw) throw new Error('sqlite harness provides raw access');
     const agentId = await harness.makeAgentId();
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,
@@ -632,7 +641,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
     const { store, raw } = harness;
     if (!raw) throw new Error('sqlite harness provides raw access');
     const agentId = await harness.makeAgentId();
-    const session = await store.createSession({ agentId });
+    const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
       ...RESERVATION_FACTS,
       sessionId: session.id,

--- a/src/frontend/components/composer/README.md
+++ b/src/frontend/components/composer/README.md
@@ -92,7 +92,8 @@ walk to verify it.
   Chat or Painting. Existing managed entries passed into a session are borrowed;
   removing them detaches them without deleting their source file. A successful
   send transfers a newly imported entry out of temporary Composer ownership;
-  failed-send restoration restores that ownership with the draft.
+  failed-send restoration restores that ownership with the draft. Unmounting a
+  composer deletes any newly imported entries it still owns.
 - `context/ComposerProvider.tsx`: the session's private draft, attachments, and
   field-ref contexts, plus the input-presentation transition. Its contexts are
   split so dispatch-only components and the dock skip keystroke re-renders.

--- a/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
+++ b/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
@@ -155,6 +155,20 @@ describe('useManagedComposerAttachments', () => {
     expect(mockDeleteEntry).toHaveBeenCalledWith('00000000-0000-7000-8000-000000000017');
   });
 
+  it('deletes a composer-owned ready attachment when its Draft unmounts', async () => {
+    mockCreateInternalEntry.mockResolvedValue(
+      resolvedFile('00000000-0000-7000-8000-000000000021', 'abandoned-ready.pdf'),
+    );
+    await renderHook();
+    await act(async () => snapshot?.addAttachments([source('abandoned-ready.pdf')]));
+    await act(flushPromises);
+
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+
+    expect(mockDeleteEntry).toHaveBeenCalledWith('00000000-0000-7000-8000-000000000021');
+  });
+
   it('hands attachments to the sender without deleting them when cleared', async () => {
     const ready = readyAttachment('00000000-0000-7000-8000-000000000014', 'sent.pdf');
     await renderHook([ready]);
@@ -197,6 +211,24 @@ describe('useManagedComposerAttachments', () => {
     await act(async () => snapshot?.removeAttachment(restored.id));
 
     expect(mockDeleteEntry).toHaveBeenCalledWith('00000000-0000-7000-8000-000000000020');
+  });
+
+  it('deletes restored ownership when a failed send finishes after Draft unmount', async () => {
+    mockCreateInternalEntry.mockResolvedValue(
+      resolvedFile('00000000-0000-7000-8000-000000000022', 'abandoned-retry.pdf'),
+    );
+    await renderHook();
+    await act(async () => snapshot?.addAttachments([source('abandoned-retry.pdf')]));
+    await act(flushPromises);
+    const restored = snapshot?.attachments[0];
+    if (!restored || restored.status !== 'ready') throw new Error('missing ready attachment');
+
+    await act(async () => snapshot?.clearAttachments());
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+    await act(async () => snapshot?.setAttachments([restored]));
+
+    expect(mockDeleteEntry).toHaveBeenCalledWith('00000000-0000-7000-8000-000000000022');
   });
 
   it('imports transient initial attachments but mounts managed ones as ready', async () => {

--- a/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
+++ b/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
@@ -63,6 +63,11 @@ export function useManagedComposerAttachments(
     },
     [file],
   );
+  const deleteEntryRef = useRef(deleteEntry);
+
+  useEffect(() => {
+    deleteEntryRef.current = deleteEntry;
+  }, [deleteEntry]);
 
   const importAttachment = useCallback(
     async (source: ComposerAttachmentSource, token: symbol): Promise<ImportResult> => {
@@ -226,6 +231,18 @@ export function useManagedComposerAttachments(
   const setAttachments = useCallback(
     (nextAttachments: ComposerAttachmentDraft[]) => {
       importTokensRef.current.clear();
+      if (!isMountedRef.current) {
+        for (const attachment of nextAttachments) {
+          if (
+            isComposerAttachmentReady(attachment) &&
+            releasedOwnedEntryIdsRef.current.delete(attachment.fileEntryId)
+          ) {
+            void deleteEntry(attachment.fileEntryId);
+          }
+        }
+        releasedOwnedEntryIdsRef.current.clear();
+        return;
+      }
       for (const attachment of nextAttachments) {
         if (
           isComposerAttachmentReady(attachment) &&
@@ -237,11 +254,23 @@ export function useManagedComposerAttachments(
       releasedOwnedEntryIdsRef.current.clear();
       commitAttachments([...nextAttachments]);
     },
-    [commitAttachments],
+    [commitAttachments, deleteEntry],
   );
 
   useEffect(() => {
     isMountedRef.current = true;
+    const ownedEntryIds = ownedEntryIdsRef.current;
+    return () => {
+      isMountedRef.current = false;
+      const abandonedEntryIds = [...ownedEntryIds];
+      ownedEntryIds.clear();
+      for (const entryId of abandonedEntryIds) {
+        void deleteEntryRef.current(entryId);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (
       initialAttachmentState.rejectedCount > 0 &&
       !didReportRejectedInitialAttachmentsRef.current
@@ -257,10 +286,6 @@ export function useManagedComposerAttachments(
       );
       if (sources.length > 0) void importAttachments(sources);
     }
-
-    return () => {
-      isMountedRef.current = false;
-    };
   }, [alert, importAttachments, initialAttachmentState, t]);
 
   return useMemo(

--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -34,6 +34,9 @@ export function ChatScreen() {
     !sessionId && Boolean(agentId) && !agent.error && (agent.isLoading || Boolean(agent.agent));
   const hasComposer =
     !isPreview && Boolean(agent.agent) && (isSessionAvailable || isNewAgentAvailable);
+  const composerSessionKey = sessionId
+    ? `session:${sessionId}`
+    : `draft:${resolvedAgentId ?? 'unavailable'}`;
   const { bottom: bottomInset } = useSafeAreaInsets();
   const contentBottomInset = hasComposer ? composerContentGap : PREVIEW_CONTENT_BOTTOM_INSET;
   const keyboardOffset = hasComposer ? getComposerKeyboardStickyOffset(bottomInset) : 0;
@@ -57,7 +60,7 @@ export function ChatScreen() {
           <ChatEmptyState contentBottomInset={contentBottomInset} />
         )}
         {hasComposer ? (
-          <ComposerSessionProvider>
+          <ComposerSessionProvider key={composerSessionKey}>
             <ComposerDock layoutMode="flow">
               <ChatInput
                 agentId={resolvedAgentId}

--- a/src/frontend/features/chat/README.md
+++ b/src/frontend/features/chat/README.md
@@ -11,8 +11,9 @@ behavior. Structured message rendering is shared with painting through
 ## Organization
 
 - `ChatScreen.tsx` is header + swappable body + composer session in normal parent flow. With a
-  Session the body is the conversation; selecting an Agent without one shows the empty state and
-  creates the Session on first send.
+  Session the body is the conversation; selecting an Agent without one shows an isolated Draft.
+  The Host creates the durable Session together with its admitted first message, and the frontend
+  switches composer identity only after that operation succeeds.
 - `input/` owns the narrow Agent Protocol wrapper around the shared composer. Agent settings are
   edited on the Agent screen; image attachment admission failures restore the managed draft and
   surface a user-facing reason.

--- a/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
+++ b/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
@@ -5,6 +5,9 @@ import { ChatScreen } from '../ChatScreen';
 let chatInputProps: Record<string, unknown> | undefined;
 let chatWorkspaceProps: Record<string, unknown> | undefined;
 let dockProps: Record<string, unknown> | undefined;
+let mockComposerProviderInstance: number | undefined;
+let mockComposerProviderMountCount: number;
+let mockRouteParams: { agentId?: string; sessionId?: string };
 let mockSessionData: { agentId: string; id: string } | undefined;
 let mockSessionIsLoading: boolean;
 
@@ -22,12 +25,17 @@ jest.mock('@/frontend/components/composer', () => ({
     dockProps = props;
     return children;
   },
-  ComposerSessionProvider: ({ children }: { children?: React.ReactNode }) => children,
+  ComposerSessionProvider: ({ children }: { children?: React.ReactNode }) => {
+    const { useState } = jest.requireActual<typeof import('react')>('react');
+    const [instance] = useState(() => ++mockComposerProviderMountCount);
+    mockComposerProviderInstance = instance;
+    return children;
+  },
 }));
 
 jest.mock('expo-router', () => ({
   useIsPreview: () => false,
-  useLocalSearchParams: () => ({ agentId: 'agent-1', sessionId: 'session-1' }),
+  useLocalSearchParams: () => mockRouteParams,
 }));
 
 jest.mock('@/frontend/components/headers', () => ({ MainHeader: () => null }));
@@ -72,6 +80,9 @@ describe('ChatScreen composer dock wiring', () => {
     chatInputProps = undefined;
     chatWorkspaceProps = undefined;
     dockProps = undefined;
+    mockComposerProviderInstance = undefined;
+    mockComposerProviderMountCount = 0;
+    mockRouteParams = { agentId: 'agent-1', sessionId: 'session-1' };
     mockSessionData = { agentId: 'agent-1', id: 'session-1' };
     mockSessionIsLoading = false;
   });
@@ -113,5 +124,18 @@ describe('ChatScreen composer dock wiring', () => {
       agentId: 'agent-1',
       sessionId: 'session-1',
     });
+  });
+
+  it('isolates a new Draft composer from the established Session composer', () => {
+    act(() => {
+      renderer = create(<ChatScreen />);
+    });
+    expect(mockComposerProviderInstance).toBe(1);
+
+    mockRouteParams = { agentId: 'agent-1' };
+    mockSessionData = undefined;
+    act(() => renderer?.update(<ChatScreen />));
+
+    expect(mockComposerProviderInstance).toBe(2);
   });
 });

--- a/src/frontend/features/chat/input/ChatInput.tsx
+++ b/src/frontend/features/chat/input/ChatInput.tsx
@@ -210,10 +210,6 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
             }
           : {}),
         ...(temporaryCapabilities.length > 0 ? { temporaryCapabilities } : {}),
-      }).then(() => {
-        if (!sessionId) {
-          setIsWebSearchEnabled(false);
-        }
       });
     },
     [
@@ -223,8 +219,6 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
       selectedModelId,
       sendMessage,
       isWebSearchEnabled,
-      sessionId,
-      setIsWebSearchEnabled,
     ],
   );
   const getSendErrorLabel = useCallback(

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -5,7 +5,9 @@ exported through `index.ts` and receives the current `agentId` and optional `ses
 
 ## Current Contract
 
-- A new Session is created lazily on the first send, then observed before the message is submitted.
+- An Agent selection owns an isolated Draft composer. Its first send uses `startSession`, which
+  admits the message before atomically creating the Session and first message pair; observation and
+  navigation begin only after that succeeds.
 - Existing Sessions submit through the live `AgentProtocol` client owned by `ChatProvider`.
 - The shared composer owns the draft, send recovery, keyboard behavior, and pasted attachment
   presentation.
@@ -26,8 +28,8 @@ exported through `index.ts` and receives the current `agentId` and optional `ses
   configuration. An explicit `default` selection bypasses the Agent effort for that turn and uses
   the selected model's default.
 - The composer menu stores web-search selection in the frontend persist cache, keyed by Session id.
-  New Sessions default to disabled, and the first send transfers the draft selection after lazy
-  Session creation. While enabled, every submission includes the turn-local `web-search`
+  New Sessions default to disabled, and an admitted first send transfers the Draft selection to the
+  returned Session. While enabled, every submission includes the turn-local `web-search`
   capability. The create-image mention remains turn-local and adds `image-generation` only to the
   draft that contains it. Neither choice mutates Agent or Agent Session persistence.
 - Follow-up queues and steering are not part of the Version 1 Agent Session composer.

--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -19,6 +19,7 @@ export type AgentSessionChatState = {
   activeTurn: AgentTurnView | null;
   enteringUserMessageId?: string;
   error?: Error;
+  hasHistoryBeforeActiveTurn?: boolean;
   liveMessages: readonly AgentMessageView[];
   pendingApprovals: readonly AgentApprovalView[];
   sessionId: string;
@@ -212,7 +213,7 @@ export class AgentSessionChatClient {
     });
     // The durable submission has succeeded even if observation later needs a
     // retry. Do not restore a Draft whose files now belong to persisted input.
-    void this.observe(session.id).catch(() => undefined);
+    await this.observe(session.id).catch(() => undefined);
     return session;
   }
 
@@ -290,11 +291,18 @@ export class AgentSessionChatClient {
 
   private installSnapshot(entry: SessionEntry, snapshot: AgentSessionSnapshot): void {
     entry.liveMessages.clear();
+    if (snapshot.activeUserMessage) {
+      entry.liveMessages.set(snapshot.activeUserMessage.id, snapshot.activeUserMessage);
+    }
     if (snapshot.streamingMessage) {
       entry.liveMessages.set(snapshot.streamingMessage.id, snapshot.streamingMessage);
     }
     this.updateState(entry, {
       activeTurn: snapshot.activeTurn,
+      ...(snapshot.activeUserMessage
+        ? { enteringUserMessageId: snapshot.activeUserMessage.id }
+        : {}),
+      hasHistoryBeforeActiveTurn: snapshot.hasHistoryBeforeActiveTurn ?? undefined,
       liveMessages: [...entry.liveMessages.values()],
       pendingApprovals: snapshot.pendingApprovals,
       sessionId: snapshot.session.id,

--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -8,6 +8,7 @@ import type {
   AgentSessionObservation,
   AgentSessionSnapshot,
   AgentSessionView,
+  AgentStartSessionInput,
   AgentSubmitMessageInput,
   AgentTurnView,
 } from '@/shared/contracts/agent';
@@ -195,8 +196,24 @@ export class AgentSessionChatClient {
     );
   }
 
-  createSession(agentId: string): Promise<AgentSessionView> {
-    return this.protocol.createSession({ agentId, executionTarget: { kind: 'local' } });
+  async startSession(
+    agentId: string,
+    parts: AgentInputPart[],
+    overrides: Pick<
+      AgentStartSessionInput,
+      'modelId' | 'reasoningEffort' | 'temporaryCapabilities'
+    > = {},
+  ): Promise<AgentSessionView> {
+    const session = await this.protocol.startSession({
+      agentId,
+      executionTarget: { kind: 'local' },
+      parts,
+      ...overrides,
+    });
+    // The durable submission has succeeded even if observation later needs a
+    // retry. Do not restore a Draft whose files now belong to persisted input.
+    void this.observe(session.id).catch(() => undefined);
+    return session;
   }
 
   async submitMessage(

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -14,9 +14,12 @@ import { AppState } from 'react-native';
 
 import { queryKeys, useBackendModule } from '@/frontend/data';
 import type { AgentInputPart, AgentSubmitMessageInput } from '@/shared/contracts/agent';
+import { loggerService } from '@/shared/core/logger/LoggerService';
 
 import { persistSessionWebSearchSelection } from '../sessionWebSearchSelection';
 import { AgentSessionChatClient, type AgentSessionChatState } from './AgentSessionChatClient';
+
+const logger = loggerService.withContext('ChatProvider');
 
 type AgentChatSendInput = {
   agentId?: string;
@@ -96,15 +99,25 @@ export function ChatProvider({ children }: PropsWithChildren) {
           throw new Error('Select an Agent before sending a message.');
         }
 
-        const session = await client.createSession(agentId);
+        const session = await client.startSession(agentId, parts, {
+          ...(modelId !== undefined ? { modelId } : {}),
+          ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+          ...(temporaryCapabilities !== undefined ? { temporaryCapabilities } : {}),
+        });
         targetSessionId = session.id;
-        persistSessionWebSearchSelection(
-          targetSessionId,
-          temporaryCapabilities?.includes('web-search') ?? false,
-        );
-        await client.observe(targetSessionId);
+        try {
+          persistSessionWebSearchSelection(
+            targetSessionId,
+            temporaryCapabilities?.includes('web-search') ?? false,
+          );
+        } catch (error) {
+          logger.warn('Failed to persist Session web-search selection', error as Error, {
+            sessionId: targetSessionId,
+          });
+        }
         navigation.openSession(targetSessionId, agentId);
-        await queryClient.invalidateQueries({ queryKey: queryKeys.agentSessions.all() });
+        void queryClient.invalidateQueries({ queryKey: queryKeys.agentSessions.all() });
+        return;
       }
 
       await client.submitMessage(targetSessionId, parts, {

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -19,9 +19,11 @@ function deferred<TValue>() {
 function snapshot(): AgentSessionSnapshot {
   return {
     activeTurn: null,
+    activeUserMessage: null,
     agent: { id: 'agent-1', name: 'Agent' },
     capabilities: { approvals: true, attachments: false, reasoning: true, tools: true },
     pendingApprovals: [],
+    hasHistoryBeforeActiveTurn: null,
     session: {
       agentId: 'agent-1',
       createdAt: '2026-08-25T00:00:00.000Z',
@@ -32,6 +34,22 @@ function snapshot(): AgentSessionSnapshot {
       updatedAt: '2026-08-25T00:00:00.000Z',
     },
     streamingMessage: null,
+  };
+}
+
+function userMessage(): AgentMessageView {
+  return {
+    createdAt: '2026-08-25T00:00:00.000Z',
+    id: 'user-1',
+    parts: [{ id: 'input-0', state: 'done', text: 'Hello', type: 'text' }],
+    role: 'user',
+    sessionId: 'session-1',
+    status: 'success',
+    turnId: 'turn-1',
+    updatedAt: '2026-08-25T00:00:00.000Z',
+    usage: null,
+    modelId: null,
+    inferenceSnapshot: null,
   };
 }
 
@@ -67,8 +85,23 @@ function protocolWithObservation(
 
 describe('AgentSessionChatClient', () => {
   test('starts a durable Session from a Draft submission before observing it', async () => {
+    const initialSnapshot: AgentSessionSnapshot = {
+      ...snapshot(),
+      activeTurn: {
+        assistantMessageId: 'assistant-1',
+        endedAt: null,
+        error: null,
+        id: 'turn-1',
+        sessionId: 'session-1',
+        startedAt: '2026-08-25T00:00:00.000Z',
+        status: 'running',
+      },
+      activeUserMessage: userMessage(),
+      hasHistoryBeforeActiveTurn: false,
+      streamingMessage: assistantMessage(),
+    };
     const protocol = protocolWithObservation(async () => ({
-      snapshot: snapshot(),
+      snapshot: initialSnapshot,
       unsubscribe: jest.fn(),
     }));
     protocol.startSession.mockResolvedValue(snapshot().session);
@@ -85,6 +118,12 @@ describe('AgentSessionChatClient', () => {
       temporaryCapabilities: ['web-search'],
     });
     expect(protocol.observeSession).toHaveBeenCalledWith('session-1', expect.any(Function));
+    expect(client.getState('session-1')).toMatchObject({
+      enteringUserMessageId: 'user-1',
+      hasHistoryBeforeActiveTurn: false,
+      liveMessages: [{ id: 'user-1' }, { id: 'assistant-1' }],
+      status: 'ready',
+    });
   });
 
   test('keeps an admitted Draft submission successful when observation needs a retry', async () => {

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -56,16 +56,49 @@ function protocolWithObservation(
 ): jest.Mocked<AgentProtocol> {
   return {
     cancelTurn: jest.fn(),
-    createSession: jest.fn(),
     deleteSession: jest.fn(),
     observeSession: jest.fn(observeSession),
     renameSession: jest.fn(),
     respondApproval: jest.fn(),
+    startSession: jest.fn(),
     submitMessage: jest.fn(),
   };
 }
 
 describe('AgentSessionChatClient', () => {
+  test('starts a durable Session from a Draft submission before observing it', async () => {
+    const protocol = protocolWithObservation(async () => ({
+      snapshot: snapshot(),
+      unsubscribe: jest.fn(),
+    }));
+    protocol.startSession.mockResolvedValue(snapshot().session);
+    const client = new AgentSessionChatClient(protocol);
+
+    await client.startSession('agent-1', [{ text: 'Hello', type: 'text' }], {
+      temporaryCapabilities: ['web-search'],
+    });
+
+    expect(protocol.startSession).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      executionTarget: { kind: 'local' },
+      parts: [{ text: 'Hello', type: 'text' }],
+      temporaryCapabilities: ['web-search'],
+    });
+    expect(protocol.observeSession).toHaveBeenCalledWith('session-1', expect.any(Function));
+  });
+
+  test('keeps an admitted Draft submission successful when observation needs a retry', async () => {
+    const protocol = protocolWithObservation(async () => {
+      throw new Error('observation unavailable');
+    });
+    protocol.startSession.mockResolvedValue(snapshot().session);
+    const client = new AgentSessionChatClient(protocol);
+
+    await expect(
+      client.startSession('agent-1', [{ text: 'Hello', type: 'text' }]),
+    ).resolves.toEqual(snapshot().session);
+  });
+
   test('forwards composer turn overrides with the submitted message', async () => {
     const protocol = protocolWithObservation(async () => ({
       snapshot: snapshot(),

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -108,7 +108,7 @@ export function ChatWorkspace({
     [alert, client, sessionId, t],
   );
   const requiresInitialHistoryLayout = shouldWaitForInitialHistoryLayout({
-    hasHistoryBeforePendingTurn: undefined,
+    hasHistoryBeforeActiveTurn: live.hasHistoryBeforeActiveTurn,
     isLoadingInitial,
     messageCount: messages.length,
   });

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -18,6 +18,7 @@ let mockMessageListProps: MessageListProps | undefined;
 let mockAgentChatSession: {
   activeTurn: null;
   enteringUserMessageId?: string;
+  hasHistoryBeforeActiveTurn?: boolean;
   liveMessages: readonly AgentMessageView[];
   pendingApprovals: readonly [];
   sessionId: string;
@@ -159,11 +160,12 @@ function renderWorkspace(
   isPreview: boolean,
   messages: readonly AgentMessageView[],
   sessionId = 'session-1',
+  isLoadingInitial = false,
 ) {
   let renderer!: ReactTestRenderer;
 
   act(() => {
-    renderer = create(createWorkspaceElement(isPreview, messages, sessionId));
+    renderer = create(createWorkspaceElement(isPreview, messages, sessionId, isLoadingInitial));
   });
 
   return renderer;
@@ -173,6 +175,7 @@ function createWorkspaceElement(
   isPreview: boolean,
   messages: readonly AgentMessageView[],
   sessionId = 'session-1',
+  isLoadingInitial = false,
 ) {
   return (
     <ChatWorkspace
@@ -180,7 +183,7 @@ function createWorkspaceElement(
       isAssistantToolbarEnabled={!isPreview}
       keyboardOffset={isPreview ? 0 : 26}
       messageWindow={{
-        isLoadingInitial: false,
+        isLoadingInitial,
         isLoadingOlder: true,
         loadOlder: mockLoadOlder,
         messages,
@@ -293,6 +296,25 @@ describe('ChatWorkspace message rendering integration', () => {
     expect(readyFrame).toBeDefined();
 
     act(() => readyFrame?.(0));
+    expect(mockCoverVisible).toBe(false);
+  });
+
+  test('shows a new Session first exchange without the history loading cover', () => {
+    const user = createMessage('user-1', 'user');
+    const assistant = createMessage('assistant-1', 'assistant', 'streaming');
+    mockAgentChatSession = {
+      ...mockAgentChatSession,
+      enteringUserMessageId: user.id,
+      hasHistoryBeforeActiveTurn: false,
+      liveMessages: [user, assistant],
+    };
+
+    renderer = renderWorkspace(false, [], 'session-1', true);
+
+    expect(mockMessageListProps?.messages.map((message) => message.id)).toEqual([
+      'user-1',
+      'assistant-1',
+    ]);
     expect(mockCoverVisible).toBe(false);
   });
 });

--- a/src/frontend/features/chat/workspace/components/README.md
+++ b/src/frontend/features/chat/workspace/components/README.md
@@ -4,7 +4,9 @@
 
 When the active Session changes, `ChatWorkspace` remounts the shared `MessageList` with a new render
 key and shows `ChatInitialRenderCover` with a centered loading indicator over the message list area.
-The cover does not block touches and does not cover the floating input.
+The cover does not block touches and does not cover the floating input. A newly created Session
+whose first active turn is supplied by the observation snapshot skips this cover and renders that
+exchange immediately.
 
 The new list renders and measures behind the cover first. After the list reports ready, the cover and loading indicator exit together with a short eased fade.
 

--- a/src/frontend/features/chat/workspace/hooks/__tests__/useMessageListInitialRenderGate.test.tsx
+++ b/src/frontend/features/chat/workspace/hooks/__tests__/useMessageListInitialRenderGate.test.tsx
@@ -145,7 +145,7 @@ describe('shouldWaitForInitialHistoryLayout', () => {
   it('waits while a normal topic query is loading', () => {
     expect(
       shouldWaitForInitialHistoryLayout({
-        hasHistoryBeforePendingTurn: undefined,
+        hasHistoryBeforeActiveTurn: undefined,
         isLoadingInitial: true,
         messageCount: 0,
       }),
@@ -155,7 +155,7 @@ describe('shouldWaitForInitialHistoryLayout', () => {
   it('waits for loaded history, including an existing topic that is streaming', () => {
     expect(
       shouldWaitForInitialHistoryLayout({
-        hasHistoryBeforePendingTurn: true,
+        hasHistoryBeforeActiveTurn: true,
         isLoadingInitial: false,
         messageCount: 2,
       }),
@@ -165,7 +165,7 @@ describe('shouldWaitForInitialHistoryLayout', () => {
   it('does not wait for a first exchange handed over by the runtime', () => {
     expect(
       shouldWaitForInitialHistoryLayout({
-        hasHistoryBeforePendingTurn: false,
+        hasHistoryBeforeActiveTurn: false,
         isLoadingInitial: true,
         messageCount: 0,
       }),
@@ -175,7 +175,7 @@ describe('shouldWaitForInitialHistoryLayout', () => {
   it('does not wait after an empty topic query settles', () => {
     expect(
       shouldWaitForInitialHistoryLayout({
-        hasHistoryBeforePendingTurn: undefined,
+        hasHistoryBeforeActiveTurn: undefined,
         isLoadingInitial: false,
         messageCount: 0,
       }),

--- a/src/frontend/features/chat/workspace/hooks/useMessageListInitialRenderGate.ts
+++ b/src/frontend/features/chat/workspace/hooks/useMessageListInitialRenderGate.ts
@@ -22,17 +22,17 @@ type PendingReadyFrame = {
 };
 
 type InitialHistoryLayoutOptions = {
-  hasHistoryBeforePendingTurn: boolean | undefined;
+  hasHistoryBeforeActiveTurn: boolean | undefined;
   isLoadingInitial: boolean;
   messageCount: number;
 };
 
 export function shouldWaitForInitialHistoryLayout({
-  hasHistoryBeforePendingTurn,
+  hasHistoryBeforeActiveTurn,
   isLoadingInitial,
   messageCount,
 }: InitialHistoryLayoutOptions) {
-  return hasHistoryBeforePendingTurn !== false && (isLoadingInitial || messageCount > 0);
+  return hasHistoryBeforeActiveTurn !== false && (isLoadingInitial || messageCount > 0);
 }
 
 export function useMessageListInitialRenderGate({

--- a/src/shared/contracts/__tests__/agent.test.ts
+++ b/src/shared/contracts/__tests__/agent.test.ts
@@ -6,6 +6,7 @@ import {
   AgentInputPartSchema,
   AgentMessageToolRefSchema,
   AgentMessagePartSchema,
+  AgentSessionSnapshotSchema,
   AgentStartSessionInputSchema,
   AgentSubmitMessageInputSchema,
   AgentToolRefSchema,
@@ -46,6 +47,58 @@ describe('Agent tool and managed-file contracts', () => {
     expect(
       AgentStartSessionInputSchema.safeParse({ ...input, sessionId: 'session-1' }).success,
     ).toBe(false);
+  });
+
+  test('round-trips the active first exchange used for Session handoff', () => {
+    const userMessage = {
+      createdAt: '2026-08-31T00:00:00.000Z',
+      id: 'user-1',
+      inferenceSnapshot: null,
+      modelId: null,
+      parts: [{ id: 'input-0', state: 'done', text: 'Hello.', type: 'text' }],
+      role: 'user',
+      sessionId: 'session-1',
+      status: 'success',
+      turnId: 'turn-1',
+      updatedAt: '2026-08-31T00:00:00.000Z',
+      usage: null,
+    } as const;
+    const assistantMessage = {
+      ...userMessage,
+      id: 'assistant-1',
+      modelId: 'provider-1::model-1',
+      parts: [],
+      role: 'assistant',
+      status: 'pending',
+    } as const;
+    const snapshot = {
+      activeTurn: {
+        assistantMessageId: assistantMessage.id,
+        endedAt: null,
+        error: null,
+        id: 'turn-1',
+        sessionId: 'session-1',
+        startedAt: '2026-08-31T00:00:00.000Z',
+        status: 'running',
+      },
+      activeUserMessage: userMessage,
+      agent: { id: 'agent-1', name: 'Agent' },
+      capabilities: { approvals: true, attachments: true, reasoning: true, tools: true },
+      hasHistoryBeforeActiveTurn: false,
+      pendingApprovals: [],
+      session: {
+        agentId: 'agent-1',
+        createdAt: '2026-08-31T00:00:00.000Z',
+        executionTarget: { kind: 'local' },
+        id: 'session-1',
+        title: '',
+        titleIsManual: false,
+        updatedAt: '2026-08-31T00:00:00.000Z',
+      },
+      streamingMessage: assistantMessage,
+    } as const;
+
+    expect(AgentSessionSnapshotSchema.parse(roundTrip(snapshot))).toEqual(snapshot);
   });
 
   test('round-trips the versioned inference snapshot and preserves unsupported versions', () => {

--- a/src/shared/contracts/__tests__/agent.test.ts
+++ b/src/shared/contracts/__tests__/agent.test.ts
@@ -6,6 +6,7 @@ import {
   AgentInputPartSchema,
   AgentMessageToolRefSchema,
   AgentMessagePartSchema,
+  AgentStartSessionInputSchema,
   AgentSubmitMessageInputSchema,
   AgentToolRefSchema,
   readAgentInferenceSnapshot,
@@ -31,6 +32,19 @@ describe('Agent tool and managed-file contracts', () => {
         ...input,
         temporaryCapabilities: ['calendar'],
       }).success,
+    ).toBe(false);
+  });
+
+  test('validates a Draft submission without requiring a durable Session id', () => {
+    const input = {
+      agentId: 'agent-1',
+      executionTarget: { kind: 'local' },
+      parts: [{ text: 'Hello.', type: 'text' }],
+    } as const;
+
+    expect(AgentStartSessionInputSchema.parse(roundTrip(input))).toEqual(input);
+    expect(
+      AgentStartSessionInputSchema.safeParse({ ...input, sessionId: 'session-1' }).success,
     ).toBe(false);
   });
 

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -439,14 +439,16 @@ export const AgentEventSchema = z.union([
 export type AgentEvent = z.infer<typeof AgentEventSchema>;
 
 /**
- * Live state composed over persisted messages. Persisted transcript pagination
- * remains a normal data read and is not duplicated here.
+ * Live state composed over persisted messages. Only the active turn's rows are
+ * repeated for route handoff; older transcript pagination remains a data read.
  */
 export const AgentSessionSnapshotSchema = z.strictObject({
   agent: AgentViewSchema,
   session: AgentSessionViewSchema,
   capabilities: AgentCapabilitiesSchema,
   activeTurn: AgentTurnViewSchema.nullable(),
+  activeUserMessage: AgentMessageViewSchema.nullable(),
+  hasHistoryBeforeActiveTurn: z.boolean().nullable(),
   streamingMessage: AgentMessageViewSchema.nullable(),
   pendingApprovals: z.array(AgentApprovalViewSchema),
 });

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -453,11 +453,6 @@ export const AgentSessionSnapshotSchema = z.strictObject({
 export type AgentSessionSnapshot = z.infer<typeof AgentSessionSnapshotSchema>;
 
 /** Operation inputs, validated by the Host at the protocol boundary. */
-export const AgentCreateSessionInputSchema = z.strictObject({
-  agentId: z.string().min(1),
-  executionTarget: AgentExecutionTargetSchema,
-  title: z.string().optional(),
-});
 export const AgentRenameSessionInputSchema = z.strictObject({
   sessionId: z.string().min(1),
   title: z.string().min(1),
@@ -476,6 +471,18 @@ export const AgentSubmitMessageInputSchema = z.strictObject({
   temporaryCapabilities: z.array(AgentTemporaryCapabilitySchema).max(2).optional(),
 });
 export type AgentSubmitMessageInput = z.infer<typeof AgentSubmitMessageInputSchema>;
+export const AgentStartSessionInputSchema = z.strictObject({
+  agentId: z.string().min(1),
+  executionTarget: AgentExecutionTargetSchema,
+  parts: z.array(AgentInputPartSchema).min(1),
+  /** Snapshots the draft composer's selected model while its Agent mutation settles. */
+  modelId: UniqueModelIdSchema.optional(),
+  /** Per-turn only; this value is never persisted back to the Agent. */
+  reasoningEffort: ReasoningEffortOptionSchema.optional(),
+  /** Input-owned capabilities enabled for this turn; never persisted to the Agent. */
+  temporaryCapabilities: z.array(AgentTemporaryCapabilitySchema).max(2).optional(),
+});
+export type AgentStartSessionInput = z.infer<typeof AgentStartSessionInputSchema>;
 export const AgentCancelTurnInputSchema = z.strictObject({
   sessionId: z.string().min(1),
   turnId: z.string().min(1),
@@ -504,13 +511,11 @@ export type AgentSessionObservation = {
 };
 
 export interface AgentProtocol {
-  createSession(input: {
-    agentId: string;
-    executionTarget: AgentExecutionTarget;
-    title?: string;
-  }): Promise<AgentSessionView>;
   renameSession(input: { sessionId: string; title: string }): Promise<AgentSessionView>;
   deleteSession(input: { sessionId: string }): Promise<void>;
+
+  /** Creates the durable Session only when its first submission is admitted. */
+  startSession(input: AgentStartSessionInput): Promise<AgentSessionView>;
 
   submitMessage(
     input: AgentSubmitMessageInput,


### PR DESCRIPTION
## Summary

- Keep new Agent chats as isolated drafts and atomically create the durable Session with the first admitted message pair.
- Isolate composer state across Draft and Session boundaries, including temporary attachment ownership and cleanup.
- Serialize Session observation with deletion and remove the obsolete public createSession path and unused start result fields.
- Document the updated Agent protocol, persistence, and streaming lifecycle.

## Verification

- pnpm format
- Changed-file oxlint and Expo lint
- git diff --check
- pnpm lint: blocked by eight import/no-unresolved errors for the unbuilt internal @cherrystudio/ai-core package in unchanged files.
- Tests, type checking, builds, and device verification were not run per repository instructions.