### PR TITLE
fix(message-list): defer generated files until response settles

### DIFF
--- a/src/frontend/components/Message/README.md
+++ b/src/frontend/components/Message/README.md
@@ -36,20 +36,23 @@ A tool that returns managed artifacts already has them in the message: the Host 
 as its own file part, right after the tool result that produced it. A per-tool renderer therefore
 renders the *call*, never the artifact, or the same file appears twice.
 
-`MessageParts` lifts every file part out of the ordered stream and renders them as one
-`MessageFileStrip` after the answer — the same strip `UserMessage` renders above its bubble. Two
-rules hold that shape:
+`MessageParts` lifts every file part out of the ordered stream and renders managed assistant
+outputs through `GeneratedFileStrip` after the answer. `UserMessage` separately uses
+`MessageFileStrip` for input attachments above its bubble. Two rules hold the assistant-result
+shape:
 
 - **Files belong to the answer, not to the step.** A deliverable buried between two blocks of prose
   is hard to find on a phone, and the position a file was emitted at tells a reader nothing. The
-  strip is the last thing in the message, so it stays put while the answer above it streams in.
+  result group stays out of layout while the answer streams, then appears at the end when the
+  message reaches any terminal status. This matches source groups and message actions, and keeps a
+  large result card from repeatedly moving the live list tail.
 - **Layout never reads `purpose`.** A file's purpose is a Runtime fact used to decide model replay,
   not a presentation input. A transcript that arrives from a peer without one must lay out
   identically, so the split keys on part type alone. Only assistant messages reach `MessageParts`
   with files, because `UserMessage` lifts its own attachments out first.
 
-The strip carries no heading: whether a file was attached or produced follows from the role of the
-message it sits in.
+Neither file group carries a heading: whether a file was attached or produced follows from the role
+of the message it sits in.
 
 ## Message Disclosure Contract
 

--- a/src/frontend/components/Message/parts/MessageParts.tsx
+++ b/src/frontend/components/Message/parts/MessageParts.tsx
@@ -40,8 +40,9 @@ export function MessageParts({
   }
 
   const { body, files, process } = partitionMessageParts(parts);
-  const isStreaming = message.status === 'pending';
-  const showSources = !isStreaming && parts.some((part) => part.type === 'source-url');
+  const isSettled = message.status !== 'pending';
+  const isStreaming = !isSettled;
+  const showSources = isSettled && parts.some((part) => part.type === 'source-url');
 
   return (
     <View className="gap-2">
@@ -87,9 +88,10 @@ export function MessageParts({
       {showSources ? (
         <SourceGroup citationNumberBySourceId={citations.sourceNumberById} parts={parts} />
       ) : null}
-      {/* Last, so the files a turn produced are the closest thing to the end of
-          the message and stay put as the answer above them streams in. */}
-      {files.length > 0 ? <GeneratedFileStrip parts={files} /> : null}
+      {/* Like sources and message actions, generated results belong to the
+          settled message footer. Hiding them while text streams prevents the
+          list tail from repeatedly moving around a large card. */}
+      {isSettled && files.length > 0 ? <GeneratedFileStrip parts={files} /> : null}
     </View>
   );
 }

--- a/src/frontend/components/Message/parts/__tests__/MessageParts.test.tsx
+++ b/src/frontend/components/Message/parts/__tests__/MessageParts.test.tsx
@@ -82,14 +82,23 @@ describe('MessageParts', () => {
     ['success', true],
     ['error', true],
     ['paused', true],
-  ] as const)('status=%s renders settled sources=%p', (status, shouldRenderSources) => {
+  ] as const)('status=%s renders settled message results=%p', (status, shouldRenderResults) => {
     const message: MessageListItem = {
       ...makeMessage(status),
-      data: { parts: [{ text: 'Hello', type: 'text' }, makeSourcePart()] },
+      data: {
+        parts: [
+          { text: 'Hello', type: 'text' },
+          makeSourcePart(),
+          makeFilePart('file-1', 'report.md'),
+        ],
+      },
     };
     const renderer = render(<MessageParts isTextSelectionEnabled message={message} />);
 
-    expect(renderer.root.findAllByType('SourceGroup')).toHaveLength(shouldRenderSources ? 1 : 0);
+    expect(renderer.root.findAllByType('SourceGroup')).toHaveLength(shouldRenderResults ? 1 : 0);
+    expect(renderer.root.findAllByType('GeneratedFileStrip')).toHaveLength(
+      shouldRenderResults ? 1 : 0,
+    );
   });
 
   test('folds intermediate text and later tool calls into the timed process', () => {


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: assistant-generated file cards entered the message layout while a response was pending and repeatedly moved the live list tail.

After this PR: generated files stay hidden until `success`, `error`, or `paused`, matching web sources and message actions; the message contract documentation and status regression coverage are updated as well.

### Screenshots or videos

N/A — Device visual verification was not run; this draft includes the behavior change and regression coverage only.

### Why we need it and why it was done in this way

The following tradeoffs were made: result cards become available only after a terminal status to keep the streaming layout stable; changing list anchoring was considered but rejected because it would treat the symptom and diverge from the existing settled-footer behavior.

Links to places where the discussion took place: N/A

### Breaking changes

- None

### Special notes for your reviewer

- `pnpm format:check`: passed
- `pnpm typecheck`: passed
- `pnpm typecheck:app`: passed after rebasing onto the latest `origin/v0.2`
- Changed-file Oxlint and Expo lint: passed
- Full `pnpm lint`: blocked by four unrelated unresolved `@cherrystudio/ai-core` imports in existing backend files
- Tests: not run per repository policy
- Device visual verification: not run per repository policy

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Generated file cards now appear after an assistant response finishes, preventing the message list tail from jumping during streaming.
```
