### PR TITLE
feat(provider-models): show useful model badges

### DIFF
--- a/packages/ui/src/components/menu/context-menu/__tests__/context-menu.android.test.tsx
+++ b/packages/ui/src/components/menu/context-menu/__tests__/context-menu.android.test.tsx
@@ -11,7 +11,7 @@ import {
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import type { NativeCherryMenuRef } from '../../use-native-menu';
-import { ContextMenuScrollBoundary } from '../context-menu-scroll-boundary';
+import { ContextMenuScrollBoundary } from '../context-menu-scroll-boundary.android';
 import { ContextMenu } from '../context-menu.android';
 
 type NativeMenuProps = {

--- a/packages/ui/src/components/menu/context-menu/context-menu.android.tsx
+++ b/packages/ui/src/components/menu/context-menu/context-menu.android.tsx
@@ -5,7 +5,7 @@ import { callback } from 'react-native-nitro-modules';
 
 import type { ContextMenuProps, MenuItem } from '../menu.types';
 import { type NativeCherryMenuRef, NativeCherryMenuView, useNativeMenu } from '../use-native-menu';
-import { useContextMenuInteraction } from './context-menu-scroll-boundary';
+import { useContextMenuInteraction } from './context-menu-scroll-boundary.android';
 
 type AccessibilityInjectedProps = {
   accessibilityActions?: readonly AccessibilityActionInfo[];

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@cherrystudio/app-icons/icons/ellipsis', () => () => null);
 jest.mock('@cherrystudio/ui/components', () => {
   const { createElement } = jest.requireActual('react');
   return {
+    ActionMenu: ({ children }: { children: ReactNode }) => children,
     Button: (props: object) => createElement('Button', props),
     ContentState: {
       Error: (props: object) => createElement('ContentState.Error', props),

--- a/src/frontend/features/chat/workspace/components/AssistantMessageToolbar.tsx
+++ b/src/frontend/features/chat/workspace/components/AssistantMessageToolbar.tsx
@@ -1,7 +1,7 @@
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
 import CopyIcon from '@cherrystudio/app-icons/icons/copy';
 import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
-import { Button, Menu, type MenuItem } from '@cherrystudio/ui/components';
+import { ActionMenu, Button, type MenuItem } from '@cherrystudio/ui/components';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
@@ -71,7 +71,7 @@ export const AssistantMessageToolbar = memo(function AssistantMessageToolbar({
         The native menu installs its own hit target over this subtree, so the
         trigger is a plain labelled View rather than a second pressable.
       */}
-      <Menu items={menuItems} trigger="tap">
+      <ActionMenu items={menuItems}>
         <View
           accessibilityLabel={t('common.more')}
           accessibilityRole="button"
@@ -80,7 +80,7 @@ export const AssistantMessageToolbar = memo(function AssistantMessageToolbar({
         >
           <EllipsisIcon className="size-4 text-muted-foreground" />
         </View>
-      </Menu>
+      </ActionMenu>
     </View>
   );
 });

--- a/src/frontend/features/chat/workspace/components/__tests__/AssistantMessageToolbar.test.tsx
+++ b/src/frontend/features/chat/workspace/components/__tests__/AssistantMessageToolbar.test.tsx
@@ -21,8 +21,9 @@ jest.mock('@cherrystudio/app-icons/icons/ellipsis', () => () => null);
 jest.mock('@cherrystudio/ui/components', () => {
   const { createElement } = jest.requireActual('react');
   return {
+    ActionMenu: ({ children, ...props }: { children: unknown }) =>
+      createElement('ActionMenu', props, children),
     Button: (props: object) => createElement('Button', props),
-    Menu: ({ children, ...props }: { children: unknown }) => createElement('Menu', props, children),
     useAlert: () => ({ alert: { show: jest.fn() } }),
   };
 });
@@ -118,8 +119,7 @@ describe('AssistantMessageToolbar', () => {
   test('offers a branch action carrying the semantic icon and forks this message', () => {
     renderToolbar(createMessage('success', 'Answer'));
 
-    const menu = renderer!.root.findByType('Menu');
-    expect(menu.props.trigger).toBe('tap');
+    const menu = renderer!.root.findByType('ActionMenu');
     expect(menu.props.items).toEqual([
       {
         icon: 'branch',

--- a/src/frontend/features/settings/ProviderScreen/ProviderModelPullScreen.tsx
+++ b/src/frontend/features/settings/ProviderScreen/ProviderModelPullScreen.tsx
@@ -11,7 +11,7 @@ import type { Provider } from '@/shared/data/types/provider';
 import { ProviderModelPurposeTabs } from './models/components/ProviderModelPurposeTabs';
 import {
   ProviderModelRow,
-  providerModelRowEstimatedHeight,
+  providerModelRowEstimatedHeights,
 } from './models/components/ProviderModelRow';
 import {
   buildProviderModelPullListItems,
@@ -146,7 +146,7 @@ export function ProviderModelPullPreviewContent({
       contentInsetAdjustmentBehavior="automatic"
       data={listItems}
       drawDistance={320}
-      estimatedItemSize={providerModelRowEstimatedHeight}
+      estimatedItemSize={providerModelRowEstimatedHeights.synchronization}
       extraData={listExtraData}
       getItemType={getPullListItemType}
       keyboardDismissMode="on-drag"
@@ -315,6 +315,7 @@ const PullModelRow = memo(function PullModelRow({
       selection={{ isDisabled: isApplying, isSelected, onToggle: handleToggle }}
       // The provider no longer serves it, whether or not the row is ticked.
       tone={section === 'missing' ? 'struck' : 'default'}
+      variant="synchronization"
     />
   );
 });

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelBadge.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelBadge.tsx
@@ -1,0 +1,44 @@
+import EyeIcon from '@cherrystudio/app-icons/icons/eye';
+import GiftIcon from '@cherrystudio/app-icons/icons/gift';
+import { StyleSheet, View } from 'react-native';
+
+import type { ProviderModelBadge as ProviderModelBadgeValue } from '../utils/providerModelBadges';
+
+const badgeMeta = {
+  free: {
+    chipClassName: 'bg-tag-green',
+    Icon: GiftIcon,
+    iconClassName: 'text-tag-green-foreground',
+  },
+  vision: {
+    chipClassName: 'bg-tag-blue',
+    Icon: EyeIcon,
+    iconClassName: 'text-tag-blue-foreground',
+  },
+} satisfies Record<
+  ProviderModelBadgeValue,
+  { chipClassName: string; Icon: typeof EyeIcon; iconClassName: string }
+>;
+
+/** A compact, inert visual mark; the containing row owns its spoken label. */
+export function ProviderModelBadge({ badge }: { badge: ProviderModelBadgeValue }) {
+  const { chipClassName, Icon, iconClassName } = badgeMeta[badge];
+
+  return (
+    <View
+      accessibilityElementsHidden
+      className={`h-5 flex-row items-center justify-center rounded-lg px-1.5 ${chipClassName}`}
+      importantForAccessibility="no-hide-descendants"
+      style={styles.badge}
+      testID={`provider-model-badge-${badge}`}
+    >
+      <Icon className={`size-3 ${iconClassName}`} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    borderCurve: 'continuous',
+  },
+});

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelListContent.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelListContent.tsx
@@ -10,7 +10,7 @@ import {
   buildProviderModelListItems,
   type ProviderModelListItem,
 } from '../utils/providerModelListItems';
-import { ProviderModelRow, providerModelRowEstimatedHeight } from './ProviderModelRow';
+import { ProviderModelRow, providerModelRowEstimatedHeights } from './ProviderModelRow';
 
 export type ProviderModelListContentProps = {
   groupByPurpose: boolean;
@@ -60,7 +60,13 @@ export function ProviderModelListContent({
         );
       }
 
-      return <ProviderModelRow model={item.model} provider={itemExtraData.provider} />;
+      return (
+        <ProviderModelRow
+          model={item.model}
+          provider={itemExtraData.provider}
+          variant="management"
+        />
+      );
     },
     [t],
   );
@@ -71,7 +77,7 @@ export function ProviderModelListContent({
       contentContainerStyle={styles.contentContainer}
       contentInsetAdjustmentBehavior="automatic"
       data={listItems}
-      estimatedItemSize={providerModelRowEstimatedHeight}
+      estimatedItemSize={providerModelRowEstimatedHeights.management}
       extraData={extraData}
       getItemType={getProviderModelListItemType}
       keyboardDismissMode="on-drag"

--- a/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelRow.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/ProviderModelRow.tsx
@@ -1,13 +1,26 @@
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pressable, Text, View } from 'react-native';
 
 import { ModelAvatar } from '@/frontend/components/avatar';
 import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 
-/** Most rows are one line; a distinct API model id adds one compact metadata line. */
-export const providerModelRowEstimatedHeight = 48;
+import { getProviderModelBadges, type ProviderModelBadge } from '../utils/providerModelBadges';
+import { ProviderModelBadge as ProviderModelBadgeChip } from './ProviderModelBadge';
+
+export type ProviderModelRowVariant = 'management' | 'synchronization';
+
+export const providerModelRowEstimatedHeights = {
+  management: 42,
+  synchronization: 58,
+} as const satisfies Record<ProviderModelRowVariant, number>;
+
+const providerModelBadgeLabelKeys = {
+  free: 'models.capability.free',
+  vision: 'models.capability.imageRecognition',
+} as const satisfies Record<ProviderModelBadge, string>;
 
 /**
  * One model, as both screens that list models draw it: the provider's own tab
@@ -27,6 +40,7 @@ export function ProviderModelRow({
   provider,
   selection,
   tone = 'default',
+  variant,
 }: {
   /** The row's trailing action. */
   children?: ReactNode;
@@ -45,12 +59,24 @@ export function ProviderModelRow({
   };
   /** `struck` reads as "on its way out", the way the pull screen marks a model the provider no longer serves. */
   tone?: 'default' | 'struck';
+  /** Management prioritizes decision-useful badges; synchronization keeps the provider's raw id. */
+  variant: ProviderModelRowVariant;
 }) {
+  const { t } = useTranslation();
   const hasDistinctModelId = model.modelId.trim() !== model.name.trim();
-  const accessibilityLabel = hasDistinctModelId ? `${model.name}, ${model.modelId}` : model.name;
-  const rowClassName = className
-    ? `flex-row items-center gap-3 px-4 py-2 ${className}`
-    : 'flex-row items-center gap-3 px-4 py-2';
+  const badges = variant === 'management' ? getProviderModelBadges(model) : [];
+  const accessibilityDetails =
+    variant === 'synchronization' && hasDistinctModelId
+      ? [model.modelId]
+      : badges.map((badge) => t(providerModelBadgeLabelKeys[badge]));
+  const accessibilityLabel = [model.name, ...accessibilityDetails].join(', ');
+  const rowClassName = [
+    'flex-row items-center gap-3 px-4 py-2',
+    selection ? 'min-h-11' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
   const content = (
     <>
       {selection ? (
@@ -74,7 +100,7 @@ export function ProviderModelRow({
         >
           {model.name}
         </Text>
-        {hasDistinctModelId ? (
+        {variant === 'synchronization' && hasDistinctModelId ? (
           <Text
             selectable={!selection}
             className="text-foreground-tertiary text-xs"
@@ -84,6 +110,13 @@ export function ProviderModelRow({
           </Text>
         ) : null}
       </View>
+      {badges.length > 0 ? (
+        <View className="flex-row items-center gap-1">
+          {badges.map((badge) => (
+            <ProviderModelBadgeChip badge={badge} key={`${model.id}:${badge}`} />
+          ))}
+        </View>
+      ) : null}
       {children}
     </>
   );

--- a/src/frontend/features/settings/ProviderScreen/models/components/__tests__/ProviderModelRow.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/__tests__/ProviderModelRow.test.tsx
@@ -1,0 +1,74 @@
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+
+import { ProviderModelRow } from '../ProviderModelRow';
+
+jest.mock('@cherrystudio/app-icons/icons/check', () => () => null);
+jest.mock('@cherrystudio/app-icons/icons/eye', () => () => null);
+jest.mock('@cherrystudio/app-icons/icons/gift', () => () => null);
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/frontend/components/avatar', () => ({ ModelAvatar: () => null }));
+
+const model: Model = {
+  capabilities: [MODEL_CAPABILITY.IMAGE_RECOGNITION],
+  id: createUniqueModelId('agent', 'agent/model(free)'),
+  isDeprecated: false,
+  isEnabled: true,
+  isHidden: false,
+  modelId: 'agent/model(free)',
+  name: 'Display name',
+  providerId: 'agent',
+  supportsStreaming: true,
+};
+
+describe('ProviderModelRow variants', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('replaces the raw model id with decision-useful badges in management', () => {
+    act(() => {
+      renderer = create(
+        <ProviderModelRow model={model} provider={undefined} variant="management" />,
+      );
+    });
+
+    expect(renderer?.root.findAllByProps({ children: model.modelId })).toHaveLength(0);
+    expect(renderer?.root.findAllByProps({ testID: 'provider-model-badge-free' })).toHaveLength(1);
+    expect(renderer?.root.findAllByProps({ testID: 'provider-model-badge-vision' })).toHaveLength(
+      1,
+    );
+    expect(
+      renderer?.root.findByProps({
+        accessibilityLabel:
+          'Display name, models.capability.free, models.capability.imageRecognition',
+      }),
+    ).toBeDefined();
+  });
+
+  it('keeps the raw model id in synchronization without management badges', () => {
+    act(() => {
+      renderer = create(
+        <ProviderModelRow model={model} provider={undefined} variant="synchronization" />,
+      );
+    });
+
+    expect(renderer?.root.findByProps({ children: model.modelId })).toBeDefined();
+    expect(renderer?.root.findAllByProps({ testID: 'provider-model-badge-free' })).toHaveLength(0);
+    expect(renderer?.root.findAllByProps({ testID: 'provider-model-badge-vision' })).toHaveLength(
+      0,
+    );
+    expect(
+      renderer?.root.findByProps({ accessibilityLabel: `Display name, ${model.modelId}` }),
+    ).toBeDefined();
+  });
+});

--- a/src/frontend/features/settings/ProviderScreen/models/components/__tests__/ProviderModelRow.test.tsx
+++ b/src/frontend/features/settings/ProviderScreen/models/components/__tests__/ProviderModelRow.test.tsx
@@ -1,4 +1,5 @@
 import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
@@ -43,10 +44,16 @@ describe('ProviderModelRow variants', () => {
     });
 
     expect(renderer?.root.findAllByProps({ children: model.modelId })).toHaveLength(0);
-    expect(renderer?.root.findAllByProps({ testID: 'provider-model-badge-free' })).toHaveLength(1);
-    expect(renderer?.root.findAllByProps({ testID: 'provider-model-badge-vision' })).toHaveLength(
-      1,
-    );
+    expect(
+      renderer?.root
+        .findAllByProps({ testID: 'provider-model-badge-free' })
+        .filter((node) => node.type === View),
+    ).toHaveLength(1);
+    expect(
+      renderer?.root
+        .findAllByProps({ testID: 'provider-model-badge-vision' })
+        .filter((node) => node.type === View),
+    ).toHaveLength(1);
     expect(
       renderer?.root.findByProps({
         accessibilityLabel:

--- a/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelBadges.test.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/__tests__/providerModelBadges.test.ts
@@ -1,0 +1,56 @@
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+
+import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+
+import { getProviderModelBadges } from '../providerModelBadges';
+
+describe('provider model badges', () => {
+  it('keeps only free and vision in a stable priority order', () => {
+    const model = createModel({
+      capabilities: [MODEL_CAPABILITY.REASONING, MODEL_CAPABILITY.IMAGE_RECOGNITION],
+      modelId: 'agent/model:free',
+    });
+
+    expect(getProviderModelBadges(model)).toEqual(['free', 'vision']);
+  });
+
+  it('does not claim vision from catalog modalities without runtime capability support', () => {
+    const model = createModel({ inputModalities: ['text', 'image'] });
+
+    expect(getProviderModelBadges(model)).toEqual([]);
+  });
+
+  it('recognizes explicit free variants without matching ordinary words', () => {
+    expect(getProviderModelBadges(createModel({ modelId: 'model(free)' }))).toEqual(['free']);
+    expect(getProviderModelBadges(createModel({ modelId: 'model-freestyle' }))).toEqual([]);
+  });
+
+  it('keeps CherryAI models free without relying on their names', () => {
+    expect(getProviderModelBadges(createModel({ providerId: 'CherryAI' }))).toEqual(['free']);
+  });
+});
+
+function createModel({
+  capabilities = [],
+  inputModalities,
+  modelId = 'model',
+  providerId = 'provider',
+}: {
+  capabilities?: Model['capabilities'];
+  inputModalities?: Model['inputModalities'];
+  modelId?: string;
+  providerId?: string;
+} = {}): Model {
+  return {
+    capabilities,
+    id: createUniqueModelId(providerId, modelId),
+    inputModalities,
+    isDeprecated: false,
+    isEnabled: true,
+    isHidden: false,
+    modelId,
+    name: 'Display name',
+    providerId,
+    supportsStreaming: true,
+  };
+}

--- a/src/frontend/features/settings/ProviderScreen/models/utils/providerModelBadges.ts
+++ b/src/frontend/features/settings/ProviderScreen/models/utils/providerModelBadges.ts
@@ -1,0 +1,37 @@
+import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+
+import type { Model } from '@/shared/data/types/model';
+
+export const PROVIDER_MODEL_BADGES = ['free', 'vision'] as const;
+
+export type ProviderModelBadge = (typeof PROVIDER_MODEL_BADGES)[number];
+
+const FREE_MARKER_PATTERN = /(?:^|[^a-z0-9])free(?:$|[^a-z0-9])/i;
+
+/** The small set of model traits that materially helps someone choose from a provider list. */
+export function getProviderModelBadges(model: Model): ProviderModelBadge[] {
+  const badges: ProviderModelBadge[] = [];
+
+  if (isFreeProviderModel(model)) {
+    badges.push('free');
+  }
+  if (isVisionProviderModel(model)) {
+    badges.push('vision');
+  }
+
+  return badges;
+}
+
+function isFreeProviderModel(model: Model): boolean {
+  if (model.providerId.toLocaleLowerCase() === 'cherryai') {
+    return true;
+  }
+
+  return [model.modelId, model.apiModelId, model.name, model.presetModelId].some(
+    (value) => value != null && FREE_MARKER_PATTERN.test(value),
+  );
+}
+
+function isVisionProviderModel(model: Model): boolean {
+  return model.capabilities.includes(MODEL_CAPABILITY.IMAGE_RECOGNITION);
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

Provider model management rows exposed raw model IDs while omitting the small set of traits that help users choose a model.

After this PR:

- Management rows hide raw model IDs and show compact Free and Vision badges.
- Synchronization rows retain raw model IDs because they are useful when reconciling provider catalogs.
- Vision is reported only when the runtime-backed `image-recognition` capability is present.
- Row accessibility labels include the localized badge meanings.

### Screenshots or videos

Not included yet. This is a draft PR, and device verification was not run because verification is user-owned for this workspace.

### Why we need it and why it was done in this way

The provider list should communicate product-relevant meaning instead of registry internals. The implementation deliberately projects only Free and Vision rather than rendering every generic registry tag.

The following tradeoffs were made:

- Free is inferred from CherryAI ownership or an explicit `free` marker because there is no authoritative pricing or entitlement field yet.
- Vision follows the same `image-recognition` capability used by the chat runtime; catalog input modalities alone do not qualify.
- Badge chips are feature-local because this presentation belongs specifically to provider model management.

The following alternatives were considered:

- Rendering all generic capability tags was rejected because several tags do not have complete mobile product flows.
- Treating an image input modality as sufficient for Vision was rejected because it can overstate current runtime support.

### Breaking changes

None.

### Special notes for your reviewer

Local checks:

- `pnpm lint` passed with existing repository warnings and no errors.
- `pnpm format:check` passed.
- Tests, typecheck, and manual device verification were not run per workspace verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: A screenshot or video still needs to be captured during device verification
- [x] Code: The change is kept feature-local and focused
- [x] Upgrade: No upgrade-flow impact
- [x] Documentation: No user-guide update is required for this presentation-only change
- [x] Self-review: Reviewed the final diff against `origin/v0.2`

### Release note

```release-note
Provider model lists now replace raw model IDs with compact Free and Vision badges.
```