### PR TITLE
fix: improve mobile citation presentation

### DIFF
--- a/packages/ui/src/components/markdown-text/__tests__/markdown-text.test.tsx
+++ b/packages/ui/src/components/markdown-text/__tests__/markdown-text.test.tsx
@@ -105,13 +105,6 @@ describe('MarkdownText', () => {
             padding: 12,
             textAlign: 'center',
           }),
-          linkVariants: {
-            '^cite:': {
-              backgroundColor: 'secondary',
-              color: 'foreground-tertiary',
-              underline: false,
-            },
-          },
           superscript: { baselineOffsetScale: 0.3, fontScale: 0.75 },
         }),
       );

--- a/packages/ui/src/components/markdown-text/components/markdown-text.tsx
+++ b/packages/ui/src/components/markdown-text/components/markdown-text.tsx
@@ -15,7 +15,6 @@ const markdownThemeVariables = [
   '--color-background',
   '--color-primary',
   '--color-muted-foreground',
-  '--color-foreground-tertiary',
   '--color-link',
   '--color-border',
   '--color-secondary',
@@ -119,7 +118,6 @@ export function MarkdownText({
     backgroundValue,
     primaryValue,
     mutedForegroundValue,
-    foregroundTertiaryValue,
     linkValue,
     borderValue,
     secondaryValue,
@@ -132,7 +130,6 @@ export function MarkdownText({
   const background = resolveCSSString(backgroundValue);
   const primary = resolveCSSString(primaryValue);
   const mutedForeground = resolveCSSString(mutedForegroundValue);
-  const foregroundTertiary = resolveCSSString(foregroundTertiaryValue);
   const link = resolveCSSString(linkValue);
   const border = resolveCSSString(borderValue);
   const secondary = resolveCSSString(secondaryValue);
@@ -187,9 +184,6 @@ export function MarkdownText({
         syntaxColors: resolveSyntaxColors(theme, mutedForeground),
       },
       link: { color: link, underline: false },
-      linkVariants: {
-        '^cite:': { backgroundColor: secondary, color: foregroundTertiary, underline: false },
-      },
       strong: { color: foreground },
       em: { color: foreground },
       strikethrough: { color: mutedForeground },
@@ -231,7 +225,6 @@ export function MarkdownText({
     codeBlock,
     fontSizeStep,
     foreground,
-    foregroundTertiary,
     inlineCode,
     inlineCodeForeground,
     link,

--- a/src/frontend/components/messages/parts/MessageParts.tsx
+++ b/src/frontend/components/messages/parts/MessageParts.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { View } from 'react-native';
 
 import type { MessageListItem } from '../types';
-import { resolveMessageCitationText } from './citations';
+import { resolveMessageCitations } from './citations';
 import { MessageFileStrip } from './MessageFileStrip';
 import { MessagePartRenderer } from './MessagePartRenderer';
 import { partitionMessageParts } from './partitionMessageParts';
@@ -31,10 +31,9 @@ export function MessageParts({
   renderMode = 'markdown',
 }: MessagePartsProps) {
   const parts = message.data.parts;
-  // Parts keep their identity across renders (see the projection cache), so this
-  // has to be memoized: a fresh ResolvedCitationText per render would defeat the
-  // memo on MessagePartRenderer for every message that carries citations.
-  const citationText = useMemo(() => resolveMessageCitationText(parts ?? []), [parts]);
+  // Parts keep their identity across renders (see the projection cache), so the
+  // resolved text and source-number map stay stable for their consumers too.
+  const citations = useMemo(() => resolveMessageCitations(parts ?? []), [parts]);
 
   if (!parts?.length) {
     return null;
@@ -47,7 +46,7 @@ export function MessageParts({
     <View className="gap-2">
       {process.length > 0 ? (
         <ProcessGroupPart
-          citationText={citationText}
+          citationText={citations.textByPartIndex}
           isTextSelectionEnabled={isTextSelectionEnabled}
           items={process.map(({ index, part }) => ({
             index,
@@ -67,10 +66,12 @@ export function MessageParts({
           messageParts={parts}
           part={item.part}
           renderMode={renderMode}
-          resolvedText={citationText.get(item.index)}
+          resolvedText={citations.textByPartIndex.get(item.index)}
         />
       ))}
-      {hasSources ? <SourceGroup parts={parts} /> : null}
+      {hasSources ? (
+        <SourceGroup citationNumberBySourceId={citations.sourceNumberById} parts={parts} />
+      ) : null}
       {/* Last, so the files a turn produced are the closest thing to the end of
           the message and stay put as the answer above them streams in. */}
       {files.length > 0 ? <MessageFileStrip parts={files} /> : null}

--- a/src/frontend/components/messages/parts/SourceGroup.tsx
+++ b/src/frontend/components/messages/parts/SourceGroup.tsx
@@ -9,13 +9,17 @@ import { resolveCitationWebSources } from './webSource';
 import { WebSourceCard, WebSourceFavicon } from './WebSourceCard';
 
 type SourceGroupProps = {
+  citationNumberBySourceId: ReadonlyMap<string, number>;
   parts: readonly CherryMessagePart[];
 };
 
-export function SourceGroup({ parts }: SourceGroupProps) {
+export function SourceGroup({ citationNumberBySourceId, parts }: SourceGroupProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
-  const sources = useMemo(() => resolveCitationWebSources(parts), [parts]);
+  const sources = useMemo(
+    () => resolveCitationWebSources(parts, citationNumberBySourceId),
+    [citationNumberBySourceId, parts],
+  );
   const label = t('chat.sources.count', { count: sources.length });
 
   if (sources.length === 0) {
@@ -27,8 +31,7 @@ export function SourceGroup({ parts }: SourceGroupProps) {
       <Pressable
         accessibilityLabel={label}
         accessibilityRole="button"
-        className="-mx-2 min-h-10 self-start flex-row items-center gap-2 rounded-lg px-2 active:bg-secondary-active active:opacity-80"
-        hitSlop={4}
+        className="-mx-2 min-h-11 self-start flex-row items-center gap-2 rounded-lg px-2 active:bg-secondary-active active:opacity-80"
         onPress={() => setIsOpen(true)}
       >
         <View className="flex-row items-center">

--- a/src/frontend/components/messages/parts/WebSourceCard.tsx
+++ b/src/frontend/components/messages/parts/WebSourceCard.tsx
@@ -13,13 +13,18 @@ type WebSourceCardProps = {
 
 export function WebSourceCard({ source }: WebSourceCardProps) {
   const { t } = useTranslation();
+  const citationNumber = source.citationNumber;
+  const openLabel = t('chat.webSearch.openResult', {
+    domain: source.siteName,
+    title: source.title ?? source.siteName,
+  });
+  const accessibilityLabel = citationNumber
+    ? `${t('chat.sources.title')} ${citationNumber}. ${openLabel}`
+    : openLabel;
 
   return (
     <Pressable
-      accessibilityLabel={t('chat.webSearch.openResult', {
-        domain: source.siteName,
-        title: source.title ?? source.siteName,
-      })}
+      accessibilityLabel={accessibilityLabel}
       accessibilityRole="link"
       className="gap-2.5 rounded-2xl border-continuous bg-background-subtle px-3 py-4 active:bg-secondary-active active:opacity-80"
       onPress={() => void openExternalUrl(source.url)}

--- a/src/frontend/components/messages/parts/__tests__/citations.test.ts
+++ b/src/frontend/components/messages/parts/__tests__/citations.test.ts
@@ -1,8 +1,8 @@
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
-import { resolveMessageCitationText } from '../citations';
+import { resolveMessageCitations } from '../citations';
 
-describe('resolveMessageCitationText', () => {
+describe('resolveMessageCitations', () => {
   test('resolves IDs from projected source URL parts', () => {
     const parts = [
       {
@@ -14,10 +14,13 @@ describe('resolveMessageCitationText', () => {
       { text: 'See [cite:aaaa1111-1].', type: 'text' },
     ] satisfies CherryMessagePart[];
 
-    expect(resolveMessageCitationText(parts).get(1)).toEqual({
-      markdown: 'See ^[1](cite:https%3A%2F%2Fcherry-ai.com)^.',
+    const citations = resolveMessageCitations(parts);
+
+    expect(citations.textByPartIndex.get(1)).toEqual({
+      markdown: 'See ^❶^.',
       plainText: 'See [1].',
     });
+    expect(citations.sourceNumberById.get('aaaa1111-1')).toBe(1);
   });
 
   test('resolves message-local tool result IDs by first marker appearance', () => {
@@ -35,11 +38,18 @@ describe('resolveMessageCitationText', () => {
       { text: 'Second [cite:aaaa1111-2], first [cite:aaaa1111-1].', type: 'text' },
     ] as CherryMessagePart[];
 
-    expect(resolveMessageCitationText(parts).get(1)).toEqual({
-      markdown:
-        'Second ^[1](cite:https%3A%2F%2Fb.example)^, first ^[2](cite:https%3A%2F%2Fa.example)^.',
+    const citations = resolveMessageCitations(parts);
+
+    expect(citations.textByPartIndex.get(1)).toEqual({
+      markdown: 'Second ^❶^, first ^❷^.',
       plainText: 'Second [1], first [2].',
     });
+    expect(citations.sourceNumberById).toEqual(
+      new Map([
+        ['aaaa1111-1', 2],
+        ['aaaa1111-2', 1],
+      ]),
+    );
   });
 
   test('keeps unknown markers and code examples literal', () => {
@@ -56,8 +66,8 @@ describe('resolveMessageCitationText', () => {
       },
     ] as CherryMessagePart[];
 
-    expect(resolveMessageCitationText(parts).get(1)?.markdown).toBe(
-      '`[cite:aaaa1111-1]` [cite:missing] ^[1](cite:https%3A%2F%2Fa.example)^',
+    expect(resolveMessageCitations(parts).textByPartIndex.get(1)?.markdown).toBe(
+      '`[cite:aaaa1111-1]` [cite:missing] ^❶^',
     );
   });
 
@@ -78,6 +88,14 @@ describe('resolveMessageCitationText', () => {
       { text: 'A [cite:aaaa1111-1] B [cite:bbbb2222-1]', type: 'text' },
     ] as CherryMessagePart[];
 
-    expect(resolveMessageCitationText(parts).get(2)?.plainText).toBe('A [1] B [1]');
+    const citations = resolveMessageCitations(parts);
+
+    expect(citations.textByPartIndex.get(2)?.plainText).toBe('A [1] B [1]');
+    expect(citations.sourceNumberById).toEqual(
+      new Map([
+        ['aaaa1111-1', 1],
+        ['bbbb2222-1', 1],
+      ]),
+    );
   });
 });

--- a/src/frontend/components/messages/parts/__tests__/webSource.test.ts
+++ b/src/frontend/components/messages/parts/__tests__/webSource.test.ts
@@ -70,6 +70,36 @@ describe('webSource', () => {
     ]);
   });
 
+  test('orders source cards by citation number and exposes their matching labels', () => {
+    const parts = [
+      {
+        sourceId: 'result-1',
+        title: 'First result',
+        type: 'source-url',
+        url: 'https://a.example',
+      },
+      {
+        sourceId: 'result-2',
+        title: 'Second result',
+        type: 'source-url',
+        url: 'https://b.example',
+      },
+    ] as CherryMessagePart[];
+
+    expect(
+      resolveCitationWebSources(
+        parts,
+        new Map([
+          ['result-1', 2],
+          ['result-2', 1],
+        ]),
+      ),
+    ).toEqual([
+      expect.objectContaining({ citationNumber: 1, id: 'result-2' }),
+      expect.objectContaining({ citationNumber: 2, id: 'result-1' }),
+    ]);
+  });
+
   test('uses the persisted cited sentence when a result has no summary', () => {
     const parts = [
       {

--- a/src/frontend/components/messages/parts/citations.ts
+++ b/src/frontend/components/messages/parts/citations.ts
@@ -1,8 +1,29 @@
-import { createCitationLinkUrl } from '@/frontend/components/markdown/citationLink';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
 const CITABLE_TOOL_NAMES = new Set(['web_search', 'web_fetch', 'kb_search', 'kb_read']);
 const MARKDOWN_CODE_PATTERN = /```[\s\S]*?```|`[^`\n]*`/gm;
+const CIRCLED_CITATION_MARKERS = [
+  '❶',
+  '❷',
+  '❸',
+  '❹',
+  '❺',
+  '❻',
+  '❼',
+  '❽',
+  '❾',
+  '❿',
+  '⓫',
+  '⓬',
+  '⓭',
+  '⓮',
+  '⓯',
+  '⓰',
+  '⓱',
+  '⓲',
+  '⓳',
+  '⓴',
+] as const;
 
 type CitationSource = {
   content?: string;
@@ -16,15 +37,22 @@ export type ResolvedCitationText = {
   plainText: string;
 };
 
+export type ResolvedMessageCitations = {
+  sourceNumberById: ReadonlyMap<string, number>;
+  textByPartIndex: ReadonlyMap<number, ResolvedCitationText>;
+};
+
 /** Resolve persisted citation markers from their message-local tool results. */
-export function resolveMessageCitationText(
+export function resolveMessageCitations(
   parts: readonly CherryMessagePart[],
-): Map<number, ResolvedCitationText> {
+): ResolvedMessageCitations {
   const sourceById = collectCitationSources(parts);
-  if (sourceById.size === 0) return new Map();
+  if (sourceById.size === 0) {
+    return { sourceNumberById: new Map(), textByPartIndex: new Map() };
+  }
 
   const numberBySource = new Map<CitationSource, number>();
-  const result = new Map<number, ResolvedCitationText>();
+  const textByPartIndex = new Map<number, ResolvedCitationText>();
   let nextNumber = 1;
 
   parts.forEach((part, index) => {
@@ -32,9 +60,9 @@ export function resolveMessageCitationText(
 
     const replace = (content: string, markdown: boolean) =>
       mapMarkdownOutsideCode(content, (text) =>
-        text.replace(/\[cite:([\w-]+)\]/g, (marker, id: string) => {
+        text.replace(/\[cite:([\w-]+)\]/g, (rawMarker, id: string) => {
           const source = sourceById.get(id);
-          if (!source) return marker;
+          if (!source) return rawMarker;
 
           let number = numberBySource.get(source);
           if (!number) {
@@ -42,19 +70,26 @@ export function resolveMessageCitationText(
             numberBySource.set(source, number);
           }
 
-          return markdown && source.url
-            ? `^[${number}](${createCitationLinkUrl(source.url)})^`
-            : `[${number}]`;
+          // Inline citations annotate the claim but are intentionally not touch
+          // targets. SourceGroup owns the mobile-sized entry and source links.
+          const marker = CIRCLED_CITATION_MARKERS[number - 1] ?? String(number);
+          return markdown ? `^${marker}^` : `[${number}]`;
         }),
       );
 
-    result.set(index, {
+    textByPartIndex.set(index, {
       markdown: replace(part.text, true),
       plainText: replace(part.text, false),
     });
   });
 
-  return result;
+  const sourceNumberById = new Map<string, number>();
+  sourceById.forEach((source, id) => {
+    const number = numberBySource.get(source);
+    if (number !== undefined) sourceNumberById.set(id, number);
+  });
+
+  return { sourceNumberById, textByPartIndex };
 }
 
 function collectCitationSources(parts: readonly CherryMessagePart[]): Map<string, CitationSource> {

--- a/src/frontend/components/messages/parts/webSource.ts
+++ b/src/frontend/components/messages/parts/webSource.ts
@@ -4,6 +4,7 @@ type SourceUrlPart = Extract<CherryMessagePart, { type: 'source-url' }>;
 
 export type WebSource = {
   aliases?: string[];
+  citationNumber?: number;
   content?: string;
   faviconUrl?: string;
   id: number | string;
@@ -33,7 +34,10 @@ export function enrichWebSources(
   });
 }
 
-export function resolveCitationWebSources(messageParts: readonly CherryMessagePart[]): WebSource[] {
+export function resolveCitationWebSources(
+  messageParts: readonly CherryMessagePart[],
+  citationNumberBySourceId: ReadonlyMap<string, number> = new Map(),
+): WebSource[] {
   const metadataByUrl = collectWebSourceMetadata(messageParts);
   const citationContextById = collectCitationContext(messageParts);
   const sourceParts: SourceUrlPart[] = [];
@@ -47,7 +51,18 @@ export function resolveCitationWebSources(messageParts: readonly CherryMessagePa
   const sourcesByUrl = new Map<string, WebSource>();
 
   sourceParts.forEach((part, index) => {
-    if (sourcesByUrl.has(part.url)) return;
+    const citationNumber = citationNumberBySourceId.get(part.sourceId);
+    const existingSource = sourcesByUrl.get(part.url);
+    if (existingSource) {
+      if (
+        citationNumber !== undefined &&
+        (existingSource.citationNumber === undefined ||
+          citationNumber < existingSource.citationNumber)
+      ) {
+        sourcesByUrl.set(part.url, { ...existingSource, citationNumber });
+      }
+      return;
+    }
 
     const source = toWebSource(part, part.sourceId || index + 1);
     if (!source) return;
@@ -57,16 +72,21 @@ export function resolveCitationWebSources(messageParts: readonly CherryMessagePa
       ...source,
       title: getPageTitle(part.title, part.url) ?? source.title,
     };
+    const resolvedSource = withCitationContext(
+      metadata ? mergeWebSources(titledSource, metadata) : titledSource,
+      citationContextById,
+    );
     sourcesByUrl.set(
       part.url,
-      withCitationContext(
-        metadata ? mergeWebSources(titledSource, metadata) : titledSource,
-        citationContextById,
-      ),
+      citationNumber === undefined ? resolvedSource : { ...resolvedSource, citationNumber },
     );
   });
 
-  return [...sourcesByUrl.values()];
+  return [...sourcesByUrl.values()].sort((left, right) => {
+    if (left.citationNumber === undefined) return right.citationNumber === undefined ? 0 : 1;
+    if (right.citationNumber === undefined) return -1;
+    return left.citationNumber - right.citationNumber;
+  });
 }
 
 export function getFaviconUrls(source: WebSource): string[] {


### PR DESCRIPTION
## Summary

- render inline citations as non-interactive, filled circular superscripts
- move source interaction to a 44pt source entry and full-width source cards
- order source cards by first citation appearance without repeating large number badges

## Validation

- `pnpm lint` (0 errors; existing warnings remain in unrelated files)
- `pnpm format:check`
- Tests not run per repository verification policy
- Typecheck not run because the repository command invokes package builds, which were not authorized