### PR TITLE
feat(chat-draft): add branded welcome state

### DIFF
--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -24,7 +24,7 @@ import { DataApiError, ErrorCode } from '@/shared/data/api/errors';
 
 import { ChatInput } from './input';
 import { ChatRouteResolver } from './navigation';
-import { ChatEmptyState, ChatWorkspace } from './workspace';
+import { ChatDraftState, ChatEmptyState, ChatWorkspace } from './workspace';
 
 const PREVIEW_CONTENT_BOTTOM_INSET = 12;
 
@@ -90,6 +90,8 @@ function ResolvedChatScreen({ target }: { target: ChatTarget }) {
             messageWindow={messageWindow}
             sessionId={sessionId}
           />
+        ) : target.kind === 'draft' ? (
+          <ChatDraftState contentBottomInset={contentBottomInset} />
         ) : (
           <ChatEmptyState contentBottomInset={contentBottomInset} />
         )}

--- a/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
+++ b/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
@@ -87,6 +87,7 @@ jest.mock('../navigation', () => ({
 }));
 
 jest.mock('../workspace', () => ({
+  ChatDraftState: () => null,
   ChatEmptyState: () => null,
   ChatWorkspace: (props: Record<string, unknown>) => {
     chatWorkspaceProps = props;

--- a/src/frontend/features/chat/workspace/components/ChatDraftState.tsx
+++ b/src/frontend/features/chat/workspace/components/ChatDraftState.tsx
@@ -1,0 +1,36 @@
+import { Image } from '@cherrystudio/ui/components';
+import { useTranslation } from 'react-i18next';
+import { Text, View } from 'react-native';
+
+const CHERRY_STUDIO_LOGO = require('@/assets/cherry-studio-splash-logo.png');
+
+type ChatDraftStateProps = {
+  contentBottomInset: number;
+};
+
+/** Quiet brand surface shown before the first message is sent. */
+export function ChatDraftState({ contentBottomInset }: ChatDraftStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <View
+      className="flex-1 items-center justify-center px-8"
+      style={{ paddingBottom: contentBottomInset }}
+    >
+      <View className="items-center gap-6">
+        <View className="size-16 items-center justify-center rounded-full bg-primary/10">
+          <Image
+            accessibilityIgnoresInvertColors
+            accessible={false}
+            className="size-16"
+            contentFit="contain"
+            source={CHERRY_STUDIO_LOGO}
+          />
+        </View>
+        <Text className="text-center font-medium text-foreground text-xl" numberOfLines={2}>
+          {t('chat.draft.greeting')}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/src/frontend/features/chat/workspace/index.ts
+++ b/src/frontend/features/chat/workspace/index.ts
@@ -1,2 +1,3 @@
 export { ChatWorkspace } from './ChatWorkspace';
+export { ChatDraftState } from './components/ChatDraftState';
 export { ChatEmptyState } from './components/ChatEmptyState';

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -127,6 +127,7 @@
   "chat.attachments.importFailed_one": "Could not add {{count}} attachment.",
   "chat.attachments.importFailed_other": "Could not add {{count}} attachments.",
   "chat.attachments.unsupportedImageFormat": "Only JPEG, PNG, GIF, and WebP images are supported.",
+  "chat.draft.greeting": "What should we create together today?",
   "chat.errorPart.message": "Unknown error",
   "chat.errorPart.reason.auth": "Authentication failed",
   "chat.errorPart.reason.contentFilter": "Content was blocked",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -126,6 +126,7 @@
   "chat.attachments.image": "图片附件",
   "chat.attachments.importFailed": "有 {{count}} 个附件导入失败。",
   "chat.attachments.unsupportedImageFormat": "仅支持 JPEG、PNG、GIF 和 WebP 格式的图片。",
+  "chat.draft.greeting": "今天想一起做点什么？",
   "chat.errorPart.message": "未知错误",
   "chat.errorPart.reason.auth": "身份验证失败",
   "chat.errorPart.reason.contentFilter": "内容被安全策略拦截",


### PR DESCRIPTION
## Summary

- add a dedicated centered welcome surface for draft chats
- use the static Cherry Studio mark with a compact soft brand background
- show a concise localized greeting without agent or model identity

## Validation

- `pnpm format:check`
- `pnpm lint` (passes with existing repository warnings)

Not run per workspace instructions: tests, builds, or simulator verification.