### PR TITLE
feat(chat-messages): refine assistant response presentation

### DIFF
--- a/packages/app-icons/src/icons/git-fork.tsx
+++ b/packages/app-icons/src/icons/git-fork.tsx
@@ -1,0 +1,5 @@
+import Icon from 'lucide-react-native/icons/git-fork';
+
+import { createIcon } from '../create-icon';
+
+export default createIcon(Icon, 'GitForkIcon');

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -109,6 +109,10 @@ translations, file identifiers, or application navigation:
 </MessagePart.Tool>
 ```
 
+`MessagePart.Process` is the inline disclosure used for one total-duration row before an answer.
+The product adapter supplies its localized duration and every visible pre-result child; the
+primitive owns the quiet divider, running shimmer, disclosure state, and compact chevron.
+
 The native Storybook exposes these states under the dedicated top-level `Message Parts` section.
 `Message Parts/Playground` collects every public message-part primitive and state on one interactive
 page for visual debugging.

--- a/packages/ui/src/components/markdown-text/__tests__/markdown-text.test.tsx
+++ b/packages/ui/src/components/markdown-text/__tests__/markdown-text.test.tsx
@@ -52,7 +52,7 @@ describe('MarkdownText', () => {
           allowTrailingMargin: false,
           flavor: 'github',
           markdown: 'Hello',
-          md4cFlags: { latexMath: true, underline: false },
+          md4cFlags: { latexMath: true, superscript: true, underline: false },
           selectable: true,
         }),
       );
@@ -61,7 +61,7 @@ describe('MarkdownText', () => {
           paragraph: expect.objectContaining({
             color: 'foreground',
             fontSize: 20,
-            lineHeight: 26,
+            lineHeight: 28,
             marginBottom: 12,
             marginTop: 0,
           }),
@@ -76,8 +76,8 @@ describe('MarkdownText', () => {
           list: expect.objectContaining({
             fontSize: 20,
             gapWidth: 10,
-            lineHeight: 26,
-            marginLeft: 20,
+            lineHeight: 28,
+            marginLeft: 8,
             marginTop: 0,
             markerMinWidth: 30,
           }),
@@ -105,6 +105,14 @@ describe('MarkdownText', () => {
             padding: 12,
             textAlign: 'center',
           }),
+          linkVariants: {
+            '^cite:': {
+              backgroundColor: 'secondary',
+              color: 'foreground-tertiary',
+              underline: false,
+            },
+          },
+          superscript: { baselineOffsetScale: 0.3, fontScale: 0.75 },
         }),
       );
       expect(renderer.root.findAllByType(excluded)).toHaveLength(0);

--- a/packages/ui/src/components/markdown-text/components/markdown-text.tsx
+++ b/packages/ui/src/components/markdown-text/components/markdown-text.tsx
@@ -15,6 +15,7 @@ const markdownThemeVariables = [
   '--color-background',
   '--color-primary',
   '--color-muted-foreground',
+  '--color-foreground-tertiary',
   '--color-link',
   '--color-border',
   '--color-secondary',
@@ -43,9 +44,10 @@ function createMarkdownTypographyStyle(
   monoFontFamily: string,
 ): MarkdownStyle {
   const scale = resolveTypographyScale(fontSizeStep);
+  const prose = { ...scale.base, lineHeight: scale.base.lineHeight + 2 };
 
   return {
-    paragraph: { ...scale.base, marginBottom: 12, marginTop: 0 },
+    paragraph: { ...prose, marginBottom: 12, marginTop: 0 },
     h1: { ...scale.xl, fontWeight: '700', marginBottom: 10, marginTop: 0 },
     h2: { ...scale.lg, fontWeight: '600', marginBottom: 8, marginTop: 0 },
     h3: { ...scale.base, fontWeight: '600', marginBottom: 8, marginTop: 0 },
@@ -53,7 +55,7 @@ function createMarkdownTypographyStyle(
     h5: { ...scale.base, fontWeight: '600', marginBottom: 6, marginTop: 0 },
     h6: { ...scale.sm, fontWeight: '600', marginBottom: 6, marginTop: 0 },
     blockquote: {
-      ...scale.base,
+      ...prose,
       borderRadius: 0,
       borderWidth: 3,
       gapWidth: 12,
@@ -62,12 +64,12 @@ function createMarkdownTypographyStyle(
       padding: 2,
     },
     list: {
-      ...scale.base,
+      ...prose,
       bulletSize: 6,
       gapWidth: 10,
       itemSpacing: 6,
       marginBottom: 12,
-      marginLeft: 20,
+      marginLeft: 8,
       marginTop: 0,
       markerFontWeight: '500',
       // Floors every marker column to the width an ordered list reserves for
@@ -117,6 +119,7 @@ export function MarkdownText({
     backgroundValue,
     primaryValue,
     mutedForegroundValue,
+    foregroundTertiaryValue,
     linkValue,
     borderValue,
     secondaryValue,
@@ -129,6 +132,7 @@ export function MarkdownText({
   const background = resolveCSSString(backgroundValue);
   const primary = resolveCSSString(primaryValue);
   const mutedForeground = resolveCSSString(mutedForegroundValue);
+  const foregroundTertiary = resolveCSSString(foregroundTertiaryValue);
   const link = resolveCSSString(linkValue);
   const border = resolveCSSString(borderValue);
   const secondary = resolveCSSString(secondaryValue);
@@ -183,6 +187,9 @@ export function MarkdownText({
         syntaxColors: resolveSyntaxColors(theme, mutedForeground),
       },
       link: { color: link, underline: false },
+      linkVariants: {
+        '^cite:': { backgroundColor: secondary, color: foregroundTertiary, underline: false },
+      },
       strong: { color: foreground },
       em: { color: foreground },
       strikethrough: { color: mutedForeground },
@@ -216,6 +223,7 @@ export function MarkdownText({
       inlineMath: { color: foreground },
       highlight: { backgroundColor: secondary, color: foreground },
       spoiler: { color: mutedForeground, solid: { borderRadius: 4 } },
+      superscript: { baselineOffsetScale: 0.3, fontScale: 0.75 },
     };
   }, [
     background,
@@ -223,6 +231,7 @@ export function MarkdownText({
     codeBlock,
     fontSizeStep,
     foreground,
+    foregroundTertiary,
     inlineCode,
     inlineCodeForeground,
     link,
@@ -239,7 +248,7 @@ export function MarkdownText({
       flavor="github"
       markdown={markdown}
       markdownStyle={markdownStyle}
-      md4cFlags={{ latexMath: true, underline: false }}
+      md4cFlags={{ latexMath: true, superscript: true, underline: false }}
       onLinkPress={handleLinkPress}
       selectable={selectable}
     />

--- a/packages/ui/src/components/message-part/__tests__/message-part.test.tsx
+++ b/packages/ui/src/components/message-part/__tests__/message-part.test.tsx
@@ -16,10 +16,6 @@ jest.mock(
   () => jest.requireActual('react-native').View,
 );
 jest.mock(
-  '@cherrystudio/app-icons/icons/list-checks',
-  () => jest.requireActual('react-native').View,
-);
-jest.mock(
   '@cherrystudio/app-icons/icons/circle-alert',
   () => jest.requireActual('react-native').View,
 );
@@ -42,7 +38,6 @@ jest.mock('@cherrystudio/app-icons/icons/triangle-alert', () => {
     return <MockView {...props} testID="unknown-warning-icon" />;
   };
 });
-jest.mock('@cherrystudio/app-icons/icons/wrench', () => jest.requireActual('react-native').View);
 
 jest.mock('../../bottom-sheet', () => {
   const { View } = jest.requireActual('react-native');
@@ -171,7 +166,6 @@ describe('MessagePart', () => {
       );
     });
 
-    expect(renderer!.root.findByProps({ active: true })).toBeDefined();
     expect(findRenderedByTestId(renderer!, 'thinking-detail')).toHaveLength(0);
     act(() => renderer!.root.findByProps({ testID: 'thinking-trigger' }).props.onPress());
     expect(mockBottomSheetProps).toEqual({});
@@ -182,6 +176,28 @@ describe('MessagePart', () => {
     act(() => renderer!.root.findByProps({ testID: 'thinking-trigger' }).props.onPress());
     expect(onDisclosureToggle).toHaveBeenCalledTimes(2);
     expect(findRenderedByTestId(renderer!, 'thinking-detail')).toHaveLength(0);
+  });
+
+  it('keeps the total process duration folded until the reader expands it', () => {
+    const onDisclosureToggle = jest.fn();
+    act(() => {
+      renderer = create(
+        <MessagePart.Process
+          onDisclosureToggle={onDisclosureToggle}
+          state="complete"
+          testID="process"
+          title="Took 16s"
+        >
+          <Text>Reasoning and tools</Text>
+        </MessagePart.Process>,
+      );
+    });
+
+    expect(renderer!.root.findAllByProps({ testID: 'process-detail' })).toHaveLength(0);
+    act(() => renderer!.root.findByProps({ testID: 'process-trigger' }).props.onPress());
+    expect(onDisclosureToggle).toHaveBeenCalledTimes(1);
+    expect(renderer!.root.findByProps({ testID: 'process-detail' })).toBeDefined();
+    expect(renderer!.root.findByProps({ children: 'Reasoning and tools' })).toBeDefined();
   });
 
   it('shimmers the running tool title without removing its status text', () => {

--- a/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
@@ -53,7 +53,7 @@ export function MessagePartProcess({
   };
 
   return (
-    <View className="gap-1.5 border-border-subtle border-b pb-2">
+    <View className={`gap-1.5 border-border-subtle border-b ${isOpen ? 'pb-2' : ''}`}>
       <MessagePartStatus
         accessibilityLabel={title}
         expanded={isOpen}

--- a/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
@@ -1,6 +1,4 @@
 import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
-import ListChecksIcon from '@cherrystudio/app-icons/icons/list-checks';
-import WrenchIcon from '@cherrystudio/app-icons/icons/wrench';
 import { useEffect, useState } from 'react';
 import { ScrollView, Text, View } from 'react-native';
 import Animated, {
@@ -13,10 +11,10 @@ import Animated, {
 import { duration, easing } from '../../../motion';
 import { BottomSheet } from '../../bottom-sheet';
 import { Image } from '../../image';
-import { PrismSweep } from '../../loading';
 import { ShimmerText } from '../../shimmer-text';
 import type {
   MessagePartDetailProps,
+  MessagePartProcessProps,
   MessagePartReasoningProps,
   MessagePartSummaryProps,
   MessagePartTone,
@@ -36,9 +34,53 @@ const disclosureIconMotion = {
 
 const toneClassName = {
   danger: 'text-destructive',
-  default: 'text-muted-foreground',
+  default: 'text-foreground-tertiary',
   warning: 'text-warning',
 } as const satisfies Record<MessagePartTone, string>;
+
+export function MessagePartProcess({
+  children,
+  onDisclosureToggle,
+  state,
+  testID = 'process',
+  title,
+}: MessagePartProcessProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const isRunning = state === 'running';
+  const toggle = () => {
+    onDisclosureToggle?.();
+    setIsOpen((open) => !open);
+  };
+
+  return (
+    <View className="gap-1.5 border-border-subtle border-b pb-2">
+      <MessagePartStatus
+        accessibilityLabel={title}
+        expanded={isOpen}
+        onPress={toggle}
+        testID={`${testID}-trigger`}
+      >
+        <View className="min-w-0 flex-row items-center gap-1">
+          <View className="min-w-0 shrink">
+            {isRunning ? (
+              <ShimmerText className="text-sm" numberOfLines={1}>
+                {title}
+              </ShimmerText>
+            ) : (
+              <Text className="text-foreground-tertiary text-sm" numberOfLines={1}>
+                {title}
+              </Text>
+            )}
+          </View>
+          <MessagePartDisclosureIcon isOpen={isOpen} />
+        </View>
+      </MessagePartStatus>
+      <MessagePartCollapsible className="gap-1" isOpen={isOpen} testID={`${testID}-detail`}>
+        {children}
+      </MessagePartCollapsible>
+    </View>
+  );
+}
 
 export function MessagePartReasoning({
   children,
@@ -62,14 +104,13 @@ export function MessagePartReasoning({
         onPress={toggle}
         testID={`${testID}-trigger`}
       >
-        {isRunning ? <PrismSweep active /> : null}
-        <View className="min-w-0 flex-1">
+        <View className="min-w-0 shrink">
           {isRunning ? (
             <ShimmerText className="text-sm" numberOfLines={1}>
               {statusText}
             </ShimmerText>
           ) : (
-            <Text className="text-muted-foreground text-sm" numberOfLines={1}>
+            <Text className="text-foreground-tertiary text-sm" numberOfLines={1}>
               {statusText}
             </Text>
           )}
@@ -115,8 +156,7 @@ export function MessagePartToolGroup({
         onPress={toggle}
         testID={`${testID}-trigger`}
       >
-        <ListChecksIcon className={`size-4 ${colorClassName}`} />
-        <View className="min-w-0 flex-1">
+        <View className="min-w-0 shrink">
           {isRunning ? (
             <ShimmerText className="text-sm" numberOfLines={1}>
               {title}
@@ -127,12 +167,13 @@ export function MessagePartToolGroup({
             </Text>
           )}
         </View>
+        <MessagePartDisclosureIcon isOpen={isOpen} />
+        <View className="flex-1" />
         {statusText ? (
           <Text className={`max-w-[38%] shrink-0 text-xs ${colorClassName}`} numberOfLines={1}>
             {statusText}
           </Text>
         ) : null}
-        <MessagePartDisclosureIcon isOpen={isOpen} />
       </MessagePartStatus>
       <MessagePartCollapsible className="gap-1" isOpen={isOpen} testID={`${testID}-steps`}>
         {children}
@@ -154,7 +195,7 @@ function MessagePartDisclosureIcon({ isOpen }: { isOpen: boolean }) {
 
   return (
     <Animated.View pointerEvents="none" style={animatedStyle}>
-      <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      <ChevronRightIcon className="size-3 shrink-0 text-foreground-tertiary" />
     </Animated.View>
   );
 }
@@ -163,8 +204,6 @@ export function MessagePartTool({
   children,
   detailTitle,
   detailVariant = 'default',
-  icon: Icon = WrenchIcon,
-  imageSource,
   state,
   statusText,
   statusTone = 'default',
@@ -176,8 +215,6 @@ export function MessagePartTool({
   return (
     <View className="gap-1.5">
       <MessagePartSummary
-        icon={Icon}
-        imageSource={imageSource}
         onPress={() => setIsOpen(true)}
         state={state}
         statusText={statusText}
@@ -201,7 +238,7 @@ export function MessagePartTool({
 }
 
 export function MessagePartSummary({
-  icon: Icon = WrenchIcon,
+  icon: Icon,
   imageSource,
   onPress,
   state,
@@ -226,10 +263,10 @@ export function MessagePartSummary({
           contentFit="contain"
           source={imageSource}
         />
-      ) : (
+      ) : Icon ? (
         <Icon className={`size-4 ${colorClassName}`} />
-      )}
-      <View className="min-w-0 flex-1">
+      ) : null}
+      <View className="min-w-0 shrink">
         {isRunning ? (
           <ShimmerText className="text-sm" numberOfLines={1} testID={`${testID}-running-title`}>
             {title}
@@ -240,12 +277,13 @@ export function MessagePartSummary({
           </Text>
         )}
       </View>
+      <ChevronRightIcon className="size-3 shrink-0 text-foreground-tertiary" />
+      <View className="flex-1" />
       {statusText ? (
         <Text className={`max-w-[38%] shrink-0 text-xs ${colorClassName}`} numberOfLines={1}>
           {statusText}
         </Text>
       ) : null}
-      <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
     </MessagePartStatus>
   );
 }

--- a/packages/ui/src/components/message-part/components/message-part.tsx
+++ b/packages/ui/src/components/message-part/components/message-part.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import type { MessagePartRootProps } from '../message-part.types';
 import {
   MessagePartDetail,
+  MessagePartProcess,
   MessagePartReasoning,
   MessagePartSummary,
   MessagePartTool,
@@ -34,6 +35,7 @@ export const MessagePart = Object.assign(MessagePartRoot, {
   Error: MessagePartError,
   Pending: MessagePartPending,
   Placeholder: MessagePartPlaceholder,
+  Process: MessagePartProcess,
   Reasoning: MessagePartReasoning,
   SectionTitle: MessagePartSectionTitle,
   Source: MessagePartSource,

--- a/packages/ui/src/components/message-part/index.ts
+++ b/packages/ui/src/components/message-part/index.ts
@@ -4,6 +4,7 @@ export type {
   MessagePartErrorProps,
   MessagePartPendingProps,
   MessagePartPlaceholderProps,
+  MessagePartProcessProps,
   MessagePartReasoningProps,
   MessagePartRootProps,
   MessagePartSectionTitleProps,

--- a/packages/ui/src/components/message-part/message-part.types.ts
+++ b/packages/ui/src/components/message-part/message-part.types.ts
@@ -26,6 +26,15 @@ export type MessagePartReasoningProps = {
   testID?: string;
 };
 
+export type MessagePartProcessProps = {
+  children: ReactNode;
+  /** Runs before a reader-initiated inline disclosure toggle. */
+  onDisclosureToggle?: () => void;
+  state: 'complete' | 'running';
+  title: string;
+  testID?: string;
+};
+
 export type MessagePartToolGroupProps = {
   children: ReactNode;
   /** Runs before a reader-initiated inline disclosure toggle. */
@@ -67,7 +76,10 @@ export type MessagePartSummaryProps = {
   title: string;
 };
 
-export type MessagePartToolProps = Omit<MessagePartSummaryProps, 'onPress'> & {
+export type MessagePartToolProps = Omit<
+  MessagePartSummaryProps,
+  'icon' | 'imageSource' | 'onPress'
+> & {
   children: ReactNode;
   detailTitle?: string;
   detailVariant?: 'default' | 'source-list';

--- a/packages/ui/src/components/scroll-to-bottom-button/__tests__/scroll-to-bottom-button.test.tsx
+++ b/packages/ui/src/components/scroll-to-bottom-button/__tests__/scroll-to-bottom-button.test.tsx
@@ -75,15 +75,15 @@ describe('ScrollToBottomButton', () => {
     });
 
     expect(renderer!.root.findByType('Surface').props).toMatchObject({
-      className: 'border border-border bg-secondary',
+      className: 'border border-border bg-background',
       cornerRadius: 20,
       interactive: true,
       style: [
         { alignItems: 'center', height: 40, justifyContent: 'center', width: 40 },
         { borderColor: 'rgba(160, 160, 160, 0.3)', borderWidth: 1 },
       ],
-      tintColor: 'rgba(120, 120, 120, 0.24)',
     });
+    expect(renderer!.root.findByType('Surface').props.tintColor).toBeUndefined();
 
     const animatedViews = renderer!.root.findAllByType('AnimatedView');
     expect(animatedViews[0].props.style).toEqual([

--- a/packages/ui/src/components/scroll-to-bottom-button/components/scroll-to-bottom-button.tsx
+++ b/packages/ui/src/components/scroll-to-bottom-button/components/scroll-to-bottom-button.tsx
@@ -6,8 +6,8 @@ import { useResolveClassNames } from 'uniwind';
 import { duration, easing } from '../../../motion';
 import { Surface } from '../../surface';
 
-const BUTTON_SIZE = 40;
-const SURFACE_CLASS_NAME = 'border border-border bg-secondary';
+export const scrollToBottomButtonSize = 40;
+const SURFACE_CLASS_NAME = 'border border-border bg-background';
 const visibilityMotion = { duration: duration.fast, easing: easing.settle } as const;
 
 export type ScrollToBottomButtonProps = {
@@ -26,8 +26,6 @@ export function ScrollToBottomButton({
   onPress,
 }: ScrollToBottomButtonProps) {
   const surfaceTokens = useResolveClassNames(SURFACE_CLASS_NAME);
-  const tintColor =
-    typeof surfaceTokens.backgroundColor === 'string' ? surfaceTokens.backgroundColor : undefined;
   const surfaceStyle = [
     styles.surface,
     { borderColor: surfaceTokens.borderColor, borderWidth: surfaceTokens.borderWidth },
@@ -57,10 +55,9 @@ export function ScrollToBottomButton({
         >
           <Surface
             className={SURFACE_CLASS_NAME}
-            cornerRadius={BUTTON_SIZE / 2}
+            cornerRadius={scrollToBottomButtonSize / 2}
             interactive
             style={surfaceStyle}
-            tintColor={tintColor}
           >
             <ArrowDownIcon className="size-5 text-foreground" />
           </Surface>
@@ -73,9 +70,9 @@ export function ScrollToBottomButton({
 const styles = StyleSheet.create({
   surface: {
     alignItems: 'center',
-    height: BUTTON_SIZE,
+    height: scrollToBottomButtonSize,
     justifyContent: 'center',
-    width: BUTTON_SIZE,
+    width: scrollToBottomButtonSize,
   },
   wrap: {
     alignItems: 'center',

--- a/packages/ui/src/components/scroll-to-bottom-button/index.ts
+++ b/packages/ui/src/components/scroll-to-bottom-button/index.ts
@@ -1,2 +1,5 @@
-export { ScrollToBottomButton } from './components/scroll-to-bottom-button';
+export {
+  ScrollToBottomButton,
+  scrollToBottomButtonSize,
+} from './components/scroll-to-bottom-button';
 export type { ScrollToBottomButtonProps } from './components/scroll-to-bottom-button';

--- a/packages/ui/stories/message-parts/playground.stories.tsx
+++ b/packages/ui/stories/message-parts/playground.stories.tsx
@@ -1,5 +1,3 @@
-import SearchIcon from '@cherrystudio/app-icons/icons/search';
-import WrenchIcon from '@cherrystudio/app-icons/icons/wrench';
 import { FilePreview, MarkdownText, MessagePart } from '@cherrystudio/ui/components';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import type { ReactNode } from 'react';
@@ -171,20 +169,18 @@ export const AllStates: Story = {
           <StoryGroup title="Tools">
             <MessagePart>
               <MessagePart.Tool
-                icon={SearchIcon}
                 state="running"
                 statusText="Searching"
                 testID="playground-search-running"
-                title="Cherry Studio"
+                title="Search web"
               >
                 <Text className="text-foreground text-base">Waiting for results...</Text>
               </MessagePart.Tool>
               <MessagePart.Tool
-                icon={SearchIcon}
                 state="complete"
                 statusText="3 results"
                 testID="playground-search-complete"
-                title="Cherry Studio"
+                title="Search web"
               >
                 <MessagePart.Source
                   label="Cherry Studio"
@@ -200,7 +196,6 @@ export const AllStates: Story = {
                 />
               </MessagePart.Tool>
               <MessagePart.Tool
-                icon={WrenchIcon}
                 state="running"
                 statusText="Running"
                 testID="playground-tool-running"
@@ -209,7 +204,6 @@ export const AllStates: Story = {
                 <MessagePart.ValueSection title="Arguments" value={{ expression: '21 * 2' }} />
               </MessagePart.Tool>
               <MessagePart.Tool
-                icon={WrenchIcon}
                 state="complete"
                 statusText="Completed"
                 testID="playground-tool-complete"

--- a/packages/ui/stories/message-parts/tools.stories.tsx
+++ b/packages/ui/stories/message-parts/tools.stories.tsx
@@ -1,5 +1,3 @@
-import SearchIcon from '@cherrystudio/app-icons/icons/search';
-import WrenchIcon from '@cherrystudio/app-icons/icons/wrench';
 import { MessagePart } from '@cherrystudio/ui/components';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { Text } from 'react-native';
@@ -27,20 +25,18 @@ export const States: Story = {
       {() => (
         <MessagePart>
           <MessagePart.Tool
-            icon={SearchIcon}
             state="running"
             statusText="Searching"
             testID="story-search-running"
-            title="Cherry Studio"
+            title="Search web"
           >
             <Text className="text-foreground text-base">Waiting for results...</Text>
           </MessagePart.Tool>
           <MessagePart.Tool
-            icon={SearchIcon}
             state="complete"
             statusText="3 results"
             testID="story-search-complete"
-            title="Cherry Studio"
+            title="Search web"
           >
             <MessagePart.Source
               label="Cherry Studio"
@@ -56,7 +52,6 @@ export const States: Story = {
             />
           </MessagePart.Tool>
           <MessagePart.Tool
-            icon={WrenchIcon}
             state="running"
             statusText="Running"
             testID="story-tool-running"
@@ -65,7 +60,6 @@ export const States: Story = {
             <MessagePart.ValueSection title="Arguments" value={{ expression: '21 * 2' }} />
           </MessagePart.Tool>
           <MessagePart.Tool
-            icon={WrenchIcon}
             state="complete"
             statusText="Completed"
             testID="story-tool-complete"

--- a/src/frontend/components/markdown/README.md
+++ b/src/frontend/components/markdown/README.md
@@ -4,6 +4,10 @@ Application adapter over CherryUI `MarkdownText` for chat content and non-chat p
 only the global typography preference and opening external links; CherryUI owns renderer selection,
 theme tokens, syntax highlighting, GitHub flavor, LaTeX, and typography styles.
 
+Message citations use an internal `cite:` link prefix. CherryUI recognizes that prefix for its
+quiet gray superscript treatment, while this adapter decodes it back to the original HTTP URL
+before opening it. Ordinary body links keep the standard link treatment.
+
 ## Code blocks
 
 Syntax highlighting is native (tree-sitter, compiled into the binary) and math is rendered by

--- a/src/frontend/components/markdown/citationLink.ts
+++ b/src/frontend/components/markdown/citationLink.ts
@@ -1,0 +1,15 @@
+const CITATION_LINK_PREFIX = 'cite:';
+
+export function createCitationLinkUrl(url: string): string {
+  return `${CITATION_LINK_PREFIX}${encodeURIComponent(url)}`;
+}
+
+export function resolveCitationLinkUrl(url: string): string | undefined {
+  if (!url.startsWith(CITATION_LINK_PREFIX)) return undefined;
+
+  try {
+    return decodeURIComponent(url.slice(CITATION_LINK_PREFIX.length));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/frontend/components/markdown/components/MarkdownText.tsx
+++ b/src/frontend/components/markdown/components/MarkdownText.tsx
@@ -5,6 +5,8 @@ import { usePreference } from '@/frontend/data/hooks';
 import { openExternalUrl } from '@/frontend/utils/openExternalUrl';
 import type { FontSizeStep } from '@/shared/data/preference';
 
+import { resolveCitationLinkUrl } from '../citationLink';
+
 type MarkdownTextProps = {
   fontSizeStep?: FontSizeStep;
   isStreaming?: boolean;
@@ -32,5 +34,5 @@ export function MarkdownText({
 }
 
 function handleLinkPress(url: string) {
-  void openExternalUrl(url);
+  void openExternalUrl(resolveCitationLinkUrl(url) ?? url);
 }

--- a/src/frontend/components/markdown/components/__tests__/MarkdownText.test.tsx
+++ b/src/frontend/components/markdown/components/__tests__/MarkdownText.test.tsx
@@ -53,4 +53,17 @@ describe('MarkdownText adapter', () => {
       expect.objectContaining({ fontSizeStep: 2, isStreaming: true }),
     );
   });
+
+  it('opens a prefixed citation link as its original external URL', () => {
+    act(() => {
+      create(<MarkdownText markdown="Citation" />);
+    });
+
+    const onLinkPress = mockCherryMarkdownText.mock.calls[0]?.[0].onLinkPress as
+      | ((url: string) => void)
+      | undefined;
+    act(() => onLinkPress?.('cite:https%3A%2F%2Fgoldprice.org%2Fgold-price.html'));
+
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://goldprice.org/gold-price.html');
+  });
 });

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -1,4 +1,8 @@
-import { ContextMenuScrollBoundary, ScrollToBottomButton } from '@cherrystudio/ui/components';
+import {
+  ContextMenuScrollBoundary,
+  ScrollToBottomButton,
+  scrollToBottomButtonSize,
+} from '@cherrystudio/ui/components';
 import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list/keyboard';
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -85,7 +89,11 @@ export function MessageList({
     [contentTopInset, headerAccessory],
   );
   const contentContainerStyle = useMemo(
-    () => ({ paddingBottom: contentBottomInset, paddingTop: MESSAGE_LIST_TOP_PADDING }),
+    () => ({
+      paddingBottom:
+        contentBottomInset + scrollToBottomButtonSize + SCROLL_BUTTON_GAP_ABOVE_ACCESSORY * 2,
+      paddingTop: MESSAGE_LIST_TOP_PADDING,
+    }),
     [contentBottomInset],
   );
   const renderMessageRow = useCallback(

--- a/src/frontend/components/messages/README.md
+++ b/src/frontend/components/messages/README.md
@@ -58,17 +58,17 @@ instead of creating feature-owned rows or sheets:
 
 | Layer | Owner | Contract |
 | --- | --- | --- |
-| Summary | `MessagePart.Summary` | Renders the leading icon slot, title, status text, tone, running shimmer, and disclosure chevron. |
+| Summary | `MessagePart.Summary` | Renders the title, status text, tone, running shimmer, and disclosure chevron. |
 | Interaction | `MessagePart.Tool` | Owns local open/close state and connects the summary press to its detail. Business renderers do not lift this transient state. |
+| Process | `MessagePart.Process` | Renders one total-duration disclosure before the answer and expands every pre-result part inline. |
 | Grouping | `MessagePart.ToolGroup` | Owns the group summary row and inline step container for a run of tool calls. Expanded while the run is live, folded once it settles; a manual toggle always wins. |
 | Detail shell | `MessagePart.Detail` | Owns the `BottomSheet`, title, dismissal, scrolling, content insets, and spacing. Tool and source details share this shell. |
 | Detail content | The part renderer | Supplies the business-specific content inside the shell. This content remains intentionally unconstrained until its visual variants are designed. |
 
-`MessagePart.Summary` standardizes an icon *slot*, not one icon. The slot has one size, position,
-and alignment; the product adapter chooses its `icon` or `imageSource`. An image source takes
-precedence over the icon component, and the wrench is only the fallback when neither is supplied.
-The adapter also derives localized title and status text plus the semantic status tone. It must not
-recreate the shared row geometry.
+Tool summaries deliberately omit decorative icons and implementation-specific arguments. The
+adapter derives a localized action title and status text plus the semantic status tone; URLs,
+queries, and other invocation arguments remain available in the detail sheet instead of competing
+with the answer. It must not recreate the shared row geometry.
 
 `MessagePart.Tool` is the required outer composition for generic, MCP, web-search, write-file, and
 Meta tool calls. Those tool renderers remain separate while their detail semantics differ. A common
@@ -83,8 +83,11 @@ may summarize user-facing metadata such as its filename and size, but it does no
 entry ids or repeat the file body.
 
 Reasoning expands inline: `MessagePart.Reasoning` owns the toggle and the left-rail container its
-markdown renders into, so a reader keeps their place in the transcript. Source groups retain their
-domain-specific compact triggers, but their expanded views must use `MessagePart.Detail`. New
+markdown renders into, so a reader keeps their place in the transcript. Every visible transcript
+part except the final result text sits inside one collapsed `MessagePart.Process` row whose label is
+the message's total wall-clock duration. Expanding it reveals the original parts in order. Source
+groups use a borderless row of overlapping favicons and their source count, while their expanded
+views must use `MessagePart.Detail`. New
 interactive message parts may introduce a distinct compact trigger only when their semantics cannot
 be expressed by `MessagePart.Summary`; they must not introduce another bottom-sheet shell.
 
@@ -93,13 +96,10 @@ the part adapter notifies the list scroll controller, which leaves live-edge fol
 any scheduled end correction. LegendList's size anchoring then keeps the tapped summary in place so
 the detail expands below it, even when the viewport started at the bottom.
 
-`partitionMessageParts` folds a run of two or more consecutive visible tool calls into one
-`tool-group` body item that `ToolGroupPart` renders through `MessagePart.ToolGroup`. The answer —
-not the process — is the visual subject of a settled message, so the group collapses to one summary
-row when the run completes. Failed or denied steps are never silent: their count and tone surface on
-the folded summary. A lone tool call keeps its own row, whose title already says everything a group
-summary would. Provider-executed web searches render nothing, so they neither count toward a group
-nor split one, and lifted source and file parts do not split a run they interleave with.
+`partitionMessageParts` finds the last visible text part and leaves only that part in the article
+body. Earlier prose, reasoning, and tool calls all enter the timed process disclosure. A text part
+followed by a tool is therefore treated as intermediate narration, not as the result. Provider-
+executed web searches render nothing; source and file parts retain their dedicated result rows.
 
 ### Detail Content Status
 

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -143,6 +143,7 @@ jest.mock('@cherrystudio/ui/components', () => ({
     mockScrollButtonProps = props;
     return null;
   },
+  scrollToBottomButtonSize: 40,
 }));
 
 jest.mock('react-i18next', () => ({
@@ -570,7 +571,7 @@ describe('MessageList scroll-controller ownership', () => {
       expect(mockLatestListProps?.getItemType?.(messages[1])).toBe('assistant');
       expect(mockLatestListProps?.keyboardDismissMode).toBe('on-drag');
       expect(mockLatestListProps?.contentContainerStyle).toEqual({
-        paddingBottom: 80,
+        paddingBottom: 130,
         paddingTop: 12,
       });
       expect(mockLatestListProps?.showsVerticalScrollIndicator).toBe(false);

--- a/src/frontend/components/messages/parts/MessageParts.tsx
+++ b/src/frontend/components/messages/parts/MessageParts.tsx
@@ -6,8 +6,8 @@ import { resolveMessageCitationText } from './citations';
 import { MessageFileStrip } from './MessageFileStrip';
 import { MessagePartRenderer } from './MessagePartRenderer';
 import { partitionMessageParts } from './partitionMessageParts';
+import { ProcessGroupPart } from './ProcessGroupPart';
 import { SourceGroup } from './SourceGroup';
-import { ToolGroupPart } from './tools/ToolGroupPart';
 
 type MessagePartsProps = {
   isTextSelectionEnabled: boolean;
@@ -40,33 +40,36 @@ export function MessageParts({
     return null;
   }
 
-  const { body, files } = partitionMessageParts(parts);
+  const { body, files, process } = partitionMessageParts(parts);
   const hasSources = parts.some((part) => part.type === 'source-url');
 
   return (
     <View className="gap-2">
-      {body.map((item) =>
-        item.kind === 'tool-group' ? (
-          <ToolGroupPart
-            items={item.items.map(({ index, part }) => ({
-              key: getMessagePartKey(message, part, index),
-              part,
-            }))}
-            key={getMessagePartKey(message, item.items[0].part, item.index)}
-            messageParts={parts}
-          />
-        ) : (
-          <MessagePartRenderer
-            isStreaming={message.status === 'pending'}
-            isTextSelectionEnabled={isTextSelectionEnabled}
-            key={getMessagePartKey(message, item.part, item.index)}
-            messageParts={parts}
-            part={item.part}
-            renderMode={renderMode}
-            resolvedText={citationText.get(item.index)}
-          />
-        ),
-      )}
+      {process.length > 0 ? (
+        <ProcessGroupPart
+          citationText={citationText}
+          isTextSelectionEnabled={isTextSelectionEnabled}
+          items={process.map(({ index, part }) => ({
+            index,
+            key: getMessagePartKey(message, part, index),
+            part,
+          }))}
+          message={message}
+          messageParts={parts}
+          renderMode={renderMode}
+        />
+      ) : null}
+      {body.map((item) => (
+        <MessagePartRenderer
+          isStreaming={message.status === 'pending'}
+          isTextSelectionEnabled={isTextSelectionEnabled}
+          key={getMessagePartKey(message, item.part, item.index)}
+          messageParts={parts}
+          part={item.part}
+          renderMode={renderMode}
+          resolvedText={citationText.get(item.index)}
+        />
+      ))}
       {hasSources ? <SourceGroup parts={parts} /> : null}
       {/* Last, so the files a turn produced are the closest thing to the end of
           the message and stay put as the answer above them streams in. */}

--- a/src/frontend/components/messages/parts/ProcessGroupPart.tsx
+++ b/src/frontend/components/messages/parts/ProcessGroupPart.tsx
@@ -1,0 +1,86 @@
+import { MessagePart } from '@cherrystudio/ui/components';
+import { useTranslation } from 'react-i18next';
+
+import type { CherryMessagePart } from '@/shared/data/types/message';
+import { readCherryMeta } from '@/shared/data/types/uiParts';
+
+import { useMessageListDisclosureToggle } from '../list/MessageListDisclosureContext';
+import type { MessageListItem } from '../types';
+import type { ResolvedCitationText } from './citations';
+import { MessagePartRenderer } from './MessagePartRenderer';
+import type { MessagePartRenderMode } from './MessageParts';
+import type { MessageProcessItem } from './partitionMessageParts';
+import { useElapsedTimerMs } from './useElapsedTimerMs';
+
+type ProcessGroupItem = MessageProcessItem & { key: string };
+
+type ProcessGroupPartProps = {
+  citationText: ReadonlyMap<number, ResolvedCitationText>;
+  isTextSelectionEnabled: boolean;
+  items: readonly ProcessGroupItem[];
+  message: MessageListItem;
+  messageParts: readonly CherryMessagePart[];
+  renderMode: MessagePartRenderMode;
+};
+
+export function ProcessGroupPart({
+  citationText,
+  isTextSelectionEnabled,
+  items,
+  message,
+  messageParts,
+  renderMode,
+}: ProcessGroupPartProps) {
+  const { t } = useTranslation();
+  const handleDisclosureToggle = useMessageListDisclosureToggle();
+  const isRunning = message.status === 'pending';
+  const startedAt = parseTimestamp(message.createdAt);
+  const persistedDurationMs = resolvePersistedDurationMs(message, items);
+  const elapsedMs = useElapsedTimerMs(isRunning, startedAt, persistedDurationMs);
+  const seconds = Math.max(1, Math.round(elapsedMs / 1000));
+  const title = t('chat.process.duration', { seconds });
+
+  return (
+    <MessagePart.Process
+      onDisclosureToggle={handleDisclosureToggle}
+      state={isRunning ? 'running' : 'complete'}
+      title={title}
+    >
+      {items.map(({ index, key, part }) => (
+        <MessagePartRenderer
+          isStreaming={isRunning}
+          isTextSelectionEnabled={isTextSelectionEnabled}
+          key={key}
+          messageParts={messageParts}
+          part={part}
+          renderMode={renderMode}
+          resolvedText={citationText.get(index)}
+        />
+      ))}
+    </MessagePart.Process>
+  );
+}
+
+function resolvePersistedDurationMs(
+  message: MessageListItem,
+  items: readonly ProcessGroupItem[],
+): number | undefined {
+  const startedAt = parseTimestamp(message.createdAt);
+  const endedAt = parseTimestamp(message.updatedAt);
+  if (startedAt !== undefined && endedAt !== undefined && endedAt >= startedAt) {
+    return endedAt - startedAt;
+  }
+
+  const reasoningDurations = items.flatMap(({ part }) => {
+    if (part.type !== 'reasoning') return [];
+    const thinkingMs = readCherryMeta(part)?.thinkingMs;
+    return thinkingMs === undefined ? [] : [thinkingMs];
+  });
+  return reasoningDurations.length > 0 ? Math.max(...reasoningDurations) : undefined;
+}
+
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}

--- a/src/frontend/components/messages/parts/SourceGroup.tsx
+++ b/src/frontend/components/messages/parts/SourceGroup.tsx
@@ -1,5 +1,3 @@
-import ChevronRightIcon from '@cherrystudio/app-icons/icons/chevron-right';
-import GlobeIcon from '@cherrystudio/app-icons/icons/globe';
 import { MessagePart } from '@cherrystudio/ui/components';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -8,7 +6,7 @@ import { Pressable, Text, View } from 'react-native';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { resolveCitationWebSources } from './webSource';
-import { WebSourceCard } from './WebSourceCard';
+import { WebSourceCard, WebSourceFavicon } from './WebSourceCard';
 
 type SourceGroupProps = {
   parts: readonly CherryMessagePart[];
@@ -20,18 +18,27 @@ export function SourceGroup({ parts }: SourceGroupProps) {
   const sources = useMemo(() => resolveCitationWebSources(parts), [parts]);
   const label = t('chat.sources.count', { count: sources.length });
 
+  if (sources.length === 0) {
+    return null;
+  }
+
   return (
     <>
       <Pressable
         accessibilityLabel={label}
         accessibilityRole="button"
-        className="min-h-8 self-start flex-row items-center gap-1.5 rounded-full border border-border bg-secondary px-2.5 active:bg-secondary-active active:opacity-80"
-        hitSlop={6}
+        className="-mx-2 min-h-10 self-start flex-row items-center gap-2 rounded-lg px-2 active:bg-secondary-active active:opacity-80"
+        hitSlop={4}
         onPress={() => setIsOpen(true)}
       >
-        <GlobeIcon className="size-3.5 text-muted-foreground" />
-        <Text className="font-medium text-muted-foreground text-xs">{label}</Text>
-        <ChevronRightIcon className="size-3.5 text-muted-foreground" />
+        <View className="flex-row items-center">
+          {sources.slice(0, 3).map((source, index) => (
+            <View key={source.url} style={{ marginLeft: index === 0 ? 0 : -4, zIndex: 3 - index }}>
+              <WebSourceFavicon source={source} />
+            </View>
+          ))}
+        </View>
+        <Text className="font-medium text-foreground-tertiary text-sm">{label}</Text>
       </Pressable>
       {isOpen ? (
         <MessagePart.Detail

--- a/src/frontend/components/messages/parts/WebSourceCard.tsx
+++ b/src/frontend/components/messages/parts/WebSourceCard.tsx
@@ -54,7 +54,7 @@ export function WebSourceCard({ source }: WebSourceCardProps) {
 
 type FaviconStatus = 'failed' | 'loaded' | 'loading';
 
-function WebSourceFavicon({ source }: { source: WebSource }) {
+export function WebSourceFavicon({ source }: { source: WebSource }) {
   const faviconUrls = getFaviconUrls(source);
   const [sourceIndex, setSourceIndex] = useState(0);
   const [status, setStatus] = useState<FaviconStatus>(

--- a/src/frontend/components/messages/parts/__tests__/MessageParts.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/MessageParts.test.tsx
@@ -30,11 +30,11 @@ jest.mock('../MessageFileStrip', () => {
   };
 });
 
-jest.mock('../tools/ToolGroupPart', () => {
+jest.mock('../ProcessGroupPart', () => {
   const { createElement } = jest.requireActual('react');
 
   return {
-    ToolGroupPart: (props: object) => createElement('ToolGroupPart', props),
+    ProcessGroupPart: (props: object) => createElement('ProcessGroupPart', props),
   };
 });
 
@@ -82,7 +82,7 @@ describe('MessageParts', () => {
     expect(renderer.root.findByType('SourceGroup').props.parts).toEqual(message.data.parts);
   });
 
-  test('renders a run of tool calls as one group keyed by source part identity', () => {
+  test('folds intermediate text and later tool calls into the timed process', () => {
     const toolPart = (id: string) =>
       ({
         input: {},
@@ -101,8 +101,44 @@ describe('MessageParts', () => {
     };
     const renderer = render(<MessageParts isTextSelectionEnabled={false} message={message} />);
 
-    const group = renderer.root.findByType('ToolGroupPart');
-    expect(group.props.items.map((item: { key: string }) => item.key)).toEqual(['key-a', 'key-b']);
+    const process = renderer.root.findByType('ProcessGroupPart');
+    expect(process.props.items.map((item: { key: string }) => item.key)).toEqual([
+      'key-text',
+      'key-a',
+      'key-b',
+    ]);
+    expect(renderer.root.findAllByType('MessagePartRenderer')).toHaveLength(0);
+  });
+
+  test('folds reasoning and tools before the answer into one timed process group', () => {
+    const reasoningPart = { state: 'done' as const, text: 'Reasoning', type: 'reasoning' as const };
+    const toolPart = {
+      input: {},
+      output: {},
+      state: 'output-available' as const,
+      toolCallId: 'call-a',
+      toolName: 'a',
+      type: 'dynamic-tool' as const,
+    } as unknown as NonNullable<MessageListItem['data']['parts']>[number];
+    const message: MessageListItem = {
+      ...makeMessage('success'),
+      createdAt: '2026-09-02T00:00:00.000Z',
+      data: {
+        partKeys: ['reasoning-key', 'tool-key', 'text-key'],
+        parts: [reasoningPart, toolPart, { text: 'Answer', type: 'text' }],
+      },
+      updatedAt: '2026-09-02T00:00:16.000Z',
+    };
+
+    const renderer = render(<MessageParts isTextSelectionEnabled message={message} />);
+    const process = renderer.root.findByType('ProcessGroupPart');
+
+    expect(process.props.items.map((item: { key: string }) => item.key)).toEqual([
+      'reasoning-key',
+      'tool-key',
+    ]);
+    expect(process.props.isTextSelectionEnabled).toBe(true);
+    expect(process.props.renderMode).toBe('markdown');
     expect(renderer.root.findAllByType('MessagePartRenderer')).toHaveLength(1);
   });
 
@@ -123,7 +159,7 @@ describe('MessageParts', () => {
     );
 
     expect(rendered.map((node) => node.type)).toEqual([
-      'MessagePartRenderer',
+      'ProcessGroupPart',
       'MessagePartRenderer',
       'MessageFileStrip',
     ]);

--- a/src/frontend/components/messages/parts/__tests__/ProcessGroupPart.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/ProcessGroupPart.test.tsx
@@ -1,0 +1,73 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { MessageListItem } from '../../types';
+import { ProcessGroupPart } from '../ProcessGroupPart';
+
+jest.mock('@cherrystudio/ui/components', () => {
+  const { createElement } = jest.requireActual('react');
+
+  return {
+    MessagePart: {
+      Process: ({ children, ...props }: { children: unknown }) =>
+        createElement('MessagePartProcess', props, children),
+    },
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values: { seconds: number }) =>
+      key === 'chat.process.duration' ? `用时 ${values.seconds}秒` : key,
+  }),
+}));
+
+jest.mock('../MessagePartRenderer', () => {
+  const { createElement } = jest.requireActual('react');
+
+  return {
+    MessagePartRenderer: (props: object) => createElement('MessagePartRenderer', props),
+  };
+});
+
+jest.mock('../../list/MessageListDisclosureContext', () => ({
+  useMessageListDisclosureToggle: () => jest.fn(),
+}));
+
+describe('ProcessGroupPart', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  test('uses the persisted message lifetime as the total process duration', () => {
+    const part = { state: 'done' as const, text: 'Reasoning', type: 'reasoning' as const };
+    const message: MessageListItem = {
+      createdAt: '2026-09-02T00:00:00.000Z',
+      data: { parts: [part] },
+      id: 'assistant-1',
+      role: 'assistant',
+      status: 'success',
+      updatedAt: '2026-09-02T00:00:16.000Z',
+    };
+
+    act(() => {
+      renderer = create(
+        <ProcessGroupPart
+          citationText={new Map()}
+          isTextSelectionEnabled
+          items={[{ index: 0, key: 'reasoning-1', part }]}
+          message={message}
+          messageParts={[part]}
+          renderMode="markdown"
+        />,
+      );
+    });
+
+    expect(renderer!.root.findByType('MessagePartProcess').props).toMatchObject({
+      state: 'complete',
+      title: '用时 16秒',
+    });
+  });
+});

--- a/src/frontend/components/messages/parts/__tests__/citations.test.ts
+++ b/src/frontend/components/messages/parts/__tests__/citations.test.ts
@@ -15,7 +15,7 @@ describe('resolveMessageCitationText', () => {
     ] satisfies CherryMessagePart[];
 
     expect(resolveMessageCitationText(parts).get(1)).toEqual({
-      markdown: 'See [1](https://cherry-ai.com).',
+      markdown: 'See ^[1](cite:https%3A%2F%2Fcherry-ai.com)^.',
       plainText: 'See [1].',
     });
   });
@@ -36,7 +36,8 @@ describe('resolveMessageCitationText', () => {
     ] as CherryMessagePart[];
 
     expect(resolveMessageCitationText(parts).get(1)).toEqual({
-      markdown: 'Second [1](https://b.example), first [2](https://a.example).',
+      markdown:
+        'Second ^[1](cite:https%3A%2F%2Fb.example)^, first ^[2](cite:https%3A%2F%2Fa.example)^.',
       plainText: 'Second [1], first [2].',
     });
   });
@@ -56,7 +57,7 @@ describe('resolveMessageCitationText', () => {
     ] as CherryMessagePart[];
 
     expect(resolveMessageCitationText(parts).get(1)?.markdown).toBe(
-      '`[cite:aaaa1111-1]` [cite:missing] [1](https://a.example)',
+      '`[cite:aaaa1111-1]` [cite:missing] ^[1](cite:https%3A%2F%2Fa.example)^',
     );
   });
 

--- a/src/frontend/components/messages/parts/__tests__/partitionMessageParts.test.ts
+++ b/src/frontend/components/messages/parts/__tests__/partitionMessageParts.test.ts
@@ -18,7 +18,7 @@ function text(value: string): CherryMessagePart {
 
 describe('partitionMessageParts', () => {
   test('lifts every file out of the body, in the order it was produced', () => {
-    const { body, files } = partitionMessageParts([
+    const { body, files, process } = partitionMessageParts([
       text('before'),
       file('a'),
       text('after'),
@@ -27,7 +27,8 @@ describe('partitionMessageParts', () => {
 
     expect(
       body.map((item) => (item.kind === 'part' ? (item.part as { text: string }).text : item.kind)),
-    ).toEqual(['before', 'after']);
+    ).toEqual(['after']);
+    expect(process.map((item) => (item.part as { text: string }).text)).toEqual(['before']);
     expect(files.map((part) => part.filename)).toEqual(['a.md', 'b.md']);
   });
 
@@ -58,31 +59,36 @@ describe('partitionMessageParts', () => {
     expect(body.map(({ index }) => index)).toEqual([1]);
   });
 
-  test('folds a run of consecutive tool calls into one group with original indices', () => {
-    const { body } = partitionMessageParts([text('intro'), tool('a'), tool('b'), text('answer')]);
+  test('folds intermediate prose and tools while keeping only the final result text', () => {
+    const { body, process } = partitionMessageParts([
+      text('intro'),
+      tool('a'),
+      tool('b'),
+      text('answer'),
+    ]);
 
-    expect(body.map((item) => item.kind)).toEqual(['part', 'tool-group', 'part']);
-    const group = body[1];
-    if (group.kind !== 'tool-group') {
-      throw new Error('expected a tool group');
-    }
-    expect(group.index).toBe(1);
-    expect(group.items.map(({ index }) => index)).toEqual([1, 2]);
+    expect(process.map(({ index }) => index)).toEqual([0, 1, 2]);
+    expect(body.map(({ index }) => index)).toEqual([3]);
   });
 
-  test('keeps a lone tool call as its own row', () => {
-    const { body } = partitionMessageParts([tool('a'), text('answer')]);
+  test('collects reasoning and tools before the answer as one process prefix', () => {
+    const { body, process } = partitionMessageParts([
+      reasoning('thinking'),
+      tool('a'),
+      text('answer'),
+    ]);
 
-    expect(body.map((item) => item.kind)).toEqual(['part', 'part']);
+    expect(process.map(({ index }) => index)).toEqual([0, 1]);
+    expect(body.map((item) => item.kind)).toEqual(['part']);
   });
 
-  test('splits runs on prose but not on lifted source and file parts', () => {
+  test('folds every visible part before the final result despite interleaved sources and files', () => {
     const source: CherryMessagePart = {
       sourceId: 'source-1',
       type: 'source-url',
       url: 'https://cherry-ai.com',
     };
-    const { body } = partitionMessageParts([
+    const partitioned = partitionMessageParts([
       tool('a'),
       source,
       file('artifact'),
@@ -90,27 +96,35 @@ describe('partitionMessageParts', () => {
       text('answer'),
       tool('c'),
       tool('d'),
+      text('final answer'),
     ]);
 
-    expect(body.map((item) => item.kind)).toEqual(['tool-group', 'part', 'tool-group']);
+    expect(partitioned.process.map(({ index }) => index)).toEqual([0, 3, 4, 5, 6]);
+    expect(partitioned.body.map(({ index }) => index)).toEqual([7]);
   });
 
-  test('provider web searches neither count toward a group nor render inside one', () => {
+  test('does not expose an earlier text part when a tool is still the last visible content', () => {
+    const partitioned = partitionMessageParts([text('intermediate'), tool('a')]);
+
+    expect(partitioned.process.map(({ index }) => index)).toEqual([0, 1]);
+    expect(partitioned.body).toHaveLength(0);
+  });
+
+  test('provider web searches stay invisible and do not create an empty process group', () => {
     const provider = providerWebSearch();
     const grouped = partitionMessageParts([tool('a'), provider, tool('b')]);
-    expect(grouped.body.map((item) => item.kind)).toEqual(['tool-group']);
-    const group = grouped.body[0];
-    if (group.kind !== 'tool-group') {
-      throw new Error('expected a tool group');
-    }
-    expect(group.items).toHaveLength(2);
+    expect(grouped.process).toHaveLength(2);
+    expect(grouped.body).toHaveLength(0);
 
-    // One visible call beside a provider search is still a lone call, and the
-    // provider part passes through for its renderer to suppress.
     const single = partitionMessageParts([provider, tool('a')]);
-    expect(single.body.map((item) => item.kind)).toEqual(['part', 'part']);
+    expect(single.process).toHaveLength(1);
+    expect(single.body).toHaveLength(0);
   });
 });
+
+function reasoning(value: string): CherryMessagePart {
+  return { state: 'done', text: value, type: 'reasoning' } as CherryMessagePart;
+}
 
 function tool(id: string): CherryMessagePart {
   return {

--- a/src/frontend/components/messages/parts/citations.ts
+++ b/src/frontend/components/messages/parts/citations.ts
@@ -1,3 +1,4 @@
+import { createCitationLinkUrl } from '@/frontend/components/markdown/citationLink';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
 const CITABLE_TOOL_NAMES = new Set(['web_search', 'web_fetch', 'kb_search', 'kb_read']);
@@ -41,7 +42,9 @@ export function resolveMessageCitationText(
             numberBySource.set(source, number);
           }
 
-          return markdown && source.url ? `[${number}](${source.url})` : `[${number}]`;
+          return markdown && source.url
+            ? `^[${number}](${createCitationLinkUrl(source.url)})^`
+            : `[${number}]`;
         }),
       );
 

--- a/src/frontend/components/messages/parts/partitionMessageParts.ts
+++ b/src/frontend/components/messages/parts/partitionMessageParts.ts
@@ -1,29 +1,28 @@
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
-import {
-  isProviderWebSearchToolPart,
-  isToolMessagePart,
-  type ToolMessagePart,
-} from './tools/toolPartState';
+import { isProviderWebSearchToolPart, isToolMessagePart } from './tools/toolPartState';
 
 type MessageFilePart = Extract<CherryMessagePart, { type: 'file' }>;
+export type MessageProcessItem = {
+  index: number;
+  part: CherryMessagePart;
+};
 
-export type MessageBodyToolItem = { index: number; part: ToolMessagePart };
-
-export type MessageBodyItem =
-  | { kind: 'part'; index: number; part: CherryMessagePart }
-  | { kind: 'tool-group'; index: number; items: readonly MessageBodyToolItem[] };
+export type MessageBodyItem = { kind: 'part'; index: number; part: CherryMessagePart };
 
 export type PartitionedMessageParts = {
-  /** Everything rendered in transcript order, carrying its original index. */
+  /** The final result text, carrying its original index for citation resolution. */
   body: readonly MessageBodyItem[];
   /** Every file in the message, shown as one row after the body. */
   files: readonly MessageFilePart[];
+  /** Every visible transcript part except the final result text. */
+  process: readonly MessageProcessItem[];
 };
 
 /**
- * Splits a message into its ordered body and the files it produced, and folds
- * runs of consecutive tool calls into one `tool-group` item.
+ * Splits a message into its timed process, final result text, and produced
+ * files. Only the last visible text part remains in the article body; earlier
+ * prose, reasoning, and tools all belong to the process disclosure.
  *
  * Files are lifted out of the stream and shown after the answer rather than at
  * the tool call that wrote them. A deliverable buried between two blocks of
@@ -38,35 +37,16 @@ export type PartitionedMessageParts = {
  *
  * Source parts drop out too; `SourceGroup` collects them separately.
  *
- * Tool grouping rules:
- * - Only runs of two or more visible tool calls group; a lone call keeps its
- *   own row, whose title already says everything a group summary would.
- * - Provider-executed web searches render nothing, so they neither count
- *   toward a group nor split one; outside a group they pass through unchanged.
- * - Source and file parts are lifted out of the stream anyway, so they do not
- *   split a run they happen to interleave with. Any other part type does.
+ * Provider-owned invisible parts do not create an empty process row. Source
+ * and file parts remain dedicated result affordances outside this split.
  */
 export function partitionMessageParts(
   parts: readonly CherryMessagePart[],
 ): PartitionedMessageParts {
   const body: MessageBodyItem[] = [];
   const files: MessageFilePart[] = [];
-  let run: MessageBodyToolItem[] = [];
-
-  const flushRun = () => {
-    if (run.length === 0) {
-      return;
-    }
-    const visible = run.filter((item) => !isProviderWebSearchToolPart(item.part));
-    if (visible.length >= 2) {
-      body.push({ index: visible[0].index, items: visible, kind: 'tool-group' });
-    } else {
-      for (const item of run) {
-        body.push({ kind: 'part', ...item });
-      }
-    }
-    run = [];
-  };
+  const process: MessageProcessItem[] = [];
+  const resultTextIndex = findResultTextIndex(parts);
 
   parts.forEach((part, index) => {
     if (part.type === 'source-url') {
@@ -78,15 +58,45 @@ export function partitionMessageParts(
       return;
     }
 
-    if (isToolMessagePart(part)) {
-      run.push({ index, part });
+    if (isInvisiblePart(part)) {
       return;
     }
 
-    flushRun();
+    if (index !== resultTextIndex) {
+      process.push({ index, part });
+      return;
+    }
+
     body.push({ index, kind: 'part', part });
   });
-  flushRun();
 
-  return { body, files };
+  return { body, files, process };
+}
+
+function findResultTextIndex(parts: readonly CherryMessagePart[]): number | undefined {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index];
+    if (!part) continue;
+    if (part.type === 'source-url' || part.type === 'file' || isInvisiblePart(part)) {
+      continue;
+    }
+
+    if (part.type === 'text' && part.text.trim()) {
+      return index;
+    }
+
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function isInvisiblePart(part: CherryMessagePart) {
+  return (
+    (part.type === 'reasoning' && part.state !== 'streaming' && !part.text.trim()) ||
+    part.type === 'step-start' ||
+    part.type === 'source-document' ||
+    part.type === 'data-video' ||
+    (isToolMessagePart(part) && isProviderWebSearchToolPart(part))
+  );
 }

--- a/src/frontend/components/messages/parts/tools/EditFileToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/EditFileToolPart.tsx
@@ -1,7 +1,6 @@
 import { MessagePart } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
 
-import { getBuiltInToolDisplay } from './builtInTool/builtInToolDisplay';
 import { GenericToolPart } from './GenericToolPart';
 import { getToolName, isRecord, type ToolMessagePart } from './toolPartState';
 
@@ -20,7 +19,6 @@ export function EditFileToolPart({ part }: EditFileToolPartProps) {
     return <GenericToolPart part={part} />;
   }
 
-  const display = getBuiltInToolDisplay(EDIT_FILE_TOOL_NAME);
   if (editedFile !== null) {
     const details = {
       [t('chat.builtinTool.file.filename')]: editedFile.filename,
@@ -32,8 +30,6 @@ export function EditFileToolPart({ part }: EditFileToolPartProps) {
 
     return (
       <MessagePart.Tool
-        icon={display?.icon}
-        imageSource={display?.imageSource}
         state="complete"
         statusText={t('chat.builtinTool.file.edited')}
         testID="edit-file-tool-part"
@@ -46,8 +42,6 @@ export function EditFileToolPart({ part }: EditFileToolPartProps) {
 
   return (
     <MessagePart.Tool
-      icon={display?.icon}
-      imageSource={display?.imageSource}
       state="complete"
       statusText={t('chat.tool.callError')}
       statusTone="danger"

--- a/src/frontend/components/messages/parts/tools/GenericToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/GenericToolPart.tsx
@@ -18,14 +18,13 @@ type GenericToolPartProps = {
 
 export function GenericToolPart({ part }: GenericToolPartProps) {
   const { t } = useTranslation();
-  const toolDisplay = getBuiltInToolDisplay(getToolName(part));
+  const toolName = getToolName(part);
+  const toolDisplay = getBuiltInToolDisplay(toolName);
   const title = getToolLabel(part, toolDisplay?.titleKey, t);
   const statusText = getToolStatusText(part, t);
 
   return (
     <MessagePart.Tool
-      icon={toolDisplay?.icon}
-      imageSource={toolDisplay?.imageSource}
       state={getToolDisplayState(part)}
       statusText={statusText}
       statusTone={getToolStatusTone(part)}

--- a/src/frontend/components/messages/parts/tools/WebSearchToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/WebSearchToolPart.tsx
@@ -1,4 +1,3 @@
-import SearchIcon from '@cherrystudio/app-icons/icons/search';
 import { MessagePart } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
 import { Text } from 'react-native';
@@ -7,7 +6,7 @@ import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { enrichWebSources, parseWebSources } from '../webSource';
 import { WebSourceCard } from '../WebSourceCard';
-import { getToolStatusTone, isRecord, type ToolMessagePart } from './toolPartState';
+import { getToolStatusTone, type ToolMessagePart } from './toolPartState';
 
 type WebSearchToolPartProps = {
   messageParts?: readonly CherryMessagePart[];
@@ -16,25 +15,23 @@ type WebSearchToolPartProps = {
 
 export function WebSearchToolPart({ messageParts, part }: WebSearchToolPartProps) {
   const { t } = useTranslation();
-  const query = getWebSearchQuery(part.input);
   const rawResults = part.state === 'output-available' ? parseWebSources(part.output) : [];
   const results = messageParts ? enrichWebSources(rawResults, messageParts) : rawResults;
   const statusText = getWebSearchStatusText(part, results.length, t);
-  const title = query || part.title?.trim() || t('chat.actions.webSearch');
+  const actionTitle = t('chat.builtinTool.web.search');
   const detailTitle =
-    results.length > 0 ? t('chat.webSearch.detailTitle', { count: results.length }) : title;
+    results.length > 0 ? t('chat.webSearch.detailTitle', { count: results.length }) : actionTitle;
   const isSearching = part.state === 'input-streaming' || part.state === 'input-available';
 
   return (
     <MessagePart.Tool
       detailTitle={detailTitle}
       detailVariant="source-list"
-      icon={SearchIcon}
       state={isSearching ? 'running' : 'complete'}
       statusText={statusText}
       statusTone={getToolStatusTone(part)}
       testID="web-search-tool-part"
-      title={title}
+      title={actionTitle}
     >
       {results.length === 0 ? (
         <Text className="text-foreground text-base italic" selectable>
@@ -77,9 +74,4 @@ function getWebSearchStatusText(
   }
 
   return t('chat.webSearch.searching');
-}
-
-function getWebSearchQuery(input: unknown) {
-  if (!isRecord(input) || typeof input.query !== 'string') return '';
-  return input.query.trim();
 }

--- a/src/frontend/components/messages/parts/tools/WriteFileToolPart.tsx
+++ b/src/frontend/components/messages/parts/tools/WriteFileToolPart.tsx
@@ -1,7 +1,6 @@
 import { MessagePart } from '@cherrystudio/ui/components';
 import { useTranslation } from 'react-i18next';
 
-import { getBuiltInToolDisplay } from './builtInTool/builtInToolDisplay';
 import { GenericToolPart } from './GenericToolPart';
 import { getToolName, isRecord, type ToolMessagePart } from './toolPartState';
 
@@ -28,8 +27,6 @@ export function WriteFileToolPart({ part }: WriteFileToolPartProps) {
     return <GenericToolPart part={part} />;
   }
 
-  const display = getBuiltInToolDisplay(WRITE_FILE_TOOL_NAME);
-
   if (createdWrite !== null) {
     const details = {
       [t('chat.builtinTool.file.filename')]: createdWrite.filename,
@@ -40,8 +37,6 @@ export function WriteFileToolPart({ part }: WriteFileToolPartProps) {
 
     return (
       <MessagePart.Tool
-        icon={display?.icon}
-        imageSource={display?.imageSource}
         state="complete"
         statusText={t('chat.builtinTool.file.created')}
         testID="write-file-tool-part"
@@ -58,8 +53,6 @@ export function WriteFileToolPart({ part }: WriteFileToolPartProps) {
 
   return (
     <MessagePart.Tool
-      icon={display?.icon}
-      imageSource={display?.imageSource}
       state="complete"
       statusText={t('chat.tool.callError')}
       statusTone="danger"

--- a/src/frontend/components/messages/parts/tools/__tests__/ToolParts.test.tsx
+++ b/src/frontend/components/messages/parts/tools/__tests__/ToolParts.test.tsx
@@ -161,6 +161,19 @@ describe('tool message detail sheets', () => {
     expect(trigger.props.statusText).toBe('chat.tool.inputReady');
   });
 
+  it('keeps the web fetch action free of implementation details', async () => {
+    await render(
+      <GenericToolPart
+        part={makeToolPart({
+          input: { urls: ['https://www.goldprice.org/gold-price.html'] },
+          toolName: 'web_fetch',
+        })}
+      />,
+    );
+
+    expect(findByTestID('tool-part-trigger').props.title).toBe('chat.builtinTool.web.fetch');
+  });
+
   it('opens MCP tool details with the server and tool name', async () => {
     await render(
       <McpToolPart
@@ -200,7 +213,7 @@ describe('tool message detail sheets', () => {
     );
 
     const trigger = findByTestID('web-search-tool-part-trigger');
-    expect(trigger.props.title).toBe('Cherry Studio');
+    expect(trigger.props.title).toBe('chat.builtinTool.web.search');
     expect(trigger.props.statusText).toBe('chat.webSearch.resultCount');
     expect(findAllByTestID('web-search-tool-part-detail')).toHaveLength(0);
 
@@ -208,7 +221,9 @@ describe('tool message detail sheets', () => {
       trigger.props.onPress();
     });
 
-    expect(findByTestID('web-search-tool-part-detail').props.title).toBe('Cherry Studio');
+    expect(findByTestID('web-search-tool-part-detail').props.title).toBe(
+      'chat.webSearch.detailTitle',
+    );
     expect(findText('Cherry Studio')).not.toHaveLength(0);
   });
 

--- a/src/frontend/components/messages/parts/useElapsedTimerMs.ts
+++ b/src/frontend/components/messages/parts/useElapsedTimerMs.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+/** Keeps an elapsed wall-clock duration live, then settles on the persisted final value. */
+export function useElapsedTimerMs(
+  isRunning: boolean,
+  startedAt: number | undefined,
+  finalMs: number | undefined,
+  tickMs = 1000,
+): number {
+  const [displayMs, setDisplayMs] = useState(() => {
+    if (isRunning) {
+      return startedAt === undefined ? 0 : Math.max(0, Date.now() - startedAt);
+    }
+    return finalMs ?? 0;
+  });
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    const update = () => {
+      setDisplayMs((previous) =>
+        startedAt === undefined ? previous + tickMs : Math.max(0, Date.now() - startedAt),
+      );
+    };
+    const resetTimeout = setTimeout(update, 0);
+    const interval = setInterval(update, tickMs);
+
+    return () => {
+      clearTimeout(resetTimeout);
+      clearInterval(interval);
+    };
+  }, [isRunning, startedAt, tickMs]);
+
+  return isRunning ? displayMs : (finalMs ?? 0);
+}

--- a/src/frontend/components/messages/parts/useThinkingTimerMs.ts
+++ b/src/frontend/components/messages/parts/useThinkingTimerMs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useElapsedTimerMs } from './useElapsedTimerMs';
 
 /**
  * Ticks a live "how long has the model been thinking" duration while
@@ -11,31 +11,5 @@ export function useThinkingTimerMs(
   startedAt: number | undefined,
   finalMs: number | undefined,
 ): number {
-  const [displayMs, setDisplayMs] = useState(() => {
-    if (isThinking) {
-      return startedAt !== undefined ? Math.max(0, Date.now() - startedAt) : 0;
-    }
-    return finalMs ?? 0;
-  });
-  useEffect(() => {
-    if (!isThinking) {
-      return;
-    }
-
-    const resetTimeout = setTimeout(() => {
-      setDisplayMs(startedAt !== undefined ? Math.max(0, Date.now() - startedAt) : 0);
-    }, 0);
-    const interval = setInterval(() => {
-      setDisplayMs((previous) =>
-        startedAt !== undefined ? Math.max(0, Date.now() - startedAt) : previous + 100,
-      );
-    }, 100);
-
-    return () => {
-      clearTimeout(resetTimeout);
-      clearInterval(interval);
-    };
-  }, [isThinking, startedAt]);
-
-  return isThinking ? displayMs : (finalMs ?? 0);
+  return useElapsedTimerMs(isThinking, startedAt, finalMs, 100);
 }

--- a/src/frontend/components/messages/types.ts
+++ b/src/frontend/components/messages/types.ts
@@ -17,6 +17,8 @@ export type MessageListItem = Readonly<{
   model?: Readonly<Pick<Model, 'id' | 'modelId' | 'name' | 'providerId'>>;
   role: 'assistant' | 'user';
   status: MessageStatus;
+  /** Last persisted update; terminal assistant messages use it as their completion time. */
+  updatedAt?: string;
 }>;
 
 export type MessageListProps = {

--- a/src/frontend/features/chat/runtime/__tests__/agentMessageProjection.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/agentMessageProjection.test.ts
@@ -56,6 +56,7 @@ describe('agentMessageProjection', () => {
         name: 'GPT-5',
         providerId: 'openai',
       },
+      updatedAt: '2026-08-25T00:00:00.000Z',
     });
   });
 

--- a/src/frontend/features/chat/runtime/agentMessageProjection.ts
+++ b/src/frontend/features/chat/runtime/agentMessageProjection.ts
@@ -265,6 +265,7 @@ export function toAgentMessageListItem(
     ...(model ? { model } : {}),
     role: message.role,
     status: toDisplayStatus(message.status),
+    updatedAt: message.updatedAt,
   } satisfies MessageListItem;
   cache?.itemsByMessageId.set(message.id, { item, source: message });
   return item;

--- a/src/frontend/features/chat/workspace/components/AssistantMessageToolbar.tsx
+++ b/src/frontend/features/chat/workspace/components/AssistantMessageToolbar.tsx
@@ -1,7 +1,7 @@
 import CheckIcon from '@cherrystudio/app-icons/icons/check';
 import CopyIcon from '@cherrystudio/app-icons/icons/copy';
-import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
-import { ActionMenu, Button, type MenuItem } from '@cherrystudio/ui/components';
+import GitForkIcon from '@cherrystudio/app-icons/icons/git-fork';
+import { Button } from '@cherrystudio/ui/components';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
@@ -30,20 +30,6 @@ export const AssistantMessageToolbar = memo(function AssistantMessageToolbar({
     [isSettled, message],
   );
   const isCopied = copiedMessageId === message.id;
-  const menuItems = useMemo<readonly MenuItem[]>(
-    () =>
-      isSettled
-        ? [
-            {
-              icon: 'branch',
-              id: 'fork',
-              label: t('chat.messageActions.fork'),
-              onPress: () => forkFromAssistantMessage({ messageId: message.id }),
-            },
-          ]
-        : [],
-    [forkFromAssistantMessage, isSettled, message.id, t],
-  );
 
   if (!isSettled) {
     return null;
@@ -67,20 +53,14 @@ export const AssistantMessageToolbar = memo(function AssistantMessageToolbar({
           variant="ghost"
         />
       ) : null}
-      {/*
-        The native menu installs its own hit target over this subtree, so the
-        trigger is a plain labelled View rather than a second pressable.
-      */}
-      <ActionMenu items={menuItems}>
-        <View
-          accessibilityLabel={t('common.more')}
-          accessibilityRole="button"
-          className="size-7 items-center justify-center"
-          testID="assistant-message-more"
-        >
-          <EllipsisIcon className="size-4 text-muted-foreground" />
-        </View>
-      </ActionMenu>
+      <Button
+        accessibilityLabel={t('chat.messageActions.fork')}
+        icon={<GitForkIcon className="text-muted-foreground" />}
+        onPress={() => forkFromAssistantMessage({ messageId: message.id })}
+        size="xs"
+        testID="assistant-message-fork"
+        variant="ghost"
+      />
     </View>
   );
 });

--- a/src/frontend/features/chat/workspace/components/ChatMessage.tsx
+++ b/src/frontend/features/chat/workspace/components/ChatMessage.tsx
@@ -48,7 +48,7 @@ function renderChatAssistantMessage(
           {message.model ? (
             <View className="min-w-0 shrink flex-row items-center gap-1">
               <ModelAvatar model={message.model} size={16} />
-              <Text className="min-w-0 shrink text-muted-foreground text-sm" numberOfLines={1}>
+              <Text className="min-w-0 shrink text-foreground-tertiary text-sm" numberOfLines={1}>
                 {message.model.name}
               </Text>
             </View>

--- a/src/frontend/features/chat/workspace/components/__tests__/AssistantMessageToolbar.test.tsx
+++ b/src/frontend/features/chat/workspace/components/__tests__/AssistantMessageToolbar.test.tsx
@@ -16,13 +16,11 @@ jest.mock('expo-clipboard', () => ({
 
 jest.mock('@cherrystudio/app-icons/icons/check', () => () => null);
 jest.mock('@cherrystudio/app-icons/icons/copy', () => () => null);
-jest.mock('@cherrystudio/app-icons/icons/ellipsis', () => () => null);
+jest.mock('@cherrystudio/app-icons/icons/git-fork', () => () => null);
 
 jest.mock('@cherrystudio/ui/components', () => {
   const { createElement } = jest.requireActual('react');
   return {
-    ActionMenu: ({ children, ...props }: { children: unknown }) =>
-      createElement('ActionMenu', props, children),
     Button: (props: object) => createElement('Button', props),
     useAlert: () => ({ alert: { show: jest.fn() } }),
   };
@@ -102,9 +100,7 @@ describe('AssistantMessageToolbar', () => {
     ).toBe('chat.messageActions.copied');
   });
 
-  test('keeps the more menu reachable on a message with nothing to copy', () => {
-    // A tool-only reply has no copyable text, but branching from it is still
-    // the whole point of the menu.
+  test('keeps the direct branch action reachable on a message with nothing to copy', () => {
     renderToolbar(createMessage('success', '   '));
 
     expect(renderer?.root.findAllByProps({ testID: 'assistant-message-copy' })).toHaveLength(0);
@@ -112,24 +108,21 @@ describe('AssistantMessageToolbar', () => {
       renderer?.root.findAllByProps({ testID: 'assistant-message-toolbar' }).length,
     ).toBeGreaterThan(0);
     expect(
-      renderer?.root.findAllByProps({ testID: 'assistant-message-more' }).length,
+      renderer?.root.findAllByProps({ testID: 'assistant-message-fork' }).length,
     ).toBeGreaterThan(0);
   });
 
-  test('offers a branch action carrying the semantic icon and forks this message', () => {
+  test('forks this message from the direct branch button', () => {
     renderToolbar(createMessage('success', 'Answer'));
 
-    const menu = renderer!.root.findByType('ActionMenu');
-    expect(menu.props.items).toEqual([
-      {
-        icon: 'branch',
-        id: 'fork',
-        label: 'chat.messageActions.fork',
-        onPress: expect.any(Function),
-      },
-    ]);
+    const forkButton = renderer!.root.findByProps({ testID: 'assistant-message-fork' });
+    expect(forkButton.props).toMatchObject({
+      accessibilityLabel: 'chat.messageActions.fork',
+      size: 'xs',
+      variant: 'ghost',
+    });
 
-    act(() => menu.props.items[0].onPress());
+    act(() => forkButton.props.onPress());
     expect(mockForkSession).toHaveBeenCalledWith({
       fromMessageId: 'assistant-1',
       sessionId: 'session-1',

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -173,6 +173,7 @@
   "chat.model.select": "Select model",
   "chat.newSession.description": "Choose an agent to start a session.",
   "chat.newSession.title": "What would you like to work on?",
+  "chat.process.duration": "Took {{seconds}}s",
   "chat.reasoning.auto": "Auto",
   "chat.reasoning.faster": "Faster",
   "chat.reasoning.default": "Default",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -172,6 +172,7 @@
   "chat.model.select": "选择模型",
   "chat.newSession.description": "选择一个智能体后开始会话。",
   "chat.newSession.title": "今天想完成什么？",
+  "chat.process.duration": "用时 {{seconds}}秒",
   "chat.reasoning.auto": "自动",
   "chat.reasoning.faster": "更快",
   "chat.reasoning.default": "默认",


### PR DESCRIPTION
### What this PR does

Before this PR:

Assistant responses interleaved reasoning, tool activity, and final prose in the main transcript. Source and citation affordances were visually prominent, while the fork action was hidden in an overflow menu.

After this PR:

- Keeps the last visible text part as the article body and folds earlier narration, reasoning, and tools into one timed process disclosure.
- Simplifies tool summaries and refines source and citation presentation.
- Exposes the assistant-message fork action directly and reserves enough list inset for the scroll-to-bottom control.
- Documents and exercises the shared message-part contracts used by the new presentation.

### Screenshots or videos

Not captured yet. This draft still needs light- and dark-theme device verification.

### Why we need it and why it was done in this way

The final answer should remain the visual subject of an assistant message while intermediate work stays available on demand. The split remains deterministic by treating only the last visible text part as the result and preserving every earlier visible part in transcript order inside the process disclosure.

The following tradeoffs were made:

- Intermediate prose is intentionally classified as process content when a later visible text result exists.
- Total duration prefers the persisted message lifetime and falls back to reasoning metadata when needed.

The following alternatives were considered:

- Keeping separate reasoning and consecutive-tool disclosures, which left the response process visually fragmented.
- Leaving fork inside the overflow menu, which made a primary message action harder to discover.

### Breaking changes

None.

### Special notes for your reviewer

Local checks completed:

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`

Not run under the workspace verification policy:

- `pnpm typecheck` because it invokes `pnpm packages:build`
- Automated tests
- Device acceptance and screenshots

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: Light- and dark-theme screenshots or video are still pending
- [x] Code: The change keeps process grouping and presentation ownership explicit
- [x] Documentation: Package and frontend ownership notes were updated
- [x] Self-review: The final diff was reviewed against `origin/v0.2`

### Release note

```release-note
Refined assistant responses into a cleaner article layout with collapsible process details, clearer sources, and quicker message actions.
```