### PR TITLE
fix(chat-messages): keep attachments with user text

### DIFF
--- a/src/frontend/components/messages/parts/MessageFileStrip.tsx
+++ b/src/frontend/components/messages/parts/MessageFileStrip.tsx
@@ -38,6 +38,8 @@ export function MessageFileStrip({ parts }: { parts: readonly MessageFilePart[] 
 
 const styles = StyleSheet.create({
   strip: {
+    flexGrow: 0,
+    flexShrink: 0,
     height: FILE_CARD_SIZE,
   },
 });

--- a/src/frontend/components/messages/rows/__tests__/UserMessage.test.tsx
+++ b/src/frontend/components/messages/rows/__tests__/UserMessage.test.tsx
@@ -49,7 +49,13 @@ describe('UserMessage', () => {
     expect(scrollView.props.showsHorizontalScrollIndicator).toBe(false);
     // The row owns its own height; the wrapper only pins it to the user column.
     expect(attachmentContainer).toBeDefined();
-    expect(StyleSheet.flatten(scrollView.props.style)?.height).toBe(112);
+    expect(StyleSheet.flatten(scrollView.props.style)).toEqual(
+      expect.objectContaining({
+        flexGrow: 0,
+        flexShrink: 0,
+        height: 112,
+      }),
+    );
     expect(renderer.root.findAllByType('FilePart').map((node) => node.props.part)).toEqual([
       first,
       second,


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: React Native's default `ScrollView` flex growth could expand an image attachment strip from 112 to 476 points, separating the user's text from the image and placing an assistant reply between them.

After this PR: attachment strips opt out of flex growth and shrinking, preserving their 112-point height and keeping image and text parts together.

### Screenshots or videos

Verified on the workspace iPhone 17 Pro simulator in light and dark modes; the attachment strip measured 112 points after the fix and the text rendered directly below the image.

### Why we need it and why it was done in this way

The following tradeoffs were made: the fix overrides only the inherited flex behavior at the attachment strip boundary, leaving message data, list virtualization, and component structure unchanged.

The following alternatives were considered: restructuring the message row or list measurement was rejected because runtime inspection proved the message remained intact and only the nested horizontal `ScrollView` had the wrong height.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validation: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and the focused `UserMessage` test suite all pass; lint reports only existing repository warnings.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Fixes image attachments causing user message text to appear separated in chat.
```
