### PR TITLE
fix(menu): arbitrate Android context menus against scrolling

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -304,7 +304,12 @@ menu's recognition ownership. Call sites express which interaction they mean by 
 component instead of configuring a trigger:
 
 ```tsx
-import { ActionMenu, ContextMenu, type MenuItem } from '@cherrystudio/ui/components';
+import {
+  ActionMenu,
+  ContextMenu,
+  ContextMenuScrollBoundary,
+  type MenuItem,
+} from '@cherrystudio/ui/components';
 
 const items = [
   { id: 'rename', label: 'Rename', onPress: rename },
@@ -320,6 +325,11 @@ const items = [
 <ContextMenu items={items}>
   <MessageRow />
 </ContextMenu>;
+
+// The scroll owner exposes drag and momentum state to every descendant context menu.
+<ContextMenuScrollBoundary>
+  {(scrollHandlers) => <ScrollView {...scrollHandlers}>{rows}</ScrollView>}
+</ContextMenuScrollBoundary>;
 ```
 
 Item IDs must be unique within a menu. `checked` is controlled; omitting it creates a regular
@@ -328,16 +338,26 @@ unchanged. Both platforms render text actions; iOS uses `UIMenu` / `UIContextMen
 Android uses `PopupMenu`. Each keeps the system style for destructive items. Expo Router page
 previews remain owned by `Link.Preview` / `Link.Menu`, not these components.
 
+Wrap every scroll component containing an Android `ContextMenu` in one
+`ContextMenuScrollBoundary`. The boundary supplies drag, momentum, and touch handlers through its
+render callback without rendering another native view. Pass an existing scroll handler to the
+boundary itself when it needs to be composed with menu arbitration. A touch that only stops
+momentum stays ineligible for a context menu until that touch ends. On iOS the supplied handlers are
+forwarded unchanged because UIKit already owns menu arbitration. On Android, a custom trigger
+component must forward `accessibilityActions` and `onAccessibilityAction` to its accessible native
+target.
+
 `ContextMenu` recognition follows
 [Interaction And Gesture Arbitration](../../docs/references/interaction-and-gesture-arbitration.md):
 on iOS the system `UIContextMenuInteraction` owns the long press and its coordination with scroll
 ancestors; on Android the long press is a `react-native-gesture-handler` recognizer in the shared
 gesture arena, so committed scrolling and pan gestures cancel it, and the native view only presents
-the already-arbitrated menu. Recognition timing and touch slop stay on the platform recognizer's
-defaults. On Android the enabled items are also exposed as accessibility custom actions on the
-trigger child, so the contextual operations do not depend on long press; iOS accessibility stays
-with the system interaction. Verify changed gesture boundaries on a device — the arbitration
-reference is `Status: design` and JavaScript tests cannot prove recognizer timing.
+the already-arbitrated menu. Recognition timing and touch slop come from Android
+`ViewConfiguration`, including the user's system long-press timeout. On Android the enabled items
+are also exposed as accessibility custom actions on the trigger child, so the contextual operations
+do not depend on long press; iOS accessibility stays with the system interaction. Verify changed
+gesture boundaries on a device — the arbitration reference is `Status: design` and JavaScript tests
+cannot prove recognizer timing.
 
 The native implementation is adapted from MIT-licensed Nitro menu projects. See
 [third-party-notices.md](third-party-notices.md) for the complete attribution and license text.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -298,35 +298,46 @@ compatible `Input` props. Its `style` prop targets the composed field container.
 also disables its visibility action. Plain inputs default to `type="text"`, and their `style` prop
 continues to target the native field.
 
-`Menu` is the shared native action menu. It accepts one trigger element and a flat, stable `items`
-array; the package owns Nitro wiring, native action dispatch, and platform gesture behavior:
+`ActionMenu` and `ContextMenu` are the shared native action menus. Each accepts one trigger element
+and a flat, stable `items` array; the package owns Nitro wiring, native action dispatch, and the
+menu's recognition ownership. Call sites express which interaction they mean by choosing the
+component instead of configuring a trigger:
 
 ```tsx
-import { Menu, type MenuItem } from '@cherrystudio/ui/components';
+import { ActionMenu, ContextMenu, type MenuItem } from '@cherrystudio/ui/components';
 
 const items = [
   { id: 'rename', label: 'Rename', onPress: rename },
   { destructive: true, id: 'delete', label: 'Delete', onPress: remove },
 ] satisfies readonly MenuItem[];
 
-<Menu items={items} trigger="longPress">
+// A tap-triggered dropdown: the tap is button behavior the menu owns outright.
+<ActionMenu items={items}>
+  <MoreButton />
+</ActionMenu>;
+
+// A long-press contextual menu that keeps the child's normal tap behavior.
+<ContextMenu items={items}>
   <MessageRow />
