### PR TITLE
fix: prevent duplicate React child keys

### DIFF
--- a/src/frontend/components/messages/parts/TextPart.tsx
+++ b/src/frontend/components/messages/parts/TextPart.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Text } from 'react-native';
 
-import { splitToolMentions } from '@/frontend/utils/toolMentions';
+import { type MentionSegment, splitToolMentions } from '@/frontend/utils/toolMentions';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import type { ResolvedCitationText } from './citations';
@@ -16,6 +16,25 @@ type TextPartProps = {
   resolvedText?: ResolvedCitationText;
 };
 
+function renderMentionSegments(segments: readonly MentionSegment[]) {
+  const occurrenceById = new Map<string, number>();
+
+  return segments.map((segment) => {
+    if (!segment.id) {
+      return segment.text;
+    }
+
+    const occurrence = occurrenceById.get(segment.id) ?? 0;
+    occurrenceById.set(segment.id, occurrence + 1);
+
+    return (
+      <Text className="text-brand" key={`${segment.id}-${occurrence}`}>
+        {segment.text}
+      </Text>
+    );
+  });
+}
+
 /**
  * Plain text with its tool mentions picked out in the brand color, showing the
  * name the sender saw rather than the link syntax carrying it. Nested `Text`
@@ -26,21 +45,7 @@ type TextPartProps = {
 function PlainTextWithMentions({ text }: { text: string }) {
   const segments = useMemo(() => splitToolMentions(text), [text]);
 
-  return (
-    <Text className="text-base text-foreground">
-      {segments.map((segment, index) =>
-        segment.id ? (
-          // Segments are derived from the text in order and never reordered, so
-          // the index is a stable identity here.
-          <Text className="text-brand" key={index}>
-            {segment.text}
-          </Text>
-        ) : (
-          segment.text
-        ),
-      )}
-    </Text>
-  );
+  return <Text className="text-base text-foreground">{renderMentionSegments(segments)}</Text>;
 }
 
 export function TextPart({

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -157,7 +157,7 @@ export function ChatWorkspace({
     <View className="flex-1 bg-background">
       <ChatOlderMessagesIndicator isLoading={isLoadingOlder} />
       <AssistantMessageActionsProvider
-        key={sessionId}
+        key={`assistant-actions-${sessionId}`}
         isAssistantToolbarEnabled={isAssistantToolbarEnabled}
         sessionId={sessionId}
       >
@@ -178,7 +178,7 @@ export function ChatWorkspace({
       </AssistantMessageActionsProvider>
       <ChatInitialRenderCover isVisible={isCoverVisible} />
       <ToolApprovalSheet
-        key={sessionId}
+        key={`tool-approval-${sessionId}`}
         approvals={pendingApprovals}
         isOpen={pendingApprovals.length > 0}
         onRespond={handleApprovalRespond}

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -277,6 +277,22 @@ describe('ChatWorkspace message rendering integration', () => {
     ).toBeGreaterThan(0);
   });
 
+  test('does not reuse a child key across Session-scoped surfaces', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      renderer = renderWorkspace(false, [createMessage('assistant-1', 'assistant')]);
+
+      expect(
+        consoleError.mock.calls.some(([message]) =>
+          String(message).includes('Encountered two children with the same key'),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test('does not show copy failure feedback from the previous Session', async () => {
     const clipboardWrite = createDeferred<void>();
     const assistant = createMessage('assistant-1', 'assistant');

--- a/src/frontend/features/home/aiUsage/components/AiUsageCalendar.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageCalendar.tsx
@@ -193,11 +193,11 @@ export function AiUsageCalendar({
                 {t('aiUsage.less')}
               </Text>
               <View accessible={false} className="flex-row gap-1">
-                {levelColors.map((color, level) => (
+                {aiUsageLevelColors.map((colorName, level) => (
                   <View
                     className="size-3"
-                    key={color}
-                    style={{ backgroundColor: color }}
+                    key={colorName}
+                    style={{ backgroundColor: levelColors[level] }}
                     testID={`ai-usage-legend-level-${level}`}
                   />
                 ))}


### PR DESCRIPTION
## Summary

- give session-scoped chat surfaces distinct React keys to stop repeated LogBox warnings
- use stable identities for tool mentions and AI usage legend items
- add regression coverage for duplicate sibling keys in the chat workspace

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with 16 existing warnings)
- `pnpm format:check`
- 7 related Jest suites: 57 tests passed

## Notes

- Manual device verification was not run.
