### PR TITLE
fix(chat-messages): stabilize streaming lifecycle and layout

### DIFF
--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -780,7 +780,11 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       for await (const event of events) {
         const isTerminal = await this.handleRuntimeEvent(sessionId, state, event);
         if (MESSAGE_SURFACE_EVENTS.has(event.type)) {
-          state.backgroundReply.update(state.assistantMessage);
+          if (event.type === 'text.delta') {
+            state.backgroundReply.update(state.assistantMessage, { deferPreview: true });
+          } else {
+            state.backgroundReply.update(state.assistantMessage);
+          }
         }
         if (isTerminal) {
           return;

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -413,6 +413,9 @@ describe('MobileAgentHost', () => {
     // One notification per message-changing event (part.add, two text.delta,
     // part.replace) — a handled event that stops notifying would show up here.
     expect(backgroundReplyTurn.update).toHaveBeenCalledTimes(4);
+    expect(
+      backgroundReplyTurn.update.mock.calls.filter(([, options]) => options?.deferPreview),
+    ).toHaveLength(2);
     expect(backgroundReplyTurn.update).toHaveBeenLastCalledWith(
       expect.objectContaining({
         id: submitted.assistantMessageId,

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -24,9 +24,11 @@ import { loggerService } from '@/shared/core/logger/LoggerService';
 
 import type {
   BackgroundReplyLifecycle,
+  BackgroundReplyMessage,
   BackgroundReplyOutcome,
   BackgroundReplyTurn,
   BackgroundReplyTurnInput,
+  BackgroundReplyUpdateOptions,
 } from './backgroundReplyTypes';
 import {
   type BackgroundReplyTranslate,
@@ -37,6 +39,7 @@ import {
 const PREFERENCE_KEY = 'chat.background_reply.enabled';
 const SESSION_TAG = 'chat.backgroundReply';
 const FINISH_TITLE_GRACE_MS = 5_000;
+const PREVIEW_UPDATE_INTERVAL_MS = 1_000;
 const logger = loggerService.withContext('BackgroundReply');
 
 type ChatActivitySession = BackgroundActivitySession<BackgroundReplyActivityProps>;
@@ -48,8 +51,10 @@ type TurnRecord = {
   deepLinkUrl: string;
   generation: number;
   key: string;
+  latestMessage?: BackgroundReplyMessage;
   session?: ChatActivitySession;
   startedAtEpochMs: number;
+  updateTimer?: ReturnType<typeof setTimeout>;
 };
 
 type BackgroundActivityPort = {
@@ -112,7 +117,10 @@ export class BackgroundReplyRuntime
 
   onActivate(): void {
     try {
-      for (const record of this.turns.values()) this.ensureSession(record, true);
+      for (const record of this.turns.values()) {
+        this.refreshContent(record);
+        this.ensureSession(record, true);
+      }
     } catch (error) {
       this.cancelSessions();
       throw error;
@@ -125,16 +133,18 @@ export class BackgroundReplyRuntime
 
   private cancelSessions(): void {
     for (const record of this.turns.values()) {
+      this.clearUpdateTimer(record);
       record.session?.cancel();
       record.session = undefined;
     }
   }
 
   startTurn = (input: BackgroundReplyTurnInput): BackgroundReplyTurn => {
-    if (Platform.OS !== 'ios' || this.disposed) return noOpTurn;
+    if (Platform.OS !== 'ios' || !this.isActivated || this.disposed) return noOpTurn;
 
     const normalized = normalizeTurnInput(input);
     const existing = this.turns.get(normalized.key);
+    if (existing) this.clearUpdateTimer(existing);
     const generation = ++this.generation;
     const content = deriveBackgroundReplyContent(undefined, this.environment.translate);
     const actorName =
@@ -158,7 +168,11 @@ export class BackgroundReplyRuntime
           if (!this.isCurrent(record.key, generation)) return;
           const current = this.turns.get(record.key);
           if (!current) return;
-          const latest = deriveBackgroundReplyContent(message, this.environment.translate);
+          if (message) current.latestMessage = message;
+          this.clearUpdateTimer(current);
+          const latest = current.latestMessage
+            ? deriveBackgroundReplyContent(current.latestMessage, this.environment.translate)
+            : current.content;
           current.content = {
             detail: this.environment.translate('chat.backgroundReply.awaitingApproval'),
             phase: 'awaiting-approval',
@@ -178,9 +192,9 @@ export class BackgroundReplyRuntime
           },
         );
       },
-      update: (message) =>
+      update: (message, options) =>
         this.runTurnCallback(record.key, 'update turn', () => {
-          this.updateTurn(record.key, generation, message);
+          this.updateTurn(record.key, generation, message, options);
         }),
     };
   };
@@ -206,6 +220,7 @@ export class BackgroundReplyRuntime
     if (!record) return;
 
     this.turns.delete(key);
+    this.clearUpdateTimer(record);
     record.session?.cancel();
     record.session = undefined;
   }
@@ -217,6 +232,7 @@ export class BackgroundReplyRuntime
     const records = [...this.turns.values()];
     this.turns.clear();
     for (const record of records) {
+      this.clearUpdateTimer(record);
       record.session?.cancel();
       record.session = undefined;
     }
@@ -235,19 +251,61 @@ export class BackgroundReplyRuntime
   private updateTurn(
     key: string,
     generation: number,
-    message: Parameters<BackgroundReplyTurn['update']>[0],
+    message: BackgroundReplyMessage,
+    options: BackgroundReplyUpdateOptions | undefined,
   ) {
     if (!this.isCurrent(key, generation)) return;
     const record = this.turns.get(key);
     if (!record) return;
 
-    const nextContent = deriveBackgroundReplyContent(message, this.environment.translate);
+    record.latestMessage = message;
+    if (!this.isActivated) return;
+
+    if (options?.deferPreview) {
+      if (record.content.phase === 'thinking' && !hasReplyText(message)) {
+        return;
+      }
+      if (record.content.phase === 'responding' || record.content.phase === 'using-tool') {
+        this.scheduleContentUpdate(record, generation);
+        return;
+      }
+    }
+
+    this.clearUpdateTimer(record);
+    this.refreshContent(record);
+  }
+
+  private refreshContent(record: TurnRecord): void {
+    if (!record.latestMessage) return;
+
+    const nextContent = deriveBackgroundReplyContent(
+      record.latestMessage,
+      this.environment.translate,
+    );
     const phaseChanged = nextContent.phase !== record.content.phase;
     record.content = nextContent;
     record.session?.update(this.toActivityProps(record), {
       keepAlive: isGeneratingPhase(nextContent.phase),
       urgent: phaseChanged,
     });
+  }
+
+  private scheduleContentUpdate(record: TurnRecord, generation: number): void {
+    if (record.updateTimer !== undefined) return;
+
+    record.updateTimer = setTimeout(() => {
+      record.updateTimer = undefined;
+      if (!this.isActivated || !this.isCurrent(record.key, generation)) return;
+      this.runTurnCallback(record.key, 'update deferred preview', () => {
+        this.refreshContent(record);
+      });
+    }, PREVIEW_UPDATE_INTERVAL_MS);
+  }
+
+  private clearUpdateTimer(record: TurnRecord): void {
+    if (record.updateTimer === undefined) return;
+    clearTimeout(record.updateTimer);
+    record.updateTimer = undefined;
   }
 
   private async finishTurn(
@@ -260,9 +318,15 @@ export class BackgroundReplyRuntime
     const record = this.turns.get(key);
     if (!record) return;
 
+    const hasDeferredPreview = record.updateTimer !== undefined;
+    this.clearUpdateTimer(record);
+    const preview =
+      outcome === 'completed' && hasDeferredPreview && record.latestMessage
+        ? deriveBackgroundReplyContent(record.latestMessage, this.environment.translate).preview
+        : record.content.preview;
     record.content = getTerminalBackgroundReplyContent(
       outcome,
-      record.content.preview,
+      preview,
       this.environment.translate,
     );
     record.session?.update(this.toActivityProps(record), { keepAlive: false, urgent: true });
@@ -393,6 +457,10 @@ function isGeneratingPhase(phase: BackgroundReplyPhase): boolean {
     phase === 'using-tool' ||
     phase === 'responding'
   );
+}
+
+function hasReplyText(message: BackgroundReplyMessage): boolean {
+  return message.parts.some((part) => part.type === 'text' && part.text.length > 0);
 }
 
 function backgroundReplyIcon(phase: BackgroundReplyPhase): BackgroundActivityIcon {

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -231,6 +231,59 @@ describe('BackgroundReplyRuntime', () => {
     await runtime._doStop();
   });
 
+  test('coalesces high-frequency reply preview updates and publishes the latest text', async () => {
+    const runtime = await createRuntime();
+    const turn = runtime.startTurn({
+      agentId: 'agent-1',
+      agentName: 'Alpha',
+      sessionId: 'session-1',
+      sessionTitle: 'First session',
+    });
+    const session = mockSessions[0];
+    turn.update({ parts: [textPart('hello')] });
+    session?.update.mockClear();
+
+    jest.useFakeTimers();
+    try {
+      turn.update({ parts: [textPart('hello more')] }, { deferPreview: true });
+      turn.update({ parts: [textPart('hello latest')] }, { deferPreview: true });
+
+      expect(session?.update).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(999);
+      expect(session?.update).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(1);
+      expect(session?.update).toHaveBeenCalledTimes(1);
+      expect(session?.update).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: 'responding', preview: 'hello latest' }),
+        { keepAlive: true, urgent: false },
+      );
+    } finally {
+      jest.useRealTimers();
+      await runtime._doStop();
+    }
+  });
+
+  test('uses the latest deferred preview when the turn finishes before its timer fires', async () => {
+    const runtime = await createRuntime();
+    const turn = runtime.startTurn({
+      agentId: 'agent-1',
+      agentName: 'Alpha',
+      sessionId: 'session-1',
+      sessionTitle: 'First session',
+    });
+    const session = mockSessions[0];
+    turn.update({ parts: [textPart('hello')] });
+    turn.update({ parts: [textPart('latest complete reply')] }, { deferPreview: true });
+
+    turn.finish('completed');
+    await flushOperations();
+
+    expect(session?.finish).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'completed', preview: 'latest complete reply' }),
+    );
+    await runtime._doStop();
+  });
+
   test.each([
     ['cancelled', '已取消'],
     ['failed', '回复失败'],
@@ -388,15 +441,19 @@ describe('BackgroundReplyRuntime', () => {
 
     Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
     enabled = false;
-    const disabledRuntime = await createRuntime();
+    const translate = jest.fn((key: string) => key);
+    const disabledRuntime = await createRuntime(translate);
     expect(disabledRuntime.isActivated).toBe(false);
-    disabledRuntime.startTurn({
+    const disabledTurn = disabledRuntime.startTurn({
       agentId: 'agent-1',
       agentName: 'Alpha',
       sessionId: 'session-2',
       sessionTitle: 'Second session',
     });
+    disabledTurn.update({ parts: [textPart('ignored')] }, { deferPreview: true });
+    disabledTurn.finish('completed');
     expect(mockStartSession).not.toHaveBeenCalled();
+    expect(translate).not.toHaveBeenCalled();
     await disabledRuntime._doStop();
   });
 

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -17,6 +17,10 @@ export type BackgroundReplyOutcome = Extract<
 
 export type BackgroundReplyMessage = Pick<AgentMessageView, 'parts'>;
 
+export type BackgroundReplyUpdateOptions = {
+  deferPreview?: boolean;
+};
+
 /**
  * Capability handle for one reply generation. Calls never throw, and handles
  * superseded by a newer generation become no-ops.
@@ -25,7 +29,7 @@ export type BackgroundReplyTurn = {
   awaitApproval: (message?: BackgroundReplyMessage) => void;
   /** Shows terminal content immediately; `waitFor` delays only final surface dismissal. */
   finish: (outcome: BackgroundReplyOutcome, options?: { waitFor?: Promise<unknown> }) => void;
-  update: (message: BackgroundReplyMessage) => void;
+  update: (message: BackgroundReplyMessage, options?: BackgroundReplyUpdateOptions) => void;
 };
 
 export type BackgroundReplyTurnInput = {

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -118,8 +118,8 @@ export function MessageList({
     [contentBottomInset],
   );
   const renderMessageRow = useCallback(
-    ({ item }: LegendListRenderItemProps<MessageListItem>) => (
-      <MessageListRow message={item} renderMessage={renderMessage} />
+    ({ extraData: rowExtraData, item }: LegendListRenderItemProps<MessageListItem>) => (
+      <MessageListRow extraData={rowExtraData} message={item} renderMessage={renderMessage} />
     ),
     [renderMessage],
   );

--- a/src/frontend/components/messages/MessageList.tsx
+++ b/src/frontend/components/messages/MessageList.tsx
@@ -1,13 +1,9 @@
-import {
-  ContextMenuScrollBoundary,
-  ScrollToBottomButton,
-  scrollToBottomButtonSize,
-} from '@cherrystudio/ui/components';
+import { ContextMenuScrollBoundary, ScrollToBottomButton } from '@cherrystudio/ui/components';
 import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list/keyboard';
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Platform, View } from 'react-native';
+import { type LayoutChangeEvent, Platform, View } from 'react-native';
 import { runOnJS, useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
 
 import { MessageListDisclosureProvider } from './list/MessageListDisclosureContext';
@@ -63,10 +59,46 @@ export function MessageList({
     scrollMessageToEnd,
   });
   const isAtBottom = useSharedValue(true);
+  const contentHeightRef = useRef({ dataKey, height: 0 });
+  const viewportHeightRef = useRef(0);
+  const [contentScrollability, setContentScrollability] = useState({
+    dataKey,
+    isScrollable: false,
+  });
+  const isContentScrollable =
+    contentScrollability.dataKey === dataKey && contentScrollability.isScrollable;
   const [isNativeAtBottomForButton, setIsNativeAtBottomForButton] = useState(true);
   const syncScrollButtonVisibility = useCallback((atBottom: boolean) => {
     setIsNativeAtBottomForButton(atBottom);
   }, []);
+  const syncContentScrollability = useCallback(() => {
+    const contentHeight =
+      contentHeightRef.current.dataKey === dataKey ? contentHeightRef.current.height : 0;
+    const nextIsScrollable =
+      viewportHeightRef.current > 0 && contentHeight > viewportHeightRef.current;
+    setContentScrollability((current) => {
+      if (current.dataKey === dataKey && current.isScrollable === nextIsScrollable) {
+        return current;
+      }
+      return { dataKey, isScrollable: nextIsScrollable };
+    });
+  }, [dataKey]);
+  const handleListContentSizeChange = useCallback(
+    (_width: number, height: number) => {
+      contentHeightRef.current = { dataKey, height };
+      syncContentScrollability();
+      handleContentSizeChange();
+    },
+    [dataKey, handleContentSizeChange, syncContentScrollability],
+  );
+  const handleListLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      viewportHeightRef.current = event.nativeEvent.layout.height;
+      syncContentScrollability();
+      handleLayout(event);
+    },
+    [handleLayout, syncContentScrollability],
+  );
 
   useAnimatedReaction(
     () => isAtBottom.get(),
@@ -80,8 +112,7 @@ export function MessageList({
   const listHeader = useMemo(() => <View style={{ height: contentTopInset }} />, [contentTopInset]);
   const contentContainerStyle = useMemo(
     () => ({
-      paddingBottom:
-        contentBottomInset + scrollToBottomButtonSize + SCROLL_BUTTON_GAP_ABOVE_ACCESSORY * 2,
+      paddingBottom: contentBottomInset,
       paddingTop: MESSAGE_LIST_TOP_PADDING,
     }),
     [contentBottomInset],
@@ -134,8 +165,8 @@ export function MessageList({
               ListHeaderComponent={listHeader}
               {...(!dataKey ? { initialScrollAtEnd: true } : {})}
               maintainVisibleContentPosition={MAINTAIN_VISIBLE_CONTENT_POSITION}
-              onContentSizeChange={handleContentSizeChange}
-              onLayout={handleLayout}
+              onContentSizeChange={handleListContentSizeChange}
+              onLayout={handleListLayout}
               onLoad={handleLoad}
               onScroll={handleScroll}
               onStartReached={onLoadOlder ? handleStartReached : undefined}
@@ -157,7 +188,7 @@ export function MessageList({
             accessibilityLabel={t('chat.message.scrollToBottom')}
             bottomAccessoryHeight={bottomAccessoryHeight}
             gap={SCROLL_BUTTON_GAP_ABOVE_ACCESSORY}
-            isAtBottom={isNativeAtBottomForButton || isFollowing}
+            isAtBottom={!isContentScrollable || isNativeAtBottomForButton || isFollowing}
             // The press only enters following mode, which already hides the
             // button. Mirroring an optimistic at-end state here would stick at
             // `true` whenever the scroll does not actually land at the end.

--- a/src/frontend/components/messages/README.md
+++ b/src/frontend/components/messages/README.md
@@ -61,7 +61,7 @@ instead of creating feature-owned rows or sheets:
 | --- | --- | --- |
 | Summary | `MessagePart.Summary` | Renders the title, status text, tone, running shimmer, and disclosure chevron. |
 | Interaction | `MessagePart.Tool` | Owns local open/close state and connects the summary press to its detail. Business renderers do not lift this transient state. |
-| Process | `MessagePart.Process` | Renders one total-duration disclosure before the answer and expands every pre-result part inline. |
+| Process | `MessagePart.Process` | After streaming settles, renders one collapsed total-duration disclosure before the answer and expands every pre-result part inline. |
 | Grouping | `MessagePart.ToolGroup` | Owns the group summary row and inline step container for a run of tool calls. Expanded while the run is live, folded once it settles; a manual toggle always wins. |
 | Detail shell | `MessagePart.Detail` | Owns the `BottomSheet`, title, dismissal, scrolling, content insets, and spacing. Tool and source details share this shell. |
 | Detail content | The part renderer | Supplies the business-specific content inside the shell. This content remains intentionally unconstrained until its visual variants are designed. |
@@ -84,9 +84,10 @@ may summarize user-facing metadata such as its filename and size, but it does no
 entry ids or repeat the file body.
 
 Reasoning expands inline: `MessagePart.Reasoning` owns the toggle and the left-rail container its
-markdown renders into, so a reader keeps their place in the transcript. Every visible transcript
-part except the final result text sits inside one collapsed `MessagePart.Process` row whose label is
-the message's total wall-clock duration. Expanding it reveals the original parts in order. Source
+markdown renders into, so a reader keeps their place in the transcript. While a response streams,
+its process parts remain visible without a total-duration wrapper. Once the response settles, every
+visible transcript part except the final result text moves into one collapsed `MessagePart.Process`
+row whose label is the message's total wall-clock duration. Expanding it reveals the original parts in order. Source
 groups use a borderless row of overlapping favicons and their source count, while their expanded
 views must use `MessagePart.Detail`. New
 interactive message parts may introduce a distinct compact trigger only when their semantics cannot
@@ -168,7 +169,9 @@ ChatScreen or PaintingComposer
   bottom insets across the list API.
 - `MessageList` owns scrolling, content insets, row gutters, role-level row spacing, anchoring, and
   the placement of every rendered message. The feature renderer supplies content; it does not
-  recreate list spacing.
+  recreate list spacing. Its trailing content inset comes only from the screen-owned layout; the
+  floating scroll button does not reserve persistent space after the final row and remains hidden
+  unless the content exceeds the viewport.
 - `UserMessage` and `AssistantMessage` own role presentation inside the row frame. They may define
   intrinsic width, internal grouping, bubbles, and surfaces, but do not add list or
   screen gutters.

--- a/src/frontend/components/messages/list/MessageListRow.tsx
+++ b/src/frontend/components/messages/list/MessageListRow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { StyleSheet, type StyleProp, View, type ViewStyle } from 'react-native';
 
 import type { MessageListItem, MessageRenderer } from '../types';
@@ -8,9 +9,12 @@ type MessageListRowProps = {
   renderMessage: MessageRenderer;
 };
 
-export function MessageListRow({ message, renderMessage }: MessageListRowProps) {
+export const MessageListRow = memo(function MessageListRow({
+  message,
+  renderMessage,
+}: MessageListRowProps) {
   return <View style={messageRowStyles[message.role]}>{renderMessage(message)}</View>;
-}
+});
 
 const styles = StyleSheet.create({
   assistant: {

--- a/src/frontend/components/messages/list/MessageListRow.tsx
+++ b/src/frontend/components/messages/list/MessageListRow.tsx
@@ -5,6 +5,8 @@ import type { MessageListItem, MessageRenderer } from '../types';
 import { MESSAGE_ROW_HORIZONTAL_PADDING, MESSAGE_ROW_VERTICAL_PADDING } from './messageListLayout';
 
 type MessageListRowProps = {
+  /** Keeps LegendList's external invalidation token visible to the memo boundary. */
+  extraData?: unknown;
   message: MessageListItem;
   renderMessage: MessageRenderer;
 };

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -41,7 +41,7 @@ type MockLegendListProps = {
   onTouchStart?: () => void;
   recycleItems?: boolean;
   ref?: Ref<LegendListRef>;
-  renderItem?: (info: { index: number; item: MessageListItem }) => ReactNode;
+  renderItem?: (info: { extraData?: unknown; index: number; item: MessageListItem }) => ReactNode;
   sharedValues?: { isAtEnd: SharedValue<boolean> };
   showsVerticalScrollIndicator?: boolean;
 };
@@ -116,7 +116,9 @@ jest.mock('@legendapp/list/keyboard', () => {
       return (
         <View testID="message-list">
           {props.data?.map((item, index) => (
-            <Fragment key={item.id}>{props.renderItem?.({ index, item })}</Fragment>
+            <Fragment key={item.id}>
+              {props.renderItem?.({ extraData: props.extraData, index, item })}
+            </Fragment>
           ))}
         </View>
       );
@@ -506,6 +508,25 @@ describe('MessageList scroll-controller ownership', () => {
 
     expect(mockRenderMessage).toHaveBeenCalledTimes(1);
     expect(mockRenderMessage).toHaveBeenCalledWith(updatedStreamingMessage);
+  });
+
+  test('rerenders every row when extra data invalidates external rendering state', () => {
+    const messages = [createMessage('user-1', 'user'), createMessage('assistant-1', 'assistant')];
+    const initialExtraData = { isToolbarEnabled: false };
+    act(() => {
+      renderer = create(<MessageList {...listProps(messages, { extraData: initialExtraData })} />);
+    });
+    mockRenderMessage.mockClear();
+
+    act(() => {
+      renderer?.update(
+        <MessageList {...listProps(messages, { extraData: { isToolbarEnabled: true } })} />,
+      );
+    });
+
+    expect(mockRenderMessage).toHaveBeenCalledTimes(2);
+    expect(mockRenderMessage).toHaveBeenNthCalledWith(1, messages[0]);
+    expect(mockRenderMessage).toHaveBeenNthCalledWith(2, messages[1]);
   });
 
   test('flushes the outgoing anchor and ignores its late momentum end after a data switch', async () => {

--- a/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/messages/list/__tests__/MessageList.test.tsx
@@ -213,6 +213,12 @@ function listProps(
   };
 }
 
+function layoutEvent(height: number): LayoutChangeEvent {
+  return {
+    nativeEvent: { layout: { height, width: 390, x: 0, y: 0 } },
+  } as LayoutChangeEvent;
+}
+
 describe('MessageList scroll-controller ownership', () => {
   let renderer: ReactTestRenderer | undefined;
   let frameCallbacks: Map<number, FrameRequestCallback>;
@@ -443,6 +449,10 @@ describe('MessageList scroll-controller ownership', () => {
       renderer = create(<MessageList {...listProps(messages)} />);
     });
     await loadList();
+    act(() => {
+      mockLatestListProps?.onLayout?.(layoutEvent(400));
+      mockLatestListProps?.onContentSizeChange?.(390, 500);
+    });
 
     const reaction = mockAnimatedReactions[0];
     mockLatestListProps?.sharedValues?.isAtEnd.set(false);
@@ -452,6 +462,50 @@ describe('MessageList scroll-controller ownership', () => {
     act(() => mockLatestListProps?.onScrollBeginDrag?.());
 
     expect(mockScrollButtonProps?.isAtBottom).toBe(false);
+  });
+
+  test('only exposes the scroll button when the content exceeds the viewport', async () => {
+    const messages = [createMessage('user-1', 'user')];
+    act(() => {
+      renderer = create(<MessageList {...listProps(messages)} />);
+    });
+    await loadList();
+
+    act(() => {
+      mockLatestListProps?.onLayout?.(layoutEvent(400));
+      mockLatestListProps?.onContentSizeChange?.(390, 300);
+      mockLatestListProps?.onScrollBeginDrag?.();
+    });
+    const reaction = mockAnimatedReactions[0];
+    mockLatestListProps?.sharedValues?.isAtEnd.set(false);
+    act(() => reaction.react(reaction.prepare(), true));
+
+    expect(mockScrollButtonProps?.isAtBottom).toBe(true);
+
+    act(() => mockLatestListProps?.onContentSizeChange?.(390, 500));
+
+    expect(mockScrollButtonProps?.isAtBottom).toBe(false);
+  });
+
+  test('rerenders only the changed row during a streaming update', () => {
+    const userMessage = createMessage('user-1', 'user');
+    const streamingMessage = createMessage('assistant-1', 'assistant');
+    const messages = [userMessage, streamingMessage];
+    act(() => {
+      renderer = create(<MessageList {...listProps(messages)} />);
+    });
+    mockRenderMessage.mockClear();
+
+    const updatedStreamingMessage: MessageListItem = {
+      ...streamingMessage,
+      data: { parts: [{ text: 'assistant-1 updated', type: 'text' }] },
+    };
+    act(() => {
+      renderer?.update(<MessageList {...listProps([userMessage, updatedStreamingMessage])} />);
+    });
+
+    expect(mockRenderMessage).toHaveBeenCalledTimes(1);
+    expect(mockRenderMessage).toHaveBeenCalledWith(updatedStreamingMessage);
   });
 
   test('flushes the outgoing anchor and ignores its late momentum end after a data switch', async () => {
@@ -542,7 +596,11 @@ describe('MessageList scroll-controller ownership', () => {
     mockListScrollToEnd.mockClear();
     mockListState.isAtEnd = false;
 
-    act(() => mockLatestListProps?.onScrollBeginDrag?.());
+    act(() => {
+      mockLatestListProps?.onLayout?.(layoutEvent(400));
+      mockLatestListProps?.onContentSizeChange?.(390, 500);
+      mockLatestListProps?.onScrollBeginDrag?.();
+    });
     const reaction = mockAnimatedReactions[0];
     mockLatestListProps?.sharedValues?.isAtEnd.set(false);
     act(() => reaction.react(reaction.prepare(), true));
@@ -571,7 +629,7 @@ describe('MessageList scroll-controller ownership', () => {
       expect(mockLatestListProps?.getItemType?.(messages[1])).toBe('assistant');
       expect(mockLatestListProps?.keyboardDismissMode).toBe('on-drag');
       expect(mockLatestListProps?.contentContainerStyle).toEqual({
-        paddingBottom: 130,
+        paddingBottom: 80,
         paddingTop: 12,
       });
       expect(mockLatestListProps?.showsVerticalScrollIndicator).toBe(false);

--- a/src/frontend/components/messages/parts/MessagePartRenderer.tsx
+++ b/src/frontend/components/messages/parts/MessagePartRenderer.tsx
@@ -12,7 +12,7 @@ import { ReasoningPart } from './ReasoningPart';
 import { SourceUrlPart } from './SourceUrlPart';
 import { TextPart } from './TextPart';
 import { ToolPartRenderer } from './tools/ToolPartRenderer';
-import { isToolMessagePart } from './tools/toolPartState';
+import { isToolMessagePart, isWebSearchToolPart } from './tools/toolPartState';
 import { TranslationPart } from './TranslationPart';
 import { UnknownPart } from './UnknownPart';
 
@@ -89,4 +89,26 @@ export const MessagePartRenderer = memo(function MessagePartRenderer({
     default:
       return <UnknownPart />;
   }
-});
+}, areMessagePartRendererPropsEqual);
+
+function areMessagePartRendererPropsEqual(
+  previous: MessagePartRendererProps,
+  next: MessagePartRendererProps,
+) {
+  if (
+    previous.isStreaming !== next.isStreaming ||
+    previous.isTextSelectionEnabled !== next.isTextSelectionEnabled ||
+    previous.part !== next.part ||
+    previous.renderMode !== next.renderMode ||
+    previous.resolvedText?.markdown !== next.resolvedText?.markdown ||
+    previous.resolvedText?.plainText !== next.resolvedText?.plainText
+  ) {
+    return false;
+  }
+
+  return (
+    !isToolMessagePart(next.part) ||
+    !isWebSearchToolPart(next.part) ||
+    previous.messageParts === next.messageParts
+  );
+}

--- a/src/frontend/components/messages/parts/MessageParts.tsx
+++ b/src/frontend/components/messages/parts/MessageParts.tsx
@@ -41,26 +41,41 @@ export function MessageParts({
 
   const { body, files, process } = partitionMessageParts(parts);
   const hasSources = parts.some((part) => part.type === 'source-url');
+  const isStreaming = message.status === 'pending';
 
   return (
     <View className="gap-2">
       {process.length > 0 ? (
-        <ProcessGroupPart
-          citationText={citations.textByPartIndex}
-          isTextSelectionEnabled={isTextSelectionEnabled}
-          items={process.map(({ index, part }) => ({
-            index,
-            key: getMessagePartKey(message, part, index),
-            part,
-          }))}
-          message={message}
-          messageParts={parts}
-          renderMode={renderMode}
-        />
+        isStreaming ? (
+          process.map(({ index, part }) => (
+            <MessagePartRenderer
+              isStreaming
+              isTextSelectionEnabled={isTextSelectionEnabled}
+              key={getMessagePartKey(message, part, index)}
+              messageParts={parts}
+              part={part}
+              renderMode={renderMode}
+              resolvedText={citations.textByPartIndex.get(index)}
+            />
+          ))
+        ) : (
+          <ProcessGroupPart
+            citationText={citations.textByPartIndex}
+            isTextSelectionEnabled={isTextSelectionEnabled}
+            items={process.map(({ index, part }) => ({
+              index,
+              key: getMessagePartKey(message, part, index),
+              part,
+            }))}
+            message={message}
+            messageParts={parts}
+            renderMode={renderMode}
+          />
+        )
       ) : null}
       {body.map((item) => (
         <MessagePartRenderer
-          isStreaming={message.status === 'pending'}
+          isStreaming={isStreaming}
           isTextSelectionEnabled={isTextSelectionEnabled}
           key={getMessagePartKey(message, item.part, item.index)}
           messageParts={parts}

--- a/src/frontend/components/messages/parts/ProcessGroupPart.tsx
+++ b/src/frontend/components/messages/parts/ProcessGroupPart.tsx
@@ -10,7 +10,6 @@ import type { ResolvedCitationText } from './citations';
 import { MessagePartRenderer } from './MessagePartRenderer';
 import type { MessagePartRenderMode } from './MessageParts';
 import type { MessageProcessItem } from './partitionMessageParts';
-import { useElapsedTimerMs } from './useElapsedTimerMs';
 
 type ProcessGroupItem = MessageProcessItem & { key: string };
 
@@ -33,22 +32,15 @@ export function ProcessGroupPart({
 }: ProcessGroupPartProps) {
   const { t } = useTranslation();
   const handleDisclosureToggle = useMessageListDisclosureToggle();
-  const isRunning = message.status === 'pending';
-  const startedAt = parseTimestamp(message.createdAt);
   const persistedDurationMs = resolvePersistedDurationMs(message, items);
-  const elapsedMs = useElapsedTimerMs(isRunning, startedAt, persistedDurationMs);
-  const seconds = Math.max(1, Math.round(elapsedMs / 1000));
+  const seconds = Math.max(1, Math.round((persistedDurationMs ?? 0) / 1000));
   const title = t('chat.process.duration', { seconds });
 
   return (
-    <MessagePart.Process
-      onDisclosureToggle={handleDisclosureToggle}
-      state={isRunning ? 'running' : 'complete'}
-      title={title}
-    >
+    <MessagePart.Process onDisclosureToggle={handleDisclosureToggle} state="complete" title={title}>
       {items.map(({ index, key, part }) => (
         <MessagePartRenderer
-          isStreaming={isRunning}
+          isStreaming={false}
           isTextSelectionEnabled={isTextSelectionEnabled}
           key={key}
           messageParts={messageParts}

--- a/src/frontend/components/messages/parts/__tests__/MessagePartRenderer.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/MessagePartRenderer.test.tsx
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { MessagePartRenderer } from '../MessagePartRenderer';
+import { TextPart } from '../TextPart';
 
 jest.mock('../CodePart', () => ({ CodePart: () => null }));
 jest.mock('../CompactPart', () => ({ CompactPart: () => null }));
@@ -10,12 +11,18 @@ jest.mock('../ErrorPart', () => ({ ErrorPart: () => null }));
 jest.mock('../FilePart', () => ({ FilePart: () => null }));
 jest.mock('../ReasoningPart', () => ({ ReasoningPart: () => null }));
 jest.mock('../SourceUrlPart', () => ({ SourceUrlPart: () => null }));
-jest.mock('../TextPart', () => ({ TextPart: () => null }));
+jest.mock('../TextPart', () => ({ TextPart: jest.fn(() => null) }));
 jest.mock('../tools/ToolPartRenderer', () => ({ ToolPartRenderer: () => null }));
 jest.mock('../TranslationPart', () => ({ TranslationPart: () => null }));
 jest.mock('../UnknownPart', () => ({ UnknownPart: () => null }));
 
+const mockTextPart = jest.mocked(TextPart);
+
 describe('MessagePartRenderer', () => {
+  beforeEach(() => {
+    mockTextPart.mockClear();
+  });
+
   test.each([
     {
       filename: 'reference.pdf',
@@ -38,5 +45,37 @@ describe('MessagePartRenderer', () => {
     });
 
     expect(renderer?.toJSON()).toBeNull();
+  });
+
+  test('does not rerender an unchanged part when only surrounding message parts change', () => {
+    const part = { state: 'done', text: 'Stable answer', type: 'text' } as const;
+    const firstResolvedText = { markdown: 'Stable answer', plainText: 'Stable answer' };
+    let renderer: ReactTestRenderer | undefined;
+    act(() => {
+      renderer = create(
+        <MessagePartRenderer
+          isStreaming={false}
+          isTextSelectionEnabled
+          messageParts={[part]}
+          part={part}
+          resolvedText={firstResolvedText}
+        />,
+      );
+    });
+    mockTextPart.mockClear();
+
+    act(() => {
+      renderer?.update(
+        <MessagePartRenderer
+          isStreaming={false}
+          isTextSelectionEnabled
+          messageParts={[part, { state: 'streaming', text: 'New text', type: 'text' }]}
+          part={part}
+          resolvedText={{ ...firstResolvedText }}
+        />,
+      );
+    });
+
+    expect(mockTextPart).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/components/messages/parts/__tests__/MessageParts.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/MessageParts.test.tsx
@@ -142,6 +142,49 @@ describe('MessageParts', () => {
     expect(renderer.root.findAllByType('MessagePartRenderer')).toHaveLength(1);
   });
 
+  test('keeps process parts ungrouped while streaming and groups them after completion', () => {
+    const reasoningPart = {
+      state: 'streaming' as const,
+      text: 'Reasoning',
+      type: 'reasoning' as const,
+    };
+    const pendingMessage: MessageListItem = {
+      ...makeMessage('pending'),
+      data: {
+        partKeys: ['reasoning-key', 'text-key'],
+        parts: [reasoningPart, { state: 'streaming', text: 'Answer', type: 'text' }],
+      },
+    };
+    const renderer = render(<MessageParts isTextSelectionEnabled message={pendingMessage} />);
+
+    expect(renderer.root.findAllByType('ProcessGroupPart')).toHaveLength(0);
+    expect(
+      renderer.root.findAllByType('MessagePartRenderer').map((part) => part.props.part.type),
+    ).toEqual(['reasoning', 'text']);
+
+    act(() => {
+      renderer.update(
+        <MessageParts
+          isTextSelectionEnabled
+          message={{
+            ...pendingMessage,
+            data: {
+              ...pendingMessage.data,
+              parts: [
+                { ...reasoningPart, state: 'done' },
+                { state: 'done', text: 'Answer', type: 'text' },
+              ],
+            },
+            status: 'success',
+          }}
+        />,
+      );
+    });
+
+    expect(renderer.root.findAllByType('ProcessGroupPart')).toHaveLength(1);
+    expect(renderer.root.findAllByType('MessagePartRenderer')).toHaveLength(1);
+  });
+
   test('shows a file produced mid-answer after the answer, not where it interrupted it', () => {
     const message: MessageListItem = {
       ...makeMessage('success'),

--- a/src/frontend/components/messages/parts/__tests__/ProcessGroupPart.test.tsx
+++ b/src/frontend/components/messages/parts/__tests__/ProcessGroupPart.test.tsx
@@ -69,5 +69,6 @@ describe('ProcessGroupPart', () => {
       state: 'complete',
       title: '用时 16秒',
     });
+    expect(renderer!.root.findByType('MessagePartRenderer').props.isStreaming).toBe(false);
   });
 });

--- a/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
+++ b/src/frontend/features/chat/runtime/AgentSessionChatClient.ts
@@ -36,10 +36,14 @@ type SessionEntry = {
   generation: number;
   listeners: Set<() => void>;
   liveMessages: Map<string, AgentMessageView>;
+  liveMessagesFlush?: ReturnType<typeof setTimeout>;
   observation?: AgentSessionObservation;
   observationPromise?: Promise<void>;
+  pendingTextDeltas: Map<string, { chunks: string[]; messageId: string; partId: string }>;
   state: AgentSessionChatState;
 };
+
+const LIVE_MESSAGE_FLUSH_INTERVAL_MS = 16;
 
 const TERMINAL_TURN_STATUSES = new Set<AgentTurnView['status']>([
   'completed',
@@ -92,6 +96,10 @@ function applyMessageDelta(message: AgentMessageView, delta: AgentMessageDelta):
   }
 }
 
+function isTerminalMessage(message: AgentMessageView): boolean {
+  return message.status !== 'pending' && message.status !== 'streaming';
+}
+
 export class AgentSessionChatClient {
   private readonly sessions = new Map<string, SessionEntry>();
 
@@ -113,6 +121,9 @@ export class AgentSessionChatClient {
       entry.listeners.delete(listener);
       if (entry.listeners.size === 0) {
         this.stopObservation(entry);
+        if (this.sessions.get(sessionId) === entry) {
+          this.sessions.delete(sessionId);
+        }
       }
     };
   }
@@ -162,6 +173,9 @@ export class AgentSessionChatClient {
         for (const event of queuedEvents) {
           this.applyEvent(entry, event);
         }
+        if (entry.liveMessagesFlush !== undefined) {
+          this.commitLiveMessages(entry);
+        }
       })
       .catch((error: unknown) => {
         if (entry.generation !== generation) {
@@ -208,9 +222,8 @@ export class AgentSessionChatClient {
       parts,
       ...overrides,
     });
-    // The durable submission has succeeded even if observation later needs a
-    // retry. Do not restore a Draft whose files now belong to persisted input.
-    await this.observe(session.id).catch(() => undefined);
+    // The destination route observes after navigation. Its atomic Host snapshot
+    // reconstructs any live turn state without leaving an ownerless listener here.
     return session;
   }
 
@@ -224,9 +237,7 @@ export class AgentSessionChatClient {
       sessionId,
       ...(title ? { title } : {}),
     });
-    // The fork is durable even if observation needs a retry; the caller
-    // navigates to it either way, and the transcript is a data read.
-    await this.observe(session.id).catch(() => undefined);
+    // As with a new Session, the destination route owns observation.
     return session;
   }
 
@@ -235,8 +246,49 @@ export class AgentSessionChatClient {
     parts: AgentInputPart[],
     overrides: Pick<AgentSubmitMessageInput, 'modelId' | 'reasoningEffort'> = {},
   ) {
+    const entry = this.getEntry(sessionId);
     await this.observe(sessionId);
-    return this.protocol.submitMessage({ parts, sessionId, ...overrides });
+    try {
+      return await this.protocol.submitMessage({ parts, sessionId, ...overrides });
+    } finally {
+      // Non-React callers may submit without ever installing a subscriber. The
+      // Host snapshot makes a later observation lossless, so do not retain an
+      // ownerless listener or SessionEntry after admission completes.
+      if (entry.listeners.size === 0 && this.sessions.get(sessionId) === entry) {
+        this.stopObservation(entry);
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+
+  reconcilePersistedMessages(
+    sessionId: string,
+    persistedMessages: readonly AgentMessageView[],
+  ): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry || entry.liveMessages.size === 0 || persistedMessages.length === 0) {
+      return;
+    }
+
+    const persistedById = new Map(persistedMessages.map((message) => [message.id, message]));
+    let changed = false;
+    for (const [messageId, liveMessage] of entry.liveMessages) {
+      const persistedMessage = persistedById.get(messageId);
+      if (
+        persistedMessage &&
+        isTerminalMessage(liveMessage) &&
+        isTerminalMessage(persistedMessage) &&
+        persistedMessage.status === liveMessage.status &&
+        persistedMessage.updatedAt === liveMessage.updatedAt
+      ) {
+        entry.liveMessages.delete(messageId);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this.commitLiveMessages(entry);
+    }
   }
 
   async cancelTurn(sessionId: string): Promise<void> {
@@ -286,6 +338,7 @@ export class AgentSessionChatClient {
       generation: 0,
       listeners: new Set(),
       liveMessages: new Map(),
+      pendingTextDeltas: new Map(),
       state: createSessionState(sessionId),
     };
     this.sessions.set(sessionId, entry);
@@ -294,6 +347,8 @@ export class AgentSessionChatClient {
 
   private stopObservation(entry: SessionEntry): void {
     entry.generation += 1;
+    this.cancelLiveMessagesFlush(entry);
+    entry.pendingTextDeltas.clear();
     entry.observation?.unsubscribe();
     entry.observation = undefined;
     entry.observationPromise = undefined;
@@ -351,10 +406,8 @@ export class AgentSessionChatClient {
         return;
       case 'message.created':
         entry.liveMessages.set(event.message.id, event.message);
-        this.updateState(entry, {
-          ...entry.state,
+        this.commitLiveMessages(entry, {
           ...(event.message.role === 'user' ? { enteringUserMessageId: event.message.id } : {}),
-          liveMessages: [...entry.liveMessages.values()],
         });
         if (event.message.role === 'user') {
           this.options.onSessionChanged?.(entry.state.sessionId);
@@ -362,6 +415,15 @@ export class AgentSessionChatClient {
         this.options.onTranscriptChanged?.(entry.state.sessionId);
         return;
       case 'message.delta': {
+        if (event.delta.op === 'text.append') {
+          if (!this.queueTextDelta(entry, event.messageId, event.delta)) {
+            return;
+          }
+          this.scheduleLiveMessagesFlush(entry);
+          return;
+        }
+
+        this.applyPendingTextDeltas(entry);
         const message = entry.liveMessages.get(event.messageId);
         if (!message) {
           return;
@@ -371,18 +433,13 @@ export class AgentSessionChatClient {
           return;
         }
         entry.liveMessages.set(event.messageId, nextMessage);
-        this.updateState(entry, {
-          ...entry.state,
-          liveMessages: [...entry.liveMessages.values()],
-        });
+        this.commitLiveMessages(entry);
         return;
       }
       case 'message.finalized':
+        entry.pendingTextDeltas.clear();
         entry.liveMessages.set(event.message.id, event.message);
-        this.updateState(entry, {
-          ...entry.state,
-          liveMessages: [...entry.liveMessages.values()],
-        });
+        this.commitLiveMessages(entry);
         this.options.onTranscriptChanged?.(entry.state.sessionId);
         return;
       case 'approval.requested':
@@ -402,6 +459,82 @@ export class AgentSessionChatClient {
           ),
         });
     }
+  }
+
+  private cancelLiveMessagesFlush(entry: SessionEntry): void {
+    if (entry.liveMessagesFlush === undefined) {
+      return;
+    }
+    clearTimeout(entry.liveMessagesFlush);
+    entry.liveMessagesFlush = undefined;
+  }
+
+  private commitLiveMessages(
+    entry: SessionEntry,
+    statePatch: Partial<AgentSessionChatState> = {},
+  ): void {
+    this.applyPendingTextDeltas(entry);
+    this.cancelLiveMessagesFlush(entry);
+    this.updateState(entry, {
+      ...entry.state,
+      ...statePatch,
+      liveMessages: [...entry.liveMessages.values()],
+    });
+  }
+
+  private scheduleLiveMessagesFlush(entry: SessionEntry): void {
+    if (entry.liveMessagesFlush !== undefined) {
+      return;
+    }
+    entry.liveMessagesFlush = setTimeout(() => {
+      entry.liveMessagesFlush = undefined;
+      this.commitLiveMessages(entry);
+    }, LIVE_MESSAGE_FLUSH_INTERVAL_MS);
+  }
+
+  private queueTextDelta(
+    entry: SessionEntry,
+    messageId: string,
+    delta: Extract<AgentMessageDelta, { op: 'text.append' }>,
+  ): boolean {
+    if (delta.text.length === 0) return false;
+
+    const message = entry.liveMessages.get(messageId);
+    const target = message?.parts.find(
+      (part) => part.id === delta.partId && (part.type === 'text' || part.type === 'reasoning'),
+    );
+    if (!target) return false;
+
+    const key = `${messageId}\u0000${delta.partId}`;
+    const pending = entry.pendingTextDeltas.get(key);
+    if (pending) {
+      pending.chunks.push(delta.text);
+    } else {
+      entry.pendingTextDeltas.set(key, {
+        chunks: [delta.text],
+        messageId,
+        partId: delta.partId,
+      });
+    }
+    return true;
+  }
+
+  private applyPendingTextDeltas(entry: SessionEntry): void {
+    if (entry.pendingTextDeltas.size === 0) return;
+
+    for (const { chunks, messageId, partId } of entry.pendingTextDeltas.values()) {
+      const message = entry.liveMessages.get(messageId);
+      if (!message) continue;
+      const nextMessage = applyMessageDelta(message, {
+        op: 'text.append',
+        partId,
+        text: chunks.join(''),
+      });
+      if (nextMessage !== message) {
+        entry.liveMessages.set(messageId, nextMessage);
+      }
+    }
+    entry.pendingTextDeltas.clear();
   }
 
   private updateState(entry: SessionEntry, state: AgentSessionChatState): void {

--- a/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/AgentSessionChatClient.test.ts
@@ -87,24 +87,9 @@ function protocolWithObservation(
 }
 
 describe('AgentSessionChatClient', () => {
-  test('starts a durable Session from a Draft submission before observing it', async () => {
-    const initialSnapshot: AgentSessionSnapshot = {
-      ...snapshot(),
-      activeTurn: {
-        assistantMessageId: 'assistant-1',
-        endedAt: null,
-        error: null,
-        id: 'turn-1',
-        sessionId: 'session-1',
-        startedAt: '2026-08-25T00:00:00.000Z',
-        status: 'running',
-      },
-      activeUserMessage: userMessage(),
-      hasHistoryBeforeActiveTurn: false,
-      streamingMessage: assistantMessage(),
-    };
+  test('starts a durable Session without leaving an ownerless observation before navigation', async () => {
     const protocol = protocolWithObservation(async () => ({
-      snapshot: initialSnapshot,
+      snapshot: snapshot(),
       unsubscribe: jest.fn(),
     }));
     protocol.startSession.mockResolvedValue(snapshot().session);
@@ -117,16 +102,10 @@ describe('AgentSessionChatClient', () => {
       executionTarget: { kind: 'local' },
       parts: [{ text: 'Hello', type: 'text' }],
     });
-    expect(protocol.observeSession).toHaveBeenCalledWith('session-1', expect.any(Function));
-    expect(client.getState('session-1')).toMatchObject({
-      enteringUserMessageId: 'user-1',
-      hasHistoryBeforeActiveTurn: false,
-      liveMessages: [{ id: 'user-1' }, { id: 'assistant-1' }],
-      status: 'ready',
-    });
+    expect(protocol.observeSession).not.toHaveBeenCalled();
   });
 
-  test('keeps an admitted Draft submission successful when observation needs a retry', async () => {
+  test('keeps an admitted Draft submission independent from destination observation', async () => {
     const protocol = protocolWithObservation(async () => {
       throw new Error('observation unavailable');
     });
@@ -136,6 +115,7 @@ describe('AgentSessionChatClient', () => {
     await expect(
       client.startSession('agent-1', [{ text: 'Hello', type: 'text' }]),
     ).resolves.toEqual(snapshot().session);
+    expect(protocol.observeSession).not.toHaveBeenCalled();
   });
 
   test('forwards composer turn overrides with the submitted message', async () => {
@@ -257,6 +237,111 @@ describe('AgentSessionChatClient', () => {
     release();
 
     expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(client.getState('session-1')).toMatchObject({ liveMessages: [], status: 'idle' });
+  });
+
+  test('coalesces consecutive text deltas into one live-message notification', async () => {
+    jest.useFakeTimers();
+    let release = () => {};
+    try {
+      let listener: ((event: AgentEvent) => void) | undefined;
+      const protocol = protocolWithObservation(async (_sessionId, nextListener) => {
+        listener = nextListener;
+        return { snapshot: snapshot(), unsubscribe: jest.fn() };
+      });
+      const client = new AgentSessionChatClient(protocol);
+      await client.observe('session-1');
+      const onChange = jest.fn();
+      release = client.subscribe('session-1', onChange);
+      listener?.({ type: 'message.created', message: assistantMessage() });
+      onChange.mockClear();
+
+      listener?.({
+        type: 'message.delta',
+        messageId: 'assistant-1',
+        delta: { op: 'text.append', partId: 'text-1', text: 'Hello' },
+      });
+      listener?.({
+        type: 'message.delta',
+        messageId: 'assistant-1',
+        delta: { op: 'text.append', partId: 'text-1', text: ' world' },
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(16);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(client.getState('session-1').liveMessages[0]?.parts).toEqual([
+        { id: 'text-1', state: 'streaming', text: 'Hello world', type: 'text' },
+      ]);
+    } finally {
+      release();
+      jest.useRealTimers();
+    }
+  });
+
+  test('publishes a terminal message immediately and cancels its pending text flush', async () => {
+    jest.useFakeTimers();
+    let release = () => {};
+    try {
+      let listener: ((event: AgentEvent) => void) | undefined;
+      const protocol = protocolWithObservation(async (_sessionId, nextListener) => {
+        listener = nextListener;
+        return { snapshot: snapshot(), unsubscribe: jest.fn() };
+      });
+      const client = new AgentSessionChatClient(protocol);
+      await client.observe('session-1');
+      const onChange = jest.fn();
+      release = client.subscribe('session-1', onChange);
+      listener?.({ type: 'message.created', message: assistantMessage() });
+      onChange.mockClear();
+      listener?.({
+        type: 'message.delta',
+        messageId: 'assistant-1',
+        delta: { op: 'text.append', partId: 'text-1', text: 'Partial' },
+      });
+      listener?.({
+        type: 'message.finalized',
+        message: {
+          ...assistantMessage(),
+          parts: [{ id: 'text-1', state: 'done', text: 'Complete', type: 'text' }],
+          status: 'success',
+        },
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(client.getState('session-1').liveMessages[0]).toMatchObject({
+        parts: [{ text: 'Complete' }],
+        status: 'success',
+      });
+      jest.advanceTimersByTime(16);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    } finally {
+      release();
+      jest.useRealTimers();
+    }
+  });
+
+  test('drops terminal live copies once the durable transcript contains the same versions', async () => {
+    let listener: ((event: AgentEvent) => void) | undefined;
+    const protocol = protocolWithObservation(async (_sessionId, nextListener) => {
+      listener = nextListener;
+      return { snapshot: snapshot(), unsubscribe: jest.fn() };
+    });
+    const client = new AgentSessionChatClient(protocol);
+    await client.observe('session-1');
+    const finalizedAssistant = {
+      ...assistantMessage(),
+      parts: [{ id: 'text-1', state: 'done' as const, text: 'Hello', type: 'text' as const }],
+      status: 'success' as const,
+      updatedAt: '2026-08-25T00:00:01.000Z',
+    };
+    listener?.({ type: 'message.created', message: userMessage() });
+    listener?.({ type: 'message.created', message: assistantMessage() });
+    listener?.({ type: 'message.finalized', message: finalizedAssistant });
+
+    client.reconcilePersistedMessages('session-1', [userMessage(), finalizedAssistant]);
+
+    expect(client.getState('session-1').liveMessages).toEqual([]);
   });
 
   test('applies Session title events and invalidates Session queries', async () => {

--- a/src/frontend/features/chat/workspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/workspace/ChatWorkspace.tsx
@@ -1,6 +1,6 @@
 import { ContentState, useAlert } from '@cherrystudio/ui/components';
 import { useHeaderHeight } from 'expo-router/react-navigation';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 
@@ -60,6 +60,9 @@ export function ChatWorkspace({
   const headerHeight = useHeaderHeight();
   const { t } = useTranslation();
   const { alert } = useAlert();
+  useEffect(() => {
+    client.reconcilePersistedMessages(sessionId, messages);
+  }, [client, messages, sessionId]);
   const mergedMessages = useMemo(
     () => mergeAgentMessageViews(messages, live.liveMessages),
     [live.liveMessages, messages],

--- a/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/workspace/__tests__/ChatWorkspace.test.tsx
@@ -8,6 +8,7 @@ import { ChatWorkspace } from '../ChatWorkspace';
 
 const mockLoadOlder = jest.fn(async () => undefined);
 const mockRetry = jest.fn(async () => undefined);
+const mockReconcilePersistedMessages = jest.fn();
 const mockRespondApproval = jest.fn(async () => undefined);
 const mockForkSession = jest.fn(async () => undefined);
 const mockSetStringAsync = jest.fn(async (_text: string): Promise<void> => undefined);
@@ -124,7 +125,10 @@ jest.mock('../../runtime', () => ({
         role: message.role,
         status: message.status === 'success' ? 'success' : 'pending',
       })),
-  useAgentChatActions: () => ({ respondApproval: mockRespondApproval }),
+  useAgentChatActions: () => ({
+    reconcilePersistedMessages: mockReconcilePersistedMessages,
+    respondApproval: mockRespondApproval,
+  }),
   useAgentChatFork: () => mockForkSession,
   useAgentChatSession: () => mockAgentChatSession,
 }));
@@ -280,6 +284,7 @@ describe('ChatWorkspace message rendering integration', () => {
     expect(mockMessageListProps?.keyboardOffset).toBe(26);
     expect(mockMessageListProps?.onLoadOlder).toBe(mockLoadOlder);
     expect(mockIsLoadingOlder).toBe(true);
+    expect(mockReconcilePersistedMessages).toHaveBeenCalledWith('session-1', messages);
 
     const renderMessage = mockMessageListProps?.renderMessage;
     act(() => renderer?.update(createWorkspaceElement(false, messages)));


### PR DESCRIPTION
## Summary

- remove reserved message-list space for the scroll-to-bottom affordance and only expose it for content taller than the viewport
- keep process details ungrouped during streaming, then show the completed duration group collapsed after the turn finishes
- coalesce text deltas and background preview writes, clean up ownerless observations, reconcile durable transcript copies, and preserve stable row and part identities
- add regression coverage for stream notification batching, lifecycle cleanup, process grouping, scroll visibility, and unchanged-row render isolation

## Validation

- Passed: targeted Jest suites for AgentSessionChatClient, message projection, ChatWorkspace, MessageList, MessageParts, and MessagePartRenderer (6 suites, 59 tests)
- Passed on the final diff: targeted oxfmt check, oxlint, Expo lint, and git diff --check
- Passed: full pnpm format:check
- Full pnpm lint is blocked by seven existing Expo import-resolution errors for unbuilt @cherrystudio/ai-core workspace modules; full oxlint completed before those errors
- Not run: pnpm typecheck, build commands, or device acceptance because workspace policy requires explicit authorization for compilation and device verification
