### PR TITLE
fix(navigation): keep chat surface fixed under drawer

### DIFF
--- a/src/app/(drawer)/_layout.tsx
+++ b/src/app/(drawer)/_layout.tsx
@@ -24,7 +24,9 @@ export default function DrawerLayout() {
         drawerContent={renderSidebar}
         screenOptions={{
           drawerStyle: { width },
-          drawerType: 'slide',
+          // The chat surface is stable context; the sidebar is a temporary
+          // surface that slides over it as the only moving plane.
+          drawerType: 'front',
           headerShown: false,
           // Dim the exposed scene while preserving the drawer's native progress
           // animation and tap-to-close interaction.


### PR DESCRIPTION
## Summary

- present the full-width sidebar as a foreground overlay
- keep the chat surface stationary during drawer transitions
- preserve the native drawer spring, gesture handoff, scrim, and tap-to-close behavior

## Validation

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`
- `pnpm typecheck`
- device acceptance not run