### PR TITLE
refactor(logging): remove noisy development diagnostics

### DIFF
--- a/src/backend/ai/generation/AiSdkGenerator.ts
+++ b/src/backend/ai/generation/AiSdkGenerator.ts
@@ -133,7 +133,6 @@ export class AiSdkGenerator<Key extends AppProviderKey = AppProviderKey> {
         await safeCall('onAbort', hooks.onAbort);
         throw error;
       }
-      logger.error('AI SDK generation error', error as Error);
       if (hooks.onError) {
         try {
           await hooks.onError({ error: toError(error) });

--- a/src/backend/core/lifecycle/LifecycleManager.ts
+++ b/src/backend/core/lifecycle/LifecycleManager.ts
@@ -107,14 +107,10 @@ export class LifecycleManager {
 
     const graph = this.container.buildDependencyGraph(phase);
     if (graph.length === 0) {
-      logger.debug(`No services registered for phase '${phase}'`);
       return;
     }
 
     const layers = this.resolver.resolveLayered(graph);
-    const order = layers.map((layer) => `[${layer.join(', ')}]`).join(' -> ');
-    logger.info(`--- ${phase} start (${layers.flat().length} services) --- ${order}`);
-
     const startedAt = performance.now();
 
     for (const layer of layers) {
@@ -129,7 +125,9 @@ export class LifecycleManager {
       this.initializationOrder.push(...layer);
     }
 
-    logger.info(`--- ${phase} complete (${(performance.now() - startedAt).toFixed(1)}ms) ---`);
+    logger.info(
+      `Phase '${phase}' initialized (${graph.length} services, ${(performance.now() - startedAt).toFixed(1)}ms)`,
+    );
   }
 
   /**
@@ -213,7 +211,6 @@ export class LifecycleManager {
 
       const duration = performance.now() - startedAt;
       this.serviceTiming.set(serviceName, duration);
-      logger.debug(`Service '${serviceName}' initialized (${duration.toFixed(1)}ms)`);
     } catch (error) {
       this.handleInitError(serviceName, error as Error);
     }

--- a/src/backend/data/db/DbService.ts
+++ b/src/backend/data/db/DbService.ts
@@ -139,7 +139,6 @@ export class DbService extends BaseService {
       this.sqlite.execSync('PRAGMA journal_mode = WAL');
       this.sqlite.execSync('PRAGMA synchronous = NORMAL');
       this.sqlite.execSync('PRAGMA foreign_keys = ON');
-      logger.info('Database PRAGMAs configured');
     } catch (error) {
       logger.warn('Failed to configure database PRAGMAs', error as Error);
     }

--- a/src/backend/data/db/seeding/SeedRunner.ts
+++ b/src/backend/data/db/seeding/SeedRunner.ts
@@ -29,7 +29,6 @@ export class SeedRunner {
       const journal = journalMap.get(key);
 
       if (journal?.version === seeder.version) {
-        logger.debug(`Skipping seed "${seeder.name}" (v${seeder.version}) - already applied`);
         continue;
       }
 

--- a/src/backend/data/services/McpServerService.ts
+++ b/src/backend/data/services/McpServerService.ts
@@ -15,7 +15,6 @@ import {
   mcpServerTable,
   monotonicUpdateTimestamp,
 } from '@/backend/data/db/schemas';
-import { loggerService } from '@/shared/core/logger/LoggerService';
 import { DataApiErrorFactory } from '@/shared/data/api/errors';
 import {
   type CreateMcpServerDto,
@@ -27,8 +26,6 @@ import type { OffsetPaginationResponse } from '@/shared/data/api/types';
 import type { McpServer } from '@/shared/data/types/mcpServer';
 
 import { timestampToISO } from './utils/rowMappers';
-
-const logger = loggerService.withContext('DataApi:McpServerService');
 
 export type ListMcpServersQuery = {
   id?: string;
@@ -122,7 +119,6 @@ export class McpServerService {
       })
       .returning();
 
-    logger.info('Created MCP server', { id: row.id, name: row.name });
     return rowToMcpServer(row);
   }
 
@@ -158,7 +154,6 @@ export class McpServerService {
       throw DataApiErrorFactory.notFound('McpServer', id);
     }
 
-    logger.info('Updated MCP server', { changes: Object.keys(updates), id });
     return rowToMcpServer(row);
   }
 
@@ -180,8 +175,6 @@ export class McpServerService {
         throw DataApiErrorFactory.notFound('McpServer', id);
       }
     });
-
-    logger.info('Deleted MCP server', { id });
   }
 
   /**

--- a/src/backend/services/jobs/JobRuntime.ts
+++ b/src/backend/services/jobs/JobRuntime.ts
@@ -705,7 +705,14 @@ export class JobRuntime extends BaseService {
         this.handlers,
         (jobId) => this.inFlightExecuted.has(jobId) || (this.startupLocalIds?.has(jobId) ?? false),
       );
-      logger.info('startup recovery done', { ...stats });
+      if (
+        stats.cancelled > 0 ||
+        stats.pendingReset > 0 ||
+        stats.delayedKept > 0 ||
+        stats.singletonKept > 0
+      ) {
+        logger.info('startup recovery reconciled jobs', { ...stats });
+      }
     } finally {
       this.startupLocalIds = null;
     }

--- a/src/backend/services/keepAlive/KeepAliveCoordinator.ts
+++ b/src/backend/services/keepAlive/KeepAliveCoordinator.ts
@@ -51,12 +51,11 @@ export class KeepAliveCoordinator extends BaseService {
     this.registerAppStateListener(this.handleAppStateChange);
   }
 
-  acquire(tag: string): KeepAliveLease {
+  acquire(_tag: string): KeepAliveLease {
     if (Platform.OS !== 'ios' || this.disposed) return noOpLease;
 
     let released = false;
     this.holderCount += 1;
-    logger.info('Keep-alive lease acquired', { holderCount: this.holderCount, tag });
     void this.enqueue(() => this.reconcile());
 
     return {
@@ -64,7 +63,6 @@ export class KeepAliveCoordinator extends BaseService {
         if (released || this.disposed) return;
         released = true;
         this.holderCount -= 1;
-        logger.info('Keep-alive lease released', { holderCount: this.holderCount, tag });
         void this.enqueue(() => this.reconcile());
       },
     };
@@ -126,7 +124,6 @@ export class KeepAliveCoordinator extends BaseService {
       );
       this.clearRetryTimer();
       this.retryDelayMs = KEEP_ALIVE_RETRY_BASE_MS;
-      logger.info('Background audio started', { holderCount: this.holderCount });
     } catch (error) {
       if (player) this.releasePlayer(player);
       logger.error('Background audio failed to start', error as Error, {
@@ -155,7 +152,6 @@ export class KeepAliveCoordinator extends BaseService {
     }
     try {
       player.remove();
-      logger.info('Background audio stopped');
     } catch (error) {
       logger.error('Background audio removal failed', error as Error);
     }

--- a/src/backend/services/webSearch/WebSearchService.ts
+++ b/src/backend/services/webSearch/WebSearchService.ts
@@ -138,22 +138,9 @@ export class WebSearchService extends BaseService {
     request: RunCapabilityRequest,
     httpOptions?: RequestInit,
   ): Promise<WebSearchResponse> {
-    let context: PreparedWebSearchContext | undefined;
-
-    try {
-      context = await this.prepareContext(request);
-      const searchResults = await this.executeCapability(context, httpOptions);
-      return await this.buildFinalResponse(context, searchResults, httpOptions);
-    } catch (error) {
-      if (!isAbortError(error) || !httpOptions?.signal?.aborted) {
-        const normalizedError = error instanceof Error ? error : new Error(String(error));
-        logger.error('Web search failed', normalizedError, {
-          providerId: context?.provider.id ?? request.providerId,
-          capability: context?.capability ?? request.capability,
-        });
-      }
-      throw error;
-    }
+    const context = await this.prepareContext(request);
+    const searchResults = await this.executeCapability(context, httpOptions);
+    return this.buildFinalResponse(context, searchResults, httpOptions);
   }
 
   async searchKeywords(

--- a/src/frontend/components/composer/components/ComposerSurface.tsx
+++ b/src/frontend/components/composer/components/ComposerSurface.tsx
@@ -72,7 +72,6 @@ export function ComposerSurface({
 
     const attemptId = ++nextSendAttemptIdRef.current;
     activeSendAttemptIdRef.current = attemptId;
-    logger.debug('Message send started', { attemptId });
 
     const draftSnapshot = draft;
 
@@ -100,7 +99,6 @@ export function ComposerSurface({
       });
     } finally {
       activeSendAttemptIdRef.current = null;
-      logger.debug('Message send finished', { attemptId });
     }
   }, [
     attachments,

--- a/src/frontend/components/composer/components/__tests__/ComposerSurface.test.tsx
+++ b/src/frontend/components/composer/components/__tests__/ComposerSurface.test.tsx
@@ -92,7 +92,6 @@ describe('ComposerSurface', () => {
     });
 
     expect(onSend).toHaveBeenCalledTimes(1);
-    expect(mockLoggerDebug).toHaveBeenCalledWith('Message send started', { attemptId: 1 });
     expect(mockLoggerDebug).toHaveBeenCalledWith('Ignored duplicate message send', {
       attemptId: 1,
     });
@@ -118,7 +117,6 @@ describe('ComposerSurface', () => {
 
     expect(onSend).toHaveBeenNthCalledWith(1, { attachments: [], text: 'first' });
     expect(onSend).toHaveBeenNthCalledWith(2, { attachments: [], text: 'second' });
-    expect(mockLoggerDebug).toHaveBeenCalledWith('Message send started', { attemptId: 2 });
   });
 
   it('restores the exact draft and attachments once when sending fails', async () => {

--- a/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
+++ b/src/frontend/components/composer/hooks/__tests__/useManagedComposerAttachments.test.tsx
@@ -13,7 +13,6 @@ import { useManagedComposerAttachments } from '../useManagedComposerAttachments'
 const mockCreateInternalEntry = jest.fn();
 const mockDeleteEntry = jest.fn(async () => true);
 const mockAlertShow = jest.fn();
-const mockLoggerDebug = jest.fn();
 const mockLoggerWarn = jest.fn();
 const mockFileModule = {
   createInternalEntry: mockCreateInternalEntry,
@@ -32,7 +31,6 @@ jest.mock('@cherrystudio/ui/components', () => ({
 jest.mock('@/shared/core/logger/LoggerService', () => ({
   loggerService: {
     withContext: () => ({
-      debug: (...args: unknown[]) => mockLoggerDebug(...args),
       warn: (...args: unknown[]) => mockLoggerWarn(...args),
     }),
   },
@@ -268,27 +266,6 @@ describe('useManagedComposerAttachments', () => {
         status: 'ready',
       }),
     ]);
-  });
-
-  it('logs import duration without file identity or location', async () => {
-    const pending = deferred<ReturnType<typeof resolvedFile>>();
-    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
-    mockCreateInternalEntry.mockReturnValue(pending.promise);
-    await renderHook();
-
-    await act(async () => snapshot?.addAttachments([source('private.pdf')]));
-    now.mockReturnValue(1_830);
-    await act(async () => {
-      pending.resolve(resolvedFile('00000000-0000-7000-8000-000000000015', 'private.pdf'));
-      await pending.promise;
-    });
-
-    expect(mockLoggerDebug).toHaveBeenCalledWith('Attachment import finished', {
-      durationMs: 830,
-      kind: 'file',
-      result: 'ready',
-      size: 128,
-    });
   });
 
   it('rejects unsupported images before importing them', async () => {

--- a/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
+++ b/src/frontend/components/composer/hooks/useManagedComposerAttachments.ts
@@ -71,19 +71,7 @@ export function useManagedComposerAttachments(
 
   const importAttachment = useCallback(
     async (source: ComposerAttachmentSource, token: symbol): Promise<ImportResult> => {
-      const startedAt = Date.now();
       let importedSize = source.size;
-      const finishImport = (result: ImportResult) => {
-        if (__DEV__) {
-          logger.debug('Attachment import finished', {
-            durationMs: Date.now() - startedAt,
-            kind: source.kind,
-            result,
-            size: importedSize ?? null,
-          });
-        }
-        return result;
-      };
 
       try {
         const resolved = await file.createInternalEntry({
@@ -95,15 +83,15 @@ export function useManagedComposerAttachments(
 
         if (cancelledImportTokensRef.current.delete(token)) {
           await deleteEntry(resolved.entry.id);
-          return finishImport('ignored');
+          return 'ignored';
         }
         if (!isMountedRef.current) {
           await deleteEntry(resolved.entry.id);
-          return finishImport('ignored');
+          return 'ignored';
         }
         if (importTokensRef.current.get(source.id) !== token) {
           await deleteEntry(resolved.entry.id);
-          return finishImport('ignored');
+          return 'ignored';
         }
 
         importTokensRef.current.delete(source.id);
@@ -123,13 +111,13 @@ export function useManagedComposerAttachments(
               : attachment,
           ),
         );
-        return finishImport('ready');
+        return 'ready';
       } catch {
         if (cancelledImportTokensRef.current.delete(token)) {
-          return finishImport('ignored');
+          return 'ignored';
         }
         if (importTokensRef.current.get(source.id) !== token || !isMountedRef.current) {
-          return finishImport('ignored');
+          return 'ignored';
         }
 
         importTokensRef.current.delete(source.id);
@@ -138,7 +126,7 @@ export function useManagedComposerAttachments(
           kind: source.kind,
           size: importedSize ?? null,
         });
-        return finishImport('failed');
+        return 'failed';
       }
     },
     [commitAttachments, deleteEntry, file],

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -17,7 +17,6 @@ import {
   MESSAGE_LIST_TOP_PADDING,
   messageKeyExtractor,
 } from './list/messageListLayout';
-import { scrollLog } from './list/messageListLogger';
 import { MessageListRow } from './list/MessageListRow';
 import { useMessageListScrollController } from './list/useMessageListScrollController';
 import type { MessageListItem, MessageListProps } from './types';
@@ -107,7 +106,6 @@ export function MessageList({
       return;
     }
 
-    scrollLog.debug('[SCROLL] startReached', { t: Date.now() });
     void onLoadOlder();
   }, [onLoadOlder]);
   const sharedValues = useMemo(() => ({ isAtEnd: isAtBottom }), [isAtBottom]);

--- a/src/frontend/components/messages/list/messageListLogger.ts
+++ b/src/frontend/components/messages/list/messageListLogger.ts
@@ -1,4 +1,0 @@
-import { loggerService } from '@/shared/core/logger/LoggerService';
-
-// Development-only diagnostics for the values that can move the message list.
-export const scrollLog = loggerService.withContext('ChatScroll');

--- a/src/frontend/components/messages/list/useMessageListScrollController.ts
+++ b/src/frontend/components/messages/list/useMessageListScrollController.ts
@@ -4,10 +4,10 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
 import { cacheService } from '@/frontend/data/CacheService';
+import { loggerService } from '@/shared/core/logger/LoggerService';
 import type { ChatScrollAnchor } from '@/shared/data/cache/cacheSchemas';
 
 import type { MessageListItem } from '../types';
-import { scrollLog } from './messageListLogger';
 import { computeScrollAnchor, resolveRestoreTarget } from './messageListScrollMemory';
 import {
   type FollowingReason,
@@ -16,6 +16,7 @@ import {
 } from './useViewportFollowState';
 
 const SAVE_THROTTLE_MS = 200;
+const scrollLog = loggerService.withContext('ChatScroll');
 
 type ScrollMessageToEnd = (options: { animated: boolean; closeKeyboard: boolean }) => Promise<void>;
 
@@ -332,17 +333,12 @@ export function useMessageListScrollController(inputs: MessageListScrollControll
 
   const handleLoad = useCallback(() => {
     didListLoadRef.current = true;
-    scrollLog.debug('[SCROLL] listLoaded', { t: Date.now() });
     attemptRestore();
   }, [attemptRestore]);
 
-  const handleContentSizeChange = useCallback(
-    (_width: number, height: number) => {
-      scrollLog.debug('[SCROLL] contentSize', { h: Math.round(height), t: Date.now() });
-      stickToBottomIfFollowing();
-    },
-    [stickToBottomIfFollowing],
-  );
+  const handleContentSizeChange = useCallback(() => {
+    stickToBottomIfFollowing();
+  }, [stickToBottomIfFollowing]);
 
   // A viewport resize (keyboard, rotation) moves the live edge without changing
   // content size, so it needs the same correction from its own native callback.

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -1,6 +1,6 @@
 import { ContentState, useAlert } from '@cherrystudio/ui/components';
 import { useHeaderHeight } from 'expo-router/react-navigation';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 
@@ -28,7 +28,6 @@ import {
 } from './hooks/useMessageListInitialRenderGate';
 
 const logger = loggerService.withContext('AgentChatWorkspace');
-const gateLog = loggerService.withContext('AgentChatGate');
 
 type ChatWorkspaceProps = {
   assistantAvatarUri?: null | string;
@@ -133,15 +132,6 @@ export function ChatWorkspace({
     forkedFromSessionId && isAtHistoryStart ? (
       <ChatForkOriginDivider sourceSessionId={forkedFromSessionId} />
     ) : undefined;
-
-  useEffect(() => {
-    gateLog.debug('[GATE] state', {
-      isLoadingInitial,
-      isCoverVisible,
-      len: listMessages.length,
-      t: Date.now(),
-    });
-  }, [isLoadingInitial, isCoverVisible, listMessages.length]);
 
   if (error && !isLoadingInitial && listMessages.length === 0) {
     return (

--- a/src/frontend/features/chat/workspace/hooks/useMessageListInitialRenderGate.ts
+++ b/src/frontend/features/chat/workspace/hooks/useMessageListInitialRenderGate.ts
@@ -1,9 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { loggerService } from '@/shared/core/logger/LoggerService';
-
-const gateLog = loggerService.withContext('ChatGate');
-
 export type MessageListInitialRenderGateOptions = {
   renderGateKey: string;
   requiresInitialHistoryLayout: boolean;
@@ -84,12 +80,10 @@ export function useMessageListInitialRenderGate({
       cancelAnimationFrame(pendingReadyFrame.id);
     }
 
-    gateLog.debug('[GATE] markListLoaded(onReady)', { t: Date.now() });
     const readyFrameId = requestAnimationFrame(() => {
       if (pendingReadyFrameRef.current?.id === readyFrameId) {
         pendingReadyFrameRef.current = null;
       }
-      gateLog.debug('[GATE] gateResolved(rAF)', { t: Date.now() });
       if (activeRenderTokenRef.current === renderToken) {
         setResolvedRenderToken(renderToken);
       }


### PR DESCRIPTION
## Summary

- remove high-frequency chat scroll and render-gate diagnostics plus routine success-path logs
- collapse lifecycle startup logging to one phase summary and only report job recovery when work was reconciled
- remove duplicate lower-layer error logs and tests that asserted log-only implementation details

## Validation

- `pnpm format`
- `pnpm format:check`
- targeted Oxlint and Expo lint for the changed files
- `pnpm lint` remains blocked by 7 existing unresolved `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` imports; it also reports existing repository warnings
- not run per workspace instructions: tests, typecheck, builds, or device verification