### PR TITLE
feat(chat-input): enable web search by default

### DIFF
--- a/docs/references/web-search.md
+++ b/docs/references/web-search.md
@@ -14,7 +14,7 @@ Cherry Mobile retains two independent configurations:
 `WebSearchService` reaches Agent turns through the application-owned `web_search` and `web_fetch`
 Runtime tools, never through an AI SDK tool set. The composer stores enabled Session ids in the
 frontend MMKV cache; this state does not enter SQLite or the Agent protocol's Session model. New
-Sessions default to disabled. While enabled, every `submitMessage` carries
+Sessions default to enabled. While enabled, every `submitMessage` carries
 `temporaryCapabilities: ['web-search']`, keeping the turn catalog immutable. The setting is never
 persisted on the Agent.
 

--- a/src/frontend/features/chat/input/README.md
+++ b/src/frontend/features/chat/input/README.md
@@ -28,7 +28,7 @@ exported through `index.ts` and receives the current `agentId` and optional `ses
   configuration. An explicit `default` selection bypasses the Agent effort for that turn and uses
   the selected model's default.
 - The composer menu stores web-search selection in the frontend persist cache, keyed by Session id.
-  New Sessions default to disabled, and an admitted first send transfers the Draft selection to the
+  New Sessions default to enabled, and an admitted first send transfers the Draft selection to the
   returned Session. While enabled, every submission includes the turn-local `web-search`
   capability. The create-image mention remains turn-local and adds `image-generation` only to the
   draft that contains it. Neither choice mutates Agent or Agent Session persistence.

--- a/src/frontend/features/chat/input/hooks/__tests__/useChatInputWebSearchSelection.test.tsx
+++ b/src/frontend/features/chat/input/hooks/__tests__/useChatInputWebSearchSelection.test.tsx
@@ -52,7 +52,7 @@ describe('useChatInputWebSearchSelection', () => {
     await act(async () => renderer?.unmount());
   });
 
-  test('keeps a new Session draft local until creation assigns an id', async () => {
+  test('defaults each new Session draft to enabled and keeps its selection local', async () => {
     let snapshot: Snapshot | undefined;
     let renderer: ReactTestRenderer | undefined;
 
@@ -66,6 +66,11 @@ describe('useChatInputWebSearchSelection', () => {
         />,
       );
     });
+    expect(snapshot?.isWebSearchEnabled).toBe(true);
+
+    await act(async () => snapshot?.setIsWebSearchEnabled(false));
+    expect(snapshot?.isWebSearchEnabled).toBe(false);
+
     await act(async () => snapshot?.setIsWebSearchEnabled(true));
 
     expect(snapshot?.isWebSearchEnabled).toBe(true);
@@ -95,7 +100,7 @@ describe('useChatInputWebSearchSelection', () => {
         />,
       );
     });
-    expect(snapshot?.isWebSearchEnabled).toBe(false);
+    expect(snapshot?.isWebSearchEnabled).toBe(true);
 
     await act(async () => renderer?.unmount());
   });

--- a/src/frontend/features/chat/input/hooks/useChatInputWebSearchSelection.ts
+++ b/src/frontend/features/chat/input/hooks/useChatInputWebSearchSelection.ts
@@ -10,7 +10,10 @@ import {
 type DraftSelection = {
   agentId?: string;
   isEnabled: boolean;
+  sessionId?: string;
 };
+
+const DEFAULT_WEB_SEARCH_ENABLED = true;
 
 /**
  * Stores established Session selections in the frontend persist cache while
@@ -23,14 +26,16 @@ export function useChatInputWebSearchSelection(input: { agentId?: string; sessio
   );
   const [draftSelection, setDraftSelection] = useState<DraftSelection>({
     agentId,
-    isEnabled: false,
+    isEnabled: DEFAULT_WEB_SEARCH_ENABLED,
+    sessionId,
   });
   let activeDraftSelection = draftSelection;
-  if (
-    (sessionId && draftSelection.isEnabled) ||
-    (!sessionId && draftSelection.agentId !== agentId)
-  ) {
-    activeDraftSelection = { agentId, isEnabled: false };
+  if (draftSelection.agentId !== agentId || draftSelection.sessionId !== sessionId) {
+    activeDraftSelection = {
+      agentId,
+      isEnabled: DEFAULT_WEB_SEARCH_ENABLED,
+      sessionId,
+    };
     setDraftSelection(activeDraftSelection);
   }
 
@@ -46,7 +51,7 @@ export function useChatInputWebSearchSelection(input: { agentId?: string; sessio
       return;
     }
 
-    setDraftSelection({ agentId, isEnabled });
+    setDraftSelection({ agentId, isEnabled, sessionId });
   };
 
   return { isWebSearchEnabled, setIsWebSearchEnabled };


### PR DESCRIPTION
## Summary
- enable web search by default for every new chat draft
- preserve per-session web search selection and manual opt-out
- document the enabled-by-default behavior

## Verification
- `pnpm format:check` passed
- targeted `oxlint` and Expo ESLint checks for the changed TypeScript files passed
- `pnpm lint` was attempted but is blocked by pre-existing unresolved `@cherrystudio/ai-core` imports in unrelated backend files
- tests and typecheck were not run per repository workspace instructions