### PR TITLE
fix(agent-session): preserve activity and fork boundaries

### DIFF
--- a/docs/references/agent/agent-persistence.md
+++ b/docs/references/agent/agent-persistence.md
@@ -24,8 +24,9 @@ record for mobile-originated Agent Sessions only.
   The `agent` table intentionally starts empty; retired Assistant data is discarded rather than
   migrated.
 
-Branching is a fork, not a message tree, so `agent_session` carries one nullable lineage column and
-no per-message parent/active-path columns ([Agent Protocol](./agent-protocol.md#branching)).
+Branching is a fork, not a message tree, so `agent_session` carries nullable source and copied-prefix
+boundary metadata but no per-message parent/active-path columns
+([Agent Protocol](./agent-protocol.md#branching)).
 
 Out of scope: message-tree columns, background turns, Mobile Skill configuration/loading, and broader
 Pi provider coverage. The Host projects Agent-specific MCP bindings into each Runtime snapshot.
@@ -204,9 +205,10 @@ specific MCP tools. Plain indexes cover Agent listing/cascade and MCP server del
 | `title` | text | NOT NULL DEFAULT `''` | |
 | `titleIsManual` | integer (bool) | NOT NULL DEFAULT `false` | |
 | `executionTarget` | text (json) | NOT NULL DEFAULT `{"kind":"local"}` | Mobile app execution boundary, never a Runtime id or remote-control target |
-| `lastActivityAt` | integer | NOT NULL | Updated only when a turn reserves or finalizes |
+| `lastActivityAt` | integer | NOT NULL | Latest real conversation activity; mirrors the relevant message `activityAt` |
 | `createdAt` / `updatedAt` | integer | helper defaults | Hard delete; no `deletedAt` |
 | `forkedFromSessionId` | text | FK → `agent_session.id` ON DELETE SET NULL | Fork lineage; `NULL` for an ordinary Session and reset to `NULL` when the source is deleted |
+| `forkBoundaryMessageId` | text | NULL | Message inside the fork that closes the copied prefix; maintained atomically with lineage and not a cross-table FK |
 
 Indexes: `agent_session_agent_id_idx`, `agent_session_last_activity_idx` (list ordering is
 recency; no `orderKey`).
@@ -228,7 +230,8 @@ recency; no `orderKey`).
 | `messageSnapshot` | text (json) | NULL | Versioned Agent inference snapshot; raw JSON retained for unknown versions |
 | `searchableText` | text | NOT NULL DEFAULT `''` | Trigger-populated |
 | `ftsRowid` | integer | NULL, UNIQUE | Stable FTS5 `content_rowid`, trigger-assigned |
-| `createdAt` / `updatedAt` | integer | helper defaults | Hard delete via session cascade |
+| `activityAt` | integer | NOT NULL | Conversation-event time; initialized on reservation, copied with history, and advanced only by normal terminal settlement |
+| `createdAt` / `updatedAt` | integer | helper defaults | Physical row timestamps; hard delete via session cascade |
 
 Indexes: `(sessionId, createdAt)`, `turnId`, `status` (backs boot reconciliation), unique
 `ftsRowid`, and the invariant-1 guard:
@@ -266,12 +269,21 @@ projection:
   status, parts, usage, turn-level error, and an optional validated context checkpoint — in one
   write (invariant 5). Failed, cancelled, and interrupted terminal rows force the checkpoint to
   `NULL`. The error part and turn-level error column receive the same `AgentErrorView`; historical
-  rows without a failure snapshot remain valid. `deleteSession` is one cascading delete.
+  rows without a failure snapshot remain valid. Reservation writes one `activityAt` across the
+  user/assistant pair and Session; normal finalization advances the assistant and Session activity
+  with one new value while their physical `updatedAt` fields remain row timestamps.
+  Startup reconciliation is administrative recovery and preserves the reservation activity time.
+  `deleteSession` explicitly clears surviving forks' source and boundary metadata, advancing their `updatedAt`, before
+  cascading the source delete to its messages.
 - `forkSession` inserts the new Session and every copied message in one `withWriteTx` transaction.
   It copies `titleIsManual` and `executionTarget` from the source, takes `title` from the caller
   or else from the source, sets
-  `forkedFromSessionId`, and stamps `lastActivityAt` to now so the fork sorts to the top of the
-  recency list. Copied rows keep `createdAt`, `role`, `data`, `status`, `usage`, `error`,
+  `forkedFromSessionId`, records the reissued copied anchor as `forkBoundaryMessageId`, and copies
+  `lastActivityAt` from the source message's `activityAt` at the inclusive fork point. Creating the
+  fork is an administrative row mutation, not conversation
+  activity, so it does not move the fork to "now" in the recency list. Startup recovery preserves
+  the original reservation activity because it is not new conversation activity. Copied rows keep
+  `createdAt`, `activityAt`, `role`, `data`, `status`, `usage`, `error`,
   `modelId`, and `messageSnapshot` verbatim; `turnId` is reissued through a per-fork map so pairing
   survives without colliding across Sessions; `contextCheckpoint` is forced to `NULL` because a
   checkpoint anchors to a turn that no longer exists. Keeping `createdAt` deliberately breaks the
@@ -280,6 +292,8 @@ projection:
   preserves order while stamping "now" on every row would be visibly wrong in the UI.
   `searchableText` and `ftsRowid` are left to the insert trigger, which is race-free because the
   whole copy runs inside the serialized write transaction.
+  The boundary is Session metadata rather than a synthetic Message, so it does not enter FTS,
+  transcript pagination counts, Runtime history, or recursive fork copies.
 - The latest assistant row with a non-null checkpoint is the replay candidate. The Host validates
   schema version, anchor membership, and the 256 KiB payload ceiling. Invalid, incompatible,
   oversized, or orphaned candidates are classified in logs and ignored; execution receives full

--- a/docs/references/agent/agent-protocol.md
+++ b/docs/references/agent/agent-protocol.md
@@ -59,6 +59,7 @@ type AgentSessionView = {
   executionTarget: AgentExecutionTarget
   title: string
   titleIsManual: boolean
+  forkBoundaryMessageId: string | null
   forkedFromSessionId: string | null
   createdAt: string
   updatedAt: string
@@ -521,11 +522,11 @@ Rules:
    the operation outright while the source Session has an active turn, and the store rejects an
    anchor whose own row has not settled. Unsettled rows before the anchor are skipped rather than
    copied, so a fork never carries a placeholder that will never resolve.
-2. Sessions record lineage so clients can present provenance. Only `forkedFromSessionId` is
-   stored — enough to name and open the source. The fork point itself is not recorded: no surface
-   asks which message a fork was cut at, and storing it would add a second column and a second
-   dangling reference to reconcile. Lineage is a self-referencing `ON DELETE SET NULL` foreign
-   key, so deleting the source clears the claim and leaves the fork intact.
+2. Sessions record `forkedFromSessionId` so clients can name and open the direct source, plus
+   `forkBoundaryMessageId`, which names the copied Message inside the new Session that closes its
+   inherited prefix. The client synthesizes a display-only divider after that Message when the
+   paginated history window contains it; no annotation Message or Message Part enters persistence
+   or model context. Deleting the source clears both fields and leaves the fork intact.
 3. Copied history keeps past tool calls and results verbatim. A fork opens a new future; it does
    not claim to undo executed side effects, and results in the copied transcript reflect the
    world at fork time. Copied messages keep their original `createdAt` for the same reason: the
@@ -534,8 +535,8 @@ Rules:
 Message editing is not implemented, and when it is it follows the same model. An edit-and-continue
 operation creates a new Session, copies the clean transcript before the edited user message, inserts
 the replacement input, and starts a new turn. It does not mutate an already-executed Agent history
-in place, copy later assistant output, or claim to undo tool side effects. A display-only
-annotation, if ever added, must be named separately and must not change model context.
+in place, copy later assistant output, or claim to undo tool side effects. Any display-only
+timeline event remains a client projection and does not change model context.
 
 Fork was an additive protocol extension: no existing operation, event, snapshot, or invariant
 changed.

--- a/docs/references/domain-language.md
+++ b/docs/references/domain-language.md
@@ -23,7 +23,8 @@ _Avoid_: Topic, room
 
 **Session Fork**:
 A new Agent Session created by copying an existing transcript up to and including a chosen Message.
-The fork records only the Session it came from, and the source is never modified.
+The fork records the Session it came from plus the copied Message that closes its inherited prefix;
+the source is never modified.
 _Avoid_: branch, clone, duplicate
 
 **Message**:

--- a/migrations/sqlite-drizzle/0015_agent-session-activity-and-fork-boundary.sql
+++ b/migrations/sqlite-drizzle/0015_agent-session-activity-and-fork-boundary.sql
@@ -1,0 +1,79 @@
+DROP TRIGGER IF EXISTS `agent_session_message_ai`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `agent_session_message_ad`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `agent_session_message_au`;--> statement-breakpoint
+CREATE TABLE `__new_agent_session_message` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`turn_id` text,
+	`role` text NOT NULL,
+	`data` text NOT NULL,
+	`status` text NOT NULL,
+	`usage` text,
+	`error` text,
+	`model_id` text,
+	`message_snapshot` text,
+	`searchable_text` text DEFAULT '' NOT NULL,
+	`fts_rowid` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`context_checkpoint` text,
+	`activity_at` integer NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `agent_session`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`model_id`) REFERENCES `user_model`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "agent_session_message_role_check" CHECK("role" IN ('user', 'assistant', 'system')),
+	CONSTRAINT "agent_session_message_status_check" CHECK("status" IN ('pending', 'streaming', 'success', 'error', 'cancelled', 'interrupted'))
+);--> statement-breakpoint
+INSERT INTO `__new_agent_session_message` (
+	`id`,
+	`session_id`,
+	`turn_id`,
+	`role`,
+	`data`,
+	`status`,
+	`usage`,
+	`error`,
+	`model_id`,
+	`message_snapshot`,
+	`searchable_text`,
+	`fts_rowid`,
+	`created_at`,
+	`updated_at`,
+	`context_checkpoint`,
+	`activity_at`
+)
+SELECT
+	message.`id`,
+	message.`session_id`,
+	message.`turn_id`,
+	message.`role`,
+	message.`data`,
+	message.`status`,
+	message.`usage`,
+	message.`error`,
+	message.`model_id`,
+	message.`message_snapshot`,
+	message.`searchable_text`,
+	message.`fts_rowid`,
+	message.`created_at`,
+	message.`updated_at`,
+	message.`context_checkpoint`,
+	CASE
+		WHEN message.`role` = 'assistant'
+			AND message.`status` IN ('success', 'error', 'cancelled')
+			AND message.`created_at` >= session.`created_at`
+		THEN message.`updated_at`
+		ELSE message.`created_at`
+	END
+FROM `agent_session_message` AS message
+JOIN `agent_session` AS session ON session.`id` = message.`session_id`;--> statement-breakpoint
+DROP TABLE `agent_session_message`;--> statement-breakpoint
+ALTER TABLE `__new_agent_session_message` RENAME TO `agent_session_message`;--> statement-breakpoint
+CREATE INDEX `agent_session_message_session_created_idx` ON `agent_session_message` (`session_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `agent_session_message_turn_id_idx` ON `agent_session_message` (`turn_id`);--> statement-breakpoint
+CREATE INDEX `agent_session_message_status_idx` ON `agent_session_message` (`status`);--> statement-breakpoint
+CREATE UNIQUE INDEX `agent_session_message_active_turn_uniq` ON `agent_session_message` (`session_id`) WHERE "agent_session_message"."role" = 'assistant' and "agent_session_message"."status" in ('pending', 'streaming');--> statement-breakpoint
+CREATE UNIQUE INDEX `agent_session_message_fts_rowid_uniq` ON `agent_session_message` (`fts_rowid`);--> statement-breakpoint
+-- The boundary names a copied message inside the same Session. The store writes
+-- it in the fork transaction and clears it with lineage; no cross-table FK is
+-- added because agent_session_message already depends on agent_session.
+ALTER TABLE `agent_session` ADD `fork_boundary_message_id` text;

--- a/migrations/sqlite-drizzle/meta/0015_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1776 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2dc62c47-c7bf-4b13-af56-ba409fca5675",
+  "prevId": "20d29326-0474-4b00-9bc9-c4f7df765dc0",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        }
+      },
+      "indexes": {
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_approval_mode": {
+          "name": "tool_approval_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "disabled_capabilities": {
+          "name": "disabled_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_created_at_idx": {
+          "name": "agent_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "agent_order_key_idx": {
+          "name": "agent_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_model_id_user_model_id_fk": {
+          "name": "agent_model_id_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_tool_binding": {
+      "name": "agent_tool_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_tool_name": {
+          "name": "raw_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "approval": {
+          "name": "approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "display_name_snapshot": {
+          "name": "display_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_tool_binding_agent_id_idx": {
+          "name": "agent_tool_binding_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_tool_binding_mcp_server_id_idx": {
+          "name": "agent_tool_binding_mcp_server_id_idx",
+          "columns": ["mcp_server_id"],
+          "isUnique": false
+        },
+        "agent_tool_binding_builtin_uniq": {
+          "name": "agent_tool_binding_builtin_uniq",
+          "columns": ["agent_id", "capability_id"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'builtin'"
+        },
+        "agent_tool_binding_mcp_server_default_uniq": {
+          "name": "agent_tool_binding_mcp_server_default_uniq",
+          "columns": ["agent_id", "mcp_server_id"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"raw_tool_name\" IS NULL"
+        },
+        "agent_tool_binding_mcp_tool_uniq": {
+          "name": "agent_tool_binding_mcp_tool_uniq",
+          "columns": ["agent_id", "mcp_server_id", "raw_tool_name"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"raw_tool_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_binding_agent_id_agent_id_fk": {
+          "name": "agent_tool_binding_agent_id_agent_id_fk",
+          "tableFrom": "agent_tool_binding",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_tool_binding_identity_check": {
+          "name": "agent_tool_binding_identity_check",
+          "value": "(\n        (\"agent_tool_binding\".\"source\" = 'builtin' AND \"agent_tool_binding\".\"capability_id\" IS NOT NULL AND length(\"agent_tool_binding\".\"capability_id\") > 0 AND \"agent_tool_binding\".\"mcp_server_id\" IS NULL AND \"agent_tool_binding\".\"raw_tool_name\" IS NULL)\n        OR\n        (\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"capability_id\" IS NULL AND \"agent_tool_binding\".\"mcp_server_id\" IS NOT NULL AND length(\"agent_tool_binding\".\"mcp_server_id\") > 0 AND (\"agent_tool_binding\".\"raw_tool_name\" IS NULL OR length(\"agent_tool_binding\".\"raw_tool_name\") > 0))\n      )"
+        },
+        "agent_tool_binding_approval_check": {
+          "name": "agent_tool_binding_approval_check",
+          "value": "\"agent_tool_binding\".\"approval\" IN ('auto', 'ask', 'deny')"
+        }
+      }
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title_is_manual": {
+          "name": "title_is_manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"kind\":\"local\"}'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "forked_from_session_id": {
+          "name": "forked_from_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fork_boundary_message_id": {
+          "name": "fork_boundary_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_agent_id_idx": {
+          "name": "agent_session_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_session_last_activity_at_idx": {
+          "name": "agent_session_last_activity_at_idx",
+          "columns": ["last_activity_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_forked_from_session_id_agent_session_id_fk": {
+          "name": "agent_session_forked_from_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent_session",
+          "columnsFrom": ["forked_from_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_checkpoint": {
+          "name": "context_checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_snapshot": {
+          "name": "message_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_created_idx": {
+          "name": "agent_session_message_session_created_idx",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        },
+        "agent_session_message_turn_id_idx": {
+          "name": "agent_session_message_turn_id_idx",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "agent_session_message_status_idx": {
+          "name": "agent_session_message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agent_session_message_active_turn_uniq": {
+          "name": "agent_session_message_active_turn_uniq",
+          "columns": ["session_id"],
+          "isUnique": true,
+          "where": "\"agent_session_message\".\"role\" = 'assistant' and \"agent_session_message\".\"status\" in ('pending', 'streaming')"
+        },
+        "agent_session_message_fts_rowid_uniq": {
+          "name": "agent_session_message_fts_rowid_uniq",
+          "columns": ["fts_rowid"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_message_model_id_user_model_id_fk": {
+          "name": "agent_session_message_model_id_user_model_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_session_message_role_check": {
+          "name": "agent_session_message_role_check",
+          "value": "\"agent_session_message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "agent_session_message_status_check": {
+          "name": "agent_session_message_status_check",
+          "value": "\"agent_session_message\".\"status\" IN ('pending', 'streaming', 'success', 'error', 'cancelled', 'interrupted')"
+        }
+      }
+    },
+    "ai_usage_record": {
+      "name": "ai_usage_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_kind": {
+          "name": "record_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_icon": {
+          "name": "source_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_label": {
+          "name": "api_key_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_masked": {
+          "name": "api_key_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_attribution": {
+          "name": "api_key_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_cache_tokens": {
+          "name": "no_cache_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_snapshot": {
+          "name": "pricing_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_first_token_ms": {
+          "name": "time_first_token_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_completion_ms": {
+          "name": "time_completion_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_thinking_ms": {
+          "name": "time_thinking_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usage_record_request_id_idx": {
+          "name": "ai_usage_record_request_id_idx",
+          "columns": ["request_id"],
+          "isUnique": true
+        },
+        "ai_usage_record_created_at_idx": {
+          "name": "ai_usage_record_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_message_created_idx": {
+          "name": "ai_usage_record_message_created_idx",
+          "columns": ["message_kind", "message_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_provider_created_idx": {
+          "name": "ai_usage_record_provider_created_idx",
+          "columns": ["provider_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_model_created_idx": {
+          "name": "ai_usage_record_model_created_idx",
+          "columns": ["model_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_api_key_created_idx": {
+          "name": "ai_usage_record_api_key_created_idx",
+          "columns": ["api_key_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_source_created_idx": {
+          "name": "ai_usage_record_source_created_idx",
+          "columns": ["source_type", "source_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_usage_record_record_kind_check": {
+          "name": "ai_usage_record_record_kind_check",
+          "value": "\"ai_usage_record\".\"record_kind\" IN ('invocation', 'legacy-aggregate')"
+        },
+        "ai_usage_record_message_kind_check": {
+          "name": "ai_usage_record_message_kind_check",
+          "value": "\"ai_usage_record\".\"message_kind\" IN ('chat', 'agent-session')"
+        },
+        "ai_usage_record_source_type_check": {
+          "name": "ai_usage_record_source_type_check",
+          "value": "\"ai_usage_record\".\"source_type\" IN ('assistant', 'agent')"
+        },
+        "ai_usage_record_modality_check": {
+          "name": "ai_usage_record_modality_check",
+          "value": "\"ai_usage_record\".\"modality\" IN ('language', 'embedding', 'image', 'rerank')"
+        },
+        "ai_usage_record_attribution_check": {
+          "name": "ai_usage_record_attribution_check",
+          "value": "\"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched', 'auth', 'unknown')"
+        },
+        "ai_usage_record_auth_method_check": {
+          "name": "ai_usage_record_auth_method_check",
+          "value": "\"ai_usage_record\".\"auth_method\" IN ('oauth', 'external-cli', 'iam-aws', 'api-key-aws', 'iam-gcp', 'iam-azure')"
+        },
+        "ai_usage_record_cost_source_check": {
+          "name": "ai_usage_record_cost_source_check",
+          "value": "\"ai_usage_record\".\"cost_source\" IN ('provider', 'computed')"
+        },
+        "ai_usage_record_cost_currency_check": {
+          "name": "ai_usage_record_cost_currency_check",
+          "value": "\"ai_usage_record\".\"cost_currency\" IN ('USD', 'CNY')"
+        },
+        "ai_usage_record_kind_identity_check": {
+          "name": "ai_usage_record_kind_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"record_kind\" = 'invocation'\n        AND \"ai_usage_record\".\"request_count\" = 1\n        AND \"ai_usage_record\".\"provider_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"model_id\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"record_kind\" = 'legacy-aggregate'\n        AND \"ai_usage_record\".\"request_count\" >= 1\n        AND \"ai_usage_record\".\"message_kind\" IS NOT NULL\n        AND \"ai_usage_record\".\"message_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_message_identity_check": {
+          "name": "ai_usage_record_message_identity_check",
+          "value": "(\"ai_usage_record\".\"message_kind\" IS NULL AND \"ai_usage_record\".\"message_id\" IS NULL)\n        OR (\"ai_usage_record\".\"message_kind\" IS NOT NULL AND \"ai_usage_record\".\"message_id\" IS NOT NULL)"
+        },
+        "ai_usage_record_source_identity_check": {
+          "name": "ai_usage_record_source_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"source_type\" IS NULL\n        AND \"ai_usage_record\".\"source_id\" IS NULL\n        AND \"ai_usage_record\".\"source_name\" IS NULL\n        AND \"ai_usage_record\".\"source_icon\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"source_type\" IS NOT NULL\n        AND \"ai_usage_record\".\"source_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_api_key_identity_check": {
+          "name": "ai_usage_record_api_key_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched')\n        AND \"ai_usage_record\".\"api_key_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'auth'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'unknown'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      )"
+        },
+        "ai_usage_record_cost_tuple_check": {
+          "name": "ai_usage_record_cost_tuple_check",
+          "value": "(\n        \"ai_usage_record\".\"cost\" IS NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NULL\n        AND \"ai_usage_record\".\"cost_breakdown\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"cost\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_image_count_check": {
+          "name": "ai_usage_record_image_count_check",
+          "value": "(\n        \"ai_usage_record\".\"modality\" = 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NOT NULL\n        AND \"ai_usage_record\".\"image_count\" >= 0\n      ) OR (\n        \"ai_usage_record\".\"modality\" <> 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NULL\n      )"
+        },
+        "ai_usage_record_nonnegative_check": {
+          "name": "ai_usage_record_nonnegative_check",
+          "value": "\n        (\"ai_usage_record\".\"input_tokens\" IS NULL OR \"ai_usage_record\".\"input_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR \"ai_usage_record\".\"output_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR \"ai_usage_record\".\"total_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR \"ai_usage_record\".\"reasoning_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR \"ai_usage_record\".\"no_cache_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR \"ai_usage_record\".\"cache_read_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR \"ai_usage_record\".\"cache_write_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" >= 0)\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR \"ai_usage_record\".\"time_first_token_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR \"ai_usage_record\".\"time_completion_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR \"ai_usage_record\".\"time_thinking_ms\" >= 0)\n      "
+        },
+        "ai_usage_record_integer_check": {
+          "name": "ai_usage_record_integer_check",
+          "value": "\n        typeof(\"ai_usage_record\".\"request_count\") = 'integer'\n        AND (\"ai_usage_record\".\"input_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"input_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"output_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"total_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"reasoning_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"no_cache_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_read_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_write_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"image_count\" IS NULL OR typeof(\"ai_usage_record\".\"image_count\") = 'integer')\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_first_token_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_completion_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_thinking_ms\") = 'integer')\n        AND typeof(\"ai_usage_record\".\"created_at\") = 'integer'\n      "
+        },
+        "ai_usage_record_finite_cost_check": {
+          "name": "ai_usage_record_finite_cost_check",
+          "value": "\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" <= 1.7976931348623157e308"
+        }
+      }
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_url": {
+          "name": "endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_is_enabled_idx": {
+          "name": "mcp_server_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "painting": {
+      "name": "painting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"input\":[],\"output\":[]}'"
+        }
+      },
+      "indexes": {
+        "painting_order_key_idx": {
+          "name": "painting_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "user_model_custom_config_check": {
+          "name": "user_model_custom_config_check",
+          "value": "\"user_model\".\"preset_model_id\" IS NOT NULL OR (\"user_model\".\"name\" IS NOT NULL AND \"user_model\".\"capabilities\" IS NOT NULL AND \"user_model\".\"supports_streaming\" IS NOT NULL)"
+        }
+      }
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788259032494,
       "tag": "0014_agent-disabled-capabilities",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1788336595250,
+      "tag": "0015_agent-session-activity-and-fork-boundary",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -2129,10 +2129,9 @@ describe('MobileAgentHost', () => {
       fromMessageId: first.assistantMessageId,
     });
     expect(forked.forkedFromSessionId).toBe(session.id);
-    expect((await store.listMessages(forked.id)).map((message) => message.role)).toEqual([
-      'user',
-      'assistant',
-    ]);
+    const forkedMessages = await store.listMessages(forked.id);
+    expect(forkedMessages.map((message) => message.role)).toEqual(['user', 'assistant']);
+    expect(forked.forkBoundaryMessageId).toBe(forkedMessages.at(-1)?.id);
     // The fork is idle and immediately usable, with no turn carried over.
     const observation = await host.observeSession(forked.id, () => {});
     expect(observation.snapshot.activeTurn).toBeNull();

--- a/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
@@ -34,6 +34,7 @@ const SESSION: AgentSessionView = {
   executionTarget: { kind: 'local' },
   title: '',
   titleIsManual: false,
+  forkBoundaryMessageId: null,
   forkedFromSessionId: null,
   createdAt: NOW,
   updatedAt: NOW,

--- a/src/backend/ai/agent/sessionStore/AgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/AgentSessionStore.ts
@@ -122,7 +122,8 @@ export interface AgentSessionStore {
    * Atomically creates a Session carrying the source's transcript up to and
    * including the fork point (agent-protocol.md "Branching"). Unsettled rows
    * are skipped, turn ids are reissued so the copy shares no correlation with
-   * its source, and no turn is started: the new Session is idle.
+   * its source, the copied anchor is recorded as the Session boundary, and no
+   * turn is started: the new Session is idle.
    */
   forkSession(input: ForkSessionInput): Promise<ForkSessionResult>;
 

--- a/src/backend/ai/agent/sessionStore/InMemoryAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/InMemoryAgentSessionStore.ts
@@ -34,6 +34,7 @@ function cloneJson<T>(value: T): T {
 
 /** One stored message: the view plus the turn-level error column. */
 type StoredMessage = {
+  activityAt: string;
   view: AgentMessageView;
   error: AgentErrorView | null;
   contextCheckpoint: unknown | null;
@@ -53,6 +54,7 @@ function createSessionView(input: {
     executionTarget: input.executionTarget ?? { kind: 'local' },
     title: input.title ?? '',
     titleIsManual: input.titleIsManual ?? input.title !== undefined,
+    forkBoundaryMessageId: null,
     forkedFromSessionId: input.forkedFromSessionId ?? null,
     createdAt: timestamp,
     updatedAt: timestamp,
@@ -115,8 +117,8 @@ function reserveInTranscript(
     updatedAt: timestamp,
   };
   transcript.push(
-    { view: userMessage, error: null, contextCheckpoint: null },
-    { view: assistantMessage, error: null, contextCheckpoint: null },
+    { activityAt: timestamp, view: userMessage, error: null, contextCheckpoint: null },
+    { activityAt: timestamp, view: assistantMessage, error: null, contextCheckpoint: null },
   );
   return { turnId, userMessage, assistantMessage };
 }
@@ -200,7 +202,12 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
     // source and only loses the lineage claim.
     for (const [forkId, session] of this.sessions) {
       if (session.forkedFromSessionId === sessionId) {
-        this.sessions.set(forkId, { ...session, forkedFromSessionId: null });
+        this.sessions.set(forkId, {
+          ...session,
+          forkBoundaryMessageId: null,
+          forkedFromSessionId: null,
+          updatedAt: nowIso(),
+        });
       }
     }
     return true;
@@ -235,6 +242,7 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
       .slice(0, anchorIndex + 1)
       .filter((stored) => !UNSETTLED_MESSAGE_STATUSES.has(stored.view.status))
       .map<StoredMessage>((stored) => ({
+        activityAt: stored.activityAt,
         // Runtime-private and anchored to a turn id this copy no longer
         // carries, so the fork replays full history instead.
         contextCheckpoint: null,
@@ -247,10 +255,15 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
           updatedAt: nowIso(),
         }),
       }));
+    const forkBoundaryMessageId = forkedTranscript.at(-1)?.view.id;
+    if (!forkBoundaryMessageId) {
+      throw new Error('Fork transcript is missing its settled boundary message.');
+    }
+    const forkedSession = { ...session, forkBoundaryMessageId, updatedAt: nowIso() };
 
-    this.sessions.set(session.id, session);
+    this.sessions.set(session.id, forkedSession);
     this.messages.set(session.id, forkedTranscript);
-    return { session: cloneJson(session), status: 'forked' };
+    return { session: cloneJson(forkedSession), status: 'forked' };
   }
 
   async reserveInitialSubmission(
@@ -267,9 +280,10 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
       modelId: input.modelId,
       inferenceSnapshot: input.inferenceSnapshot,
     });
-    this.sessions.set(session.id, session);
+    const activeSession = { ...session, updatedAt: reserved.assistantMessage.createdAt };
+    this.sessions.set(session.id, activeSession);
     this.messages.set(session.id, transcript);
-    return cloneJson({ ...reserved, session });
+    return cloneJson({ ...reserved, session: activeSession });
   }
 
   async reserveSubmission(input: ReserveSubmissionInput): Promise<ReserveSubmissionResult> {
@@ -277,7 +291,15 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
     if (!transcript) {
       throw new Error(`Cannot reserve a submission for an unknown session: ${input.sessionId}`);
     }
-    return cloneJson(reserveInTranscript(transcript, input));
+    const reserved = reserveInTranscript(transcript, input);
+    const session = this.sessions.get(input.sessionId);
+    if (session) {
+      this.sessions.set(input.sessionId, {
+        ...session,
+        updatedAt: reserved.assistantMessage.createdAt,
+      });
+    }
+    return cloneJson(reserved);
   }
 
   async listMessages(sessionId: string): Promise<AgentMessageView[]> {
@@ -334,25 +356,31 @@ export class InMemoryAgentSessionStore extends BaseService implements AgentSessi
   }
 
   async finalizeAssistantMessage(input: FinalizeAssistantMessageInput): Promise<AgentMessageView> {
-    for (const transcript of this.messages.values()) {
+    for (const [sessionId, transcript] of this.messages) {
       const stored = transcript.find((entry) => entry.view.id === input.assistantMessageId);
       if (!stored) {
         continue;
       }
       // Synchronous section: message terminal state settles atomically
       // (invariant 5).
+      const activityAt = nowIso();
       stored.view = {
         ...stored.view,
         status: input.status,
         parts: cloneJson(input.parts),
         usage: input.usage === null ? null : cloneJson(input.usage),
-        updatedAt: nowIso(),
+        updatedAt: activityAt,
       };
+      stored.activityAt = activityAt;
       stored.error = input.error === null ? null : cloneJson(input.error);
       stored.contextCheckpoint =
         input.status === 'success' && input.contextCheckpoint !== null
           ? cloneJson(input.contextCheckpoint)
           : null;
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        this.sessions.set(sessionId, { ...session, updatedAt: stored.view.updatedAt });
+      }
       return cloneJson(stored.view);
     }
     throw new Error(`Cannot finalize an unknown message: ${input.assistantMessageId}`);

--- a/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
@@ -113,6 +113,12 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
 
   async deleteSession(sessionId: string): Promise<boolean> {
     return this.dbService.withWriteTx(async (tx) => {
+      // Advance each surviving fork's row timestamp through Drizzle before the
+      // FK's ON DELETE SET NULL fallback can clear the lineage invisibly.
+      await tx
+        .update(agentSessionTable)
+        .set({ forkBoundaryMessageId: null, forkedFromSessionId: null })
+        .where(eq(agentSessionTable.forkedFromSessionId, sessionId));
       // Messages go with the session via the ON DELETE CASCADE foreign key.
       const deleted = await tx
         .delete(agentSessionTable)
@@ -131,31 +137,39 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
         .values({
           agentId: input.agentId,
           executionTarget: input.executionTarget,
-          lastActivityAt: Date.now(),
         })
         .returning();
-      const reserved = await insertSubmission(tx, {
+      const { activityAt, ...reserved } = await insertSubmission(tx, {
         sessionId: sessionRow.id,
         userParts: input.userParts,
         modelId: input.modelId,
         inferenceSnapshot: input.inferenceSnapshot,
       });
-      return { ...reserved, session: toAgentSessionView(sessionRow) };
+      const [activeSessionRow] = await tx
+        .update(agentSessionTable)
+        .set({ lastActivityAt: activityAt })
+        .where(eq(agentSessionTable.id, sessionRow.id))
+        .returning();
+      return { ...reserved, session: toAgentSessionView(activeSessionRow) };
     });
   }
 
   async reserveSubmission(input: ReserveSubmissionInput): Promise<ReserveSubmissionResult> {
     return this.dbService.withWriteTx(async (tx) => {
-      const now = Date.now();
-      const touched = await tx
-        .update(agentSessionTable)
-        .set({ lastActivityAt: now })
+      const [session] = await tx
+        .select({ id: agentSessionTable.id })
+        .from(agentSessionTable)
         .where(eq(agentSessionTable.id, input.sessionId))
-        .returning({ id: agentSessionTable.id });
-      if (touched.length === 0) {
+        .limit(1);
+      if (!session) {
         throw new Error(`Cannot reserve a submission for an unknown session: ${input.sessionId}`);
       }
-      return insertSubmission(tx, input);
+      const { activityAt, ...reserved } = await insertSubmission(tx, input);
+      await tx
+        .update(agentSessionTable)
+        .set({ lastActivityAt: activityAt })
+        .where(eq(agentSessionTable.id, input.sessionId));
+      return reserved;
     });
   }
 
@@ -172,6 +186,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
 
       const [anchor] = await tx
         .select({
+          activityAt: agentSessionMessageTable.activityAt,
           createdAt: agentSessionMessageTable.createdAt,
           id: agentSessionMessageTable.id,
           status: agentSessionMessageTable.status,
@@ -197,7 +212,9 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
           agentId: source.agentId,
           executionTarget: source.executionTarget,
           forkedFromSessionId: source.id,
-          lastActivityAt: Date.now(),
+          // A fork copies history but creates no conversation activity of its
+          // own. Keep the last included message's original activity time.
+          lastActivityAt: anchor.activityAt,
           // Falls back to the source's name. Auto-naming will not rewrite
           // either form later, because neither is empty nor matches the
           // first-user-message title the naming policy expects to overwrite.
@@ -234,7 +251,9 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       // generated UUID v7 ids staying monotonic in transcript order, and a
       // batched insert would also risk the bound-parameter ceiling on a long
       // transcript.
+      let forkBoundaryMessageId: string | undefined;
       for (const row of copied) {
+        const copiedMessageId = createOrderedUuid();
         await tx.insert(agentSessionMessageTable).values({
           // Deliberate exception to the "never write createdAt" rule in
           // `_columnHelpers.ts`: the fork presents the same history, so its
@@ -242,8 +261,10 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
           // holds because createdAt is the major sort key and the reissued ids
           // break ties in the same direction as the source.
           createdAt: row.createdAt,
+          activityAt: row.activityAt,
           data: row.data,
           error: row.error,
+          id: copiedMessageId,
           messageSnapshot: row.messageSnapshot,
           modelId: row.modelId,
           role: row.role,
@@ -255,9 +276,21 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
           turnId: reissueTurnId(forkedTurnIds, row.turnId),
           usage: row.usage,
         });
+        if (row.id === anchor.id) {
+          forkBoundaryMessageId = copiedMessageId;
+        }
       }
 
-      return { session: toAgentSessionView(forked), status: 'forked' };
+      if (!forkBoundaryMessageId) {
+        throw new Error('Fork transcript is missing its settled boundary message.');
+      }
+      const [forkedWithBoundary] = await tx
+        .update(agentSessionTable)
+        .set({ forkBoundaryMessageId })
+        .where(eq(agentSessionTable.id, forked.id))
+        .returning();
+
+      return { session: toAgentSessionView(forkedWithBoundary), status: 'forked' };
     });
   }
 
@@ -379,9 +412,11 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
 
   async finalizeAssistantMessage(input: FinalizeAssistantMessageInput): Promise<AgentMessageView> {
     return this.dbService.withWriteTx(async (tx) => {
+      const activityAt = Date.now();
       const [row] = await tx
         .update(agentSessionMessageTable)
         .set({
+          activityAt,
           status: input.status,
           data: { version: 1, parts: input.parts },
           usage: input.usage,
@@ -395,7 +430,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
       }
       await tx
         .update(agentSessionTable)
-        .set({ lastActivityAt: Date.now() })
+        .set({ lastActivityAt: activityAt })
         .where(eq(agentSessionTable.id, row.sessionId));
       return toAgentMessageView(row);
     });
@@ -454,11 +489,13 @@ function reissueTurnId(reissued: Map<string, string>, turnId: string | null): st
 async function insertSubmission(
   tx: Database,
   input: ReserveSubmissionInput,
-): Promise<ReserveSubmissionResult> {
+): Promise<ReserveSubmissionResult & { activityAt: number }> {
+  const activityAt = Date.now();
   const turnId = createOrderedUuid();
   const [userRow] = await tx
     .insert(agentSessionMessageTable)
     .values({
+      activityAt,
       sessionId: input.sessionId,
       turnId,
       role: 'user',
@@ -469,6 +506,7 @@ async function insertSubmission(
   const [assistantRow] = await tx
     .insert(agentSessionMessageTable)
     .values({
+      activityAt,
       sessionId: input.sessionId,
       turnId,
       role: 'assistant',
@@ -479,6 +517,7 @@ async function insertSubmission(
     })
     .returning();
   return {
+    activityAt,
     turnId,
     userMessage: toAgentMessageView(userRow),
     assistantMessage: toAgentMessageView(assistantRow),

--- a/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
@@ -253,6 +253,40 @@ describe.each([
     expect(reserved.assistantMessage.sessionId).toBe(reserved.session.id);
   });
 
+  test('conversation activity advances the Session row timestamp', async () => {
+    const reservationTime = 2_000_000_001_000;
+    const finalizationTime = 2_000_000_002_000;
+    jest.useFakeTimers({ now: 2_000_000_000_000 });
+    try {
+      const session = await harness.createEmptySession({ agentId });
+
+      jest.setSystemTime(reservationTime);
+      const reserved = await store.reserveSubmission({
+        ...RESERVATION_FACTS,
+        sessionId: session.id,
+        userParts: [{ id: 'input-0', type: 'text', text: 'Hello.', state: 'done' }],
+      });
+      expect((await store.getSession(session.id))?.updatedAt).toBe(
+        new Date(reservationTime).toISOString(),
+      );
+
+      jest.setSystemTime(finalizationTime);
+      await store.finalizeAssistantMessage({
+        assistantMessageId: reserved.assistantMessage.id,
+        status: 'success',
+        parts: [],
+        usage: null,
+        error: null,
+        contextCheckpoint: null,
+      });
+      expect((await store.getSession(session.id))?.updatedAt).toBe(
+        new Date(finalizationTime).toISOString(),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('finalizeAssistantMessage settles status, parts, usage, and turn error', async () => {
     const session = await harness.createEmptySession({ agentId });
     const reserved = await store.reserveSubmission({
@@ -380,6 +414,7 @@ describe.each([
       'user',
       'assistant',
     ]);
+    expect(fork.forkBoundaryMessageId).toBe(copied.at(-1)?.id);
     expect(copied.map((message) => message.status)).toEqual([
       'success',
       'success',
@@ -401,7 +436,6 @@ describe.each([
     expect(copied.map((message) => message.createdAt)).toEqual(
       original.slice(0, 4).map((message) => message.createdAt),
     );
-
     // Nothing is shared with the source: fresh message ids, reissued turn ids,
     // and the pairing within each submission still holds.
     const sourceIds = new Set(original.map((message) => message.id));
@@ -417,6 +451,59 @@ describe.each([
     expect(await store.getLatestContextCheckpoint(fork.id)).toBeNull();
     // The source is untouched.
     expect(await store.listMessages(source.id)).toEqual(original);
+  });
+
+  test('nested forks record the direct source and their own copied boundary', async () => {
+    const source = await harness.createEmptySession({ agentId, title: 'Source' });
+    const sourceTurn = await store.reserveSubmission({
+      ...RESERVATION_FACTS,
+      sessionId: source.id,
+      userParts: [{ id: 'input-0', type: 'text', text: 'one', state: 'done' }],
+    });
+    await store.finalizeAssistantMessage({
+      assistantMessageId: sourceTurn.assistantMessage.id,
+      status: 'success',
+      parts: [{ id: 'text-1', type: 'text', text: 'answer one', state: 'done' }],
+      usage: null,
+      error: null,
+      contextCheckpoint: null,
+    });
+    const firstResult = await store.forkSession({
+      sessionId: source.id,
+      fromMessageId: sourceTurn.assistantMessage.id,
+    });
+    expect(firstResult.status).toBe('forked');
+    if (firstResult.status !== 'forked') return;
+
+    const forkTurn = await store.reserveSubmission({
+      ...RESERVATION_FACTS,
+      sessionId: firstResult.session.id,
+      userParts: [{ id: 'input-0', type: 'text', text: 'two', state: 'done' }],
+    });
+    await store.finalizeAssistantMessage({
+      assistantMessageId: forkTurn.assistantMessage.id,
+      status: 'success',
+      parts: [{ id: 'text-1', type: 'text', text: 'answer two', state: 'done' }],
+      usage: null,
+      error: null,
+      contextCheckpoint: null,
+    });
+    const secondResult = await store.forkSession({
+      sessionId: firstResult.session.id,
+      fromMessageId: forkTurn.assistantMessage.id,
+    });
+    expect(secondResult.status).toBe('forked');
+    if (secondResult.status !== 'forked') return;
+
+    const copied = await store.listMessages(secondResult.session.id);
+    expect(secondResult.session.forkedFromSessionId).toBe(firstResult.session.id);
+    expect(secondResult.session.forkBoundaryMessageId).toBe(copied.at(-1)?.id);
+    expect(copied.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant',
+    ]);
   });
 
   test('forkSession names the copy from the caller when one is supplied', async () => {
@@ -438,6 +525,45 @@ describe.each([
     expect(result.session.title).toBe('Branch - Maths');
     // Renaming the copy must not touch the Session it was copied from.
     expect((await store.getSession(source.id))?.title).toBe('Maths');
+  });
+
+  test('deleting a fork source advances the surviving Session row timestamp', async () => {
+    const deletionTime = 2_000_000_001_000;
+    jest.useFakeTimers({ now: 2_000_000_000_000 });
+    try {
+      const source = await harness.createEmptySession({ agentId, title: 'Source' });
+      const reserved = await store.reserveSubmission({
+        ...RESERVATION_FACTS,
+        sessionId: source.id,
+        userParts: [{ id: 'input-0', type: 'text', text: 'one', state: 'done' }],
+      });
+      await store.finalizeAssistantMessage({
+        assistantMessageId: reserved.assistantMessage.id,
+        status: 'success',
+        parts: [],
+        usage: null,
+        error: null,
+        contextCheckpoint: null,
+      });
+      const result = await store.forkSession({
+        sessionId: source.id,
+        fromMessageId: reserved.assistantMessage.id,
+      });
+      expect(result.status).toBe('forked');
+      if (result.status !== 'forked') return;
+
+      jest.setSystemTime(deletionTime);
+      expect(await store.deleteSession(source.id)).toBe(true);
+      expect(await store.getSession(result.session.id)).toEqual(
+        expect.objectContaining({
+          forkBoundaryMessageId: null,
+          forkedFromSessionId: null,
+          updatedAt: new Date(deletionTime).toISOString(),
+        }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('forkSession refuses an unknown session, a foreign anchor, and an unsettled fork point', async () => {
@@ -720,12 +846,29 @@ describe('SqliteAgentSessionStore database guarantees', () => {
       contextCheckpoint: null,
     });
 
+    // Model a historical fork point whose source Session has newer activity.
+    const anchorActivityAt = 10_000;
+    raw
+      .prepare('UPDATE agent_session_message SET activity_at = ? WHERE id = ?')
+      .run(anchorActivityAt, reserved.assistantMessage.id);
+    raw
+      .prepare('UPDATE agent_session SET last_activity_at = ? WHERE id = ?')
+      .run(20_000, source.id);
+
     const result = await store.forkSession({
       sessionId: source.id,
       fromMessageId: reserved.assistantMessage.id,
     });
     expect(result.status).toBe('forked');
     if (result.status !== 'forked') return;
+
+    const forkTimestamps = raw
+      .prepare(
+        'SELECT last_activity_at AS lastActivityAt, updated_at AS updatedAt FROM agent_session WHERE id = ?',
+      )
+      .get(result.session.id) as { lastActivityAt: number; updatedAt: number };
+    expect(forkTimestamps.lastActivityAt).toBe(anchorActivityAt);
+    expect(forkTimestamps.updatedAt).toBeGreaterThan(anchorActivityAt);
 
     // The AFTER INSERT trigger has to run for every row the copy writes, not
     // just the first: fts_rowid is assigned as MAX+1 per insert.
@@ -750,15 +893,116 @@ describe('SqliteAgentSessionStore database guarantees', () => {
       ).count,
     ).toBe(4);
 
-    // Deleting the source drops the lineage claim, never the fork itself.
+    const copiedAssistant = (await store.listMessages(result.session.id))[1];
+    if (!copiedAssistant) throw new Error('fork should copy the assistant anchor');
+    const recursive = await store.forkSession({
+      sessionId: result.session.id,
+      fromMessageId: copiedAssistant.id,
+    });
+    expect(recursive.status).toBe('forked');
+    if (recursive.status !== 'forked') return;
+    const recursiveFork = raw
+      .prepare('SELECT last_activity_at AS lastActivityAt FROM agent_session WHERE id = ?')
+      .get(recursive.session.id) as { lastActivityAt: number };
+    expect(recursiveFork.lastActivityAt).toBe(anchorActivityAt);
+
+    // Deleting the source drops the lineage claim and never deletes the fork itself.
     expect(await store.deleteSession(source.id)).toBe(true);
     expect(await store.getSession(result.session.id)).toEqual(
-      expect.objectContaining({ forkedFromSessionId: null, id: result.session.id }),
+      expect.objectContaining({
+        forkBoundaryMessageId: null,
+        forkedFromSessionId: null,
+        id: result.session.id,
+      }),
     );
     expect(await store.listMessages(result.session.id)).toHaveLength(2);
   });
 
-  test('turn-level error and activity time persist on the rows', async () => {
+  test('reservation activity and recovery settlement remain distinct', async () => {
+    const { store, raw } = harness;
+    if (!raw) throw new Error('sqlite harness provides raw access');
+    const agentId = await harness.makeAgentId();
+    const session = await harness.createEmptySession({ agentId });
+    const reserved = await store.reserveSubmission({
+      ...RESERVATION_FACTS,
+      sessionId: session.id,
+      userParts: [{ id: 'input-0', type: 'text', text: 'x', state: 'done' }],
+    });
+    const reservationActivityAt = Date.parse(reserved.assistantMessage.createdAt);
+    const beforeReconciliation = raw
+      .prepare(
+        `SELECT session.last_activity_at AS lastActivityAt, message.activity_at AS messageActivityAt
+         FROM agent_session AS session
+         JOIN agent_session_message AS message ON message.session_id = session.id
+         WHERE session.id = ? AND message.id = ?`,
+      )
+      .get(session.id, reserved.assistantMessage.id) as {
+      lastActivityAt: number;
+      messageActivityAt: number;
+    };
+    expect(beforeReconciliation.lastActivityAt).toBe(reservationActivityAt);
+    expect(beforeReconciliation.messageActivityAt).toBe(reservationActivityAt);
+
+    await store.reconcileInterrupted(INTERRUPTED);
+
+    const row = raw
+      .prepare('SELECT error FROM agent_session_message WHERE id = ?')
+      .get(reserved.assistantMessage.id) as { error: string };
+    expect(JSON.parse(row.error)).toEqual(INTERRUPTED);
+
+    const afterReconciliation = raw
+      .prepare(
+        `SELECT session.last_activity_at AS lastActivityAt, message.activity_at AS messageActivityAt
+         FROM agent_session AS session
+         JOIN agent_session_message AS message ON message.session_id = session.id
+         WHERE session.id = ? AND message.id = ?`,
+      )
+      .get(session.id, reserved.assistantMessage.id) as {
+      lastActivityAt: number;
+      messageActivityAt: number;
+    };
+    expect(afterReconciliation.lastActivityAt).toBe(reservationActivityAt);
+    expect(afterReconciliation.messageActivityAt).toBe(reservationActivityAt);
+  });
+
+  test('normal finalization advances message and Session activity together', async () => {
+    const { store, raw } = harness;
+    if (!raw) throw new Error('sqlite harness provides raw access');
+    const agentId = await harness.makeAgentId();
+    const session = await harness.createEmptySession({ agentId });
+    const reserved = await store.reserveSubmission({
+      ...RESERVATION_FACTS,
+      sessionId: session.id,
+      userParts: [{ id: 'input-0', type: 'text', text: 'x', state: 'done' }],
+    });
+
+    const finalized = await store.finalizeAssistantMessage({
+      assistantMessageId: reserved.assistantMessage.id,
+      status: 'success',
+      parts: [],
+      usage: null,
+      error: null,
+      contextCheckpoint: null,
+    });
+
+    const activity = raw
+      .prepare(
+        `SELECT session.last_activity_at AS lastActivityAt, message.activity_at AS messageActivityAt,
+                message.updated_at AS messageUpdatedAt
+         FROM agent_session AS session
+         JOIN agent_session_message AS message ON message.session_id = session.id
+         WHERE session.id = ? AND message.id = ?`,
+      )
+      .get(session.id, finalized.id) as {
+      lastActivityAt: number;
+      messageActivityAt: number;
+      messageUpdatedAt: number;
+    };
+    expect(activity.lastActivityAt).toBe(activity.messageActivityAt);
+    expect(activity.messageUpdatedAt).toBe(Date.parse(finalized.updatedAt));
+  });
+
+  test('a recovery-interrupted fork keeps the original reservation activity', async () => {
     const { store, raw } = harness;
     if (!raw) throw new Error('sqlite harness provides raw access');
     const agentId = await harness.makeAgentId();
@@ -770,15 +1014,26 @@ describe('SqliteAgentSessionStore database guarantees', () => {
     });
     await store.reconcileInterrupted(INTERRUPTED);
 
-    const row = raw
-      .prepare('SELECT error FROM agent_session_message WHERE id = ?')
-      .get(reserved.assistantMessage.id) as { error: string };
-    expect(JSON.parse(row.error)).toEqual(INTERRUPTED);
+    const result = await store.forkSession({
+      sessionId: session.id,
+      fromMessageId: reserved.assistantMessage.id,
+    });
+    expect(result.status).toBe('forked');
+    if (result.status !== 'forked') return;
 
-    const sessionRow = raw
-      .prepare('SELECT last_activity_at FROM agent_session WHERE id = ?')
-      .get(session.id) as { last_activity_at: number };
-    expect(sessionRow.last_activity_at).toBeGreaterThan(0);
+    const forkRow = raw
+      .prepare(
+        `SELECT fork.last_activity_at AS lastActivityAt, source.activity_at AS sourceActivityAt
+         FROM agent_session AS fork
+         JOIN agent_session_message AS source ON source.id = ?
+         WHERE fork.id = ?`,
+      )
+      .get(reserved.assistantMessage.id, result.session.id) as {
+      lastActivityAt: number;
+      sourceActivityAt: number;
+    };
+    expect(forkRow.lastActivityAt).toBe(forkRow.sourceActivityAt);
+    expect(forkRow.sourceActivityAt).toBe(Date.parse(reserved.assistantMessage.createdAt));
   });
 
   test('returns a corrupt checkpoint candidate for Host-side classification', async () => {

--- a/src/backend/data/db/__tests__/migrations.test.ts
+++ b/src/backend/data/db/__tests__/migrations.test.ts
@@ -123,6 +123,7 @@ describe('bundled SQLite migrations', () => {
         'created_at',
         'updated_at',
         'forked_from_session_id',
+        'fork_boundary_message_id',
       ]);
       expect(columnNames(database, 'agent_session_message')).toEqual([
         'id',
@@ -140,6 +141,7 @@ describe('bundled SQLite migrations', () => {
         'created_at',
         'updated_at',
         'context_checkpoint',
+        'activity_at',
       ]);
       expect(columnNames(database, 'agent_tool_binding')).toEqual([
         'id',
@@ -259,10 +261,10 @@ describe('bundled SQLite migrations', () => {
         ) VALUES ('binding-tool', 'agent-1', 'mcp', 'server-1', 'write', 0, 'deny', 1, 1);
         INSERT INTO agent_session (id, agent_id, last_activity_at, created_at, updated_at)
         VALUES ('session-1', 'agent-1', 1, 1, 1);
-        INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, created_at, updated_at)
-        VALUES ('m-user', 'session-1', 'turn-1', 'user', '{"version":1,"parts":[]}', 'success', 1, 1);
-        INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, created_at, updated_at)
-        VALUES ('m-assistant', 'session-1', 'turn-1', 'assistant', '{"version":1,"parts":[]}', 'pending', 1, 1);
+        INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at)
+        VALUES ('m-user', 'session-1', 'turn-1', 'user', '{"version":1,"parts":[]}', 'success', 1, 1, 1);
+        INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at)
+        VALUES ('m-assistant', 'session-1', 'turn-1', 'assistant', '{"version":1,"parts":[]}', 'pending', 1, 1, 1);
       `);
       expect(
         database.prepare("SELECT tool_approval_mode FROM agent WHERE id = 'agent-1'").get(),
@@ -292,24 +294,24 @@ describe('bundled SQLite migrations', () => {
       // race the partial unique index exists to reject.
       expect(() =>
         database.exec(`
-          INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, created_at, updated_at)
-          VALUES ('m-second', 'session-1', 'turn-2', 'assistant', '{"version":1,"parts":[]}', 'pending', 2, 2);
+          INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at)
+          VALUES ('m-second', 'session-1', 'turn-2', 'assistant', '{"version":1,"parts":[]}', 'pending', 2, 2, 2);
         `),
       ).toThrow(/UNIQUE/);
       // Settling the first frees the slot for the next reservation.
       database.exec(`
         UPDATE agent_session_message SET status = 'success' WHERE id = 'm-assistant';
-        INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, created_at, updated_at)
-        VALUES ('m-second', 'session-1', 'turn-2', 'assistant', '{"version":1,"parts":[]}', 'streaming', 2, 2);
+        INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at)
+        VALUES ('m-second', 'session-1', 'turn-2', 'assistant', '{"version":1,"parts":[]}', 'streaming', 2, 2, 2);
       `);
       expect(() =>
         database.exec(
-          "INSERT INTO agent_session_message (id, session_id, role, data, status, created_at, updated_at) VALUES ('m-bad', 'session-1', 'root', '{}', 'success', 3, 3)",
+          "INSERT INTO agent_session_message (id, session_id, role, data, status, activity_at, created_at, updated_at) VALUES ('m-bad', 'session-1', 'root', '{}', 'success', 3, 3, 3)",
         ),
       ).toThrow(/agent_session_message_role_check/);
       expect(() =>
         database.exec(
-          "INSERT INTO agent_session_message (id, session_id, role, data, status, created_at, updated_at) VALUES ('m-bad', 'session-1', 'assistant', '{}', 'paused', 3, 3)",
+          "INSERT INTO agent_session_message (id, session_id, role, data, status, activity_at, created_at, updated_at) VALUES ('m-bad', 'session-1', 'assistant', '{}', 'paused', 3, 3, 3)",
         ),
       ).toThrow(/agent_session_message_status_check/);
       // A fork points back at its source. Deleting the source must clear the
@@ -548,6 +550,61 @@ describe('bundled SQLite migrations', () => {
         ) VALUES ('fork-session', 'agent-1', 2, 2, 2, 'legacy-session');
       `);
       expect(database.prepare('PRAGMA foreign_key_check').all()).toEqual([]);
+    } finally {
+      database.close();
+    }
+  });
+
+  test('backfills message activity independently from later row updates', () => {
+    const database = new DatabaseSync(':memory:');
+
+    try {
+      database.exec('PRAGMA foreign_keys = ON');
+      const entries = readMigrationEntries();
+      const activityMigrationIndex = entries.findIndex(
+        ({ tag }) => tag === '0015_agent-session-activity-and-fork-boundary',
+      );
+      expect(activityMigrationIndex).toBeGreaterThan(0);
+
+      for (const { sql } of entries.slice(0, activityMigrationIndex)) {
+        applyMigrationSql(database, sql);
+      }
+      database.exec(`
+        INSERT INTO agent (id, name, order_key, created_at, updated_at)
+        VALUES ('agent-1', 'Agent', 'a0', 1, 1);
+        INSERT INTO agent_session (id, agent_id, last_activity_at, created_at, updated_at)
+        VALUES ('source-session', 'agent-1', 8, 1, 8);
+        INSERT INTO agent_session (
+          id, agent_id, last_activity_at, created_at, updated_at, forked_from_session_id
+        ) VALUES ('fork-session', 'agent-1', 10, 10, 10, 'source-session');
+        INSERT INTO agent_session_message (
+          id, session_id, role, data, status, created_at, updated_at
+        ) VALUES
+          ('normal-terminal', 'source-session', 'assistant', '{"version":1,"parts":[]}', 'success', 2, 5),
+          ('recovered-terminal', 'source-session', 'assistant', '{"version":1,"parts":[]}', 'interrupted', 3, 8),
+          ('copied-terminal', 'fork-session', 'assistant', '{"version":1,"parts":[]}', 'success', 2, 10);
+      `);
+
+      applyMigrationsAsDrizzleWould(database, entries.slice(activityMigrationIndex));
+
+      expect(
+        database
+          .prepare('SELECT id, activity_at AS activityAt FROM agent_session_message ORDER BY id')
+          .all(),
+      ).toEqual([
+        { activityAt: 2, id: 'copied-terminal' },
+        { activityAt: 5, id: 'normal-terminal' },
+        { activityAt: 3, id: 'recovered-terminal' },
+      ]);
+      expect(database.prepare('PRAGMA foreign_key_check').all()).toEqual([]);
+      expect(
+        (
+          database.prepare("PRAGMA table_info('agent_session_message')").all() as {
+            name: string;
+            notnull: number;
+          }[]
+        ).find(({ name }) => name === 'activity_at'),
+      ).toEqual(expect.objectContaining({ name: 'activity_at', notnull: 1 }));
     } finally {
       database.close();
     }

--- a/src/backend/data/db/migrations.ts
+++ b/src/backend/data/db/migrations.ts
@@ -13,6 +13,7 @@ import m0011 from '../../../../migrations/sqlite-drizzle/0011_file-provenance.sq
 import m0012 from '../../../../migrations/sqlite-drizzle/0012_mcp-http-headers.sql';
 import m0013 from '../../../../migrations/sqlite-drizzle/0013_agent-session-fork-lineage.sql';
 import m0014 from '../../../../migrations/sqlite-drizzle/0014_agent-disabled-capabilities.sql';
+import m0015 from '../../../../migrations/sqlite-drizzle/0015_agent-session-activity-and-fork-boundary.sql';
 import journal from '../../../../migrations/sqlite-drizzle/meta/_journal.json';
 
 // Expo SQLite migrations must be bundled into JS; unlike the desktop main
@@ -37,5 +38,6 @@ export const migrations = {
     m0012,
     m0013,
     m0014,
+    m0015,
   },
 };

--- a/src/backend/data/db/schemas/agentSession.ts
+++ b/src/backend/data/db/schemas/agentSession.ts
@@ -32,19 +32,25 @@ export const agentSessionTable = sqliteTable(
       .$type<AgentExecutionTarget>()
       .notNull()
       .default({ kind: 'local' }),
-    // Dedicated conversation activity time: updated only when a submission
-    // reserves or an assistant message settles. Renames must not move it.
+    // Dedicated conversation activity time: mirrors the relevant message's
+    // activityAt when a submission reserves, an assistant settles, or history forks.
+    // Administrative mutations such as renames and forks must not stamp "now".
     lastActivityAt: integer()
       .notNull()
       .$defaultFn(() => Date.now()),
     ...createUpdateTimestamps,
     // Fork provenance (agent-protocol.md "Branching" rule 2). SET NULL, not
     // CASCADE: deleting the source must drop the lineage claim, never the
-    // forked Session. Declared last so the column order matches the physical
-    // order produced by ALTER TABLE ADD COLUMN.
+    // forked Session. Fork metadata stays after the common timestamps so its
+    // order matches the physical ADD COLUMN migrations.
     forkedFromSessionId: text().references((): AnySQLiteColumn => agentSessionTable.id, {
       onDelete: 'set null',
     }),
+    // Id of the copied message inside this Session that closes the inherited
+    // prefix. Application-owned rather than a cross-table FK to avoid a
+    // circular Session ↔ Message schema dependency; fork/delete transactions
+    // maintain it together with forkedFromSessionId.
+    forkBoundaryMessageId: text(),
   },
   (t) => [
     index('agent_session_agent_id_idx').on(t.agentId),

--- a/src/backend/data/db/schemas/agentSessionMessage.ts
+++ b/src/backend/data/db/schemas/agentSessionMessage.ts
@@ -67,6 +67,13 @@ export const agentSessionMessageTable = sqliteTable(
     // Stable integer surrogate for the FTS5 content_rowid: trigger-assigned,
     // local-only, and nullable because the AFTER INSERT trigger fills it.
     ftsRowid: integer(),
+    // Conversation-event time for recency. Reservation initializes it and
+    // normal terminal settlement advances it; row maintenance and history
+    // copies preserve it so updatedAt remains exclusively the physical row's
+    // latest update time.
+    activityAt: integer()
+      .notNull()
+      .$defaultFn(() => Date.now()),
     ...createUpdateTimestamps,
   },
   (t) => [
@@ -133,6 +140,7 @@ export const AGENT_SESSION_MESSAGE_FTS_STATEMENTS: string[] = [
   // INSERT. MAX+1 is race-free under withWriteTx serialization and O(log N)
   // via agent_session_message_fts_rowid_uniq.
   `CREATE TRIGGER agent_session_message_ai AFTER INSERT ON agent_session_message BEGIN
+    -- activity_at is application-owned and never derived by FTS maintenance.
     UPDATE agent_session_message SET
       fts_rowid = (SELECT COALESCE(MAX(fts_rowid), 0) + 1 FROM agent_session_message),
       searchable_text = ${searchableTextExpression('NEW.data')}

--- a/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
@@ -92,8 +92,8 @@ function insertMessage(
   database
     .prepare(
       `INSERT INTO agent_session_message (
-        id, session_id, turn_id, role, data, status, created_at, updated_at
-      ) VALUES (?, 'session-1', ?, 'assistant', ?, 'success', ?, ?)`,
+        id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at
+      ) VALUES (?, 'session-1', ?, 'assistant', ?, 'success', ?, ?, ?)`,
     )
     .run(
       values.id,
@@ -102,6 +102,7 @@ function insertMessage(
         version: 1,
         parts: [{ id: `part-${values.id}`, type: 'text', text: values.text, state: 'done' }],
       }),
+      values.createdAt,
       values.createdAt,
       values.createdAt,
     );

--- a/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
+++ b/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
@@ -103,7 +103,7 @@ describe('auxiliary Data API integration', () => {
       .run(sessionId, agentId, 'Needle Session', 1, now, now, now);
     sqlite
       .prepare(
-        'INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       )
       .run(
         userMessageId,
@@ -117,10 +117,11 @@ describe('auxiliary Data API integration', () => {
         'success',
         now,
         now,
+        now,
       );
     sqlite
       .prepare(
-        'INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO agent_session_message (id, session_id, turn_id, role, data, status, activity_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       )
       .run(
         assistantMessageId,
@@ -132,6 +133,7 @@ describe('auxiliary Data API integration', () => {
           version: 1,
         }),
         'success',
+        now + 1,
         now + 1,
         now + 1,
       );

--- a/src/backend/data/services/utils/agentSessionRows.ts
+++ b/src/backend/data/services/utils/agentSessionRows.ts
@@ -20,6 +20,7 @@ export function toAgentSessionView(row: AgentSessionRow): AgentSessionView {
     executionTarget: row.executionTarget,
     title: row.title,
     titleIsManual: row.titleIsManual,
+    forkBoundaryMessageId: row.forkBoundaryMessageId,
     forkedFromSessionId: row.forkedFromSessionId,
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt),

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -30,7 +30,6 @@ export function MessageList({
   dataKey,
   enteringMessageId,
   extraData,
-  headerAccessory,
   initialLayoutReady = true,
   keyboardOffset,
   messages,
@@ -78,15 +77,7 @@ export function MessageList({
     },
   );
 
-  const listHeader = useMemo(
-    () => (
-      <>
-        <View style={{ height: contentTopInset }} />
-        {headerAccessory}
-      </>
-    ),
-    [contentTopInset, headerAccessory],
-  );
+  const listHeader = useMemo(() => <View style={{ height: contentTopInset }} />, [contentTopInset]);
   const contentContainerStyle = useMemo(
     () => ({
       paddingBottom:

--- a/src/frontend/components/messages/README.md
+++ b/src/frontend/components/messages/README.md
@@ -9,8 +9,9 @@ history, message rows and parts, viewport following, and scroll restoration.
 - `MessageList` renders a virtualized history from `MessageListItem` values and delegates
   every row to the feature-owned `renderMessage` function.
 - `MessageListItem` contains only the persistence-neutral fields needed for rendering. Its optional
-  `partKeys` carries source-owned part identity beside the projected visual parts; renderers never
-  synthesize positional identity when that source identity is available.
+  `partKeys` carries source-owned part identity beside the projected visual parts; `systemEvent`
+  carries a feature-synthesized timeline row such as a fork origin. Renderers never synthesize
+  positional part identity when source identity is available.
 - `MessageListProps` accepts layout measurements plus optional pagination, readiness, dataset
   identity, bottom-accessory inputs, the feature renderer, and optional `extraData` for rendered
   state that is not carried by message items.

--- a/src/frontend/components/messages/list/MessageListRow.tsx
+++ b/src/frontend/components/messages/list/MessageListRow.tsx
@@ -26,5 +26,6 @@ const styles = StyleSheet.create({
 
 const messageRowStyles = {
   assistant: [styles.root, styles.assistant],
+  system: undefined,
   user: [styles.root, styles.user],
 } satisfies Record<MessageListItem['role'], StyleProp<ViewStyle>>;

--- a/src/frontend/components/messages/list/messageListLayout.ts
+++ b/src/frontend/components/messages/list/messageListLayout.ts
@@ -4,6 +4,7 @@ export const MESSAGE_LIST_TOP_PADDING = 12;
 export const MESSAGE_ROW_HORIZONTAL_PADDING = 16;
 export const MESSAGE_ROW_VERTICAL_PADDING = {
   assistant: 12,
+  system: 0,
   user: 8,
 } as const satisfies Record<MessageListItem['role'], number>;
 
@@ -23,6 +24,9 @@ export function messageKeyExtractor(item: MessageListItem) {
 
 // LegendList 按角色维护真实尺寸均值；空助手行单独分类，避免用长回复均值估算 loading 行。
 export function getMessageRowType(item: MessageListItem) {
+  if (item.role === 'system') {
+    return 'system';
+  }
   if (item.role !== 'assistant') {
     return item.role;
   }

--- a/src/frontend/components/messages/types.ts
+++ b/src/frontend/components/messages/types.ts
@@ -5,7 +5,7 @@ import type { CherryMessagePart, MessageStatus } from '@/shared/data/types/messa
 import type { Model } from '@/shared/data/types/model';
 
 export type MessageListItem = Readonly<{
-  /** Creation time owned by this persisted message. */
+  /** Timeline position; synthetic rows inherit the adjacent persisted timestamp. */
   createdAt?: string;
   data: Readonly<{
     /** Stable render identities aligned one-to-one with `parts` when the source provides them. */
@@ -15,7 +15,12 @@ export type MessageListItem = Readonly<{
   id: string;
   /** Model identity captured by this message's immutable inference snapshot. */
   model?: Readonly<Pick<Model, 'id' | 'modelId' | 'name' | 'providerId'>>;
-  role: 'assistant' | 'user';
+  role: 'assistant' | 'system' | 'user';
+  /** Feature-owned timeline event synthesized beside persisted messages. */
+  systemEvent?: Readonly<{
+    type: 'fork-origin';
+    sourceSessionId: string;
+  }>;
   status: MessageStatus;
   /** Last persisted update; terminal assistant messages use it as their completion time. */
   updatedAt?: string;
@@ -28,8 +33,6 @@ export type MessageListProps = {
   dataKey?: string;
   enteringMessageId?: string;
   extraData?: unknown;
-  /** Scrolls above the first message; the caller decides when it applies. */
-  headerAccessory?: ReactNode;
   initialLayoutReady?: boolean;
   keyboardOffset: number;
   messages: readonly MessageListItem[];

--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -85,6 +85,7 @@ function ResolvedChatScreen({ target }: { target: ChatTarget }) {
             assistantName={agent.agent?.name}
             isAssistantToolbarEnabled={!isPreview}
             contentBottomInset={contentBottomInset}
+            forkBoundaryMessageId={session.data?.forkBoundaryMessageId ?? undefined}
             forkedFromSessionId={session.data?.forkedFromSessionId ?? undefined}
             keyboardOffset={keyboardOffset}
             messageWindow={messageWindow}

--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -356,6 +356,9 @@ export class AgentSessionChatClient {
           ...(event.message.role === 'user' ? { enteringUserMessageId: event.message.id } : {}),
           liveMessages: [...entry.liveMessages.values()],
         });
+        if (event.message.role === 'user') {
+          this.options.onSessionChanged?.(entry.state.sessionId);
+        }
         this.options.onTranscriptChanged?.(entry.state.sessionId);
         return;
       case 'message.delta': {

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -28,6 +28,7 @@ function snapshot(): AgentSessionSnapshot {
       agentId: 'agent-1',
       createdAt: '2026-08-25T00:00:00.000Z',
       executionTarget: { kind: 'local' },
+      forkBoundaryMessageId: null,
       forkedFromSessionId: null,
       id: 'session-1',
       title: '',
@@ -198,6 +199,23 @@ describe('AgentSessionChatClient', () => {
     await client.observe('session-1');
 
     expect(onTranscriptChanged).toHaveBeenCalledWith('session-1');
+  });
+
+  test('invalidates Session queries when a user message advances conversation activity', async () => {
+    let listener: ((event: AgentEvent) => void) | undefined;
+    const protocol = protocolWithObservation(async (_sessionId, nextListener) => {
+      listener = nextListener;
+      return { snapshot: snapshot(), unsubscribe: jest.fn() };
+    });
+    const onSessionChanged = jest.fn();
+    const client = new AgentSessionChatClient(protocol, { onSessionChanged });
+    await client.observe('session-1');
+
+    listener?.({ type: 'message.created', message: userMessage() });
+    listener?.({ type: 'message.created', message: assistantMessage() });
+
+    expect(onSessionChanged).toHaveBeenCalledTimes(1);
+    expect(onSessionChanged).toHaveBeenCalledWith('session-1');
   });
 
   test('cancels the active turn with the correlated session and turn ids', async () => {

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -34,7 +34,9 @@ type ChatWorkspaceProps = {
   assistantName?: string;
   isAssistantToolbarEnabled: boolean;
   contentBottomInset: number;
-  /** Set when this session was forked; names the session it was copied from. */
+  /** Copied message inside this Session that closes the inherited prefix. */
+  forkBoundaryMessageId?: string;
+  /** Direct source Session named by the fork-origin divider. */
   forkedFromSessionId?: string;
   keyboardOffset: number;
   messageWindow: AgentMessageHistoryWindow;
@@ -45,14 +47,14 @@ export function ChatWorkspace({
   assistantAvatarUri,
   assistantName,
   contentBottomInset,
+  forkBoundaryMessageId,
   forkedFromSessionId,
   keyboardOffset,
   messageWindow,
   isAssistantToolbarEnabled,
   sessionId,
 }: ChatWorkspaceProps) {
-  const { error, isAtHistoryStart, isLoadingInitial, isLoadingOlder, loadOlder, messages, retry } =
-    messageWindow;
+  const { error, isLoadingInitial, isLoadingOlder, loadOlder, messages, retry } = messageWindow;
   const live = useAgentChatSession(sessionId);
   const client = useAgentChatActions();
   const headerHeight = useHeaderHeight();
@@ -64,10 +66,40 @@ export function ChatWorkspace({
   );
   // eslint-disable-next-line react-hooks/exhaustive-deps -- sessionId keys the cache lifetime, not its contents
   const projectionCache = useMemo(() => createAgentMessageListProjectionCache(), [sessionId]);
-  const listMessages = useMemo(
+  const projectedMessages = useMemo(
     () => toAgentMessageListItems(mergedMessages, projectionCache),
     [mergedMessages, projectionCache],
   );
+  const listMessages = useMemo(() => {
+    if (!forkBoundaryMessageId || !forkedFromSessionId) {
+      return projectedMessages;
+    }
+    const boundaryIndex = projectedMessages.findIndex(
+      (message) => message.id === forkBoundaryMessageId,
+    );
+    if (boundaryIndex < 0) {
+      // Pagination has not loaded the persisted boundary yet. Rendering no
+      // divider is more accurate than attaching it to the current page edge.
+      return projectedMessages;
+    }
+    const boundary = projectedMessages[boundaryIndex];
+    if (!boundary) {
+      return projectedMessages;
+    }
+    const forkOriginItem = {
+      createdAt: boundary.createdAt,
+      data: {},
+      id: `fork-origin:${sessionId}`,
+      role: 'system',
+      status: 'success',
+      systemEvent: { sourceSessionId: forkedFromSessionId, type: 'fork-origin' },
+    } satisfies MessageListItem;
+    return [
+      ...projectedMessages.slice(0, boundaryIndex + 1),
+      forkOriginItem,
+      ...projectedMessages.slice(boundaryIndex + 1),
+    ];
+  }, [forkBoundaryMessageId, forkedFromSessionId, projectedMessages, sessionId]);
   const assistantPresentation = useMemo(
     () => ({
       avatarUri: assistantAvatarUri,
@@ -76,13 +108,21 @@ export function ChatWorkspace({
     [assistantAvatarUri, assistantName, t],
   );
   const renderChatMessage = useCallback(
-    (message: MessageListItem) => (
-      <ChatMessage
-        assistantPresentation={assistantPresentation}
-        isMessageActionsEnabled={isAssistantToolbarEnabled}
-        message={message}
-      />
-    ),
+    (message: MessageListItem) => {
+      if (message.role === 'system') {
+        return message.systemEvent?.type === 'fork-origin' ? (
+          <ChatForkOriginDivider sourceSessionId={message.systemEvent.sourceSessionId} />
+        ) : null;
+      }
+
+      return (
+        <ChatMessage
+          assistantPresentation={assistantPresentation}
+          isMessageActionsEnabled={isAssistantToolbarEnabled}
+          message={message}
+        />
+      );
+    },
     [assistantPresentation, isAssistantToolbarEnabled],
   );
   const messageListExtraData = useMemo(
@@ -125,13 +165,6 @@ export function ChatWorkspace({
     requiresInitialHistoryLayout,
   });
   const contentTopInset = resolveHeaderContentInset(headerHeight);
-  // The divider claims to sit above the first message, so it may only render
-  // once the whole transcript is in the window — otherwise it would hang above
-  // the earliest loaded page and lie about where the fork begins.
-  const forkOriginDivider =
-    forkedFromSessionId && isAtHistoryStart ? (
-      <ChatForkOriginDivider sourceSessionId={forkedFromSessionId} />
-    ) : undefined;
 
   if (error && !isLoadingInitial && listMessages.length === 0) {
     return (
@@ -157,7 +190,6 @@ export function ChatWorkspace({
           dataKey={sessionId}
           enteringMessageId={live.enteringUserMessageId}
           extraData={messageListExtraData}
-          headerAccessory={forkOriginDivider}
           initialLayoutReady={!requiresInitialHistoryLayout || !isLoadingInitial}
           keyboardOffset={keyboardOffset}
           messages={listMessages}

--- a/src/frontend/features/chat/workspace/README.md
+++ b/src/frontend/features/chat/workspace/README.md
@@ -21,3 +21,7 @@ placement. The virtualized list and message rendering live in `@/frontend/compon
   only by toolbar leaves; the virtualized list and expensive message body do not subscribe.
 - `hooks/` owns the cover handoff after the list controller completes initial restoration.
 - `utils/` contains pure helpers with co-located tests, including copyable-text projection.
+
+Fork provenance stays on the Session, not in persisted Messages. When the copied boundary Message
+is present in the paginated window, `ChatWorkspace` inserts a presentation-only system row after it;
+until that boundary loads, the divider remains absent rather than attaching to a page edge.

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -61,9 +61,15 @@ jest.mock('@/frontend/components/messages', () => ({
     return createElement('AssistantMessage', { message }, children);
   },
   MessageList: (props: MessageListProps) => {
+    const { createElement, Fragment } = jest.requireActual('react');
     mockMessageListProps = props;
-    const assistant = props.messages.find((message) => message.role === 'assistant');
-    return assistant ? props.renderMessage(assistant) : null;
+    return createElement(
+      Fragment,
+      null,
+      ...props.messages.map((message) =>
+        createElement(Fragment, { key: message.id }, props.renderMessage(message)),
+      ),
+    );
   },
   UserMessage: ({ message }: { message: MessageListItem }) => {
     const { createElement } = jest.requireActual('react');
@@ -130,6 +136,13 @@ jest.mock('../components/ChatInitialRenderCover', () => ({
   },
 }));
 
+jest.mock('../components/ChatForkOriginDivider', () => ({
+  ChatForkOriginDivider: ({ sourceSessionId }: { sourceSessionId: string }) => {
+    const { createElement } = jest.requireActual('react');
+    return createElement('ChatForkOriginDivider', { sourceSessionId });
+  },
+}));
+
 jest.mock('../components/ChatOlderMessagesIndicator', () => ({
   ChatOlderMessagesIndicator: ({ isLoading }: { isLoading: boolean }) => {
     mockIsLoadingOlder = isLoading;
@@ -170,11 +183,14 @@ function renderWorkspace(
   messages: readonly AgentMessageView[],
   sessionId = 'session-1',
   isLoadingInitial = false,
+  fork?: { boundaryMessageId: string; sourceSessionId: string },
 ) {
   let renderer!: ReactTestRenderer;
 
   act(() => {
-    renderer = create(createWorkspaceElement(isPreview, messages, sessionId, isLoadingInitial));
+    renderer = create(
+      createWorkspaceElement(isPreview, messages, sessionId, isLoadingInitial, fork),
+    );
   });
 
   return renderer;
@@ -185,14 +201,16 @@ function createWorkspaceElement(
   messages: readonly AgentMessageView[],
   sessionId = 'session-1',
   isLoadingInitial = false,
+  fork?: { boundaryMessageId: string; sourceSessionId: string },
 ) {
   return (
     <ChatWorkspace
       contentBottomInset={isPreview ? 12 : 96}
+      forkBoundaryMessageId={fork?.boundaryMessageId}
+      forkedFromSessionId={fork?.sourceSessionId}
       isAssistantToolbarEnabled={!isPreview}
       keyboardOffset={isPreview ? 0 : 26}
       messageWindow={{
-        isAtHistoryStart: true,
         isLoadingInitial,
         isLoadingOlder: true,
         loadOlder: mockLoadOlder,
@@ -275,6 +293,39 @@ describe('ChatWorkspace message rendering integration', () => {
     expect(
       assistantMessage.findAllByProps({ testID: 'assistant-message-toolbar' }).length,
     ).toBeGreaterThan(0);
+  });
+
+  test('renders a fork origin after the persisted copied-history boundary', () => {
+    const messages = [
+      createMessage('copied-user', 'user'),
+      createMessage('copied-assistant', 'assistant'),
+      createMessage('branch-user', 'user'),
+    ];
+
+    renderer = renderWorkspace(false, messages, 'session-1', false, {
+      boundaryMessageId: 'copied-assistant',
+      sourceSessionId: 'source-session',
+    });
+
+    expect(mockMessageListProps?.messages.map((message) => message.id)).toEqual([
+      'copied-user',
+      'copied-assistant',
+      'fork-origin:session-1',
+      'branch-user',
+    ]);
+    expect(renderer.root.findByType('ChatForkOriginDivider').props.sourceSessionId).toBe(
+      'source-session',
+    );
+  });
+
+  test('does not render a fork origin before pagination loads its boundary', () => {
+    renderer = renderWorkspace(false, [createMessage('branch-user', 'user')], 'session-1', false, {
+      boundaryMessageId: 'copied-assistant',
+      sourceSessionId: 'source-session',
+    });
+
+    expect(mockMessageListProps?.messages.map((message) => message.id)).toEqual(['branch-user']);
+    expect(renderer.root.findAllByType('ChatForkOriginDivider')).toHaveLength(0);
   });
 
   test('does not reuse a child key across Session-scoped surfaces', () => {

--- a/src/frontend/hooks/agent/useAgentMessageHistoryWindow.ts
+++ b/src/frontend/hooks/agent/useAgentMessageHistoryWindow.ts
@@ -9,11 +9,6 @@ import type { CursorPaginationResponse } from '@/shared/data/api/types';
 
 export type AgentMessageHistoryWindow = {
   error?: Error;
-  /**
-   * True once the window holds the whole transcript, so a caller may render
-   * something that claims to sit above the first message.
-   */
-  isAtHistoryStart: boolean;
   isLoadingInitial: boolean;
   isLoadingOlder: boolean;
   loadOlder: () => Promise<void>;
@@ -112,9 +107,6 @@ export function useAgentMessageHistoryWindow(
 
   return {
     error,
-    // Both gates matter: an unfetched page and a withheld render page are
-    // equally "there is more above this".
-    isAtHistoryStart: !hasNext && !hasHiddenMessages && !isLoading,
     isLoadingInitial: isLoading,
     isLoadingOlder: loadingOlderSessionId === sessionId,
     loadOlder,

--- a/src/shared/contracts/__tests__/agent.test.ts
+++ b/src/shared/contracts/__tests__/agent.test.ts
@@ -93,6 +93,7 @@ describe('Agent tool and managed-file contracts', () => {
         executionTarget: { kind: 'local' },
         // Null rather than omitted: lineage is absent, not unknown, and a JSON
         // round trip must keep telling the difference.
+        forkBoundaryMessageId: null,
         forkedFromSessionId: null,
         id: 'session-1',
         title: '',

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -141,6 +141,11 @@ export const AgentSessionViewSchema = z.strictObject({
   title: z.string(),
   titleIsManual: z.boolean(),
   /**
+   * Copied-message boundary after which the fork-origin divider is rendered.
+   * Null for ordinary or pre-boundary Sessions, and cleared with fork lineage.
+   */
+  forkBoundaryMessageId: z.string().min(1).nullable(),
+  /**
    * Fork provenance. Null for an ordinary Session, and reset to null when the
    * source Session is deleted, so a surviving fork never cites a Session the
    * user can no longer open.


### PR DESCRIPTION
## Summary

- track message-level conversation activity independently from physical row updates and keep session recency aligned across reservation, settlement, recovery, and forks
- persist each fork's copied-history boundary and render the origin divider immediately after it once pagination loads that message
- keep fork provenance out of persisted messages and model history, and ship the activity and fork-boundary schema changes in one SQLite migration

## Validation

- `pnpm format:check`
- focused `oxlint` for changed TypeScript files
- focused `eslint` for changed TypeScript files
- `pnpm db:generate --name schema-drift-check` (no schema changes)
- full `pnpm lint` partially completed: the oxlint phase passed, while Expo ESLint was blocked by missing local `@cherrystudio/ai-core` build artifacts

## Not run

- tests, typecheck, and builds (workspace policy requires explicit authorization)
