### PR TITLE
fix: reopen native permission settings

### DIFF
--- a/src/frontend/features/settings/PermissionsScreen/PermissionsScreen.tsx
+++ b/src/frontend/features/settings/PermissionsScreen/PermissionsScreen.tsx
@@ -10,7 +10,13 @@ import { useBackendModule } from '@/frontend/data';
 import type { SystemPermissionState } from '@/shared/contracts';
 
 import { usePermissionSystemStatuses } from './hooks/usePermissionSystemStatuses';
-import { getPermissionStatus, type PermissionKind, permissionConfig } from './permissionConfig';
+import {
+  getPermissionAction,
+  getPermissionStatus,
+  type PermissionAction,
+  type PermissionKind,
+  permissionConfig,
+} from './permissionConfig';
 import {
   PermissionListLeading,
   visiblePermissionKinds,
@@ -23,16 +29,16 @@ export default function PermissionsSettingsScreen() {
   const [activePermissionKind, setActivePermissionKind] = useState<PermissionKind | null>(null);
   const { refresh, statuses } = usePermissionSystemStatuses();
 
-  const handlePermissionPress = async (kind: PermissionKind, status: SystemPermissionState) => {
+  const handlePermissionPress = async (kind: PermissionKind, action: PermissionAction) => {
     if (activePermissionKind) return;
 
     setActivePermissionKind(kind);
     let hasFailed = false;
     try {
       const config = permissionConfig[kind];
-      if (status === 'undetermined') {
+      if (action === 'request') {
         await permissions.request(config.requestScope);
-      } else if (status === 'denied') {
+      } else {
         await permissions.openSystemSettings(config.permission);
       }
     } catch {
@@ -52,24 +58,30 @@ export default function PermissionsSettingsScreen() {
 
   const items = visiblePermissionKinds.map((kind) => {
     const status = getPermissionStatus(kind, statuses);
+    const action = getPermissionAction(status);
     const isUpdating = activePermissionKind === kind;
-    const isActionable = status === 'denied' || status === 'undetermined';
     const accessibilityHint =
-      status === 'denied'
-        ? t('settings.permissions.openSystemSettingsHint')
-        : status === 'undetermined'
-          ? t('settings.permissions.requestHint')
+      action === 'request'
+        ? t('settings.permissions.requestHint')
+        : action === 'open-settings'
+          ? t('settings.permissions.openSystemSettingsHint')
           : undefined;
 
     return {
       accessibilityHint,
       accessibilityState: { busy: isUpdating },
-      disabled: isActionable && activePermissionKind !== null,
+      disabled: action !== undefined && activePermissionKind !== null,
       id: kind,
       label: t(`settings.permissions.type.${kind}`),
       leading: <PermissionListLeading kind={kind} />,
-      onPress: status && isActionable ? () => void handlePermissionPress(kind, status) : undefined,
-      trailing: <PermissionStatus isUpdating={isUpdating} status={status} />,
+      onPress: action ? () => void handlePermissionPress(kind, action) : undefined,
+      trailing: (
+        <PermissionStatus
+          isActionable={action !== undefined}
+          isUpdating={isUpdating}
+          status={status}
+        />
+      ),
     };
   });
 
@@ -95,9 +107,11 @@ export default function PermissionsSettingsScreen() {
 }
 
 function PermissionStatus({
+  isActionable,
   isUpdating,
   status,
 }: {
+  isActionable: boolean;
   isUpdating: boolean;
   status: SystemPermissionState | undefined;
 }) {
@@ -118,9 +132,7 @@ function PermissionStatus({
         {t(`settings.permissions.status.${status}`)}
       </Text>
       {status === 'granted' ? <CheckIcon className="size-5 text-foreground" /> : null}
-      {status === 'denied' || status === 'undetermined' ? (
-        <ChevronRightIcon className="size-5 text-muted-foreground" />
-      ) : null}
+      {isActionable ? <ChevronRightIcon className="size-5 text-muted-foreground" /> : null}
     </View>
   );
 }

--- a/src/frontend/features/settings/PermissionsScreen/__tests__/permissionConfig.test.ts
+++ b/src/frontend/features/settings/PermissionsScreen/__tests__/permissionConfig.test.ts
@@ -1,6 +1,6 @@
 import type { PermissionStatuses } from '@/shared/contracts';
 
-import { getPermissionStatus } from '../permissionConfig';
+import { getPermissionAction, getPermissionStatus } from '../permissionConfig';
 
 const grantedStatuses: PermissionStatuses = {
   'calendar.read': 'granted',
@@ -33,4 +33,24 @@ describe('getPermissionStatus', () => {
   it('keeps the initial state loading until every scope has been checked', () => {
     expect(getPermissionStatus('calendar', { 'calendar.read': 'granted' })).toBeUndefined();
   });
+});
+
+describe('getPermissionAction', () => {
+  it('requests an undetermined permission', () => {
+    expect(getPermissionAction('undetermined')).toBe('request');
+  });
+
+  it.each(['denied', 'granted'] as const)(
+    'opens system settings for an already determined %s permission',
+    (status) => {
+      expect(getPermissionAction(status)).toBe('open-settings');
+    },
+  );
+
+  it.each([undefined, 'unavailable'] as const)(
+    'does not offer an action for an unavailable permission state',
+    (status) => {
+      expect(getPermissionAction(status)).toBeUndefined();
+    },
+  );
 });

--- a/src/frontend/features/settings/PermissionsScreen/permissionConfig.ts
+++ b/src/frontend/features/settings/PermissionsScreen/permissionConfig.ts
@@ -7,6 +7,7 @@ import type {
 
 export const permissionKinds = ['location', 'calendar', 'reminders', 'health'] as const;
 export type PermissionKind = (typeof permissionKinds)[number];
+export type PermissionAction = 'open-settings' | 'request';
 
 export const permissionConfig: Record<
   PermissionKind,
@@ -48,4 +49,12 @@ export function getPermissionStatus(
   if (scopeStatuses.some((status) => status === 'denied')) return 'denied';
   if (scopeStatuses.some((status) => status === 'undetermined')) return 'undetermined';
   return 'unavailable';
+}
+
+export function getPermissionAction(
+  status: SystemPermissionState | undefined,
+): PermissionAction | undefined {
+  if (status === 'undetermined') return 'request';
+  if (status === 'denied' || status === 'granted') return 'open-settings';
+  return undefined;
 }


### PR DESCRIPTION
## Summary

- keep granted and denied permission rows actionable
- open native app permission settings after the user has made an initial choice while preserving the first-time permission request flow
- keep status, chevron, and accessibility cues aligned with the available action
- add regression coverage for permission action mapping

## Validation

- pnpm format
- targeted Oxlint passed for all changed files
- targeted Expo ESLint passed for all changed files
- git diff --check

## Not run

- unit tests, typecheck, or manual device acceptance, per workspace verification policy
- full pnpm lint could not complete because existing app imports for unbuilt @cherrystudio/ai-core workspace packages could not be resolved; the changed files pass targeted lint