### PR TITLE
fix(design-system): refine application surface colors

### DIFF
--- a/packages/design-tokens/scripts/theme-contract.ts
+++ b/packages/design-tokens/scripts/theme-contract.ts
@@ -121,6 +121,7 @@ export const CHERRY_PRODUCT_VARIABLE_TOKENS = [
   'inline-code',
   'inline-code-foreground',
   'chat-user',
+  'chat-background',
   'tag-amber',
   'tag-amber-foreground',
   'tag-blue',

--- a/packages/design-tokens/src/styles/native.css
+++ b/packages/design-tokens/src/styles/native.css
@@ -73,6 +73,7 @@
   --color-inline-code: var(--inline-code);
   --color-inline-code-foreground: var(--inline-code-foreground);
   --color-chat-user: var(--chat-user);
+  --color-chat-background: var(--chat-background);
   --color-tag-amber: var(--tag-amber);
   --color-tag-amber-foreground: var(--tag-amber-foreground);
   --color-tag-blue: var(--tag-blue);
@@ -143,9 +144,9 @@
       --red-700: oklch(0.6256 0.2524 23.03);
       --red-900: oklch(0.5499 0.232 25.29);
       --red-1000: oklch(0.248 0.1041 18.86);
-      --background: color-mix(in srgb, var(--background-100) 50%, var(--background-200));
+      --background: #f5f5f5;
       --foreground: var(--gray-1000);
-      --card: var(--gray-100);
+      --card: var(--background-100);
       --card-foreground: var(--gray-1000);
       --popover: var(--background-100);
       --popover-foreground: var(--gray-1000);
@@ -205,6 +206,7 @@
       --inline-code-foreground: var(--red-900);
       --brand: #ff5757;
       --chat-user: var(--gray-alpha-100);
+      --chat-background: #f9f9f9;
       --tag-amber: var(--amber-100);
       --tag-amber-foreground: var(--amber-900);
       --tag-blue: var(--blue-100);
@@ -327,6 +329,7 @@
       --inline-code-foreground: var(--red-900);
       --brand: #ff5757;
       --chat-user: var(--gray-alpha-100);
+      --chat-background: var(--background);
       --tag-amber: var(--amber-100);
       --tag-amber-foreground: var(--amber-900);
       --tag-blue: var(--blue-100);

--- a/packages/design-tokens/src/styles/product.css
+++ b/packages/design-tokens/src/styles/product.css
@@ -71,6 +71,9 @@
   /* Stable product domain: user-message surface (UserMessageItem) */
   --chat-user: var(--gray-alpha-100);
 
+  /* 聊天业务的消息区表面。共享 MessageList 不认领业务颜色，由聊天工作区在消费侧覆盖。 */
+  --chat-background: #f9f9f9;
+
   /* Stable product domain: categorical badge pairs.
    * 每个色相一对：`tag-*` 是 100 号浅底，`tag-*-foreground` 是画在其上的 900 号
    * 记号，两档都随主题翻转，浅底上实测 4.8–7.7:1。这是分类用色而非状态用色 ——
@@ -112,4 +115,8 @@
   --usage-level-2: color-mix(in srgb, var(--green-700) 50%, transparent);
   --usage-level-3: color-mix(in srgb, var(--green-700) 75%, transparent);
   --usage-level-4: var(--green-700);
+}
+
+.dark {
+  --chat-background: var(--background);
 }

--- a/packages/design-tokens/src/styles/shadcn.css
+++ b/packages/design-tokens/src/styles/shadcn.css
@@ -25,11 +25,10 @@
 
 :root {
   /* Core surfaces and content */
-  /* 从纯白往 background-200 移半档，给页面一层轻微银灰，同时保留
-   * background-subtle 与 card 的层级。深色仍在下方回到纯黑。 */
-  --background: color-mix(in srgb, var(--background-100) 50%, var(--background-200));
+  /* 浅色页面统一使用明确的中性灰；深色仍在下方回到纯黑。 */
+  --background: #f5f5f5;
   --foreground: var(--gray-1000);
-  --card: var(--gray-100);
+  --card: var(--background-100);
   --card-foreground: var(--gray-1000);
   --popover: var(--background-100);
   --popover-foreground: var(--gray-1000);
@@ -93,8 +92,9 @@
 }
 
 .dark {
-  /* 抬升：浅色下浮层与页面同为白，深色下纯黑页面上必须提一档才有可见边界。 */
+  /* 深色页面回到纯黑，卡片与浮层提到 gray-100 以保留可见层级。 */
   --background: var(--background-100);
+  --card: var(--gray-100);
   --popover: var(--gray-100);
   --sidebar: var(--gray-100);
   --sidebar-accent: var(--gray-200);

--- a/packages/ui/stories/foundations/tokens.ts
+++ b/packages/ui/stories/foundations/tokens.ts
@@ -109,9 +109,9 @@ export const SEMANTIC_GROUPS: SemanticGroup[] = [
   },
   {
     title: '产品域',
-    hint: '各自只有一个消费者：代码块与行内代码在 MarkdownText，chat-user 是 user 气泡底色（bg-chat-user）。',
+    hint: '代码块与行内代码用于 MarkdownText；chat-user 是 user 气泡底色，chat-background 是聊天业务覆盖的消息区底色。',
     kind: 'surface',
-    variables: ['--code-block', '--inline-code', '--chat-user'],
+    variables: ['--code-block', '--inline-code', '--chat-user', '--chat-background'],
   },
   {
     title: '恒定黑白',

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -154,7 +154,7 @@ export function ChatWorkspace({
   }
 
   return (
-    <View className="flex-1">
+    <View className="flex-1 bg-chat-background">
       <ChatOlderMessagesIndicator isLoading={isLoadingOlder} />
       <AssistantMessageActionsProvider
         key={`assistant-actions-${sessionId}`}

--- a/src/frontend/features/chat/workspace/components/ChatInitialRenderCover.tsx
+++ b/src/frontend/features/chat/workspace/components/ChatInitialRenderCover.tsx
@@ -8,7 +8,7 @@ type ChatInitialRenderCoverProps = {
 };
 
 export function ChatInitialRenderCover({ isVisible }: ChatInitialRenderCoverProps) {
-  const [backgroundColor, indicatorColor] = useThemeColor(['background', 'muted-foreground']);
+  const indicatorColor = useThemeColor('muted-foreground');
 
   if (!isVisible) {
     return null;
@@ -18,10 +18,10 @@ export function ChatInitialRenderCover({ isVisible }: ChatInitialRenderCoverProp
   // 新列表在遮罩后完成布局，进度指示器提供即时反馈，二者准备好后再一起淡出。
   return (
     <Animated.View
-      className="absolute inset-0 items-center justify-center"
+      className="absolute inset-0 items-center justify-center bg-chat-background"
       exiting={FadeOut.duration(180).easing(Easing.out(Easing.cubic))}
       pointerEvents="none"
-      style={{ backgroundColor, zIndex: 5 }}
+      style={{ zIndex: 5 }}
     >
       <ActivityIndicator color={indicatorColor} size="small" />
     </Animated.View>


### PR DESCRIPTION
## Summary

- set the light application background to `#F5F5F5` and make card surfaces pure white
- add a chat-specific `#F9F9F9` background token and apply it to the message workspace and initial render cover
- preserve the existing elevated card and chat surfaces in dark mode

## Validation

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`
- `git diff --check`

Not run per workspace verification policy: builds, type checking, tests, `pnpm design:check`, or device UI acceptance.