### PR TITLE
build(pnpm): upgrade to 12.2.1

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.8.0
+          version: 12.2.1
 
       # Step 4: Setup Expo and EAS
       - name: Setup Expo and EAS

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.8.0
+          version: 12.2.1
 
       # Step 4: Setup Expo and EAS
       - name: Setup Expo and EAS

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.8.0
+          version: 12.2.1
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -51,7 +51,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.8.0
+          version: 12.2.1
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -78,7 +78,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.8.0
+          version: 12.2.1
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Cherry Mobile is Cherry Studio's Expo and React Native client.
 
-Use `pnpm@11.8.0`. This repository has no root application build script: build workspace packages
+Use `pnpm@12.2.1`. This repository has no root application build script: build workspace packages
 with `pnpm packages:build`, and run the complete repository type check with `pnpm typecheck`.
 
 - When naming or renaming files, directories, identifiers, or documentation, read

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ resource ownership.
 ## Requirements
 
 - Node.js 24, matching pull request CI
-- `pnpm@11.8.0`
+- `pnpm@12.2.1`
 - Xcode for iOS development or Android Studio for Android development
 
 ## Install

--- a/eas.json
+++ b/eas.json
@@ -8,7 +8,7 @@
       "developmentClient": true,
       "distribution": "internal",
       "node": "24.19.0",
-      "pnpm": "11.8.0",
+      "pnpm": "12.2.1",
       "env": {
         "PROFILE": "development"
       },
@@ -21,7 +21,7 @@
     "preview": {
       "distribution": "internal",
       "node": "24.19.0",
-      "pnpm": "11.8.0",
+      "pnpm": "12.2.1",
       "env": {
         "PROFILE": "preview"
       },
@@ -35,7 +35,7 @@
       "autoIncrement": true,
       "channel": "production",
       "node": "24.19.0",
-      "pnpm": "11.8.0",
+      "pnpm": "12.2.1",
       "env": {
         "PROFILE": "production"
       },

--- a/package.json
+++ b/package.json
@@ -195,5 +195,5 @@
     "typescript": "~6.0.3"
   },
   "private": true,
-  "packageManager": "pnpm@11.8.0"
+  "packageManager": "pnpm@12.2.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.2.1
+        version: 12.2.1
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    resolution: {integrity: sha512-efC1yfz2xbyHiMLrQAYtnoo5XP20LeAiYYcyL1962qQagZrMXIB0BoQYeZoPTLggLh0Q4MD7jpZUInU5fWxCgQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    resolution: {integrity: sha512-0bloFmxrvYY5LYex5V6SZySwg+egBk0pOW+YUeOm9fiG2U1wv+qRVLBOUvIzLAeJE7vBlAzxUwXkQAYtr12n+Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    resolution: {integrity: sha512-AZl7apVZC4TV1/vTp/bS16XUsHeqx9AHsU4V55joiGR+iR6vl+WF0WlGvGCTjqjICS4q/kThpgNrtG8aqQ9seQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    resolution: {integrity: sha512-S36+tMEGrPz3nwtfFU9kYxbHoi8sV7WJfMO9njEL4jRaShTNaLRERMAqyI2DUCiA5QCr6/a50lt4+pKCV2mCvw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    resolution: {integrity: sha512-4MQClkAk1em55LFZJpeIqb7j+gEqCgX8yC42j9DFWL42q1uMX1e1tvTy2Dtd4NoWQqgdkLxOStZ+D9CYC+28ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    resolution: {integrity: sha512-A/AlR71Leph7qgB3ThSU9yU/vLfre4HmP6nbt3/qt51fzAjQ0xuq7j+cw0f1yDskzOsGzmo5uD6ruefCwLK5uQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    resolution: {integrity: sha512-TEGUmroT6NGfo2O2+tHK9Zr1lhP1zLzpwx+QAQV19l8V4ljUoMfz8Os5V9zzNCtIpzyKcK7SuG7fkVbxFgRMzg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    resolution: {integrity: sha512-V2Q+AF8fCsw8/CC3bWF8kopOmH0aAjgk9m7H7uAQNulOYIJs9YJBiAlgByswmt+igV9axc4dBI//ZlK2NKpDcw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.2.1:
+    resolution: {integrity: sha512-9Vymiqy561q2nGb4KKmK+JoyKGcDrvH42hMcp+q01nfzS/qF4YZGepGcB5nfi29KokD33CkZszsycxkBBBYmFg==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    optional: true
+
+  pnpm@12.2.1:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.2.1
+      '@pnpm/exe.darwin-x64': 12.2.1
+      '@pnpm/exe.linux-arm64': 12.2.1
+      '@pnpm/exe.linux-arm64-musl': 12.2.1
+      '@pnpm/exe.linux-x64': 12.2.1
+      '@pnpm/exe.linux-x64-musl': 12.2.1
+      '@pnpm/exe.win32-arm64': 12.2.1
+      '@pnpm/exe.win32-x64': 12.2.1
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: local development, GitHub Actions, and EAS builds were pinned to pnpm 11.8.0.

After this PR: every toolchain entry point uses pnpm 12.2.1, with the pnpm 12 package-manager metadata recorded in the lockfile.

### Screenshots or videos

N/A: build-tooling-only change with no visible product effect.

### Why we need it and why it was done in this way

The exact version is pinned across `packageManager`, documentation, CI, and EAS so installs remain reproducible; a local fresh-install benchmark improved from 9.78s to 5.57s on average.

The following tradeoffs were made: pnpm 12 adds its cross-platform executable metadata to the lockfile.

The following alternatives were considered: a floating `pnpm@12` range was rejected because npm's default `latest` tag still points to pnpm 11 and floating versions would make environments inconsistent.

### Breaking changes

Contributors and build environments must use pnpm 12.2.1; the existing Node.js 24 requirement is compatible.

### Special notes for your reviewer

Validated with frozen install, package builds, complete typecheck, lint, format check, and all 4,090 tests.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
