### PR TITLE
fix(ui-switch): restore Android toggle interaction

### DIFF
--- a/packages/ui/src/components/switch/__tests__/switch.test.tsx
+++ b/packages/ui/src/components/switch/__tests__/switch.test.tsx
@@ -112,33 +112,54 @@ describe('Switch', () => {
     expect(control.props.isDisabled).toBe(true);
   });
 
-  test('owns the press without activating an ancestor press target', () => {
+  test('owns the press and keeps the native control presentational', () => {
     const onValueChange = jest.fn();
     const stopPropagation = jest.fn();
 
     act(() => {
       renderer = create(
-        <Switch accessibilityLabel="Airplane mode" onValueChange={onValueChange} value />,
+        <Switch
+          accessibilityLabel="Airplane mode"
+          onValueChange={onValueChange}
+          testID="airplane-mode"
+          value
+        />,
       );
     });
 
     const pressOwner = renderer!.root.find(
       (node) =>
-        node.props.accessible === false &&
-        node.props.hitSlop === 8 &&
+        node.props.accessibilityLabel === 'Airplane mode' &&
+        node.props.accessibilityRole === 'switch' &&
         typeof node.props.onPress === 'function',
     );
     const control = renderer!.root.findByProps({ mockComponent: 'switch-control' });
+    const interactionShield = renderer!.root.find(
+      (node) =>
+        node.props.pointerEvents === 'none' &&
+        node.props.mockComponent === undefined &&
+        node.findAllByProps({ mockComponent: 'switch-control' }).length === 1,
+    );
 
-    expect(pressOwner.props.accessible).toBe(false);
-    expect(pressOwner.props.hitSlop).toBe(8);
+    expect(pressOwner.props).toMatchObject({
+      accessibilityState: { checked: true, disabled: false },
+      disabled: false,
+      hitSlop: 8,
+      testID: 'airplane-mode',
+    });
+    expect(interactionShield.props.accessible).toBe(false);
+    expect(control.props).toMatchObject({
+      accessibilityElementsHidden: true,
+      importantForAccessibility: 'no-hide-descendants',
+      pointerEvents: 'none',
+      testID: 'airplane-mode-indicator',
+      value: true,
+    });
+    expect(control.props.onValueChange).toBeUndefined();
 
     act(() => pressOwner.props.onPress({ stopPropagation }));
 
     expect(stopPropagation).toHaveBeenCalledTimes(1);
-    expect(onValueChange).not.toHaveBeenCalled();
-
-    act(() => control.props.onValueChange(false));
     expect(onValueChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/ui/src/components/switch/__tests__/switch.test.tsx
+++ b/packages/ui/src/components/switch/__tests__/switch.test.tsx
@@ -1,3 +1,4 @@
+import { View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { Switch } from '../switch';
@@ -136,9 +137,10 @@ describe('Switch', () => {
     const control = renderer!.root.findByProps({ mockComponent: 'switch-control' });
     const interactionShield = renderer!.root.find(
       (node) =>
+        node.type === View &&
+        node.props.accessible === false &&
         node.props.pointerEvents === 'none' &&
-        node.props.mockComponent === undefined &&
-        node.findAllByProps({ mockComponent: 'switch-control' }).length === 1,
+        node.props.mockComponent === undefined,
     );
 
     expect(pressOwner.props).toMatchObject({

--- a/packages/ui/src/components/switch/switch-indicator.tsx
+++ b/packages/ui/src/components/switch/switch-indicator.tsx
@@ -1,4 +1,4 @@
-import type { StyleProp, ViewStyle } from 'react-native';
+import { type StyleProp, View, type ViewStyle } from 'react-native';
 
 import { SwitchControl } from './switch-control';
 import type { SwitchSize } from './switch.types';
@@ -13,11 +13,13 @@ type SwitchIndicatorProps = {
 
 export function SwitchIndicator(props: SwitchIndicatorProps) {
   return (
-    <SwitchControl
-      {...props}
-      accessibilityElementsHidden
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-    />
+    <View accessible={false} pointerEvents="none">
+      <SwitchControl
+        {...props}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+      />
+    </View>
   );
 }

--- a/packages/ui/src/components/switch/switch.tsx
+++ b/packages/ui/src/components/switch/switch.tsx
@@ -1,11 +1,7 @@
 import { Pressable, type GestureResponderEvent } from 'react-native';
 
-import { SwitchControl } from './switch-control';
+import { SwitchIndicator } from './switch-indicator';
 import type { SwitchProps } from './switch.types';
-
-function stopPressPropagation(event: GestureResponderEvent) {
-  event.stopPropagation();
-}
 
 export function Switch({
   accessibilityLabel,
@@ -16,15 +12,26 @@ export function Switch({
   testID,
   value,
 }: SwitchProps) {
+  const handlePress = (event: GestureResponderEvent) => {
+    event.stopPropagation();
+    onValueChange(!value);
+  };
+
   return (
-    <Pressable accessible={false} hitSlop={8} onPress={stopPressPropagation}>
-      <SwitchControl
-        accessibilityLabel={accessibilityLabel}
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value, disabled }}
+      disabled={disabled}
+      hitSlop={8}
+      onPress={handlePress}
+      testID={testID}
+    >
+      <SwitchIndicator
         disabled={disabled}
-        onValueChange={onValueChange}
         size={size}
         style={style}
-        testID={testID}
+        testID={testID ? `${testID}-indicator` : undefined}
         value={value}
       />
     </Pressable>


### PR DESCRIPTION
## Summary

- make the shared switch shell the single press and accessibility owner
- isolate native switch indicators behind a non-interactive React Native view
- cover toggle dispatch, propagation containment, and presentational native controls

## Cause

Android native switches continued to claim touches even when the indicator passed `pointerEvents="none"` directly to the native control. The controlled indicator had no change callback, so tapping it never updated form state. Standalone switches also split interaction ownership between the wrapper and native control.

## Verification

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`
- targeted `oxlint` and Expo lint for changed files
- tests, typecheck, builds, and device verification not run per repository instructions requiring explicit authorization