### PR TITLE
fix(markdown-renderer): preserve emoji list markers on iOS

### DIFF
--- a/packages/ui/src/components/composer/__tests__/composer-native-patch.test.ts
+++ b/packages/ui/src/components/composer/__tests__/composer-native-patch.test.ts
@@ -11,4 +11,30 @@ describe('react-native-enriched-markdown iOS patch', () => {
       'if (_editSession.isComposing) {\n+    [self updatePlaceholderVisibility];\n     return;',
     );
   });
+
+  test('anchors list markers to complete grapheme clusters', () => {
+    const patch = readFileSync(
+      `${process.cwd()}/patches/react-native-enriched-markdown@1.0.1.patch`,
+      'utf8',
+    );
+
+    expect(patch).toContain(
+      'const NSRange anchorRange = [string rangeOfComposedCharacterSequenceAtIndex:anchorLocation];',
+    );
+    expect(patch).toContain(
+      '[output addAttribute:ListItemMarkerStartAttribute value:markers range:anchorRange];',
+    );
+  });
+
+  test('uses text font metrics for list markers that follow emoji', () => {
+    const patch = readFileSync(
+      `${process.cwd()}/patches/react-native-enriched-markdown@1.0.1.patch`,
+      'utf8',
+    );
+
+    expect(patch).toContain('static NSString *const kAppleColorEmojiFontName');
+    expect(patch).toContain(
+      'if (!font || [font.fontName isEqualToString:kAppleColorEmojiFontName])',
+    );
+  });
 });

--- a/patches/react-native-enriched-markdown@1.0.1.patch
+++ b/patches/react-native-enriched-markdown@1.0.1.patch
@@ -9,3 +9,54 @@ index 9a9987e0d61c907787cff3d6a6f6cea81155f536..299e21b9750c78a30ec56e8fae651b40
 +    [self updatePlaceholderVisibility];
      return;
    }
+diff --git a/ios/renderer/ListItemRenderer.m b/ios/renderer/ListItemRenderer.m
+index 204fc185..c8800496 100644
+--- a/ios/renderer/ListItemRenderer.m
++++ b/ios/renderer/ListItemRenderer.m
+@@ -176,4 +176,10 @@ - (void)renderNodeContent:(MarkdownASTNode *)node
++  // Cover the whole grapheme cluster: anchoring on a single UTF-16 code unit
++  // splits multi-unit graphemes (emoji surrogate pairs, ZWJ sequences) across
++  // two attribute runs, which drops the glyph and hides the marker for every
++  // item but the last.
++  const NSRange anchorRange = [string rangeOfComposedCharacterSequenceAtIndex:anchorLocation];
++
+   NSArray *existingMarkers = [output attribute:ListItemMarkerStartAttribute atIndex:anchorLocation effectiveRange:NULL];
+   NSArray *markers =
+       [existingMarkers isKindOfClass:[NSArray class]] ? [existingMarkers arrayByAddingObject:marker] : @[ marker ];
+-  [output addAttribute:ListItemMarkerStartAttribute value:markers range:NSMakeRange(anchorLocation, 1)];
++  [output addAttribute:ListItemMarkerStartAttribute value:markers range:anchorRange];
+diff --git a/ios/utils/ListMarkerDrawer.m b/ios/utils/ListMarkerDrawer.m
+index 315ec083..93548a1d 100644
+--- a/ios/utils/ListMarkerDrawer.m
++++ b/ios/utils/ListMarkerDrawer.m
+@@ -9 +9,3 @@
+ extern NSString *const ListItemMarkerStartAttribute;
++
++static NSString *const kAppleColorEmojiFontName = @"AppleColorEmoji";
+@@ -58,3 +60,25 @@ - (void)drawMarkersForGlyphRange:(NSRange)glyphsToShow
+                                  CGPoint glyphLoc = [layoutManager locationForGlyphAtIndex:glyphRange.location];
+                                  CGFloat baselineY = origin.y + rect.origin.y + glyphLoc.y;
+-                                 UIFont *font = attrs[NSFontAttributeName] ?: [self defaultFont];
++
++                                 // When the anchor character is an emoji, NSFontAttributeName
++                                 // returns AppleColorEmoji whose metrics (xHeight, capHeight)
++                                 // differ widely from the text font and would misplace the
++                                 // marker. Look past the first composed character sequence
++                                 // to find the actual text font used on the line.
++                                 UIFont *font = attrs[NSFontAttributeName];
++                                 if (charRange.length > 1) {
++                                   NSRange firstGrapheme =
++                                       [storage.string rangeOfComposedCharacterSequenceAtIndex:charRange.location];
++                                   NSUInteger afterFirst = NSMaxRange(firstGrapheme);
++                                   if (afterFirst < NSMaxRange(charRange)) {
++                                     UIFont *textFont = [storage attribute:NSFontAttributeName
++                                                                   atIndex:afterFirst
++                                                            effectiveRange:NULL];
++                                     if (textFont) {
++                                       font = textFont;
++                                     }
++                                   }
++                                 }
++                                 if (!font || [font.fontName isEqualToString:kAppleColorEmojiFontName]) {
++                                   font = [self defaultFont];
++                                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ patchedDependencies:
   metro@0.84.4: bc3c69aec12bccf391b5180caffd62a4043c81bcf5848949a4b50e79184be6f7
   ollama-ai-provider-v2@3.3.1: 4cb5921e69158814eeeed8d71c80621bd261f33d769b6afabba0db40931155eb
   react-native-keyboard-controller@1.21.13: 6f5bed7a836aae55a44a2b0a97532e6d73d9dfb87032457499dfe3ff2c239186
-  react-native-enriched-markdown@1.0.1: 04cb1a5d69bf147f89b509a56d5b4e04f021e797f9f6b7754bfa677a9c057726
+  react-native-enriched-markdown@1.0.1: 6b4f6cd7cfebd01ee08d694a0afa28d1426d9f625b45b7717d2fffce02b6da00
   react-native-nitro-healthkit@1.0.0: c1231cd559844fba1fa13c5d09d4f9a84ecd4211707055a1ea2c3ba9930108e7
   react-native-reanimated@4.5.0: 98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1
   uniwind@1.6.5: 791bd6e5e63c234764db0263b41a5f7aa5c6259270634d6fc7405845de987eeb


### PR DESCRIPTION
## Summary

- backport the upstream iOS list-marker fix into the existing `react-native-enriched-markdown@1.0.1` pnpm patch
- anchor list markers to complete grapheme clusters so leading emoji remain visible
- use text-font metrics instead of Apple Color Emoji metrics to vertically align list markers
- add patch guards and update the patched-dependency checksum

Upstream fix: https://github.com/software-mansion/enriched-markdown/pull/704

## Validation

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`
- `pnpm ios --device "iPhone 17 Pro (san-diego)" --port 55080` (`Build Succeeded`; patched native files compiled and the resulting debug dylib contains the fix)

Not run: focused test suite and full typecheck (not requested).
