### PR TITLE
feat(http-client): enforce request contract and log transport diagnostics

### DIFF
--- a/src/backend/services/http/HttpClient.ts
+++ b/src/backend/services/http/HttpClient.ts
@@ -1,6 +1,10 @@
 import type { HttpError, HttpErrorDetails } from './HttpError';
 
-export type HttpMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
+export type HttpBodylessMethod = 'DELETE' | 'GET';
+
+export type HttpBodyMethod = 'PATCH' | 'POST' | 'PUT';
+
+export type HttpMethod = HttpBodylessMethod | HttpBodyMethod;
 
 export type HttpHeaders = Readonly<Record<string, string>>;
 
@@ -8,6 +12,7 @@ type HttpQueryPrimitive = boolean | number | string;
 
 export type HttpQueryValue = HttpQueryPrimitive | null | undefined | readonly HttpQueryPrimitive[];
 
+/** Arrays serialize as repeated keys (`tag=a&tag=b`); `null` and `undefined` values are omitted. */
 export type HttpQuery = Readonly<Record<string, HttpQueryValue>>;
 
 export interface HttpErrorResponse {
@@ -26,17 +31,21 @@ export interface DecodedHttpError {
 
 export type HttpErrorDecoder = (response: HttpErrorResponse) => DecodedHttpError | undefined;
 
-export interface HttpRequest<TBody = unknown> {
-  readonly body?: TBody;
+interface HttpRequestBase {
   readonly errorDecoder?: HttpErrorDecoder;
   readonly headers?: HttpHeaders;
-  readonly method: HttpMethod;
   /** Relative API path beginning with `/`. Absolute URLs are rejected. */
   readonly path: string;
   readonly query?: HttpQuery;
   readonly signal?: AbortSignal;
+  /** Positive request timeout in milliseconds. Omit to use the client default. */
   readonly timeoutMs?: number;
 }
+
+/** `GET` and `DELETE` requests carry no body, matching REST semantics and the fetch transport. */
+export type HttpRequest<TBody = unknown> =
+  | (HttpRequestBase & { readonly body?: never; readonly method: HttpBodylessMethod })
+  | (HttpRequestBase & { readonly body?: TBody; readonly method: HttpBodyMethod });
 
 export interface HttpResponse<TData = unknown> {
   readonly data: TData;

--- a/src/backend/services/http/README.md
+++ b/src/backend/services/http/README.md
@@ -16,6 +16,10 @@ pairing and configuration import.
   only that route's interceptors.
 - A request cannot supply or replace its base URL. Paths must begin with one `/`, which prevents an
   absolute URL from redirecting credentials to another authority.
+- The wire format for queries is owned here, not by the Axios version: values serialize as repeated
+  keys (`tag=a&tag=b`) and `null` or `undefined` values are omitted.
+- `GET` and `DELETE` requests carry no body, and timeouts must be positive milliseconds. Both rules
+  are enforced at the type level and revalidated after interceptors run.
 - Responses expose app-owned `data`, `status`, and lowercase `headers`. Cancellation, timeout,
   network, HTTP status, unreadable response, and invalid input leave the module as `HttpError`.
   Raw Axios errors, configs, credentials, and unvalidated response bodies do not cross the public
@@ -110,6 +114,11 @@ async function getAccount(signal?: AbortSignal) {
 The decoder must not copy unknown response values, tokens, cookies, or other secrets into the
 public error. `HttpError` safely expresses `kind`, `status`, `code`, `requestId`, `retryAfter`,
 `message`, and app-owned `details`.
+
+The public error stays stable while the real failure stays diagnosable: the transport logs the
+underlying transport code, message, method, URL, and HTTP status through `loggerService` under the
+`HttpTransport` context. Headers, bodies, and query values are never logged, and cancellation is
+not logged.
 
 ## Boundaries
 

--- a/src/backend/services/http/README.md
+++ b/src/backend/services/http/README.md
@@ -13,7 +13,10 @@ pairing and configuration import.
   route owns its base URL, default headers, timeout, error decoder, and interceptor chain.
 - All clients use one module-private Axios transport configured with the fetch adapter and
   `expo/fetch`. Every request carries its client route internally, so the global dispatcher runs
-  only that route's interceptors.
+  only that route's interceptors. The single global transport is deliberate: the engine (adapter,
+  `expo/fetch`, and future transport-wide policy such as telemetry or network gating) is configured
+  in exactly one place. Do not split it into per-client Axios instances; add clients by adding
+  routes.
 - A request cannot supply or replace its base URL. Paths must begin with one `/`, which prevents an
   absolute URL from redirecting credentials to another authority.
 - The wire format for queries is owned here, not by the Axios version: values serialize as repeated

--- a/src/backend/services/http/__tests__/createHttpClient.test.ts
+++ b/src/backend/services/http/__tests__/createHttpClient.test.ts
@@ -8,10 +8,24 @@ import {
 import { z } from 'zod';
 
 import { __testing } from '../createHttpClient';
-import type { HttpInterceptor } from '../HttpClient';
+import type { HttpInterceptor, HttpRequest } from '../HttpClient';
 import { HttpError } from '../HttpError';
 
 jest.mock('expo/fetch', () => ({ fetch: jest.fn() }));
+jest.mock('@logger', () => {
+  const logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+  return { loggerService: { withContext: () => logger } };
+});
+
+const transportLogger = (
+  jest.requireMock('@logger') as {
+    loggerService: { withContext: (module: string) => { error: jest.Mock; warn: jest.Mock } };
+  }
+).loggerService.withContext('HttpTransport');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 function response<T>(
   config: InternalAxiosRequestConfig,
@@ -305,6 +319,103 @@ describe('createHttpClient', () => {
     expect(error).toBeInstanceOf(HttpError);
     expect(error).toMatchObject({ code, kind });
     expect(error.cause).toBeUndefined();
+  });
+
+  it('rejects a body on GET and DELETE requests, including one added by an interceptor', async () => {
+    const adapter = mockAdapter(async (config) => response(config, 200, {}));
+    const createClient = __testing.createHttpClientFactoryWithAdapter(adapter);
+
+    const directClient = createClient({ baseUrl: 'https://api.cherry.example.com' });
+    await expect(
+      directClient.request({
+        body: { enabled: true },
+        method: 'DELETE',
+        path: '/agents/agent-1',
+      } as never),
+    ).rejects.toMatchObject({ code: 'INVALID_REQUEST_BODY', kind: 'internal' });
+
+    const interceptedClient = createClient({
+      baseUrl: 'https://api.cherry.example.com',
+      interceptors: [
+        {
+          onRequest: (request) =>
+            ({ ...request, body: { injected: true } }) as unknown as HttpRequest<unknown>,
+        },
+      ],
+    });
+    await expect(
+      interceptedClient.request({ method: 'GET', path: '/agents' }),
+    ).rejects.toMatchObject({ code: 'INVALID_REQUEST_BODY', kind: 'internal' });
+
+    expect(adapter).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-positive timeouts for clients and requests', async () => {
+    const adapter = mockAdapter(async (config) => response(config, 200, {}));
+    const createClient = __testing.createHttpClientFactoryWithAdapter(adapter);
+
+    let clientError: unknown;
+    try {
+      createClient({ baseUrl: 'https://api.cherry.example.com', timeoutMs: 0 });
+    } catch (error) {
+      clientError = error;
+    }
+    expect(clientError).toMatchObject({ code: 'INVALID_CLIENT_TIMEOUT', kind: 'internal' });
+
+    const client = createClient({ baseUrl: 'https://api.cherry.example.com' });
+    await expect(
+      client.request({ method: 'GET', path: '/agents', timeoutMs: 0 }),
+    ).rejects.toMatchObject({ code: 'INVALID_REQUEST_TIMEOUT', kind: 'internal' });
+    expect(adapter).not.toHaveBeenCalled();
+  });
+
+  it('reports an error interceptor that returns an invalid value without hiding the reason', async () => {
+    const adapter = mockAdapter(async (config) => {
+      throw responseError(config, 500, {});
+    });
+    const createClient = __testing.createHttpClientFactoryWithAdapter(adapter);
+    const client = createClient({
+      baseUrl: 'https://api.cherry.example.com',
+      interceptors: [{ onError: () => undefined as unknown as HttpError }],
+    });
+
+    await expect(client.request({ method: 'GET', path: '/agents' })).rejects.toMatchObject({
+      code: 'INVALID_INTERCEPTOR_ERROR',
+      kind: 'internal',
+      message: 'HTTP error interceptor returned an invalid value.',
+    });
+  });
+
+  it('logs real transport diagnostics while the public error stays stable', async () => {
+    const adapter = mockAdapter(async (config) => {
+      throw new AxiosError('Network Error', AxiosError.ERR_NETWORK, config);
+    });
+    const createClient = __testing.createHttpClientFactoryWithAdapter(adapter);
+    const client = createClient({ baseUrl: 'https://api.cherry.example.com' });
+
+    const error = await client
+      .request({
+        headers: { Authorization: 'Bearer access-secret' },
+        method: 'GET',
+        path: '/agents',
+        query: { token: 'query-secret' },
+      })
+      .catch((value) => value);
+
+    expect(error).toMatchObject({ code: 'NETWORK_ERROR', kind: 'network' });
+    expect(transportLogger.warn).toHaveBeenCalledWith(
+      'HTTP request failed.',
+      expect.objectContaining({
+        code: AxiosError.ERR_NETWORK,
+        url: 'https://api.cherry.example.com/agents',
+      }),
+    );
+    const logged = JSON.stringify([
+      ...transportLogger.warn.mock.calls,
+      ...transportLogger.error.mock.calls,
+    ]);
+    expect(logged).not.toContain('access-secret');
+    expect(logged).not.toContain('query-secret');
   });
 
   it('rejects absolute request URLs before transport', async () => {

--- a/src/backend/services/http/__tests__/serializeHttpQuery.test.ts
+++ b/src/backend/services/http/__tests__/serializeHttpQuery.test.ts
@@ -1,0 +1,22 @@
+import { serializeHttpQuery } from '../serializeHttpQuery';
+
+describe('serializeHttpQuery', () => {
+  it('serializes primitives and arrays in standard repeated-key form', () => {
+    expect(
+      serializeHttpQuery({
+        cursor: 'abc def',
+        limit: 20,
+        tag: ['a', 'b'],
+        verbose: true,
+      }),
+    ).toBe('cursor=abc+def&limit=20&tag=a&tag=b&verbose=true');
+  });
+
+  it('omits null and undefined values', () => {
+    expect(serializeHttpQuery({ a: null, b: undefined, c: 'kept' })).toBe('c=kept');
+  });
+
+  it('percent-encodes reserved characters', () => {
+    expect(serializeHttpQuery({ redirect: '/a?b=c&d' })).toBe('redirect=%2Fa%3Fb%3Dc%26d');
+  });
+});

--- a/src/backend/services/http/createHttpClient.ts
+++ b/src/backend/services/http/createHttpClient.ts
@@ -21,6 +21,7 @@ import type {
 } from './HttpClient';
 import { HttpError, isHttpError } from './HttpError';
 import { mapAxiosError } from './mapAxiosError';
+import { serializeHttpQuery } from './serializeHttpQuery';
 import { toHttpHeaders } from './toHttpHeaders';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -79,6 +80,10 @@ function assertValidBaseUrl(baseUrl: string): void {
   }
 }
 
+function isValidTimeoutMs(timeoutMs: number): boolean {
+  return Number.isFinite(timeoutMs) && timeoutMs > 0;
+}
+
 function assertValidRequest(request: HttpRequest<unknown>): void {
   if (!request || typeof request !== 'object' || !HTTP_METHODS.has(request.method)) {
     throw new HttpError('HTTP request method is invalid.', {
@@ -94,6 +99,20 @@ function assertValidRequest(request: HttpRequest<unknown>): void {
   ) {
     throw new HttpError('HTTP request path must be a relative API path beginning with `/`.', {
       code: 'INVALID_REQUEST_PATH',
+      kind: 'internal',
+    });
+  }
+
+  if ((request.method === 'DELETE' || request.method === 'GET') && request.body !== undefined) {
+    throw new HttpError('HTTP GET and DELETE requests must not include a body.', {
+      code: 'INVALID_REQUEST_BODY',
+      kind: 'internal',
+    });
+  }
+
+  if (request.timeoutMs !== undefined && !isValidTimeoutMs(request.timeoutMs)) {
+    throw new HttpError('HTTP request timeout must be a positive number of milliseconds.', {
+      code: 'INVALID_REQUEST_TIMEOUT',
       kind: 'internal',
     });
   }
@@ -149,7 +168,10 @@ async function dispatchError(error: unknown, context?: HttpRequestContext): Prom
       const interceptedError = await interceptor.onError(mappedError, context.request);
       mappedError = isHttpError(interceptedError)
         ? interceptedError
-        : mapAxiosError(new Error('HTTP error interceptor returned an invalid value.'));
+        : new HttpError('HTTP error interceptor returned an invalid value.', {
+            code: 'INVALID_INTERCEPTOR_ERROR',
+            kind: 'internal',
+          });
     } catch (interceptorError) {
       mappedError = mapAxiosError(interceptorError);
     }
@@ -245,6 +267,7 @@ function createAxiosTransport(adapter?: AxiosAdapter): AxiosInstance {
     env: {
       fetch: expoFetch as unknown as AxiosFetch,
     },
+    paramsSerializer: { serialize: serializeHttpQuery },
     timeout: DEFAULT_TIMEOUT_MS,
   });
 
@@ -260,6 +283,13 @@ function createHttpClientWithTransport(
   transport: AxiosInstance,
 ): HttpClient {
   assertValidBaseUrl(options.baseUrl);
+
+  if (options.timeoutMs !== undefined && !isValidTimeoutMs(options.timeoutMs)) {
+    throw new HttpError('HTTP client timeout must be a positive number of milliseconds.', {
+      code: 'INVALID_CLIENT_TIMEOUT',
+      kind: 'internal',
+    });
+  }
 
   const route: HttpRoute = Object.freeze({
     baseUrl: options.baseUrl,

--- a/src/backend/services/http/index.ts
+++ b/src/backend/services/http/index.ts
@@ -1,5 +1,7 @@
 export type {
   DecodedHttpError,
+  HttpBodylessMethod,
+  HttpBodyMethod,
   HttpClient,
   HttpErrorDecoder,
   HttpErrorResponse,

--- a/src/backend/services/http/mapAxiosError.ts
+++ b/src/backend/services/http/mapAxiosError.ts
@@ -1,10 +1,28 @@
+import { loggerService } from '@logger';
 import { AxiosError, isAxiosError, isCancel } from 'axios';
 
 import type { DecodedHttpError, HttpErrorDecoder, HttpErrorResponse } from './HttpClient';
 import { HttpError, isHttpError } from './HttpError';
 import { toHttpHeaders } from './toHttpHeaders';
 
+const logger = loggerService.withContext('HttpTransport');
+
 const MAX_PUBLIC_HEADER_LENGTH = 256;
+
+/**
+ * Logs the real transport failure for diagnosis. Request and response headers,
+ * bodies, and query values stay out of the log; the public `HttpError` stays
+ * stable and desensitized.
+ */
+function logTransportFailure(error: AxiosError): void {
+  logger.warn('HTTP request failed.', {
+    code: error.code,
+    message: error.message,
+    method: error.config?.method,
+    status: error.response?.status,
+    url: `${error.config?.baseURL ?? ''}${error.config?.url ?? ''}`,
+  });
+}
 
 function readPublicHeader(headers: HttpErrorResponse['headers'], name: string): string | undefined {
   const normalized = headers[name.toLowerCase()]?.trim();
@@ -60,6 +78,10 @@ export function mapAxiosError(error: unknown, decode?: HttpErrorDecoder): HttpEr
   }
 
   if (!isAxiosError(error)) {
+    logger.error(
+      'HTTP transport failed unexpectedly.',
+      error instanceof Error ? error : { value: String(error) },
+    );
     return new HttpError('HTTP request failed unexpectedly.', {
       code: 'HTTP_INTERNAL_ERROR',
       kind: 'internal',
@@ -72,6 +94,8 @@ export function mapAxiosError(error: unknown, decode?: HttpErrorDecoder): HttpEr
       kind: 'cancelled',
     });
   }
+
+  logTransportFailure(error);
 
   if (error.code === AxiosError.ECONNABORTED || error.code === AxiosError.ETIMEDOUT) {
     return new HttpError('HTTP request timed out.', {

--- a/src/backend/services/http/serializeHttpQuery.ts
+++ b/src/backend/services/http/serializeHttpQuery.ts
@@ -1,0 +1,21 @@
+import type { HttpQuery } from './HttpClient';
+
+/**
+ * Serializes query parameters in standard repeated-key form (`tag=a&tag=b`),
+ * omitting `null` and `undefined` values. The wire format is owned by this
+ * module rather than by the Axios default serializer.
+ */
+export function serializeHttpQuery(query: HttpQuery): string {
+  const searchParams = new URLSearchParams();
+
+  for (const [name, value] of Object.entries(query)) {
+    for (const item of Array.isArray(value) ? value : [value]) {
+      if (item === null || item === undefined) {
+        continue;
+      }
+      searchParams.append(name, String(item));
+    }
+  }
+
+  return searchParams.toString();
+}


### PR DESCRIPTION
## Summary

Hardens the external service HTTP transport (`src/backend/services/http`) introduced in #733, following a design review of the module:

- **Module-owned query wire format.** Query values now serialize through `serializeHttpQuery` as standard repeated keys (`tag=a&tag=b`, `null`/`undefined` omitted) instead of relying on the Axios default bracket format, so the wire contract no longer depends on Axios version behavior.
- **REST request rules enforced.** `HttpRequest` is now a discriminated union that forbids bodies on `GET`/`DELETE` at the type level, revalidated at runtime after interceptors run (`INVALID_REQUEST_BODY`). Client and request timeouts must be positive milliseconds (`INVALID_CLIENT_TIMEOUT` / `INVALID_REQUEST_TIMEOUT`), removing the `timeoutMs: 0` → "never times out" trap.
- **Real diagnostics behind stable errors.** The transport now logs the underlying failure (transport code, message, method, URL, HTTP status) via `loggerService` under the `HttpTransport` context, while the public `HttpError` stays desensitized. Headers, bodies, and query values are never logged; cancellation is not logged.
- **Interceptor error fix.** An error interceptor returning an invalid value now surfaces `INVALID_INTERCEPTOR_ERROR` with its real reason instead of a generic internal error.

## Test plan

- `npx jest src/backend/services/http` — 19 tests, including new coverage for body/timeout rejection, interceptor-injected bodies, invalid interceptor return values, diagnostic logging with secret redaction, and query serialization.
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` — all green on the final head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)