### PR TITLE
fix(testing): mock worklets in message part tests

### DIFF
--- a/packages/ui/src/components/message-part/__tests__/message-part.test.tsx
+++ b/packages/ui/src/components/message-part/__tests__/message-part.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { MessagePart } from '..';
@@ -111,6 +111,13 @@ jest.mock('react-native-reanimated', () => {
   };
 });
 
+jest.mock('react-native-worklets', () => ({
+  scheduleOnRN: (callback: () => void) => callback(),
+}));
+
+const findRenderedByTestId = (renderer: ReactTestRenderer, testID: string) =>
+  renderer.root.findAllByType(View).filter((node) => node.props.testID === testID);
+
 describe('MessagePart', () => {
   let renderer: ReactTestRenderer | undefined;
 
@@ -165,16 +172,16 @@ describe('MessagePart', () => {
     });
 
     expect(renderer!.root.findByProps({ active: true })).toBeDefined();
-    expect(renderer!.root.findAllByProps({ testID: 'thinking-detail' })).toHaveLength(0);
+    expect(findRenderedByTestId(renderer!, 'thinking-detail')).toHaveLength(0);
     act(() => renderer!.root.findByProps({ testID: 'thinking-trigger' }).props.onPress());
     expect(mockBottomSheetProps).toEqual({});
     expect(onDisclosureToggle).toHaveBeenCalledTimes(1);
-    expect(renderer!.root.findByProps({ testID: 'thinking-detail' })).toBeDefined();
+    expect(findRenderedByTestId(renderer!, 'thinking-detail')).toHaveLength(1);
     expect(renderer!.root.findByProps({ children: 'Live reasoning' })).toBeDefined();
 
     act(() => renderer!.root.findByProps({ testID: 'thinking-trigger' }).props.onPress());
     expect(onDisclosureToggle).toHaveBeenCalledTimes(2);
-    expect(renderer!.root.findAllByProps({ testID: 'thinking-detail' })).toHaveLength(0);
+    expect(findRenderedByTestId(renderer!, 'thinking-detail')).toHaveLength(0);
   });
 
   it('shimmers the running tool title without removing its status text', () => {
@@ -211,7 +218,7 @@ describe('MessagePart', () => {
     });
 
     // Live run: steps visible without any press, title shimmering.
-    expect(renderer!.root.findByProps({ testID: 'group-steps' })).toBeDefined();
+    expect(findRenderedByTestId(renderer!, 'group-steps')).toHaveLength(1);
     expect(renderer!.root.findByProps({ accessibilityHint: 'shimmer' }).props.children).toBe(
       'Working with tools…',
     );
@@ -225,9 +232,9 @@ describe('MessagePart', () => {
     });
 
     // Settled run folds to its summary until the reader asks for the steps.
-    expect(renderer!.root.findAllByProps({ testID: 'group-steps' })).toHaveLength(0);
+    expect(findRenderedByTestId(renderer!, 'group-steps')).toHaveLength(0);
     act(() => renderer!.root.findByProps({ testID: 'group-trigger' }).props.onPress());
-    expect(renderer!.root.findByProps({ testID: 'group-steps' })).toBeDefined();
+    expect(findRenderedByTestId(renderer!, 'group-steps')).toHaveLength(1);
   });
 
   it('lets a manual toggle override the running default of a tool group', () => {
@@ -246,7 +253,7 @@ describe('MessagePart', () => {
     });
 
     act(() => renderer!.root.findByProps({ testID: 'group-trigger' }).props.onPress());
-    expect(renderer!.root.findAllByProps({ testID: 'group-steps' })).toHaveLength(0);
+    expect(findRenderedByTestId(renderer!, 'group-steps')).toHaveLength(0);
     expect(renderer!.root.findByProps({ children: '1 failed' }).props.className).toContain(
       'text-destructive',
     );


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: the message-part Jest suite loaded the native Worklets module and crashed in Linux CI before running its tests.

After this PR: the suite uses a deterministic Worklets mock and checks rendered native views when asserting collapsible visibility.

### Screenshots or videos

N/A; this changes only the test harness and has no visible product effect.

### Why we need it and why it was done in this way

The mock is scoped to the affected suite, while the assertions now verify rendered output instead of matching non-rendering composite wrappers.

The alternative of a global Worklets mock was avoided because unrelated suites do not currently require it.

### Breaking changes

None.

### Special notes for your reviewer

Verified with `PRCI=true pnpm test` (380 suites, 3,158 tests), `pnpm typecheck`, `pnpm lint`, and `pnpm format:check`.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