-</Menu>;
+</ContextMenu>;
 ```
 
 Item IDs must be unique within a menu. `checked` is controlled; omitting it creates a regular
 action, while `false` and `true` create off and on check states. An empty array returns the child
 unchanged. Both platforms render text actions; iOS uses `UIMenu` / `UIContextMenuInteraction`, while
-Android uses `PopupMenu`. Each keeps the system style for destructive items. `tap` is for
-button-like dropdowns, and `longPress` is for contextual
-actions without taking over the child's normal tap. Expo Router page previews remain owned by
-`Link.Preview` / `Link.Menu`, not this component.
+Android uses `PopupMenu`. Each keeps the system style for destructive items. Expo Router page
+previews remain owned by `Link.Preview` / `Link.Menu`, not these components.
 
-The target priority and cancellation behavior between menu recognition and ancestor scrolling is
-documented in
-[Interaction And Gesture Arbitration](../../docs/references/interaction-and-gesture-arbitration.md)
-as `Status: design`. Verify the native interaction boundary on each supported platform when a menu
-is used inside a scroll surface.
+`ContextMenu` recognition follows
+[Interaction And Gesture Arbitration](../../docs/references/interaction-and-gesture-arbitration.md):
+on iOS the system `UIContextMenuInteraction` owns the long press and its coordination with scroll
+ancestors; on Android the long press is a `react-native-gesture-handler` recognizer in the shared
+gesture arena, so committed scrolling and pan gestures cancel it, and the native view only presents
+the already-arbitrated menu. Recognition timing and touch slop stay on the platform recognizer's
+defaults. On Android the enabled items are also exposed as accessibility custom actions on the
+trigger child, so the contextual operations do not depend on long press; iOS accessibility stays
+with the system interaction. Verify changed gesture boundaries on a device — the arbitration
+reference is `Status: design` and JavaScript tests cannot prove recognizer timing.
 
 The native implementation is adapted from MIT-licensed Nitro menu projects. See
 [third-party-notices.md](third-party-notices.md) for the complete attribution and license text.

--- a/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
+++ b/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
@@ -21,11 +21,13 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.events.NativeGestureUtil
 
 private class MenuFrameLayout(context: Context) : FrameLayout(context) {
-    var onLongPress: (() -> Unit)? = null
     var onTap: (() -> Unit)? = null
     private var isMenuGestureActive = false
     private var isNativeGestureActive = false
 
+    // Tap triggers are button behavior the menu may own outright. Long press competes with
+    // scrolling and pan gestures, so its recognition lives in the shared gesture arena on the
+    // JavaScript side; this view only presents through showMenu().
     private val gestureDetector = GestureDetector(
         context,
         object : GestureDetector.SimpleOnGestureListener() {
@@ -36,22 +38,20 @@ private class MenuFrameLayout(context: Context) : FrameLayout(context) {
                 activateMenu(event, handler)
                 return true
             }
-
-            override fun onLongPress(event: MotionEvent) {
-                onLongPress?.let { activateMenu(event, it) }
-            }
         },
     )
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (onTap == null) {
+            return super.dispatchTouchEvent(event)
+        }
+
         if (event.actionMasked == MotionEvent.ACTION_DOWN) {
             isMenuGestureActive = false
             isNativeGestureActive = false
-            if (onTap != null) {
-                // RootView sees ACTION_UP before descendants do. Claim tap-trigger gestures on
-                // DOWN so a wrapped React Pressable cannot release before the menu takes over.
-                startNativeGesture(event)
-            }
+            // RootView sees ACTION_UP before descendants do. Claim tap-trigger gestures on
+            // DOWN so a wrapped React Pressable cannot release before the menu takes over.
+            startNativeGesture(event)
         }
 
         gestureDetector.onTouchEvent(event)
@@ -79,9 +79,6 @@ private class MenuFrameLayout(context: Context) : FrameLayout(context) {
 
     private fun activateMenu(event: MotionEvent, handler: () -> Unit) {
         isMenuGestureActive = true
-        // Long-press claims RN's root responder here; tap already claimed it on DOWN. Both still
-        // cancel the native child that received the gesture stream.
-        startNativeGesture(event)
         MotionEvent.obtain(event).also { cancelEvent ->
             cancelEvent.action = MotionEvent.ACTION_CANCEL
             super.dispatchTouchEvent(cancelEvent)
@@ -139,14 +136,19 @@ class HybridCherryMenuView(
     private fun updateTrigger() {
         when (trigger) {
             NativeMenuTrigger.TAP -> {
-                containerView.onLongPress = null
                 containerView.onTap = ::showPopupMenu
             }
+            // A long-press menu never recognizes its own trigger on Android: the shared gesture
+            // arena arbitrates the long press against scrolling and pans, then calls showMenu().
             NativeMenuTrigger.LONGPRESS -> {
                 containerView.onTap = null
-                containerView.onLongPress = ::showPopupMenu
             }
         }
+    }
+
+    override fun showMenu() {
+        // Hybrid methods arrive on the JS thread; PopupMenu must be shown from the UI thread.
+        containerView.post(::showPopupMenu)
     }
 
     private fun showPopupMenu() {

--- a/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
+++ b/packages/ui/android/src/main/java/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuView.kt
@@ -13,6 +13,7 @@ import android.view.GestureDetector
 import android.view.Menu
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.widget.FrameLayout
 import android.widget.PopupMenu
 import androidx.annotation.Keep
@@ -144,6 +145,15 @@ class HybridCherryMenuView(
                 containerView.onTap = null
             }
         }
+    }
+
+    override fun getLongPressMinDuration(): Double =
+        ViewConfiguration.getLongPressTimeout().toDouble()
+
+    override fun getLongPressMaxDistance(): Double {
+        val touchSlop = ViewConfiguration.get(containerView.context).scaledTouchSlop
+        val density = containerView.resources.displayMetrics.density
+        return (touchSlop / density).toDouble()
     }
 
     override fun showMenu() {

--- a/packages/ui/ios/HybridCherryMenuView.swift
+++ b/packages/ui/ios/HybridCherryMenuView.swift
@@ -19,6 +19,12 @@ final class HybridCherryMenuView: HybridCherryMenuViewSpec {
     var trigger: NativeMenuTrigger = .tap {
         didSet { containerView.trigger = trigger }
     }
+
+    func showMenu() throws {
+        // iOS recognition stays system-owned: tap menus present through the UIButton primary
+        // action and long-press menus through UIContextMenuInteraction, which cannot be
+        // presented programmatically. Android is the only caller of this method.
+    }
 }
 
 private final class CherryMenuContainerView: UIView, UIContextMenuInteractionDelegate {

--- a/packages/ui/ios/HybridCherryMenuView.swift
+++ b/packages/ui/ios/HybridCherryMenuView.swift
@@ -20,6 +20,16 @@ final class HybridCherryMenuView: HybridCherryMenuViewSpec {
         didSet { containerView.trigger = trigger }
     }
 
+    func getLongPressMinDuration() throws -> Double {
+        // Android is the only caller; iOS long press stays UIKit-owned.
+        0
+    }
+
+    func getLongPressMaxDistance() throws -> Double {
+        // Android is the only caller; iOS long press stays UIKit-owned.
+        0
+    }
+
     func showMenu() throws {
         // iOS recognition stays system-owned: tap menus present through the UIButton primary
         // action and long-press menus through UIContextMenuInteraction, which cannot be

--- a/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.cpp
+++ b/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.cpp
@@ -115,6 +115,9 @@ namespace margelo::nitro::cherrystudio::ui {
   }
 
   // Methods
-  
+  void JHybridCherryMenuViewSpec::showMenu() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("showMenu");
+    method(_javaPart);
+  }
 
 } // namespace margelo::nitro::cherrystudio::ui

--- a/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.cpp
+++ b/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.cpp
@@ -115,6 +115,16 @@ namespace margelo::nitro::cherrystudio::ui {
   }
 
   // Methods
+  double JHybridCherryMenuViewSpec::getLongPressMinDuration() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getLongPressMinDuration");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridCherryMenuViewSpec::getLongPressMaxDistance() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getLongPressMaxDistance");
+    auto __result = method(_javaPart);
+    return __result;
+  }
   void JHybridCherryMenuViewSpec::showMenu() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("showMenu");
     method(_javaPart);

--- a/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.hpp
+++ b/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.hpp
@@ -59,6 +59,8 @@ namespace margelo::nitro::cherrystudio::ui {
 
   public:
     // Methods
+    double getLongPressMinDuration() override;
+    double getLongPressMaxDistance() override;
     void showMenu() override;
 
   private:

--- a/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.hpp
+++ b/packages/ui/nitrogen/generated/android/c++/JHybridCherryMenuViewSpec.hpp
@@ -59,7 +59,7 @@ namespace margelo::nitro::cherrystudio::ui {
 
   public:
     // Methods
-    
+    void showMenu() override;
 
   private:
     jni::global_ref<JHybridCherryMenuViewSpec::JavaPart> _javaPart;

--- a/packages/ui/nitrogen/generated/android/kotlin/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuViewSpec.kt
+++ b/packages/ui/nitrogen/generated/android/kotlin/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuViewSpec.kt
@@ -53,7 +53,9 @@ abstract class HybridCherryMenuViewSpec: HybridView() {
   abstract var trigger: NativeMenuTrigger
 
   // Methods
-  
+  @DoNotStrip
+  @Keep
+  abstract fun showMenu(): Unit
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/packages/ui/nitrogen/generated/android/kotlin/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuViewSpec.kt
+++ b/packages/ui/nitrogen/generated/android/kotlin/com/margelo/nitro/cherrystudio/ui/HybridCherryMenuViewSpec.kt
@@ -55,6 +55,14 @@ abstract class HybridCherryMenuViewSpec: HybridView() {
   // Methods
   @DoNotStrip
   @Keep
+  abstract fun getLongPressMinDuration(): Double
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getLongPressMaxDistance(): Double
+  
+  @DoNotStrip
+  @Keep
   abstract fun showMenu(): Unit
 
   // Default implementation of `HybridObject.toString()`

--- a/packages/ui/nitrogen/generated/ios/CherryStudioUI-Swift-Cxx-Bridge.hpp
+++ b/packages/ui/nitrogen/generated/ios/CherryStudioUI-Swift-Cxx-Bridge.hpp
@@ -26,6 +26,8 @@ namespace CherryStudioUI { class HybridCherryMenuViewSpec_cxx; }
 #include "NativeMenuCheckedState.hpp"
 #include "NativeMenuIcon.hpp"
 #include "NativeMenuItem.hpp"
+#include <NitroModules/Result.hpp>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <string>
@@ -81,5 +83,14 @@ namespace margelo::nitro::cherrystudio::ui::bridge::swift {
   // pragma MARK: std::weak_ptr<HybridCherryMenuViewSpec>
   using std__weak_ptr_HybridCherryMenuViewSpec_ = std::weak_ptr<HybridCherryMenuViewSpec>;
   inline std__weak_ptr_HybridCherryMenuViewSpec_ weakify_std__shared_ptr_HybridCherryMenuViewSpec_(const std::shared_ptr<HybridCherryMenuViewSpec>& strong) noexcept { return strong; }
+  
+  // pragma MARK: Result<void>
+  using Result_void_ = Result<void>;
+  inline Result_void_ create_Result_void_() noexcept {
+    return Result<void>::withValue();
+  }
+  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
+    return Result<void>::withError(error);
+  }
 
 } // namespace margelo::nitro::cherrystudio::ui::bridge::swift

--- a/packages/ui/nitrogen/generated/ios/CherryStudioUI-Swift-Cxx-Bridge.hpp
+++ b/packages/ui/nitrogen/generated/ios/CherryStudioUI-Swift-Cxx-Bridge.hpp
@@ -84,6 +84,15 @@ namespace margelo::nitro::cherrystudio::ui::bridge::swift {
   using std__weak_ptr_HybridCherryMenuViewSpec_ = std::weak_ptr<HybridCherryMenuViewSpec>;
   inline std__weak_ptr_HybridCherryMenuViewSpec_ weakify_std__shared_ptr_HybridCherryMenuViewSpec_(const std::shared_ptr<HybridCherryMenuViewSpec>& strong) noexcept { return strong; }
   
+  // pragma MARK: Result<double>
+  using Result_double_ = Result<double>;
+  inline Result_double_ create_Result_double_(double value) noexcept {
+    return Result<double>::withValue(std::move(value));
+  }
+  inline Result_double_ create_Result_double_(const std::exception_ptr& error) noexcept {
+    return Result<double>::withError(error);
+  }
+  
   // pragma MARK: Result<void>
   using Result_void_ = Result<void>;
   inline Result_void_ create_Result_void_() noexcept {

--- a/packages/ui/nitrogen/generated/ios/CherryStudioUI-Swift-Cxx-Umbrella.hpp
+++ b/packages/ui/nitrogen/generated/ios/CherryStudioUI-Swift-Cxx-Umbrella.hpp
@@ -25,6 +25,8 @@ namespace margelo::nitro::cherrystudio::ui { enum class NativeMenuTrigger; }
 #include "NativeMenuIcon.hpp"
 #include "NativeMenuItem.hpp"
 #include "NativeMenuTrigger.hpp"
+#include <NitroModules/Result.hpp>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <string>

--- a/packages/ui/nitrogen/generated/ios/c++/HybridCherryMenuViewSpecSwift.hpp
+++ b/packages/ui/nitrogen/generated/ios/c++/HybridCherryMenuViewSpecSwift.hpp
@@ -99,7 +99,12 @@ namespace margelo::nitro::cherrystudio::ui {
 
   public:
     // Methods
-    
+    inline void showMenu() override {
+      auto __result = _swiftPart.showMenu();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
 
   private:
     CherryStudioUI::HybridCherryMenuViewSpec_cxx _swiftPart;

--- a/packages/ui/nitrogen/generated/ios/c++/HybridCherryMenuViewSpecSwift.hpp
+++ b/packages/ui/nitrogen/generated/ios/c++/HybridCherryMenuViewSpecSwift.hpp
@@ -99,6 +99,22 @@ namespace margelo::nitro::cherrystudio::ui {
 
   public:
     // Methods
+    inline double getLongPressMinDuration() override {
+      auto __result = _swiftPart.getLongPressMinDuration();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getLongPressMaxDistance() override {
+      auto __result = _swiftPart.getLongPressMaxDistance();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline void showMenu() override {
       auto __result = _swiftPart.showMenu();
       if (__result.hasError()) [[unlikely]] {

--- a/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec.swift
+++ b/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec.swift
@@ -15,6 +15,8 @@ public protocol HybridCherryMenuViewSpec_protocol: HybridObject, HybridView {
   var trigger: NativeMenuTrigger { get set }
 
   // Methods
+  func getLongPressMinDuration() throws -> Double
+  func getLongPressMaxDistance() throws -> Double
   func showMenu() throws -> Void
 }
 

--- a/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec.swift
+++ b/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec.swift
@@ -15,7 +15,7 @@ public protocol HybridCherryMenuViewSpec_protocol: HybridObject, HybridView {
   var trigger: NativeMenuTrigger { get set }
 
   // Methods
-  
+  func showMenu() throws -> Void
 }
 
 public extension HybridCherryMenuViewSpec_protocol {

--- a/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec_cxx.swift
+++ b/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec_cxx.swift
@@ -170,6 +170,30 @@ open class HybridCherryMenuViewSpec_cxx {
 
   // Methods
   @inline(__always)
+  public final func getLongPressMinDuration() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getLongPressMinDuration()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getLongPressMaxDistance() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getLongPressMaxDistance()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func showMenu() -> bridge.Result_void_ {
     do {
       try self.__implementation.showMenu()

--- a/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec_cxx.swift
+++ b/packages/ui/nitrogen/generated/ios/swift/HybridCherryMenuViewSpec_cxx.swift
@@ -169,6 +169,17 @@ open class HybridCherryMenuViewSpec_cxx {
   }
 
   // Methods
+  @inline(__always)
+  public final func showMenu() -> bridge.Result_void_ {
+    do {
+      try self.__implementation.showMenu()
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+  
   public final func getView() -> UnsafeMutableRawPointer {
     return Unmanaged.passRetained(__implementation.view).toOpaque()
   }

--- a/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.cpp
+++ b/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.cpp
@@ -20,6 +20,7 @@ namespace margelo::nitro::cherrystudio::ui {
       prototype.registerHybridSetter("onAction", &HybridCherryMenuViewSpec::setOnAction);
       prototype.registerHybridGetter("trigger", &HybridCherryMenuViewSpec::getTrigger);
       prototype.registerHybridSetter("trigger", &HybridCherryMenuViewSpec::setTrigger);
+      prototype.registerHybridMethod("showMenu", &HybridCherryMenuViewSpec::showMenu);
     });
   }
 

--- a/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.cpp
+++ b/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.cpp
@@ -20,6 +20,8 @@ namespace margelo::nitro::cherrystudio::ui {
       prototype.registerHybridSetter("onAction", &HybridCherryMenuViewSpec::setOnAction);
       prototype.registerHybridGetter("trigger", &HybridCherryMenuViewSpec::getTrigger);
       prototype.registerHybridSetter("trigger", &HybridCherryMenuViewSpec::setTrigger);
+      prototype.registerHybridMethod("getLongPressMinDuration", &HybridCherryMenuViewSpec::getLongPressMinDuration);
+      prototype.registerHybridMethod("getLongPressMaxDistance", &HybridCherryMenuViewSpec::getLongPressMaxDistance);
       prototype.registerHybridMethod("showMenu", &HybridCherryMenuViewSpec::showMenu);
     });
   }

--- a/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.hpp
+++ b/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.hpp
@@ -60,6 +60,8 @@ namespace margelo::nitro::cherrystudio::ui {
 
     public:
       // Methods
+      virtual double getLongPressMinDuration() = 0;
+      virtual double getLongPressMaxDistance() = 0;
       virtual void showMenu() = 0;
 
     protected:

--- a/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.hpp
+++ b/packages/ui/nitrogen/generated/shared/c++/HybridCherryMenuViewSpec.hpp
@@ -60,7 +60,7 @@ namespace margelo::nitro::cherrystudio::ui {
 
     public:
       // Methods
-      
+      virtual void showMenu() = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -108,6 +108,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-enriched-markdown": "*",
+    "react-native-gesture-handler": "*",
     "react-native-keyboard-controller": "*",
     "react-native-nitro-modules": "*",
     "react-native-reanimated": "*",

--- a/packages/ui/src/components/menu/__tests__/action-menu.test.tsx
+++ b/packages/ui/src/components/menu/__tests__/action-menu.test.tsx
@@ -105,12 +105,9 @@ describe('ActionMenu', () => {
   it('forwards a semantic icon token so the native view can resolve its artwork', () => {
     act(() => {
       renderer = create(
-        <Menu
-          items={[{ icon: 'branch', id: 'fork', label: 'Branch', onPress: jest.fn() }]}
-          trigger="tap"
-        >
+        <ActionMenu items={[{ icon: 'branch', id: 'fork', label: 'Branch', onPress: jest.fn() }]}>
           <Text>Open</Text>
-        </Menu>,
+        </ActionMenu>,
       );
     });
 

--- a/packages/ui/src/components/menu/__tests__/action-menu.test.tsx
+++ b/packages/ui/src/components/menu/__tests__/action-menu.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { Text, View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
-import { Menu } from '../menu';
+import { ActionMenu } from '../action-menu';
 
 type NativeMenuProps = {
   children?: ReactNode;
@@ -24,7 +24,7 @@ jest.mock('react-native-nitro-modules', () => {
   };
 });
 
-describe('Menu', () => {
+describe('ActionMenu', () => {
   let renderer: ReactTestRenderer | undefined;
 
   afterEach(() => {
@@ -32,13 +32,13 @@ describe('Menu', () => {
     renderer = undefined;
   });
 
-  it('projects flat actions to the native view and dispatches the selected action', () => {
+  it('projects flat actions with a tap trigger and dispatches the selected action', () => {
     const onEdit = jest.fn();
     const onDelete = jest.fn();
 
     act(() => {
       renderer = create(
-        <Menu
+        <ActionMenu
           items={[
             { checked: false, id: 'edit', label: 'Edit', onPress: onEdit },
             {
@@ -50,16 +50,15 @@ describe('Menu', () => {
               onPress: onDelete,
             },
           ]}
-          trigger="longPress"
         >
           <Text>Open</Text>
-        </Menu>,
+        </ActionMenu>,
       );
     });
 
     const menu = renderer!.root.findByProps({ mockComponent: 'native-menu' });
 
-    expect(menu.props.trigger).toBe('longPress');
+    expect(menu.props.trigger).toBe('tap');
     expect(menu.props.items).toEqual([
       {
         checked: 'off',
@@ -89,9 +88,9 @@ describe('Menu', () => {
 
     act(() => {
       renderer = create(
-        <Menu items={[{ id: 'known', label: 'Known', onPress }]} trigger="tap">
+        <ActionMenu items={[{ id: 'known', label: 'Known', onPress }]}>
           <Text>Open</Text>
-        </Menu>,
+        </ActionMenu>,
       );
     });
 
@@ -122,9 +121,9 @@ describe('Menu', () => {
   it('renders its child directly when no items are available', () => {
     act(() => {
       renderer = create(
-        <Menu items={[]} trigger="tap">
+        <ActionMenu items={[]}>
           <View testID="trigger" />
-        </Menu>,
+        </ActionMenu>,
       );
     });
 

--- a/packages/ui/src/components/menu/action-menu.tsx
+++ b/packages/ui/src/components/menu/action-menu.tsx
@@ -1,0 +1,22 @@
+import { callback } from 'react-native-nitro-modules';
+
+import type { ActionMenuProps } from './menu.types';
+import { NativeCherryMenuView, useNativeMenu } from './use-native-menu';
+
+/**
+ * Tap-triggered dropdown of actions. The tap is button behavior the menu owns
+ * outright, so recognition and presentation both stay in the native view.
+ */
+export function ActionMenu({ children, items }: ActionMenuProps) {
+  const { nativeItems, onAction } = useNativeMenu(items);
+
+  if (items.length === 0) {
+    return children;
+  }
+
+  return (
+    <NativeCherryMenuView items={nativeItems} onAction={callback(onAction)} trigger="tap">
+      {children}
+    </NativeCherryMenuView>
+  );
+}

--- a/packages/ui/src/components/menu/context-menu/__tests__/context-menu.android.test.tsx
+++ b/packages/ui/src/components/menu/context-menu/__tests__/context-menu.android.test.tsx
@@ -1,15 +1,73 @@
 import type { ReactNode } from 'react';
-import { type AccessibilityActionEvent, Pressable, Text, View } from 'react-native';
+import {
+  type AccessibilityActionEvent,
+  type GestureResponderEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  Text,
+  View,
+} from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
+import type { NativeCherryMenuRef } from '../../use-native-menu';
+import { ContextMenuScrollBoundary } from '../context-menu-scroll-boundary';
 import { ContextMenu } from '../context-menu.android';
 
 type NativeMenuProps = {
   children?: ReactNode;
+  hybridRef?: (view: NativeCherryMenuRef) => void;
   items: unknown[];
   onAction: (id: string) => void;
   trigger: string;
 };
+
+type MockLongPressGesture = {
+  maxDistance: (value: number) => MockLongPressGesture;
+  maxDistanceValue?: number;
+  minDuration: (value: number) => MockLongPressGesture;
+  minDurationValue?: number;
+  onStart: (callback: () => void) => MockLongPressGesture;
+  onStartCallback?: () => void;
+  runOnJS: () => MockLongPressGesture;
+};
+
+const mockShowMenu = jest.fn();
+const mockGetLongPressMaxDistance = jest.fn(() => 16);
+const mockGetLongPressMinDuration = jest.fn(() => 625);
+const mockNativeMenuRef = {
+  getLongPressMaxDistance: mockGetLongPressMaxDistance,
+  getLongPressMinDuration: mockGetLongPressMinDuration,
+  showMenu: mockShowMenu,
+} as unknown as NativeCherryMenuRef;
+let mockLatestLongPressGesture: MockLongPressGesture | undefined;
+
+jest.mock('react-native-gesture-handler', () => {
+  return {
+    Gesture: {
+      LongPress: () => {
+        const gesture: MockLongPressGesture = {
+          maxDistance(value) {
+            gesture.maxDistanceValue = value;
+            return gesture;
+          },
+          minDuration(value) {
+            gesture.minDurationValue = value;
+            return gesture;
+          },
+          onStart(callback) {
+            gesture.onStartCallback = callback;
+            return gesture;
+          },
+          runOnJS: () => gesture,
+        };
+        mockLatestLongPressGesture = gesture;
+        return gesture;
+      },
+    },
+    GestureDetector: ({ children }: { children: ReactNode }) => children,
+  };
+});
 
 jest.mock('react-native-nitro-modules', () => {
   const React = jest.requireActual('react');
@@ -19,8 +77,17 @@ jest.mock('react-native-nitro-modules', () => {
     callback: (value: unknown) => value,
     getHostComponent:
       () =>
-      ({ children, ...props }: NativeMenuProps) =>
-        React.createElement(NativeView, { ...props, mockComponent: 'native-menu' }, children),
+      ({ children, hybridRef, ...props }: NativeMenuProps) => {
+        React.useEffect(() => {
+          hybridRef?.(mockNativeMenuRef);
+        }, [hybridRef]);
+
+        return React.createElement(
+          NativeView,
+          { ...props, mockComponent: 'native-menu' },
+          children,
+        );
+      },
   };
 });
 
@@ -28,15 +95,30 @@ function accessibilityAction(actionName: string): AccessibilityActionEvent {
   return { nativeEvent: { actionName } } as AccessibilityActionEvent;
 }
 
+function scrollEvent(): NativeSyntheticEvent<NativeScrollEvent> {
+  return { nativeEvent: {} } as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+function touchEvent(): GestureResponderEvent {
+  return { nativeEvent: {} } as GestureResponderEvent;
+}
+
 describe('ContextMenu.android', () => {
   let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    mockShowMenu.mockClear();
+    mockGetLongPressMaxDistance.mockClear();
+    mockGetLongPressMinDuration.mockClear();
+    mockLatestLongPressGesture = undefined;
+  });
 
   afterEach(() => {
     act(() => renderer?.unmount());
     renderer = undefined;
   });
 
-  it('presents through a long-press native view and dispatches the selected action', () => {
+  it('uses Android system long-press configuration before presenting the native menu', () => {
     const onRename = jest.fn();
 
     act(() => {
@@ -52,9 +134,47 @@ describe('ContextMenu.android', () => {
     expect(menu.props.items).toEqual([
       { checked: 'none', destructive: false, disabled: false, id: 'rename', label: 'Rename' },
     ]);
+    expect(mockLatestLongPressGesture?.minDurationValue).toBe(625);
+    expect(mockLatestLongPressGesture?.maxDistanceValue).toBe(16);
+
+    act(() => mockLatestLongPressGesture?.onStartCallback?.());
+    expect(mockShowMenu).toHaveBeenCalledTimes(1);
 
     act(() => menu.props.onAction('rename'));
     expect(onRename).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a touch that stops momentum blocked for its complete sequence', () => {
+    act(() => {
+      renderer = create(
+        <ContextMenuScrollBoundary>
+          {(scrollHandlers) => (
+            <View {...scrollHandlers} testID="scroll-owner">
+              <ContextMenu items={[{ id: 'rename', label: 'Rename', onPress: jest.fn() }]}>
+                <Pressable testID="row">
+                  <Text>Row</Text>
+                </Pressable>
+              </ContextMenu>
+            </View>
+          )}
+        </ContextMenuScrollBoundary>,
+      );
+    });
+
+    const scrollOwner = renderer!.root.findByProps({ testID: 'scroll-owner' });
+    act(() => {
+      scrollOwner.props.onMomentumScrollBegin(scrollEvent());
+      scrollOwner.props.onTouchStart(touchEvent());
+      scrollOwner.props.onMomentumScrollEnd(scrollEvent());
+      mockLatestLongPressGesture?.onStartCallback?.();
+    });
+    expect(mockShowMenu).not.toHaveBeenCalled();
+
+    act(() => {
+      scrollOwner.props.onTouchEnd(touchEvent());
+      mockLatestLongPressGesture?.onStartCallback?.();
+    });
+    expect(mockShowMenu).toHaveBeenCalledTimes(1);
   });
 
   it('exposes enabled items as accessibility actions on the child and dispatches them', () => {
@@ -92,14 +212,18 @@ describe('ContextMenu.android', () => {
     expect(onDisabled).not.toHaveBeenCalled();
   });
 
-  it('keeps the child accessibility contract it already declares', () => {
+  it('gives menu actions one owner while preserving unrelated child actions', () => {
     const onChildAction = jest.fn();
+    const onMenuRename = jest.fn();
 
     act(() => {
       renderer = create(
-        <ContextMenu items={[{ id: 'rename', label: 'Rename', onPress: jest.fn() }]}>
+        <ContextMenu items={[{ id: 'rename', label: 'Rename', onPress: onMenuRename }]}>
           <Pressable
-            accessibilityActions={[{ label: 'Collapse', name: 'collapse' }]}
+            accessibilityActions={[
+              { label: 'Collapse', name: 'collapse' },
+              { label: 'Rename', name: 'rename' },
+            ]}
             onAccessibilityAction={onChildAction}
             testID="row"
           >
@@ -114,6 +238,10 @@ describe('ContextMenu.android', () => {
       { label: 'Collapse', name: 'collapse' },
       { label: 'Rename', name: 'rename' },
     ]);
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('rename')));
+    expect(onMenuRename).toHaveBeenCalledTimes(1);
+    expect(onChildAction).not.toHaveBeenCalled();
 
     act(() => row.props.onAccessibilityAction(accessibilityAction('collapse')));
     expect(onChildAction).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/components/menu/context-menu/__tests__/context-menu.android.test.tsx
+++ b/packages/ui/src/components/menu/context-menu/__tests__/context-menu.android.test.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from 'react';
+import { type AccessibilityActionEvent, Pressable, Text, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ContextMenu } from '../context-menu.android';
+
+type NativeMenuProps = {
+  children?: ReactNode;
+  items: unknown[];
+  onAction: (id: string) => void;
+  trigger: string;
+};
+
+jest.mock('react-native-nitro-modules', () => {
+  const React = jest.requireActual('react');
+  const { View: NativeView } = jest.requireActual('react-native');
+
+  return {
+    callback: (value: unknown) => value,
+    getHostComponent:
+      () =>
+      ({ children, ...props }: NativeMenuProps) =>
+        React.createElement(NativeView, { ...props, mockComponent: 'native-menu' }, children),
+  };
+});
+
+function accessibilityAction(actionName: string): AccessibilityActionEvent {
+  return { nativeEvent: { actionName } } as AccessibilityActionEvent;
+}
+
+describe('ContextMenu.android', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('presents through a long-press native view and dispatches the selected action', () => {
+    const onRename = jest.fn();
+
+    act(() => {
+      renderer = create(
+        <ContextMenu items={[{ id: 'rename', label: 'Rename', onPress: onRename }]}>
+          <Text>Row</Text>
+        </ContextMenu>,
+      );
+    });
+
+    const menu = renderer!.root.findByProps({ mockComponent: 'native-menu' });
+    expect(menu.props.trigger).toBe('longPress');
+    expect(menu.props.items).toEqual([
+      { checked: 'none', destructive: false, disabled: false, id: 'rename', label: 'Rename' },
+    ]);
+
+    act(() => menu.props.onAction('rename'));
+    expect(onRename).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes enabled items as accessibility actions on the child and dispatches them', () => {
+    const onRename = jest.fn();
+    const onDelete = jest.fn();
+    const onDisabled = jest.fn();
+
+    act(() => {
+      renderer = create(
+        <ContextMenu
+          items={[
+            { id: 'rename', label: 'Rename', onPress: onRename },
+            { destructive: true, id: 'delete', label: 'Delete', onPress: onDelete },
+            { disabled: true, id: 'share', label: 'Share', onPress: onDisabled },
+          ]}
+        >
+          <Pressable testID="row">
+            <Text>Row</Text>
+          </Pressable>
+        </ContextMenu>,
+      );
+    });
+
+    const row = renderer!.root.findByProps({ testID: 'row' });
+    expect(row.props.accessibilityActions).toEqual([
+      { label: 'Rename', name: 'rename' },
+      { label: 'Delete', name: 'delete' },
+    ]);
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('delete')));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onRename).not.toHaveBeenCalled();
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('share')));
+    expect(onDisabled).not.toHaveBeenCalled();
+  });
+
+  it('keeps the child accessibility contract it already declares', () => {
+    const onChildAction = jest.fn();
+
+    act(() => {
+      renderer = create(
+        <ContextMenu items={[{ id: 'rename', label: 'Rename', onPress: jest.fn() }]}>
+          <Pressable
+            accessibilityActions={[{ label: 'Collapse', name: 'collapse' }]}
+            onAccessibilityAction={onChildAction}
+            testID="row"
+          >
+            <Text>Row</Text>
+          </Pressable>
+        </ContextMenu>,
+      );
+    });
+
+    const row = renderer!.root.findByProps({ testID: 'row' });
+    expect(row.props.accessibilityActions).toEqual([
+      { label: 'Collapse', name: 'collapse' },
+      { label: 'Rename', name: 'rename' },
+    ]);
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('collapse')));
+    expect(onChildAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders its child directly when no items are available', () => {
+    act(() => {
+      renderer = create(
+        <ContextMenu items={[]}>
+          <View testID="row" />
+        </ContextMenu>,
+      );
+    });
+
+    expect(renderer!.root.findByProps({ testID: 'row' })).toBeDefined();
+    expect(renderer!.root.findAllByProps({ mockComponent: 'native-menu' })).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/menu/context-menu/__tests__/context-menu.ios.test.tsx
+++ b/packages/ui/src/components/menu/context-menu/__tests__/context-menu.ios.test.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ContextMenu } from '../context-menu.ios';
+
+type NativeMenuProps = {
+  children?: ReactNode;
+  items: unknown[];
+  onAction: (id: string) => void;
+  trigger: string;
+};
+
+jest.mock('react-native-nitro-modules', () => {
+  const React = jest.requireActual('react');
+  const { View: NativeView } = jest.requireActual('react-native');
+
+  return {
+    callback: (value: unknown) => value,
+    getHostComponent:
+      () =>
+      ({ children, ...props }: NativeMenuProps) =>
+        React.createElement(NativeView, { ...props, mockComponent: 'native-menu' }, children),
+  };
+});
+
+describe('ContextMenu.ios', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('presents through the system long-press interaction and dispatches actions', () => {
+    const onRename = jest.fn();
+
+    act(() => {
+      renderer = create(
+        <ContextMenu items={[{ id: 'rename', label: 'Rename', onPress: onRename }]}>
+          <Pressable testID="row">
+            <Text>Row</Text>
+          </Pressable>
+        </ContextMenu>,
+      );
+    });
+
+    const menu = renderer!.root.findByProps({ mockComponent: 'native-menu' });
+    expect(menu.props.trigger).toBe('longPress');
+
+    // Accessibility for the system interaction is UIKit-owned; the child is not
+    // rewritten with custom actions on iOS.
+    const row = renderer!.root.findByProps({ testID: 'row' });
+    expect(row.props.accessibilityActions).toBeUndefined();
+
+    act(() => menu.props.onAction('rename'));
+    expect(onRename).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders its child directly when no items are available', () => {
+    act(() => {
+      renderer = create(
+        <ContextMenu items={[]}>
+          <View testID="row" />
+        </ContextMenu>,
+      );
+    });
+
+    expect(renderer!.root.findByProps({ testID: 'row' })).toBeDefined();
+    expect(renderer!.root.findAllByProps({ mockComponent: 'native-menu' })).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary-content.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary-content.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import type {
+  ContextMenuScrollBoundaryProps,
+  ContextMenuScrollHandlers,
+} from './context-menu-scroll-boundary.types';
+
+export function ContextMenuScrollBoundaryContent({
+  children,
+  onMomentumScrollBegin,
+  onMomentumScrollEnd,
+  onScrollBeginDrag,
+  onScrollEndDrag,
+  onTouchCancel,
+  onTouchEnd,
+  onTouchStart,
+}: ContextMenuScrollBoundaryProps) {
+  const handlers = useMemo<ContextMenuScrollHandlers>(
+    () => ({
+      onMomentumScrollBegin,
+      onMomentumScrollEnd,
+      onScrollBeginDrag,
+      onScrollEndDrag,
+      onTouchCancel,
+      onTouchEnd,
+      onTouchStart,
+    }),
+    [
+      onMomentumScrollBegin,
+      onMomentumScrollEnd,
+      onScrollBeginDrag,
+      onScrollEndDrag,
+      onTouchCancel,
+      onTouchEnd,
+      onTouchStart,
+    ],
+  );
+
+  return children(handlers);
+}

--- a/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.android.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.android.tsx
@@ -1,0 +1,113 @@
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
+import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+
+import { ContextMenuScrollBoundaryContent } from './context-menu-scroll-boundary-content';
+import type { ContextMenuScrollBoundaryProps } from './context-menu-scroll-boundary.types';
+
+type ContextMenuInteraction = {
+  isRecognitionBlocked: () => boolean;
+};
+
+const DEFAULT_CONTEXT_MENU_INTERACTION: ContextMenuInteraction = {
+  isRecognitionBlocked: () => false,
+};
+
+const ContextMenuInteractionContext = createContext<ContextMenuInteraction>(
+  DEFAULT_CONTEXT_MENU_INTERACTION,
+);
+
+/**
+ * Gives descendant context menus the scroll owner's drag and momentum state.
+ * A touch that begins during momentum remains blocked for its complete touch
+ * sequence, even after that touch stops the momentum animation.
+ */
+export function ContextMenuScrollBoundary({
+  children,
+  onMomentumScrollBegin,
+  onMomentumScrollEnd,
+  onScrollBeginDrag,
+  onScrollEndDrag,
+  onTouchCancel,
+  onTouchEnd,
+  onTouchStart,
+}: ContextMenuScrollBoundaryProps) {
+  const isScrollInteractionActive = useRef(false);
+  const isCurrentTouchBlocked = useRef(false);
+
+  const handleMomentumScrollBegin = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      isScrollInteractionActive.current = true;
+      onMomentumScrollBegin?.(event);
+    },
+    [onMomentumScrollBegin],
+  );
+  const handleMomentumScrollEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      isScrollInteractionActive.current = false;
+      onMomentumScrollEnd?.(event);
+    },
+    [onMomentumScrollEnd],
+  );
+  const handleScrollBeginDrag = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      isScrollInteractionActive.current = true;
+      onScrollBeginDrag?.(event);
+    },
+    [onScrollBeginDrag],
+  );
+  const handleScrollEndDrag = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      isScrollInteractionActive.current = false;
+      onScrollEndDrag?.(event);
+    },
+    [onScrollEndDrag],
+  );
+  const handleTouchStart = useCallback(
+    (event: GestureResponderEvent) => {
+      isCurrentTouchBlocked.current = isScrollInteractionActive.current;
+      onTouchStart?.(event);
+    },
+    [onTouchStart],
+  );
+  const handleTouchEnd = useCallback(
+    (event: GestureResponderEvent) => {
+      onTouchEnd?.(event);
+      isCurrentTouchBlocked.current = false;
+    },
+    [onTouchEnd],
+  );
+  const handleTouchCancel = useCallback(
+    (event: GestureResponderEvent) => {
+      onTouchCancel?.(event);
+      isCurrentTouchBlocked.current = false;
+    },
+    [onTouchCancel],
+  );
+  const interaction = useMemo<ContextMenuInteraction>(
+    () => ({
+      isRecognitionBlocked: () =>
+        isScrollInteractionActive.current || isCurrentTouchBlocked.current,
+    }),
+    [],
+  );
+
+  return (
+    <ContextMenuInteractionContext.Provider value={interaction}>
+      <ContextMenuScrollBoundaryContent
+        onMomentumScrollBegin={handleMomentumScrollBegin}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
+        onScrollBeginDrag={handleScrollBeginDrag}
+        onScrollEndDrag={handleScrollEndDrag}
+        onTouchCancel={handleTouchCancel}
+        onTouchEnd={handleTouchEnd}
+        onTouchStart={handleTouchStart}
+      >
+        {children}
+      </ContextMenuScrollBoundaryContent>
+    </ContextMenuInteractionContext.Provider>
+  );
+}
+
+export function useContextMenuInteraction() {
+  return useContext(ContextMenuInteractionContext);
+}

--- a/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.ios.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.ios.tsx
@@ -1,0 +1,28 @@
+import { ContextMenuScrollBoundaryContent } from './context-menu-scroll-boundary-content';
+import type { ContextMenuScrollBoundaryProps } from './context-menu-scroll-boundary.types';
+
+/** UIKit already arbitrates context menus against its scroll ancestors. */
+export function ContextMenuScrollBoundary({
+  children,
+  onMomentumScrollBegin,
+  onMomentumScrollEnd,
+  onScrollBeginDrag,
+  onScrollEndDrag,
+  onTouchCancel,
+  onTouchEnd,
+  onTouchStart,
+}: ContextMenuScrollBoundaryProps) {
+  return (
+    <ContextMenuScrollBoundaryContent
+      onMomentumScrollBegin={onMomentumScrollBegin}
+      onMomentumScrollEnd={onMomentumScrollEnd}
+      onScrollBeginDrag={onScrollBeginDrag}
+      onScrollEndDrag={onScrollEndDrag}
+      onTouchCancel={onTouchCancel}
+      onTouchEnd={onTouchEnd}
+      onTouchStart={onTouchStart}
+    >
+      {children}
+    </ContextMenuScrollBoundaryContent>
+  );
+}

--- a/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.tsx
@@ -1,0 +1,5 @@
+// Metro resolves the iOS or Android boundary; tests use the Android implementation.
+export {
+  ContextMenuScrollBoundary,
+  useContextMenuInteraction,
+} from './context-menu-scroll-boundary.android';

--- a/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.types.ts
+++ b/packages/ui/src/components/menu/context-menu/context-menu-scroll-boundary.types.ts
@@ -1,0 +1,19 @@
+import type { ReactElement } from 'react';
+import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+
+type ScrollEventHandler = (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+type TouchEventHandler = (event: GestureResponderEvent) => void;
+
+export type ContextMenuScrollHandlers = {
+  onMomentumScrollBegin?: ScrollEventHandler;
+  onMomentumScrollEnd?: ScrollEventHandler;
+  onScrollBeginDrag?: ScrollEventHandler;
+  onScrollEndDrag?: ScrollEventHandler;
+  onTouchCancel?: TouchEventHandler;
+  onTouchEnd?: TouchEventHandler;
+  onTouchStart?: TouchEventHandler;
+};
+
+export type ContextMenuScrollBoundaryProps = ContextMenuScrollHandlers & {
+  children: (handlers: ContextMenuScrollHandlers) => ReactElement;
+};

--- a/packages/ui/src/components/menu/context-menu/context-menu.android.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu.android.tsx
@@ -1,36 +1,59 @@
-import { cloneElement, type ReactElement, useMemo, useState } from 'react';
+import { cloneElement, type ReactElement, useCallback, useMemo, useState } from 'react';
 import type { AccessibilityActionEvent, AccessibilityActionInfo } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { callback } from 'react-native-nitro-modules';
 
 import type { ContextMenuProps, MenuItem } from '../menu.types';
 import { type NativeCherryMenuRef, NativeCherryMenuView, useNativeMenu } from '../use-native-menu';
+import { useContextMenuInteraction } from './context-menu-scroll-boundary';
 
 type AccessibilityInjectedProps = {
   accessibilityActions?: readonly AccessibilityActionInfo[];
   onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
 };
 
+type NativeMenuBinding = {
+  maxDistance: number;
+  minDuration: number;
+  view: NativeCherryMenuRef;
+};
+
 /**
  * Android long-press recognition lives in the shared gesture arena: the
  * gesture-handler long press loses to committed scrolling, drawer pans, and
  * sibling recognizers, and only a committed long press presents the native
- * PopupMenu through showMenu(). Recognition timing and touch slop stay on the
- * recognizer's platform defaults. The child also receives the enabled items as
+ * PopupMenu through showMenu(). Recognition timing and touch slop come from
+ * Android ViewConfiguration. The child also receives the enabled items as
  * accessibility custom actions so the operations do not depend on long press.
  */
 export function ContextMenu({ children, items }: ContextMenuProps) {
   const { nativeItems, onAction } = useNativeMenu(items);
-  // The hybrid view arrives once on mount; holding it as state keeps the
-  // gesture wiring out of render-time ref access.
-  const [menuView, setMenuView] = useState<NativeCherryMenuRef | null>(null);
-  const longPress = useMemo(
-    () =>
-      Gesture.LongPress()
-        .runOnJS(true)
-        .onStart(() => menuView?.showMenu()),
-    [menuView],
-  );
+  const interaction = useContextMenuInteraction();
+  const [menuBinding, setMenuBinding] = useState<NativeMenuBinding | null>(null);
+  const handleMenuView = useCallback((view: NativeCherryMenuRef) => {
+    const nextBinding = {
+      maxDistance: view.getLongPressMaxDistance(),
+      minDuration: view.getLongPressMinDuration(),
+      view,
+    };
+    setMenuBinding((current) => (current?.view === view ? current : nextBinding));
+  }, []);
+  const hybridRef = useMemo(() => callback(handleMenuView), [handleMenuView]);
+  const longPress = useMemo(() => {
+    const gesture = Gesture.LongPress().runOnJS(true);
+    if (menuBinding) {
+      gesture
+        .minDuration(menuBinding.minDuration)
+        .maxDistance(menuBinding.maxDistance)
+        .onStart(() => {
+          if (!interaction.isRecognitionBlocked()) {
+            menuBinding.view.showMenu();
+          }
+        });
+    }
+
+    return gesture;
+  }, [interaction, menuBinding]);
 
   if (items.length === 0) {
     return children;
@@ -39,7 +62,7 @@ export function ContextMenu({ children, items }: ContextMenuProps) {
   return (
     <GestureDetector gesture={longPress}>
       <NativeCherryMenuView
-        hybridRef={callback(setMenuView)}
+        hybridRef={hybridRef}
         items={nativeItems}
         onAction={callback(onAction)}
         trigger="longPress"
@@ -55,21 +78,22 @@ function withMenuAccessibilityActions(
   items: readonly MenuItem[],
 ): ReactElement {
   const actionableItems = items.filter((item) => !item.disabled);
-  if (actionableItems.length === 0) {
-    return children;
-  }
-
   const child = children as ReactElement<AccessibilityInjectedProps>;
   const { accessibilityActions = [], onAccessibilityAction } = child.props;
+  const menuItemNames = new Set(items.map((item) => item.id));
 
   return cloneElement(child, {
     accessibilityActions: [
-      ...accessibilityActions,
+      ...accessibilityActions.filter((action) => !menuItemNames.has(action.name)),
       ...actionableItems.map((item) => ({ label: item.label, name: item.id })),
     ],
     onAccessibilityAction: (event: AccessibilityActionEvent) => {
-      onAccessibilityAction?.(event);
-      actionableItems.find((item) => item.id === event.nativeEvent.actionName)?.onPress();
+      const menuItem = actionableItems.find((item) => item.id === event.nativeEvent.actionName);
+      if (menuItem) {
+        menuItem.onPress();
+      } else if (!menuItemNames.has(event.nativeEvent.actionName)) {
+        onAccessibilityAction?.(event);
+      }
     },
   });
 }

--- a/packages/ui/src/components/menu/context-menu/context-menu.android.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu.android.tsx
@@ -1,0 +1,75 @@
+import { cloneElement, type ReactElement, useMemo, useState } from 'react';
+import type { AccessibilityActionEvent, AccessibilityActionInfo } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { callback } from 'react-native-nitro-modules';
+
+import type { ContextMenuProps, MenuItem } from '../menu.types';
+import { type NativeCherryMenuRef, NativeCherryMenuView, useNativeMenu } from '../use-native-menu';
+
+type AccessibilityInjectedProps = {
+  accessibilityActions?: readonly AccessibilityActionInfo[];
+  onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
+};
+
+/**
+ * Android long-press recognition lives in the shared gesture arena: the
+ * gesture-handler long press loses to committed scrolling, drawer pans, and
+ * sibling recognizers, and only a committed long press presents the native
+ * PopupMenu through showMenu(). Recognition timing and touch slop stay on the
+ * recognizer's platform defaults. The child also receives the enabled items as
+ * accessibility custom actions so the operations do not depend on long press.
+ */
+export function ContextMenu({ children, items }: ContextMenuProps) {
+  const { nativeItems, onAction } = useNativeMenu(items);
+  // The hybrid view arrives once on mount; holding it as state keeps the
+  // gesture wiring out of render-time ref access.
+  const [menuView, setMenuView] = useState<NativeCherryMenuRef | null>(null);
+  const longPress = useMemo(
+    () =>
+      Gesture.LongPress()
+        .runOnJS(true)
+        .onStart(() => menuView?.showMenu()),
+    [menuView],
+  );
+
+  if (items.length === 0) {
+    return children;
+  }
+
+  return (
+    <GestureDetector gesture={longPress}>
+      <NativeCherryMenuView
+        hybridRef={callback(setMenuView)}
+        items={nativeItems}
+        onAction={callback(onAction)}
+        trigger="longPress"
+      >
+        {withMenuAccessibilityActions(children, items)}
+      </NativeCherryMenuView>
+    </GestureDetector>
+  );
+}
+
+function withMenuAccessibilityActions(
+  children: ReactElement,
+  items: readonly MenuItem[],
+): ReactElement {
+  const actionableItems = items.filter((item) => !item.disabled);
+  if (actionableItems.length === 0) {
+    return children;
+  }
+
+  const child = children as ReactElement<AccessibilityInjectedProps>;
+  const { accessibilityActions = [], onAccessibilityAction } = child.props;
+
+  return cloneElement(child, {
+    accessibilityActions: [
+      ...accessibilityActions,
+      ...actionableItems.map((item) => ({ label: item.label, name: item.id })),
+    ],
+    onAccessibilityAction: (event: AccessibilityActionEvent) => {
+      onAccessibilityAction?.(event);
+      actionableItems.find((item) => item.id === event.nativeEvent.actionName)?.onPress();
+    },
+  });
+}

--- a/packages/ui/src/components/menu/context-menu/context-menu.ios.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu.ios.tsx
@@ -1,0 +1,23 @@
+import { callback } from 'react-native-nitro-modules';
+
+import type { ContextMenuProps } from '../menu.types';
+import { NativeCherryMenuView, useNativeMenu } from '../use-native-menu';
+
+/**
+ * iOS long-press recognition stays system-owned: the native view attaches a
+ * UIContextMenuInteraction and UIKit arbitrates it against scroll ancestors,
+ * cancellation, and accessibility.
+ */
+export function ContextMenu({ children, items }: ContextMenuProps) {
+  const { nativeItems, onAction } = useNativeMenu(items);
+
+  if (items.length === 0) {
+    return children;
+  }
+
+  return (
+    <NativeCherryMenuView items={nativeItems} onAction={callback(onAction)} trigger="longPress">
+      {children}
+    </NativeCherryMenuView>
+  );
+}

--- a/packages/ui/src/components/menu/context-menu/context-menu.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu.tsx
@@ -1,0 +1,2 @@
+// Metro resolves context-menu.ios.tsx on iOS and context-menu.android.tsx on Android.
+export { ContextMenu } from './context-menu.android';

--- a/packages/ui/src/components/menu/index.ts
+++ b/packages/ui/src/components/menu/index.ts
@@ -1,2 +1,3 @@
-export { Menu } from './menu';
-export type { MenuIcon, MenuItem, MenuProps } from './menu.types';
+export { ActionMenu } from './action-menu';
+export { ContextMenu } from './context-menu/context-menu';
+export type { ActionMenuProps, ContextMenuProps, MenuIcon, MenuItem } from './menu.types';

--- a/packages/ui/src/components/menu/index.ts
+++ b/packages/ui/src/components/menu/index.ts
@@ -1,3 +1,4 @@
 export { ActionMenu } from './action-menu';
 export { ContextMenu } from './context-menu/context-menu';
+export { ContextMenuScrollBoundary } from './context-menu/context-menu-scroll-boundary';
 export type { ActionMenuProps, ContextMenuProps, MenuIcon, MenuItem } from './menu.types';

--- a/packages/ui/src/components/menu/menu.types.ts
+++ b/packages/ui/src/components/menu/menu.types.ts
@@ -13,8 +13,12 @@ export type MenuItem = Readonly<{
   onPress: () => void;
 }>;
 
-export type MenuProps = {
+export type ActionMenuProps = {
   children: ReactElement;
   items: readonly MenuItem[];
-  trigger: 'longPress' | 'tap';
+};
+
+export type ContextMenuProps = {
+  children: ReactElement;
+  items: readonly MenuItem[];
 };

--- a/packages/ui/src/components/menu/specs/cherry-menu-view.nitro.ts
+++ b/packages/ui/src/components/menu/specs/cherry-menu-view.nitro.ts
@@ -27,6 +27,10 @@ export interface CherryMenuViewProps extends HybridViewProps {
 }
 
 export interface CherryMenuViewMethods extends HybridViewMethods {
+  /** Android system long-press timeout in milliseconds. */
+  getLongPressMinDuration(): number;
+  /** Android system touch slop converted to React Native points. */
+  getLongPressMaxDistance(): number;
   /**
    * Presents the menu for an externally recognized trigger. Android context
    * menus recognize the long press in the shared gesture arena and only

--- a/packages/ui/src/components/menu/specs/cherry-menu-view.nitro.ts
+++ b/packages/ui/src/components/menu/specs/cherry-menu-view.nitro.ts
@@ -26,6 +26,14 @@ export interface CherryMenuViewProps extends HybridViewProps {
   trigger: NativeMenuTrigger;
 }
 
-export interface CherryMenuViewMethods extends HybridViewMethods {}
+export interface CherryMenuViewMethods extends HybridViewMethods {
+  /**
+   * Presents the menu for an externally recognized trigger. Android context
+   * menus recognize the long press in the shared gesture arena and only
+   * present through this method; iOS recognition stays system-owned, so this
+   * is a no-op there.
+   */
+  showMenu(): void;
+}
 
 export type CherryMenuView = HybridView<CherryMenuViewProps, CherryMenuViewMethods>;

--- a/packages/ui/src/components/menu/use-native-menu.ts
+++ b/packages/ui/src/components/menu/use-native-menu.ts
@@ -1,21 +1,25 @@
 import { useCallback, useMemo } from 'react';
-import { callback, getHostComponent } from 'react-native-nitro-modules';
+import { getHostComponent } from 'react-native-nitro-modules';
 
-import type { MenuIcon, MenuProps } from './menu.types';
+import type { MenuIcon, MenuItem } from './menu.types';
 import type {
+  CherryMenuView,
   CherryMenuViewMethods,
   CherryMenuViewProps,
   NativeMenuCheckedState,
   NativeMenuIcon,
+  NativeMenuItem,
 } from './specs/cherry-menu-view.nitro';
 
 const getViewConfig = () =>
   require('../../../nitrogen/generated/shared/json/CherryMenuViewConfig.json');
 
-const NativeCherryMenuView = getHostComponent<CherryMenuViewProps, CherryMenuViewMethods>(
+export const NativeCherryMenuView = getHostComponent<CherryMenuViewProps, CherryMenuViewMethods>(
   'CherryMenuView',
   getViewConfig,
 );
+
+export type NativeCherryMenuRef = CherryMenuView;
 
 function getCheckedState(checked: boolean | undefined): NativeMenuCheckedState {
   if (checked === undefined) {
@@ -29,9 +33,10 @@ function getIcon(icon: MenuIcon | undefined): NativeMenuIcon {
   return icon ?? 'none';
 }
 
-export function Menu({ children, items, trigger }: MenuProps) {
+/** Projects public menu items onto native view props and routes action ids back. */
+export function useNativeMenu(items: readonly MenuItem[]) {
   const actions = useMemo(() => new Map(items.map((item) => [item.id, item.onPress])), [items]);
-  const nativeItems = useMemo(
+  const nativeItems = useMemo<NativeMenuItem[]>(
     () =>
       items.map((item) => ({
         checked: getCheckedState(item.checked),
@@ -50,13 +55,5 @@ export function Menu({ children, items, trigger }: MenuProps) {
     [actions],
   );
 
-  if (items.length === 0) {
-    return children;
-  }
-
-  return (
-    <NativeCherryMenuView items={nativeItems} onAction={callback(onAction)} trigger={trigger}>
-      {children}
-    </NativeCherryMenuView>
-  );
+  return { nativeItems, onAction };
 }

--- a/packages/ui/stories/components/primitives/menu.stories.tsx
+++ b/packages/ui/stories/components/primitives/menu.stories.tsx
@@ -1,4 +1,9 @@
-import { ActionMenu, ContextMenu, type MenuItem } from '@cherrystudio/ui/components';
+import {
+  ActionMenu,
+  ContextMenu,
+  ContextMenuScrollBoundary,
+  type MenuItem,
+} from '@cherrystudio/ui/components';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { fn } from 'storybook/test';
@@ -21,13 +26,18 @@ const meta = {
   title: 'Components/Primitives/Menu',
   decorators: [
     (Story) => (
-      <ScrollView
-        className="flex-1"
-        contentContainerClassName="flex-grow gap-4 p-4"
-        contentInsetAdjustmentBehavior="automatic"
-      >
-        <Story />
-      </ScrollView>
+      <ContextMenuScrollBoundary>
+        {(scrollHandlers) => (
+          <ScrollView
+            {...scrollHandlers}
+            className="flex-1"
+            contentContainerClassName="flex-grow gap-4 p-4"
+            contentInsetAdjustmentBehavior="automatic"
+          >
+            <Story />
+          </ScrollView>
+        )}
+      </ContextMenuScrollBoundary>
     ),
   ],
 } satisfies Meta;

--- a/packages/ui/stories/components/primitives/menu.stories.tsx
+++ b/packages/ui/stories/components/primitives/menu.stories.tsx
@@ -1,4 +1,4 @@
-import { Menu, type MenuItem } from '@cherrystudio/ui/components';
+import { ActionMenu, ContextMenu, type MenuItem } from '@cherrystudio/ui/components';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { fn } from 'storybook/test';
@@ -45,7 +45,7 @@ export const Playground: Story = {
             <Text className="text-base font-semibold text-foreground">
               {theme === 'light' ? 'Light' : 'Dark'}
             </Text>
-            <Menu items={menuItems} trigger="tap">
+            <ActionMenu items={menuItems}>
               <Pressable
                 accessibilityLabel="More actions"
                 accessibilityRole="button"
@@ -53,7 +53,18 @@ export const Playground: Story = {
               >
                 <Text className="text-xl text-foreground">...</Text>
               </Pressable>
-            </Menu>
+            </ActionMenu>
+            <ContextMenu items={menuItems}>
+              <Pressable
+                accessibilityLabel="Session row"
+                accessibilityRole="button"
+                className="w-full active:bg-field"
+              >
+                <Text className="px-4 py-2.5 text-base text-foreground">
+                  Long press for actions
+                </Text>
+              </Pressable>
+            </ContextMenu>
           </View>
         </ScopedTheme>
       ))}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -767,6 +767,9 @@ importers:
       react-native-enriched-markdown:
         specifier: '*'
         version: 1.0.1(@expo/config-plugins@57.0.5(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-gesture-handler:
+        specifier: '*'
+        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
         specifier: '*'
         version: 1.21.13(patch_hash=6f5bed7a836aae55a44a2b0a97532e6d73d9dfb87032457499dfe3ff2c239186)(react-native-reanimated@4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)

--- a/src/frontend/components/avatar/components/AvatarImagePicker.tsx
+++ b/src/frontend/components/avatar/components/AvatarImagePicker.tsx
@@ -1,4 +1,4 @@
-import { Menu, type MenuItem } from '@cherrystudio/ui/components';
+import { ActionMenu, type MenuItem } from '@cherrystudio/ui/components';
 import * as ImagePicker from 'expo-image-picker';
 import { type ReactElement, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -95,7 +95,7 @@ export function AvatarImagePicker({
   );
 
   return (
-    <Menu items={menuItems} trigger="tap">
+    <ActionMenu items={menuItems}>
       <View
         accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
@@ -107,6 +107,6 @@ export function AvatarImagePicker({
       >
         {children}
       </View>
-    </Menu>
+    </ActionMenu>
   );
 }

--- a/src/frontend/components/headers/components/HeaderAction/HeaderAction.tsx
+++ b/src/frontend/components/headers/components/HeaderAction/HeaderAction.tsx
@@ -1,4 +1,4 @@
-import { Menu } from '@cherrystudio/ui/components';
+import { ActionMenu } from '@cherrystudio/ui/components';
 import { cn } from '@cherrystudio/ui/utils';
 import { Pressable, Text, View } from 'react-native';
 
@@ -26,7 +26,7 @@ export function HeaderAction({
       const Icon = action.icon;
 
       return (
-        <Menu items={action.items} trigger="tap">
+        <ActionMenu items={action.items}>
           <View
             accessibilityLabel={action.accessibilityLabel}
             accessibilityRole="button"
@@ -36,7 +36,7 @@ export function HeaderAction({
           >
             <Icon className={cn('size-6', contentClassName)} />
           </View>
-        </Menu>
+        </ActionMenu>
       );
     }
 

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -1,4 +1,4 @@
-import { ScrollToBottomButton } from '@cherrystudio/ui/components';
+import { ContextMenuScrollBoundary, ScrollToBottomButton } from '@cherrystudio/ui/components';
 import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list/keyboard';
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -104,48 +104,54 @@ export function MessageList({
 
   return (
     <View className="flex-1">
-      <KeyboardAwareLegendList
-        ref={listRef}
-        applyWorkaroundForContentInsetHitTestBug
-        contentContainerStyle={contentContainerStyle}
-        contentInsetAdjustmentBehavior="never"
-        data={messages}
-        {...(dataKey ? { dataKey } : {})}
-        drawDistance={80}
-        estimatedItemSize={300}
-        estimatedHeaderSize={contentTopInset}
-        extraData={extraData}
-        freeze={freeze}
-        getItemType={getMessageRowType}
-        keyExtractor={messageKeyExtractor}
-        keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
-        keyboardLiftBehavior="whenAtEnd"
-        keyboardOffset={keyboardOffset}
-        keyboardShouldPersistTaps="handled"
-        ListHeaderComponent={listHeader}
-        {...(!dataKey ? { initialScrollAtEnd: true } : {})}
-        maintainVisibleContentPosition={MAINTAIN_VISIBLE_CONTENT_POSITION}
-        onContentSizeChange={handleContentSizeChange}
-        onLayout={handleLayout}
-        onLoad={handleLoad}
+      <ContextMenuScrollBoundary
         onMomentumScrollBegin={handleMomentumScrollBegin}
         onMomentumScrollEnd={handleMomentumScrollEnd}
-        onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
         onScrollEndDrag={handleScrollEndDrag}
-        onStartReached={onLoadOlder ? handleStartReached : undefined}
-        onStartReachedThreshold={0.05}
         onTouchStart={handleTouchStart}
-        // Message parts own local disclosure state. Keep recycling disabled
-        // until that state is explicitly reset with LegendList recycling hooks.
-        recycleItems={false}
-        renderItem={renderMessageRow}
-        scrollEventThrottle={16}
-        scrollsToTop
-        sharedValues={sharedValues}
-        showsVerticalScrollIndicator={false}
-        className="flex-1"
-      />
+      >
+        {(scrollHandlers) => (
+          <KeyboardAwareLegendList
+            ref={listRef}
+            {...scrollHandlers}
+            applyWorkaroundForContentInsetHitTestBug
+            contentContainerStyle={contentContainerStyle}
+            contentInsetAdjustmentBehavior="never"
+            data={messages}
+            {...(dataKey ? { dataKey } : {})}
+            drawDistance={80}
+            estimatedItemSize={300}
+            estimatedHeaderSize={contentTopInset}
+            extraData={extraData}
+            freeze={freeze}
+            getItemType={getMessageRowType}
+            keyExtractor={messageKeyExtractor}
+            keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
+            keyboardLiftBehavior="whenAtEnd"
+            keyboardOffset={keyboardOffset}
+            keyboardShouldPersistTaps="handled"
+            ListHeaderComponent={listHeader}
+            {...(!dataKey ? { initialScrollAtEnd: true } : {})}
+            maintainVisibleContentPosition={MAINTAIN_VISIBLE_CONTENT_POSITION}
+            onContentSizeChange={handleContentSizeChange}
+            onLayout={handleLayout}
+            onLoad={handleLoad}
+            onScroll={handleScroll}
+            onStartReached={onLoadOlder ? handleStartReached : undefined}
+            onStartReachedThreshold={0.05}
+            // Message parts own local disclosure state. Keep recycling disabled
+            // until that state is explicitly reset with LegendList recycling hooks.
+            recycleItems={false}
+            renderItem={renderMessageRow}
+            scrollEventThrottle={16}
+            scrollsToTop
+            sharedValues={sharedValues}
+            showsVerticalScrollIndicator={false}
+            className="flex-1"
+          />
+        )}
+      </ContextMenuScrollBoundary>
       {messages.length > 0 ? (
         <ScrollToBottomButton
           accessibilityLabel={t('chat.message.scrollToBottom')}

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -128,6 +128,12 @@ jest.mock('@legendapp/list/keyboard', () => {
 });
 
 jest.mock('@cherrystudio/ui/components', () => ({
+  ContextMenuScrollBoundary: ({
+    children,
+    ...handlers
+  }: {
+    children: (handlers: Record<string, unknown>) => ReactNode;
+  }) => children(handlers),
   ScrollToBottomButton: (props: {
     bottomAccessoryHeight?: SharedValue<number>;
     isAtBottom: boolean;

--- a/src/frontend/components/navigation/components/ContextMenuLink/ContextMenuLink.android.tsx
+++ b/src/frontend/components/navigation/components/ContextMenuLink/ContextMenuLink.android.tsx
@@ -1,14 +1,14 @@
-import { Menu } from '@cherrystudio/ui/components';
+import { ContextMenu } from '@cherrystudio/ui/components';
 import { Link } from 'expo-router';
 
 import type { ContextMenuLinkProps } from './ContextMenuLink.types';
 
 export function ContextMenuLink({ children, href, items }: ContextMenuLinkProps) {
   return (
-    <Menu items={items} trigger="longPress">
+    <ContextMenu items={items}>
       <Link asChild href={href}>
         {children}
       </Link>
-    </Menu>
+    </ContextMenu>
   );
 }

--- a/src/frontend/components/navigation/components/ContextMenuLink/ContextMenuLink.android.tsx
+++ b/src/frontend/components/navigation/components/ContextMenuLink/ContextMenuLink.android.tsx
@@ -1,14 +1,43 @@
 import { ContextMenu } from '@cherrystudio/ui/components';
 import { Link } from 'expo-router';
+import { cloneElement, type ReactElement } from 'react';
+import type { AccessibilityActionEvent, AccessibilityActionInfo } from 'react-native';
 
 import type { ContextMenuLinkProps } from './ContextMenuLink.types';
+
+type AccessibilityChildProps = {
+  accessibilityActions?: readonly AccessibilityActionInfo[];
+  onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
+};
 
 export function ContextMenuLink({ children, href, items }: ContextMenuLinkProps) {
   return (
     <ContextMenu items={items}>
       <Link asChild href={href}>
-        {children}
+        {withContextMenuAccessibility(children, items)}
       </Link>
     </ContextMenu>
   );
+}
+
+function withContextMenuAccessibility(
+  children: ReactElement,
+  items: ContextMenuLinkProps['items'],
+) {
+  const actionableItems = items.filter((item) => !item.disabled);
+  const child = children as ReactElement<AccessibilityChildProps>;
+  const { accessibilityActions = [], onAccessibilityAction } = child.props;
+  const menuItemNames = new Set(items.map((item) => item.id));
+
+  return cloneElement(child, {
+    accessibilityActions: [
+      ...accessibilityActions.filter((action) => !menuItemNames.has(action.name)),
+      ...actionableItems.map((item) => ({ label: item.label, name: item.id })),
+    ],
+    onAccessibilityAction: (event: AccessibilityActionEvent) => {
+      if (!menuItemNames.has(event.nativeEvent.actionName)) {
+        onAccessibilityAction?.(event);
+      }
+    },
+  });
 }

--- a/src/frontend/components/navigation/components/ContextMenuLink/__tests__/ContextMenuLink.android.test.tsx
+++ b/src/frontend/components/navigation/components/ContextMenuLink/__tests__/ContextMenuLink.android.test.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from 'react';
+import {
+  type AccessibilityActionEvent,
+  type AccessibilityActionInfo,
+  Pressable,
+  Text,
+} from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ContextMenuLink } from '../ContextMenuLink.android';
+
+type AccessibilityProps = {
+  accessibilityActions?: readonly AccessibilityActionInfo[];
+  onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
+};
+
+jest.mock('@cherrystudio/ui/components', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    ContextMenu: ({ children, items }: { children: ReactElement; items: readonly MenuItem[] }) => {
+      const child = children as ReactElement<AccessibilityProps>;
+      const actionableItems = items.filter((item) => !item.disabled);
+
+      return React.cloneElement(child, {
+        accessibilityActions: actionableItems.map((item) => ({
+          label: item.label,
+          name: item.id,
+        })),
+        onAccessibilityAction: (event: AccessibilityActionEvent) => {
+          actionableItems.find((item) => item.id === event.nativeEvent.actionName)?.onPress();
+        },
+      });
+    },
+  };
+});
+
+jest.mock('expo-router', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    Link: ({ children, ...props }: { children: ReactElement; href: unknown }) => {
+      const child = children as ReactElement<AccessibilityProps>;
+      const linkProps = props as AccessibilityProps;
+      const childHandler = child.props.onAccessibilityAction;
+      const linkHandler = linkProps.onAccessibilityAction;
+
+      return React.cloneElement(child, {
+        accessibilityActions: child.props.accessibilityActions ?? linkProps.accessibilityActions,
+        onAccessibilityAction: (event: AccessibilityActionEvent) => {
+          childHandler?.(event);
+          linkHandler?.(event);
+        },
+      });
+    },
+  };
+});
+
+type MenuItem = {
+  disabled?: boolean;
+  id: string;
+  label: string;
+  onPress: () => void;
+};
+
+function accessibilityAction(actionName: string): AccessibilityActionEvent {
+  return { nativeEvent: { actionName } } as AccessibilityActionEvent;
+}
+
+describe('ContextMenuLink.android', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('gives menu actions one owner while preserving unrelated child actions', () => {
+    const onChildAction = jest.fn();
+    const onRename = jest.fn();
+    const onDelete = jest.fn();
+
+    act(() => {
+      renderer = create(
+        <ContextMenuLink
+          href="/sessions"
+          items={[
+            { id: 'rename', label: 'Rename', onPress: onRename },
+            { id: 'delete', label: 'Delete', onPress: onDelete },
+            { disabled: true, id: 'share', label: 'Share', onPress: jest.fn() },
+          ]}
+        >
+          <Pressable
+            accessibilityActions={[
+              { label: 'Collapse', name: 'collapse' },
+              { label: 'Legacy rename', name: 'rename' },
+              { label: 'Legacy share', name: 'share' },
+            ]}
+            onAccessibilityAction={onChildAction}
+            testID="row"
+          >
+            <Text>Session</Text>
+          </Pressable>
+        </ContextMenuLink>,
+      );
+    });
+
+    const row = renderer!.root.findByProps({ testID: 'row' });
+    expect(row.props.accessibilityActions).toEqual([
+      { label: 'Collapse', name: 'collapse' },
+      { label: 'Rename', name: 'rename' },
+      { label: 'Delete', name: 'delete' },
+    ]);
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('rename')));
+    expect(onRename).toHaveBeenCalledTimes(1);
+    expect(onChildAction).not.toHaveBeenCalled();
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('collapse')));
+    expect(onChildAction).toHaveBeenCalledTimes(1);
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('delete')));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+
+    act(() => row.props.onAccessibilityAction(accessibilityAction('share')));
+    expect(onChildAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/features/agents/AgentListScreen.tsx
+++ b/src/frontend/features/agents/AgentListScreen.tsx
@@ -2,7 +2,12 @@ import BotIcon from '@cherrystudio/app-icons/icons/bot';
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
 import ClockIcon from '@cherrystudio/app-icons/icons/clock';
 import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
-import { ContentState, type MenuItem, useAlert } from '@cherrystudio/ui/components';
+import {
+  ContentState,
+  ContextMenuScrollBoundary,
+  type MenuItem,
+  useAlert,
+} from '@cherrystudio/ui/components';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +27,8 @@ import {
 } from '@/frontend/components/selection';
 import { useAgentMutations, useAgentsApi } from '@/frontend/hooks/agent';
 import type { Agent } from '@/shared/data/types/agent';
+
+const EDITING_ACCESSIBILITY_ACTIONS = [{ name: 'activate' }] as const;
 
 export default function AgentListScreen() {
   const { t } = useTranslation();
@@ -203,58 +210,63 @@ export default function AgentListScreen() {
           only reports it back, so leaving it mounted would keep a stale query
           filtering rows that selection mode has no way to show. */}
       {isEditing ? null : <InlineSearch onChangeText={setQuery} value={query} />}
-      <ScrollView
-        alwaysBounceVertical={false}
-        className="flex-1"
-        contentContainerStyle={scrollContentStyle}
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
-      >
-        {listedAgents.length > 0 ? (
-          <View>
-            {listedAgents.map((agent) => (
-              <AgentListRow
-                key={agent.id}
-                agent={agent}
-                isEditing={isEditing}
-                isSelected={selectedIds.has(agent.id)}
-                onDelete={requestDeleteAgent}
-                onEdit={openAgentEditor}
-                onToggle={toggleAgent}
+      <ContextMenuScrollBoundary>
+        {(scrollHandlers) => (
+          <ScrollView
+            {...scrollHandlers}
+            alwaysBounceVertical={false}
+            className="flex-1"
+            contentContainerStyle={scrollContentStyle}
+            contentInsetAdjustmentBehavior="automatic"
+            showsVerticalScrollIndicator={false}
+          >
+            {listedAgents.length > 0 ? (
+              <View>
+                {listedAgents.map((agent) => (
+                  <AgentListRow
+                    key={agent.id}
+                    agent={agent}
+                    isEditing={isEditing}
+                    isSelected={selectedIds.has(agent.id)}
+                    onDelete={requestDeleteAgent}
+                    onEdit={openAgentEditor}
+                    onToggle={toggleAgent}
+                  />
+                ))}
+              </View>
+            ) : isFiltering ? (
+              <ContentState.Empty className="px-8 py-16" title={t('agent.list.noResults')} />
+            ) : isLoading ? (
+              <ContentState.Loading className="px-8 py-16" title={t('agent.list.loading')} />
+            ) : error ? (
+              <ContentState.Error
+                className="px-8 py-16"
+                primaryAction={{
+                  children: t('agent.actions.retry'),
+                  onPress: () => void refetch(),
+                }}
+                title={t('agent.list.loadFailed')}
               />
-            ))}
-          </View>
-        ) : isFiltering ? (
-          <ContentState.Empty className="px-8 py-16" title={t('agent.list.noResults')} />
-        ) : isLoading ? (
-          <ContentState.Loading className="px-8 py-16" title={t('agent.list.loading')} />
-        ) : error ? (
-          <ContentState.Error
-            className="px-8 py-16"
-            primaryAction={{
-              children: t('agent.actions.retry'),
-              onPress: () => void refetch(),
-            }}
-            title={t('agent.list.loadFailed')}
-          />
-        ) : (
-          <ContentState.Empty
-            description={t('agent.list.emptyDescription')}
-            icon={
-              <ContentState.Icon>
-                <BotIcon className="size-7 text-foreground" />
-              </ContentState.Icon>
-            }
-            layout="page"
-            primaryAction={{
-              accessibilityLabel: t('agent.actions.create'),
-              children: t('agent.actions.create'),
-              onPress: openCreateAgent,
-            }}
-            title={t('agent.list.emptyTitle')}
-          />
+            ) : (
+              <ContentState.Empty
+                description={t('agent.list.emptyDescription')}
+                icon={
+                  <ContentState.Icon>
+                    <BotIcon className="size-7 text-foreground" />
+                  </ContentState.Icon>
+                }
+                layout="page"
+                primaryAction={{
+                  accessibilityLabel: t('agent.actions.create'),
+                  children: t('agent.actions.create'),
+                  onPress: openCreateAgent,
+                }}
+                title={t('agent.list.emptyTitle')}
+              />
+            )}
+          </ScrollView>
         )}
-      </ScrollView>
+      </ContextMenuScrollBoundary>
       {isEditing ? (
         <SelectionToolbar
           isDeleting={isBatchDeleting}
@@ -292,35 +304,13 @@ function AgentListRow({
   const handleDeletePress = useCallback(() => {
     onDelete(agent);
   }, [agent, onDelete]);
-  const accessibilityActions = useMemo(
-    () =>
-      isEditing
-        ? [{ name: 'activate' as const }]
-        : [
-            { label: t('common.edit'), name: 'edit' as const },
-            { label: t('common.delete'), name: 'delete' as const },
-          ],
-    [isEditing, t],
-  );
   const handleAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
-      if (isEditing) {
+      if (event.nativeEvent.actionName === 'activate') {
         onToggle(agent.id);
-        return;
-      }
-
-      switch (event.nativeEvent.actionName) {
-        case 'edit':
-          handleEditPress();
-          break;
-        case 'delete':
-          handleDeletePress();
-          break;
-        default:
-          break;
       }
     },
-    [agent.id, handleDeletePress, handleEditPress, isEditing, onToggle],
+    [agent.id, onToggle],
   );
   const href = useMemo(
     () => ({
@@ -348,12 +338,12 @@ function AgentListRow({
 
   const row = (
     <GesturePressable
-      accessibilityActions={accessibilityActions}
+      accessibilityActions={isEditing ? EDITING_ACCESSIBILITY_ACTIONS : undefined}
       accessibilityLabel={agent.name}
       accessibilityRole={isEditing ? 'checkbox' : 'link'}
       accessibilityState={isEditing ? { checked: isSelected } : undefined}
       className="w-full active:bg-secondary"
-      onAccessibilityAction={handleAccessibilityAction}
+      onAccessibilityAction={isEditing ? handleAccessibilityAction : undefined}
       onPress={isEditing ? () => onToggle(agent.id) : undefined}
     >
       <View className="relative min-w-0 flex-1 flex-row items-center gap-2 border-border border-b py-2 pl-2">

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -45,7 +45,7 @@ jest.mock('@cherrystudio/ui/components', () => {
     ContentState: {
       Error: (props: object) => createElement('ContentState.Error', props),
     },
-    Menu: ({ children }: { children: ReactNode }) => children,
+    ContextMenu: ({ children }: { children: ReactNode }) => children,
     useAlert: () => ({ alert: { show: mockAlertShow } }),
   };
 });

--- a/src/frontend/features/chat/workspace/components/ChatMessage.tsx
+++ b/src/frontend/features/chat/workspace/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { Menu, type MenuItem } from '@cherrystudio/ui/components';
+import { ContextMenu, type MenuItem } from '@cherrystudio/ui/components';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
@@ -120,7 +120,7 @@ export const ChatMessage = memo(function ChatMessage({
   }, [copyAssistantMessage, copyText, isMessageActionsEnabled, message.id, t]);
 
   return (
-    <Menu items={menuItems} trigger="longPress">
+    <ContextMenu items={menuItems}>
       <View className="w-full" collapsable={false}>
         {message.role === 'user' ? (
           <UserMessage message={message} />
@@ -128,6 +128,6 @@ export const ChatMessage = memo(function ChatMessage({
           renderChatAssistantMessage(isTextSelectionEnabled, message, assistantPresentation)
         )}
       </View>
-    </Menu>
+    </ContextMenu>
   );
 });

--- a/src/frontend/features/chat/workspace/components/__tests__/ChatMessage.test.tsx
+++ b/src/frontend/features/chat/workspace/components/__tests__/ChatMessage.test.tsx
@@ -9,7 +9,7 @@ const mockCopyAssistantMessage = jest.fn();
 let mockMenuItems: readonly { disabled?: boolean; id: string }[] = [];
 
 jest.mock('@cherrystudio/ui/components', () => ({
-  Menu: ({ children, items }: { children: ReactNode; items: typeof mockMenuItems }) => {
+  ContextMenu: ({ children, items }: { children: ReactNode; items: typeof mockMenuItems }) => {
     mockMenuItems = items;
     return children;
   },

--- a/src/frontend/features/paintings/PaintingViewerScreen/components/PaintingViewerChrome.android.tsx
+++ b/src/frontend/features/paintings/PaintingViewerScreen/components/PaintingViewerChrome.android.tsx
@@ -2,7 +2,7 @@ import DownloadIcon from '@cherrystudio/app-icons/icons/download';
 import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
 import PencilIcon from '@cherrystudio/app-icons/icons/pencil';
 import ProportionsIcon from '@cherrystudio/app-icons/icons/proportions';
-import { Menu, type MenuItem } from '@cherrystudio/ui/components';
+import { ActionMenu, type MenuItem } from '@cherrystudio/ui/components';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet, View } from 'react-native';
@@ -92,7 +92,7 @@ export function PaintingViewerChrome({
         >
           <PencilIcon className="size-6 text-constant-white" />
         </HeaderIconButton>
-        <Menu items={resizeMenuItems} trigger="tap">
+        <ActionMenu items={resizeMenuItems}>
           <View
             accessibilityLabel={t('painting.viewer.resize')}
             accessibilityRole="button"
@@ -100,7 +100,7 @@ export function PaintingViewerChrome({
           >
             <ProportionsIcon className="size-6 text-constant-white" />
           </View>
-        </Menu>
+        </ActionMenu>
       </View>
     </>
   );

--- a/src/frontend/features/sessions/SessionList.tsx
+++ b/src/frontend/features/sessions/SessionList.tsx
@@ -1,7 +1,7 @@
 import BotIcon from '@cherrystudio/app-icons/icons/bot';
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
 import MessageCircleMoreIcon from '@cherrystudio/app-icons/icons/message-circle-more';
-import { ContentState } from '@cherrystudio/ui/components';
+import { ContentState, ContextMenuScrollBoundary } from '@cherrystudio/ui/components';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useRouter } from 'expo-router';
 import { memo, useCallback, useMemo } from 'react';
@@ -44,6 +44,7 @@ type SessionRowProps = {
 };
 
 const SESSION_ITEM_ESTIMATED_HEIGHT = 60;
+const EDITING_ACCESSIBILITY_ACTIONS = [{ name: 'activate' }] as const;
 
 function sessionKeyExtractor(item: AgentSessionEntity) {
   return item.id;
@@ -182,23 +183,28 @@ const SessionListView = memo(function SessionListView() {
 
   return (
     <View className="flex-1">
-      <LegendList
-        className="flex-1 bg-background"
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={contentContainerStyle}
-        data={isInitialDataSettled && !initialLoadError ? visibleSessions : []}
-        estimatedItemSize={SESSION_ITEM_ESTIMATED_HEIGHT}
-        extraData={listExtraData}
-        keyExtractor={sessionKeyExtractor}
-        keyboardDismissMode="on-drag"
-        keyboardShouldPersistTaps="handled"
-        ListEmptyComponent={listEmptyComponent}
-        onEndReached={loadMoreSessions}
-        onEndReachedThreshold={0.7}
-        recycleItems
-        renderItem={renderItem}
-        showsVerticalScrollIndicator={false}
-      />
+      <ContextMenuScrollBoundary>
+        {(scrollHandlers) => (
+          <LegendList
+            {...scrollHandlers}
+            className="flex-1 bg-background"
+            contentInsetAdjustmentBehavior="automatic"
+            contentContainerStyle={contentContainerStyle}
+            data={isInitialDataSettled && !initialLoadError ? visibleSessions : []}
+            estimatedItemSize={SESSION_ITEM_ESTIMATED_HEIGHT}
+            extraData={listExtraData}
+            keyExtractor={sessionKeyExtractor}
+            keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
+            ListEmptyComponent={listEmptyComponent}
+            onEndReached={loadMoreSessions}
+            onEndReachedThreshold={0.7}
+            recycleItems
+            renderItem={renderItem}
+            showsVerticalScrollIndicator={false}
+          />
+        )}
+      </ContextMenuScrollBoundary>
     </View>
   );
 });
@@ -235,35 +241,13 @@ export const SessionRow = memo(function SessionRow({
   const handleDeletePress = useCallback(() => {
     onDelete(session);
   }, [onDelete, session]);
-  const accessibilityActions = useMemo(
-    () =>
-      isEditing
-        ? [{ name: 'activate' as const }]
-        : [
-            { label: t('common.rename'), name: 'rename' as const },
-            { label: t('common.delete'), name: 'delete' as const },
-          ],
-    [isEditing, t],
-  );
   const handleAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
-      if (isEditing) {
+      if (event.nativeEvent.actionName === 'activate') {
         onToggle(session.id);
-        return;
-      }
-
-      switch (event.nativeEvent.actionName) {
-        case 'rename':
-          handleRenamePress();
-          break;
-        case 'delete':
-          handleDeletePress();
-          break;
-        default:
-          break;
       }
     },
-    [handleDeletePress, handleRenamePress, isEditing, onToggle, session.id],
+    [onToggle, session.id],
   );
   const href = useMemo(
     () => ({ pathname: '/' as const, params: { sessionId: session.id } }),
@@ -288,12 +272,12 @@ export const SessionRow = memo(function SessionRow({
 
   const row = (
     <Pressable
-      accessibilityActions={accessibilityActions}
+      accessibilityActions={isEditing ? EDITING_ACCESSIBILITY_ACTIONS : undefined}
       accessibilityLabel={session.title || t('session.list.untitled')}
       accessibilityRole={isEditing ? 'checkbox' : 'link'}
       accessibilityState={isEditing ? { checked: isSelected } : undefined}
       className="w-full active:bg-secondary"
-      onAccessibilityAction={handleAccessibilityAction}
+      onAccessibilityAction={isEditing ? handleAccessibilityAction : undefined}
       onPress={isEditing ? () => onToggle(session.id) : undefined}
     >
       <View className="relative min-w-0 flex-1 flex-row items-center gap-2 border-border border-b bg-transparent py-2 pl-2">

--- a/src/frontend/features/sidebar/components/SidebarBody.tsx
+++ b/src/frontend/features/sidebar/components/SidebarBody.tsx
@@ -1,7 +1,7 @@
 import BotIcon from '@cherrystudio/app-icons/icons/bot';
 import ImageIcon from '@cherrystudio/app-icons/icons/image';
 import LibraryBigIcon from '@cherrystudio/app-icons/icons/library-big';
-import { ScrollShadow } from '@cherrystudio/ui/components';
+import { ContextMenuScrollBoundary, ScrollShadow } from '@cherrystudio/ui/components';
 import type { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, View } from 'react-native';
@@ -36,18 +36,23 @@ export function SidebarBody({ children }: PropsWithChildren) {
         size={appSidebar.scrollShadowSize}
         visibility="top"
       >
-        <ScrollView
-          contentContainerStyle={{
-            // Clears the whole floating dock, whose own bottom padding is
-            // concentric with the display's corners rather than a fixed inset.
-            paddingBottom: dockBottomPadding + appSidebar.dockHeight + appSidebar.headerGapY,
-            paddingTop: headerInset,
-          }}
-          contentInsetAdjustmentBehavior="never"
-          showsVerticalScrollIndicator={false}
-        >
-          {children ?? <SidebarBodyDefault />}
-        </ScrollView>
+        <ContextMenuScrollBoundary>
+          {(scrollHandlers) => (
+            <ScrollView
+              {...scrollHandlers}
+              contentContainerStyle={{
+                // Clears the whole floating dock, whose own bottom padding is
+                // concentric with the display's corners rather than a fixed inset.
+                paddingBottom: dockBottomPadding + appSidebar.dockHeight + appSidebar.headerGapY,
+                paddingTop: headerInset,
+              }}
+              contentInsetAdjustmentBehavior="never"
+              showsVerticalScrollIndicator={false}
+            >
+              {children ?? <SidebarBodyDefault />}
+            </ScrollView>
+          )}
+        </ContextMenuScrollBoundary>
       </ScrollShadow>
     </View>
   );


### PR DESCRIPTION
### What this PR does

Before this PR:

- The shared `Menu` API exposed trigger mechanics to feature code instead of expressing whether a surface owned a tap action or a contextual long press.
- Android recognized contextual long presses inside the native menu view, outside the shared gesture arena, so scrolling, drawer pans, and momentum touches could still present a menu.
- Context-menu accessibility actions could be duplicated when composed through an Expo Router link.

After this PR:

- `ActionMenu` owns tap-triggered dropdowns and `ContextMenu` owns contextual long presses.
- iOS keeps system-owned `UIContextMenuInteraction`; Android recognizes long presses through Gesture Handler and presents the native `PopupMenu` only after arbitration.
- Android reads the system long-press timeout and touch slop from `ViewConfiguration`.
- `ContextMenuScrollBoundary` lets the scroll owner block descendant context menus during drag, momentum, and the complete touch sequence used to stop momentum.
- Message, session, agent, and sidebar scroll owners use the shared boundary.
- Android exposes enabled menu items as accessibility custom actions without duplicate dispatch through `ContextMenuLink`.
- Existing native menu icon support is preserved.

### Screenshots or videos

N/A. This changes gesture arbitration and accessibility behavior rather than visual presentation. Manual device verification was not run in this workspace.

### Why we need it and why it was done in this way

The scroll owner is the only reliable authority for active drag and momentum state. Android's `PopupMenu` presents actions but does not arbitrate its trigger, so recognition now participates in the shared gesture arena and consults the nearest scroll boundary before presentation.

The following tradeoffs were made:

- Scroll containers use a render callback to attach composed handlers without introducing another native view.
- The context-menu implementation remains platform-specific so iOS can retain UIKit's system arbitration while Android owns its explicit gesture contract.
- Nitro-generated bindings grow two Android configuration methods so the JavaScript recognizer uses platform values instead of app-defined constants.

The following alternatives were considered:

- Row-local scrolling state was rejected because rows do not own the scroll interaction.
- Arbitrary timeouts or movement thresholds were rejected in favor of `ViewConfiguration`.
- Keeping long-press recognition in the Android menu view was rejected because it cannot participate in the shared Gesture Handler arena.

### Breaking changes

The CherryUI `Menu` component and its `trigger` prop are replaced by `ActionMenu` and `ContextMenu`. All repository call sites are migrated in this PR.

### Special notes for your reviewer

Native acceptance is still required for tap, stationary long press, quick and slow vertical drags, drawer pans, momentum-stop touches, cancellation, and accessibility actions on Android and iOS.

Local validation:

- `pnpm format`
- `pnpm format:check`
- `pnpm lint` (passes with pre-existing repository warnings)

Not run under the repository's user-owned verification policy: targeted tests, typecheck, builds, or manual device acceptance.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The menu API now expresses interaction intent at call sites
- [x] Upgrade: No upgrade-flow changes are required
- [x] Documentation: The CherryUI package documentation and Storybook story are updated; no user-guide change is required
- [x] Self-review: The final diff was reviewed locally and rebased onto the latest `origin/v0.2`

### Release note

```release-note
Fixed Android context menus opening while scrolling or swiping the sidebar.
```
