### PR TITLE
fix(chat-screen): avoid page-wide refresh on first send

### DIFF
--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -4,7 +4,6 @@ import {
   getComposerKeyboardStickyOffset,
 } from '@cherrystudio/ui/components';
 import { useIsPreview, useLocalSearchParams } from 'expo-router';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -26,7 +25,8 @@ import { DataApiError, ErrorCode } from '@/shared/data/api/errors';
 import { ChatInput } from './components/ChatInput';
 import { ChatRouteResolver } from './components/ChatRouteResolver';
 import { ChatDraftState, ChatEmptyState, ChatWorkspace } from './components/ChatWorkspace';
-import { type AgentChatDraftHandoff, useAgentChatDraftHandoff } from './runtime';
+import { useChatComposerSession } from './hooks/useChatComposerSession';
+import { useAgentChatDraftHandoff } from './runtime';
 
 const PREVIEW_CONTENT_BOTTOM_INSET = 12;
 
@@ -124,57 +124,4 @@ function ResolvedChatContent({ target }: { target: ChatTarget }) {
 
 function isNotFoundError(error: Error) {
   return error instanceof DataApiError && error.code === ErrorCode.NOT_FOUND;
-}
-
-type ChatComposerSessionState = Readonly<{
-  draftAgentId?: string;
-  key: number;
-  target: ChatTarget;
-}>;
-
-function useChatComposerSession(
-  target: ChatTarget,
-  draftHandoff: AgentChatDraftHandoff | undefined,
-) {
-  const [sessionState, setSessionState] = useState<ChatComposerSessionState>(() => ({
-    key: 0,
-    target,
-  }));
-  const nextSessionState = resolveChatComposerSessionState(sessionState, target, draftHandoff);
-
-  if (nextSessionState !== sessionState) {
-    setSessionState(nextSessionState);
-  }
-
-  return nextSessionState;
-}
-
-function resolveChatComposerSessionState(
-  current: ChatComposerSessionState,
-  target: ChatTarget,
-  draftHandoff: AgentChatDraftHandoff | undefined,
-): ChatComposerSessionState {
-  if (isSameChatTarget(current.target, target)) {
-    return current;
-  }
-
-  const preservesDraftComposer =
-    current.target.kind === 'draft' &&
-    target.kind === 'session' &&
-    draftHandoff?.agentId === current.target.agentId &&
-    draftHandoff.sessionId === target.sessionId;
-
-  return {
-    ...(preservesDraftComposer ? { draftAgentId: current.target.agentId } : {}),
-    key: preservesDraftComposer ? current.key : current.key + 1,
-    target,
-  };
-}
-
-function isSameChatTarget(left: ChatTarget, right: ChatTarget) {
-  if (left.kind === 'draft') {
-    return right.kind === 'draft' && left.agentId === right.agentId;
-  }
-
-  return right.kind === 'session' && left.sessionId === right.sessionId;
 }

--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -4,6 +4,7 @@ import {
   getComposerKeyboardStickyOffset,
 } from '@cherrystudio/ui/components';
 import { useIsPreview, useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -25,10 +26,22 @@ import { DataApiError, ErrorCode } from '@/shared/data/api/errors';
 import { ChatInput } from './components/ChatInput';
 import { ChatRouteResolver } from './components/ChatRouteResolver';
 import { ChatDraftState, ChatEmptyState, ChatWorkspace } from './components/ChatWorkspace';
+import { type AgentChatDraftHandoff, useAgentChatDraftHandoff } from './runtime';
 
 const PREVIEW_CONTENT_BOTTOM_INSET = 12;
 
 export function ChatScreen() {
+  return (
+    <>
+      <MainHeader />
+      <View className="flex-1">
+        <ChatRouteContent />
+      </View>
+    </>
+  );
+}
+
+function ChatRouteContent() {
   const params = useLocalSearchParams<ChatRouteParamsInput>();
   const route = parseChatRoute(params);
 
@@ -36,16 +49,18 @@ export function ChatScreen() {
     return <ChatRouteResolver />;
   }
 
-  return <ResolvedChatScreen target={route.target} />;
+  return <ResolvedChatContent target={route.target} />;
 }
 
-function ResolvedChatScreen({ target }: { target: ChatTarget }) {
+function ResolvedChatContent({ target }: { target: ChatTarget }) {
   const { t } = useTranslation();
   const isPreview = useIsPreview();
   const agentId = target.kind === 'draft' ? target.agentId : undefined;
   const sessionId = target.kind === 'session' ? target.sessionId : undefined;
+  const draftHandoff = useAgentChatDraftHandoff(sessionId);
+  const composerSession = useChatComposerSession(target, draftHandoff);
   const session = useAgentSession(sessionId);
-  const resolvedAgentId = session.data?.agentId ?? agentId;
+  const resolvedAgentId = session.data?.agentId ?? composerSession.draftAgentId ?? agentId;
   const agent = useAgentApiById(resolvedAgentId);
   const messageWindow = useAgentMessageHistoryWindow(sessionId);
   const isSessionAvailable =
@@ -54,9 +69,6 @@ function ResolvedChatScreen({ target }: { target: ChatTarget }) {
     !sessionId && Boolean(agentId) && !agent.error && (agent.isLoading || Boolean(agent.agent));
   const hasComposer =
     !isPreview && Boolean(agent.agent) && (isSessionAvailable || isNewAgentAvailable);
-  const composerSessionKey = sessionId
-    ? `session:${sessionId}`
-    : `draft:${resolvedAgentId ?? 'unavailable'}`;
   const { bottom: bottomInset } = useSafeAreaInsets();
   const contentBottomInset = hasComposer ? composerContentGap : PREVIEW_CONTENT_BOTTOM_INSET;
   const keyboardOffset = hasComposer ? getComposerKeyboardStickyOffset(bottomInset) : 0;
@@ -67,52 +79,102 @@ function ResolvedChatScreen({ target }: { target: ChatTarget }) {
 
   return (
     <>
-      <MainHeader />
-      <View className="flex-1">
-        {sessionId && session.error ? (
-          <View className="flex-1 justify-center px-8 py-16">
-            <ContentState.Error
-              primaryAction={{
-                children: t('agent.actions.retry'),
-                onPress: () => void session.refetch(),
-              }}
-              prominence="prominent"
-              title={t('navigation.chatsLoadFailed')}
-            />
-          </View>
-        ) : isSessionAvailable && sessionId ? (
-          <ChatWorkspace
-            assistantAvatarUri={agent.agent?.avatarUri}
-            assistantName={agent.agent?.name}
-            isAssistantToolbarEnabled={!isPreview}
-            contentBottomInset={contentBottomInset}
-            forkBoundaryMessageId={session.data?.forkBoundaryMessageId ?? undefined}
-            forkedFromSessionId={session.data?.forkedFromSessionId ?? undefined}
-            keyboardOffset={keyboardOffset}
-            messageWindow={messageWindow}
-            sessionId={sessionId}
+      {sessionId && session.error ? (
+        <View className="flex-1 justify-center px-8 py-16">
+          <ContentState.Error
+            primaryAction={{
+              children: t('agent.actions.retry'),
+              onPress: () => void session.refetch(),
+            }}
+            prominence="prominent"
+            title={t('navigation.chatsLoadFailed')}
           />
-        ) : target.kind === 'draft' ? (
-          <ChatDraftState contentBottomInset={contentBottomInset} />
-        ) : (
-          <ChatEmptyState contentBottomInset={contentBottomInset} />
-        )}
-        {hasComposer ? (
-          <ComposerSessionProvider key={composerSessionKey}>
-            <ComposerDock layoutMode="flow">
-              <ChatInput
-                agentId={resolvedAgentId}
-                dismissKeyboardOnSend={false}
-                sessionId={sessionId}
-              />
-            </ComposerDock>
-          </ComposerSessionProvider>
-        ) : null}
-      </View>
+        </View>
+      ) : isSessionAvailable && sessionId ? (
+        <ChatWorkspace
+          assistantAvatarUri={agent.agent?.avatarUri}
+          assistantName={agent.agent?.name}
+          isAssistantToolbarEnabled={!isPreview}
+          contentBottomInset={contentBottomInset}
+          forkBoundaryMessageId={session.data?.forkBoundaryMessageId ?? undefined}
+          forkedFromSessionId={session.data?.forkedFromSessionId ?? undefined}
+          keyboardOffset={keyboardOffset}
+          messageWindow={messageWindow}
+          sessionId={sessionId}
+        />
+      ) : target.kind === 'draft' ? (
+        <ChatDraftState contentBottomInset={contentBottomInset} />
+      ) : (
+        <ChatEmptyState contentBottomInset={contentBottomInset} />
+      )}
+      {hasComposer ? (
+        <ComposerSessionProvider key={composerSession.key}>
+          <ComposerDock layoutMode="flow">
+            <ChatInput
+              agentId={resolvedAgentId}
+              dismissKeyboardOnSend={false}
+              sessionId={sessionId}
+            />
+          </ComposerDock>
+        </ComposerSessionProvider>
+      ) : null}
     </>
   );
 }
 
 function isNotFoundError(error: Error) {
   return error instanceof DataApiError && error.code === ErrorCode.NOT_FOUND;
+}
+
+type ChatComposerSessionState = Readonly<{
+  draftAgentId?: string;
+  key: number;
+  target: ChatTarget;
+}>;
+
+function useChatComposerSession(
+  target: ChatTarget,
+  draftHandoff: AgentChatDraftHandoff | undefined,
+) {
+  const [sessionState, setSessionState] = useState<ChatComposerSessionState>(() => ({
+    key: 0,
+    target,
+  }));
+  const nextSessionState = resolveChatComposerSessionState(sessionState, target, draftHandoff);
+
+  if (nextSessionState !== sessionState) {
+    setSessionState(nextSessionState);
+  }
+
+  return nextSessionState;
+}
+
+function resolveChatComposerSessionState(
+  current: ChatComposerSessionState,
+  target: ChatTarget,
+  draftHandoff: AgentChatDraftHandoff | undefined,
+): ChatComposerSessionState {
+  if (isSameChatTarget(current.target, target)) {
+    return current;
+  }
+
+  const preservesDraftComposer =
+    current.target.kind === 'draft' &&
+    target.kind === 'session' &&
+    draftHandoff?.agentId === current.target.agentId &&
+    draftHandoff.sessionId === target.sessionId;
+
+  return {
+    ...(preservesDraftComposer ? { draftAgentId: current.target.agentId } : {}),
+    key: preservesDraftComposer ? current.key : current.key + 1,
+    target,
+  };
+}
+
+function isSameChatTarget(left: ChatTarget, right: ChatTarget) {
+  if (left.kind === 'draft') {
+    return right.kind === 'draft' && left.agentId === right.agentId;
+  }
+
+  return right.kind === 'session' && left.sessionId === right.sessionId;
 }

--- a/src/frontend/features/chat/README.md
+++ b/src/frontend/features/chat/README.md
@@ -10,10 +10,12 @@ behavior. Structured message rendering is shared with painting through
 
 ## Organization
 
-- `ChatScreen.tsx` is header + swappable body + composer session in normal parent flow. With a
-  Session the body is the conversation; selecting an Agent without one shows an isolated Draft.
-  The Host creates the durable Session together with its admitted first message, and the frontend
-  switches composer identity only after that operation succeeds.
+- `ChatScreen.tsx` keeps the page frame outside the chat-content route-parameter subscription. The
+  header and a focused content leaf resolve their own route-derived data independently; the content
+  leaf swaps the body and composer between Session and Draft targets. The Host creates the durable
+  Session together with its admitted first message, and the frontend hands the accepted Draft to
+  that Session without remounting the composer. Navigating elsewhere still starts an isolated
+  composer identity.
 - `input/` owns the narrow Agent Protocol wrapper around the shared composer. Agent settings are
   edited on the Agent screen; image attachment admission failures restore the managed draft and
   surface a user-facing reason.
@@ -21,4 +23,5 @@ behavior. Structured message rendering is shared with painting through
   the shared `MessageList`, and owns history loading, initial-render gating, and approvals.
 - `runtime/` owns the route-scoped `AgentSessionChatClient`, observes the app-owned Mobile Agent Host
   through `Backend.agent`, and owns frontend navigation and query invalidation effects. On first
-  send it changes the route only after the new Session has accepted the submission.
+  send it changes the route only after the new Session has accepted the submission, and carries the
+  originating Agent across that one route handoff while Session detail loads.

--- a/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
+++ b/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
@@ -10,10 +10,7 @@ let dockProps: Record<string, unknown> | undefined;
 let mockRouteResolverRendered: boolean;
 let mockComposerProviderInstance: number | undefined;
 let mockComposerProviderMountCount: number;
-let mockDraftHandoff: { agentId: string; sessionId: string } | undefined;
-let mockMainHeaderRenderCount: number;
 let mockRouteParams: { agentId?: string; sessionId?: string };
-const mockRouteParamListeners = new Set<() => void>();
 let mockSessionData: { agentId: string; id: string } | undefined;
 let mockSessionError: Error | undefined;
 let mockSessionIsLoading: boolean;
@@ -50,26 +47,10 @@ jest.mock('@/frontend/components/Composer', () => ({
 
 jest.mock('expo-router', () => ({
   useIsPreview: () => false,
-  useLocalSearchParams: () => {
-    const { useSyncExternalStore } = jest.requireActual<typeof import('react')>('react');
-
-    return useSyncExternalStore(
-      (listener) => {
-        mockRouteParamListeners.add(listener);
-        return () => mockRouteParamListeners.delete(listener);
-      },
-      () => mockRouteParams,
-      () => mockRouteParams,
-    );
-  },
+  useLocalSearchParams: () => mockRouteParams,
 }));
 
-jest.mock('@/frontend/appShell/header', () => ({
-  MainHeader: () => {
-    mockMainHeaderRenderCount += 1;
-    return null;
-  },
-}));
+jest.mock('@/frontend/appShell/header', () => ({ MainHeader: () => null }));
 
 jest.mock('@/frontend/hooks/agent', () => ({
   useAgentApiById: (agentId: string | undefined) => ({
@@ -92,7 +73,7 @@ jest.mock('@/frontend/hooks/agent', () => ({
 }));
 
 jest.mock('../runtime', () => ({
-  useAgentChatDraftHandoff: () => mockDraftHandoff,
+  useAgentChatDraftHandoff: () => undefined,
 }));
 
 jest.mock('../components/ChatInput', () => ({
@@ -128,10 +109,7 @@ describe('ChatScreen composer dock wiring', () => {
     mockRouteResolverRendered = false;
     mockComposerProviderInstance = undefined;
     mockComposerProviderMountCount = 0;
-    mockDraftHandoff = undefined;
-    mockMainHeaderRenderCount = 0;
     mockRouteParams = { agentId: 'agent-1', sessionId: 'session-1' };
-    mockRouteParamListeners.clear();
     mockSessionData = { agentId: 'agent-1', id: 'session-1' };
     mockSessionError = undefined;
     mockSessionIsLoading = false;
@@ -192,56 +170,11 @@ describe('ChatScreen composer dock wiring', () => {
     });
     expect(mockComposerProviderInstance).toBe(1);
 
-    mockSessionData = undefined;
-    updateMockRouteParams({ agentId: 'agent-1' });
-
-    expect(mockComposerProviderInstance).toBe(2);
-  });
-
-  it('keeps the page frame and Draft composer stable while its first Session loads', () => {
     mockRouteParams = { agentId: 'agent-1' };
     mockSessionData = undefined;
-    act(() => {
-      renderer = create(<ChatScreen />);
-    });
-    const draftComposerProviderInstance = mockComposerProviderInstance;
-
-    mockDraftHandoff = { agentId: 'agent-1', sessionId: 'session-1' };
-    mockSessionIsLoading = true;
-    updateMockRouteParams({ sessionId: 'session-1' });
-
-    expect(chatInputProps).toMatchObject({
-      agentId: 'agent-1',
-      sessionId: 'session-1',
-    });
-    expect(mockMainHeaderRenderCount).toBe(1);
-    expect(mockComposerProviderInstance).toBe(draftComposerProviderInstance);
-    expect(mockComposerProviderMountCount).toBe(1);
-
-    mockDraftHandoff = undefined;
-    updateMockRouteParams({ sessionId: 'session-1' });
-
-    expect(chatInputProps).toMatchObject({
-      agentId: 'agent-1',
-      sessionId: 'session-1',
-    });
-    expect(mockComposerProviderInstance).toBe(draftComposerProviderInstance);
-    expect(mockComposerProviderMountCount).toBe(1);
-  });
-
-  it('starts a fresh composer when a Draft navigates to an unrelated Session', () => {
-    mockRouteParams = { agentId: 'agent-1' };
-    mockSessionData = undefined;
-    act(() => {
-      renderer = create(<ChatScreen />);
-    });
-    expect(mockComposerProviderInstance).toBe(1);
-
-    mockSessionData = { agentId: 'agent-1', id: 'session-1' };
-    updateMockRouteParams({ sessionId: 'session-1' });
+    act(() => renderer?.update(<ChatScreen />));
 
     expect(mockComposerProviderInstance).toBe(2);
-    expect(mockComposerProviderMountCount).toBe(2);
   });
 
   it('starts a fresh composer session when the route switches Sessions', () => {
@@ -250,19 +183,13 @@ describe('ChatScreen composer dock wiring', () => {
     });
     expect(mockComposerProviderInstance).toBe(1);
 
+    mockRouteParams = { agentId: 'agent-1', sessionId: 'session-2' };
     mockSessionData = { agentId: 'agent-1', id: 'session-2' };
-    updateMockRouteParams({ agentId: 'agent-1', sessionId: 'session-2' });
+    act(() => {
+      renderer?.update(<ChatScreen />);
+    });
 
     expect(mockComposerProviderInstance).toBe(2);
     expect(mockComposerProviderMountCount).toBe(2);
   });
 });
-
-function updateMockRouteParams(params: { agentId?: string; sessionId?: string }) {
-  act(() => {
-    mockRouteParams = params;
-    for (const listener of [...mockRouteParamListeners]) {
-      listener();
-    }
-  });
-}

--- a/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
+++ b/src/frontend/features/chat/__tests__/ChatScreen.test.tsx
@@ -10,7 +10,10 @@ let dockProps: Record<string, unknown> | undefined;
 let mockRouteResolverRendered: boolean;
 let mockComposerProviderInstance: number | undefined;
 let mockComposerProviderMountCount: number;
+let mockDraftHandoff: { agentId: string; sessionId: string } | undefined;
+let mockMainHeaderRenderCount: number;
 let mockRouteParams: { agentId?: string; sessionId?: string };
+const mockRouteParamListeners = new Set<() => void>();
 let mockSessionData: { agentId: string; id: string } | undefined;
 let mockSessionError: Error | undefined;
 let mockSessionIsLoading: boolean;
@@ -47,10 +50,26 @@ jest.mock('@/frontend/components/Composer', () => ({
 
 jest.mock('expo-router', () => ({
   useIsPreview: () => false,
-  useLocalSearchParams: () => mockRouteParams,
+  useLocalSearchParams: () => {
+    const { useSyncExternalStore } = jest.requireActual<typeof import('react')>('react');
+
+    return useSyncExternalStore(
+      (listener) => {
+        mockRouteParamListeners.add(listener);
+        return () => mockRouteParamListeners.delete(listener);
+      },
+      () => mockRouteParams,
+      () => mockRouteParams,
+    );
+  },
 }));
 
-jest.mock('@/frontend/appShell/header', () => ({ MainHeader: () => null }));
+jest.mock('@/frontend/appShell/header', () => ({
+  MainHeader: () => {
+    mockMainHeaderRenderCount += 1;
+    return null;
+  },
+}));
 
 jest.mock('@/frontend/hooks/agent', () => ({
   useAgentApiById: (agentId: string | undefined) => ({
@@ -70,6 +89,10 @@ jest.mock('@/frontend/hooks/agent', () => ({
     isLoading: mockSessionIsLoading,
     refetch: mockSessionRefetch,
   }),
+}));
+
+jest.mock('../runtime', () => ({
+  useAgentChatDraftHandoff: () => mockDraftHandoff,
 }));
 
 jest.mock('../components/ChatInput', () => ({
@@ -105,7 +128,10 @@ describe('ChatScreen composer dock wiring', () => {
     mockRouteResolverRendered = false;
     mockComposerProviderInstance = undefined;
     mockComposerProviderMountCount = 0;
+    mockDraftHandoff = undefined;
+    mockMainHeaderRenderCount = 0;
     mockRouteParams = { agentId: 'agent-1', sessionId: 'session-1' };
+    mockRouteParamListeners.clear();
     mockSessionData = { agentId: 'agent-1', id: 'session-1' };
     mockSessionError = undefined;
     mockSessionIsLoading = false;
@@ -166,11 +192,56 @@ describe('ChatScreen composer dock wiring', () => {
     });
     expect(mockComposerProviderInstance).toBe(1);
 
-    mockRouteParams = { agentId: 'agent-1' };
     mockSessionData = undefined;
-    act(() => renderer?.update(<ChatScreen />));
+    updateMockRouteParams({ agentId: 'agent-1' });
 
     expect(mockComposerProviderInstance).toBe(2);
+  });
+
+  it('keeps the page frame and Draft composer stable while its first Session loads', () => {
+    mockRouteParams = { agentId: 'agent-1' };
+    mockSessionData = undefined;
+    act(() => {
+      renderer = create(<ChatScreen />);
+    });
+    const draftComposerProviderInstance = mockComposerProviderInstance;
+
+    mockDraftHandoff = { agentId: 'agent-1', sessionId: 'session-1' };
+    mockSessionIsLoading = true;
+    updateMockRouteParams({ sessionId: 'session-1' });
+
+    expect(chatInputProps).toMatchObject({
+      agentId: 'agent-1',
+      sessionId: 'session-1',
+    });
+    expect(mockMainHeaderRenderCount).toBe(1);
+    expect(mockComposerProviderInstance).toBe(draftComposerProviderInstance);
+    expect(mockComposerProviderMountCount).toBe(1);
+
+    mockDraftHandoff = undefined;
+    updateMockRouteParams({ sessionId: 'session-1' });
+
+    expect(chatInputProps).toMatchObject({
+      agentId: 'agent-1',
+      sessionId: 'session-1',
+    });
+    expect(mockComposerProviderInstance).toBe(draftComposerProviderInstance);
+    expect(mockComposerProviderMountCount).toBe(1);
+  });
+
+  it('starts a fresh composer when a Draft navigates to an unrelated Session', () => {
+    mockRouteParams = { agentId: 'agent-1' };
+    mockSessionData = undefined;
+    act(() => {
+      renderer = create(<ChatScreen />);
+    });
+    expect(mockComposerProviderInstance).toBe(1);
+
+    mockSessionData = { agentId: 'agent-1', id: 'session-1' };
+    updateMockRouteParams({ sessionId: 'session-1' });
+
+    expect(mockComposerProviderInstance).toBe(2);
+    expect(mockComposerProviderMountCount).toBe(2);
   });
 
   it('starts a fresh composer session when the route switches Sessions', () => {
@@ -179,13 +250,19 @@ describe('ChatScreen composer dock wiring', () => {
     });
     expect(mockComposerProviderInstance).toBe(1);
 
-    mockRouteParams = { agentId: 'agent-1', sessionId: 'session-2' };
     mockSessionData = { agentId: 'agent-1', id: 'session-2' };
-    act(() => {
-      renderer?.update(<ChatScreen />);
-    });
+    updateMockRouteParams({ agentId: 'agent-1', sessionId: 'session-2' });
 
     expect(mockComposerProviderInstance).toBe(2);
     expect(mockComposerProviderMountCount).toBe(2);
   });
 });
+
+function updateMockRouteParams(params: { agentId?: string; sessionId?: string }) {
+  act(() => {
+    mockRouteParams = params;
+    for (const listener of [...mockRouteParamListeners]) {
+      listener();
+    }
+  });
+}

--- a/src/frontend/features/chat/components/ChatRouteResolver/ChatRouteResolver.tsx
+++ b/src/frontend/features/chat/components/ChatRouteResolver/ChatRouteResolver.tsx
@@ -4,7 +4,6 @@ import { type ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 
-import { MainHeader } from '@/frontend/appShell/header';
 import { chatRouteParams } from '@/frontend/appShell/navigation/chat';
 import { resolveChatRestoreState } from '@/frontend/appShell/navigation/chat/chatRestore';
 import { useAgentsApi, useLatestAgentSession } from '@/frontend/hooks/agent';
@@ -73,10 +72,5 @@ export function ChatRouteResolver() {
 }
 
 function ChatRouteResolverLayout({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <MainHeader />
-      <View className="flex-1">{children}</View>
-    </>
-  );
+  return <View className="flex-1">{children}</View>;
 }

--- a/src/frontend/features/chat/hooks/__tests__/useChatComposerSession.test.tsx
+++ b/src/frontend/features/chat/hooks/__tests__/useChatComposerSession.test.tsx
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { ChatTarget } from '@/frontend/appShell/navigation/chat';
+
+import type { AgentChatDraftHandoff } from '../../runtime/agentChatDraftHandoff';
+import { type ChatComposerSessionState, useChatComposerSession } from '../useChatComposerSession';
+
+type ProbeProps = {
+  draftHandoff?: AgentChatDraftHandoff;
+  onChange: (value: ChatComposerSessionState) => void;
+  target: ChatTarget;
+};
+
+let composerSession: ChatComposerSessionState | undefined;
+
+function Probe({ draftHandoff, onChange, target }: ProbeProps) {
+  const value = useChatComposerSession(target, draftHandoff);
+
+  useEffect(() => {
+    onChange(value);
+  }, [onChange, value]);
+
+  return null;
+}
+
+describe('useChatComposerSession', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    composerSession = undefined;
+    renderer = undefined;
+  });
+
+  it('preserves the Draft composer only for its accepted Session handoff', () => {
+    const draftTarget = { agentId: 'agent-1', kind: 'draft' } as const;
+    const sessionTarget = { kind: 'session', sessionId: 'session-1' } as const;
+
+    act(() => {
+      renderer = create(<Probe onChange={captureComposerSession} target={draftTarget} />);
+    });
+    const draftKey = current().key;
+
+    act(() => {
+      renderer?.update(
+        <Probe
+          draftHandoff={{ agentId: 'agent-1', sessionId: 'session-1' }}
+          onChange={captureComposerSession}
+          target={sessionTarget}
+        />,
+      );
+    });
+
+    expect(current()).toEqual({
+      draftAgentId: 'agent-1',
+      key: draftKey,
+      target: sessionTarget,
+    });
+
+    act(() => {
+      renderer?.update(<Probe onChange={captureComposerSession} target={sessionTarget} />);
+    });
+
+    expect(current()).toEqual({
+      draftAgentId: 'agent-1',
+      key: draftKey,
+      target: sessionTarget,
+    });
+  });
+
+  it('starts a fresh composer for every unrelated chat identity', () => {
+    const draftTarget = { agentId: 'agent-1', kind: 'draft' } as const;
+    const firstSessionTarget = { kind: 'session', sessionId: 'session-1' } as const;
+    const secondSessionTarget = { kind: 'session', sessionId: 'session-2' } as const;
+
+    act(() => {
+      renderer = create(<Probe onChange={captureComposerSession} target={draftTarget} />);
+    });
+    const draftKey = current().key;
+
+    act(() => {
+      renderer?.update(
+        <Probe
+          draftHandoff={{ agentId: 'agent-2', sessionId: 'session-1' }}
+          onChange={captureComposerSession}
+          target={firstSessionTarget}
+        />,
+      );
+    });
+
+    expect(current()).toEqual({ key: draftKey + 1, target: firstSessionTarget });
+
+    act(() => {
+      renderer?.update(<Probe onChange={captureComposerSession} target={secondSessionTarget} />);
+    });
+
+    expect(current()).toEqual({ key: draftKey + 2, target: secondSessionTarget });
+
+    act(() => {
+      renderer?.update(<Probe onChange={captureComposerSession} target={draftTarget} />);
+    });
+
+    expect(current()).toEqual({ key: draftKey + 3, target: draftTarget });
+  });
+});
+
+function captureComposerSession(value: ChatComposerSessionState) {
+  composerSession = value;
+}
+
+function current() {
+  if (!composerSession) {
+    throw new Error('useChatComposerSession probe was not rendered.');
+  }
+
+  return composerSession;
+}

--- a/src/frontend/features/chat/hooks/useChatComposerSession.ts
+++ b/src/frontend/features/chat/hooks/useChatComposerSession.ts
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+import type { ChatTarget } from '@/frontend/appShell/navigation/chat';
+
+import type { AgentChatDraftHandoff } from '../runtime/agentChatDraftHandoff';
+
+export type ChatComposerSessionState = Readonly<{
+  draftAgentId?: string;
+  key: number;
+  target: ChatTarget;
+}>;
+
+export function useChatComposerSession(
+  target: ChatTarget,
+  draftHandoff: AgentChatDraftHandoff | undefined,
+) {
+  const [sessionState, setSessionState] = useState<ChatComposerSessionState>(() => ({
+    key: 0,
+    target,
+  }));
+  const nextSessionState = resolveChatComposerSessionState(sessionState, target, draftHandoff);
+
+  if (nextSessionState !== sessionState) {
+    setSessionState(nextSessionState);
+  }
+
+  return nextSessionState;
+}
+
+function resolveChatComposerSessionState(
+  current: ChatComposerSessionState,
+  target: ChatTarget,
+  draftHandoff: AgentChatDraftHandoff | undefined,
+): ChatComposerSessionState {
+  if (isSameChatTarget(current.target, target)) {
+    return current;
+  }
+
+  const preservesDraftComposer =
+    current.target.kind === 'draft' &&
+    target.kind === 'session' &&
+    draftHandoff?.agentId === current.target.agentId &&
+    draftHandoff.sessionId === target.sessionId;
+
+  return {
+    ...(preservesDraftComposer ? { draftAgentId: current.target.agentId } : {}),
+    key: preservesDraftComposer ? current.key : current.key + 1,
+    target,
+  };
+}
+
+function isSameChatTarget(left: ChatTarget, right: ChatTarget) {
+  if (left.kind === 'draft') {
+    return right.kind === 'draft' && left.agentId === right.agentId;
+  }
+
+  return right.kind === 'session' && left.sessionId === right.sessionId;
+}

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from 'react';
@@ -33,9 +34,16 @@ type AgentChatForkInput = {
   title?: string;
 };
 
+export type AgentChatDraftHandoff = Readonly<{
+  agentId: string;
+  sessionId: string;
+}>;
+
 type AgentChatContextValue = {
   client: AgentSessionChatClient;
+  completeDraftHandoff: (sessionId: string) => void;
   forkSession: (input: AgentChatForkInput) => Promise<void>;
+  getDraftHandoff: (sessionId: string | undefined) => AgentChatDraftHandoff | undefined;
   sendMessage: (input: AgentChatSendInput) => Promise<void>;
 };
 
@@ -55,6 +63,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
   const pathname = usePathname();
   const router = useRouter();
   const [navigation] = useState(() => createChatNavigation({ pathname, router }));
+  const draftHandoffRef = useRef<AgentChatDraftHandoff | undefined>(undefined);
   const [client] = useState(
     () =>
       new AgentSessionChatClient(agent, {
@@ -88,6 +97,16 @@ export function ChatProvider({ children }: PropsWithChildren) {
   }, [client]);
   useEffect(() => () => client.dispose(), [client]);
 
+  const completeDraftHandoff = useCallback((sessionId: string) => {
+    if (draftHandoffRef.current?.sessionId === sessionId) {
+      draftHandoffRef.current = undefined;
+    }
+  }, []);
+  const getDraftHandoff = useCallback((sessionId: string | undefined) => {
+    const handoff = draftHandoffRef.current;
+    return sessionId && handoff?.sessionId === sessionId ? handoff : undefined;
+  }, []);
+
   const sendMessage = useCallback(
     async ({ agentId, modelId, parts, reasoningEffort, sessionId }: AgentChatSendInput) => {
       let targetSessionId = sessionId;
@@ -101,6 +120,9 @@ export function ChatProvider({ children }: PropsWithChildren) {
           ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
         });
         targetSessionId = session.id;
+        // Publish the one-shot handoff before mutating the route. The route
+        // change is what makes the chat content read and consume this value.
+        draftHandoffRef.current = { agentId, sessionId: targetSessionId };
         navigation.openSession(targetSessionId);
         void queryClient.invalidateQueries({ queryKey: queryKeys.agentSessions.all() });
         return;
@@ -122,8 +144,8 @@ export function ChatProvider({ children }: PropsWithChildren) {
     [client, navigation, queryClient],
   );
   const value = useMemo(
-    () => ({ client, forkSession, sendMessage }),
-    [client, forkSession, sendMessage],
+    () => ({ client, completeDraftHandoff, forkSession, getDraftHandoff, sendMessage }),
+    [client, completeDraftHandoff, forkSession, getDraftHandoff, sendMessage],
   );
 
   return <AgentChatContext value={value}>{children}</AgentChatContext>;
@@ -159,6 +181,22 @@ function useAgentChatContext() {
 export function useAgentChatSession(sessionId: string | undefined): AgentSessionChatState {
   const { client } = useAgentChatContext();
   return useAgentSessionSelection(client, sessionId, selectSessionState);
+}
+
+/** Keeps the Draft composer mounted while its accepted first message becomes a Session route. */
+export function useAgentChatDraftHandoff(
+  sessionId: string | undefined,
+): AgentChatDraftHandoff | undefined {
+  const { completeDraftHandoff, getDraftHandoff } = useAgentChatContext();
+  const handoff = getDraftHandoff(sessionId);
+
+  useEffect(() => {
+    if (handoff) {
+      completeDraftHandoff(handoff.sessionId);
+    }
+  }, [completeDraftHandoff, handoff]);
+
+  return handoff;
 }
 
 export function useAgentChatControls(input: { agentId?: string; sessionId?: string }) {

--- a/src/frontend/features/chat/runtime/ChatProvider.tsx
+++ b/src/frontend/features/chat/runtime/ChatProvider.tsx
@@ -7,7 +7,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   useSyncExternalStore,
 } from 'react';
@@ -17,6 +16,10 @@ import { chatHref, chatRouteParams } from '@/frontend/appShell/navigation/chat';
 import { queryKeys, useBackendModule } from '@/frontend/data';
 import type { AgentInputPart, AgentSubmitMessageInput } from '@/shared/contracts/agent';
 
+import {
+  type AgentChatDraftHandoff,
+  createAgentChatDraftHandoffState,
+} from './agentChatDraftHandoff';
 import { AgentSessionChatClient, type AgentSessionChatState } from './AgentSessionChatClient';
 
 type AgentChatSendInput = {
@@ -33,11 +36,6 @@ type AgentChatForkInput = {
   /** Localized name for the copy; omitted, the fork inherits the source's. */
   title?: string;
 };
-
-export type AgentChatDraftHandoff = Readonly<{
-  agentId: string;
-  sessionId: string;
-}>;
 
 type AgentChatContextValue = {
   client: AgentSessionChatClient;
@@ -63,7 +61,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
   const pathname = usePathname();
   const router = useRouter();
   const [navigation] = useState(() => createChatNavigation({ pathname, router }));
-  const draftHandoffRef = useRef<AgentChatDraftHandoff | undefined>(undefined);
+  const [draftHandoff] = useState(createAgentChatDraftHandoffState);
   const [client] = useState(
     () =>
       new AgentSessionChatClient(agent, {
@@ -97,16 +95,6 @@ export function ChatProvider({ children }: PropsWithChildren) {
   }, [client]);
   useEffect(() => () => client.dispose(), [client]);
 
-  const completeDraftHandoff = useCallback((sessionId: string) => {
-    if (draftHandoffRef.current?.sessionId === sessionId) {
-      draftHandoffRef.current = undefined;
-    }
-  }, []);
-  const getDraftHandoff = useCallback((sessionId: string | undefined) => {
-    const handoff = draftHandoffRef.current;
-    return sessionId && handoff?.sessionId === sessionId ? handoff : undefined;
-  }, []);
-
   const sendMessage = useCallback(
     async ({ agentId, modelId, parts, reasoningEffort, sessionId }: AgentChatSendInput) => {
       let targetSessionId = sessionId;
@@ -120,10 +108,10 @@ export function ChatProvider({ children }: PropsWithChildren) {
           ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
         });
         targetSessionId = session.id;
-        // Publish the one-shot handoff before mutating the route. The route
-        // change is what makes the chat content read and consume this value.
-        draftHandoffRef.current = { agentId, sessionId: targetSessionId };
-        navigation.openSession(targetSessionId);
+        draftHandoff.handoffToSession(
+          { agentId, sessionId: targetSessionId },
+          navigation.openSession,
+        );
         void queryClient.invalidateQueries({ queryKey: queryKeys.agentSessions.all() });
         return;
       }
@@ -133,7 +121,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
         ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
       });
     },
-    [client, navigation, queryClient],
+    [client, draftHandoff, navigation, queryClient],
   );
   const forkSession = useCallback(
     async ({ fromMessageId, sessionId, title }: AgentChatForkInput) => {
@@ -144,8 +132,14 @@ export function ChatProvider({ children }: PropsWithChildren) {
     [client, navigation, queryClient],
   );
   const value = useMemo(
-    () => ({ client, completeDraftHandoff, forkSession, getDraftHandoff, sendMessage }),
-    [client, completeDraftHandoff, forkSession, getDraftHandoff, sendMessage],
+    () => ({
+      client,
+      completeDraftHandoff: draftHandoff.complete,
+      forkSession,
+      getDraftHandoff: draftHandoff.get,
+      sendMessage,
+    }),
+    [client, draftHandoff, forkSession, sendMessage],
   );
 
   return <AgentChatContext value={value}>{children}</AgentChatContext>;

--- a/src/frontend/features/chat/runtime/__tests__/ChatProvider.test.tsx
+++ b/src/frontend/features/chat/runtime/__tests__/ChatProvider.test.tsx
@@ -1,0 +1,134 @@
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { ChatProvider, useAgentChatControls, useAgentChatDraftHandoff } from '../ChatProvider';
+
+const mockDispose = jest.fn();
+const mockInvalidateQueries = jest.fn();
+const mockRefreshObservedSessions = jest.fn();
+const mockReplace = jest.fn();
+const mockSetParams = jest.fn();
+const mockStartSession = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}));
+
+jest.mock('expo-router', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({ replace: mockReplace, setParams: mockSetParams }),
+}));
+
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: () => ({ remove: jest.fn() }),
+  },
+}));
+
+jest.mock('@/frontend/data', () => ({
+  queryKeys: {
+    agentSessions: {
+      all: () => ['agent-sessions'],
+      detail: (sessionId: string) => ['agent-sessions', sessionId],
+      messages: (sessionId: string) => ['agent-sessions', sessionId, 'messages'],
+    },
+  },
+  useBackendModule: () => ({}),
+}));
+
+jest.mock('../AgentSessionChatClient', () => ({
+  AgentSessionChatClient: jest.fn().mockImplementation(() => ({
+    dispose: mockDispose,
+    refreshObservedSessions: mockRefreshObservedSessions,
+    startSession: mockStartSession,
+  })),
+}));
+
+type AgentChatControls = ReturnType<typeof useAgentChatControls>;
+
+let chatControls: AgentChatControls | undefined;
+let draftHandoff: ReturnType<typeof useAgentChatDraftHandoff>;
+
+function Probe({ sessionId }: { sessionId?: string }) {
+  const controls = useAgentChatControls({ agentId: 'agent-1' });
+  const handoff = useAgentChatDraftHandoff(sessionId);
+
+  useEffect(() => {
+    captureChatControls(controls);
+  }, [controls]);
+  useEffect(() => {
+    captureDraftHandoff(handoff);
+  }, [handoff]);
+
+  return null;
+}
+
+function Harness({ sessionId }: { sessionId?: string }) {
+  return (
+    <ChatProvider>
+      <Probe sessionId={sessionId} />
+    </ChatProvider>
+  );
+}
+
+describe('ChatProvider Draft handoff', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    chatControls = undefined;
+    draftHandoff = undefined;
+    mockStartSession.mockResolvedValue({ id: 'session-1' });
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('publishes the admitted Draft to the destination Session for one render', async () => {
+    act(() => {
+      renderer = create(<Harness />);
+    });
+
+    await act(async () => {
+      await currentControls().sendMessage({ parts: [{ text: 'Hello', type: 'text' }] });
+    });
+
+    expect(mockSetParams).toHaveBeenCalledWith({ agentId: undefined, sessionId: 'session-1' });
+
+    act(() => {
+      renderer?.update(<Harness sessionId="session-1" />);
+    });
+
+    expect(draftHandoff).toEqual({ agentId: 'agent-1', sessionId: 'session-1' });
+
+    act(() => {
+      renderer?.update(<Harness sessionId="session-2" />);
+    });
+
+    expect(draftHandoff).toBeUndefined();
+
+    act(() => {
+      renderer?.update(<Harness sessionId="session-1" />);
+    });
+
+    expect(draftHandoff).toBeUndefined();
+  });
+});
+
+function captureChatControls(value: AgentChatControls) {
+  chatControls = value;
+}
+
+function captureDraftHandoff(value: ReturnType<typeof useAgentChatDraftHandoff>) {
+  draftHandoff = value;
+}
+
+function currentControls() {
+  if (!chatControls) {
+    throw new Error('useAgentChatControls probe was not rendered.');
+  }
+
+  return chatControls;
+}

--- a/src/frontend/features/chat/runtime/__tests__/ChatProvider.test.tsx
+++ b/src/frontend/features/chat/runtime/__tests__/ChatProvider.test.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { AppState } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { ChatProvider, useAgentChatControls, useAgentChatDraftHandoff } from '../ChatProvider';
@@ -17,12 +18,6 @@ jest.mock('@tanstack/react-query', () => ({
 jest.mock('expo-router', () => ({
   usePathname: () => '/',
   useRouter: () => ({ replace: mockReplace, setParams: mockSetParams }),
-}));
-
-jest.mock('react-native', () => ({
-  AppState: {
-    addEventListener: () => ({ remove: jest.fn() }),
-  },
 }));
 
 jest.mock('@/frontend/data', () => ({
@@ -76,6 +71,7 @@ describe('ChatProvider Draft handoff', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(AppState, 'addEventListener').mockReturnValue({ remove: jest.fn() });
     chatControls = undefined;
     draftHandoff = undefined;
     mockStartSession.mockResolvedValue({ id: 'session-1' });
@@ -84,6 +80,7 @@ describe('ChatProvider Draft handoff', () => {
   afterEach(() => {
     act(() => renderer?.unmount());
     renderer = undefined;
+    jest.restoreAllMocks();
   });
 
   it('publishes the admitted Draft to the destination Session for one render', async () => {

--- a/src/frontend/features/chat/runtime/__tests__/agentChatDraftHandoff.test.ts
+++ b/src/frontend/features/chat/runtime/__tests__/agentChatDraftHandoff.test.ts
@@ -1,0 +1,23 @@
+import { createAgentChatDraftHandoffState } from '../agentChatDraftHandoff';
+
+describe('AgentChatDraftHandoff', () => {
+  it('publishes the matching handoff before opening its Session and consumes it once', () => {
+    const state = createAgentChatDraftHandoffState();
+    const handoff = { agentId: 'agent-1', sessionId: 'session-1' };
+    let handoffAtNavigation: typeof handoff | undefined;
+
+    state.handoffToSession(handoff, (sessionId) => {
+      handoffAtNavigation = state.get(sessionId);
+    });
+
+    expect(handoffAtNavigation).toEqual(handoff);
+    expect(state.get('session-2')).toBeUndefined();
+    expect(state.get('session-1')).toEqual(handoff);
+
+    state.complete('session-2');
+    expect(state.get('session-1')).toEqual(handoff);
+
+    state.complete('session-1');
+    expect(state.get('session-1')).toBeUndefined();
+  });
+});

--- a/src/frontend/features/chat/runtime/agentChatDraftHandoff.ts
+++ b/src/frontend/features/chat/runtime/agentChatDraftHandoff.ts
@@ -1,0 +1,26 @@
+export type AgentChatDraftHandoff = Readonly<{
+  agentId: string;
+  sessionId: string;
+}>;
+
+type OpenSession = (sessionId: string) => void;
+
+/** Owns the one pending Draft-to-Session handoff for a chat route. */
+export function createAgentChatDraftHandoffState() {
+  let pending: AgentChatDraftHandoff | undefined;
+
+  return {
+    complete(sessionId: string) {
+      if (pending?.sessionId === sessionId) {
+        pending = undefined;
+      }
+    },
+    get(sessionId: string | undefined) {
+      return sessionId && pending?.sessionId === sessionId ? pending : undefined;
+    },
+    handoffToSession(handoff: AgentChatDraftHandoff, openSession: OpenSession) {
+      pending = handoff;
+      openSession(handoff.sessionId);
+    },
+  };
+}

--- a/src/frontend/features/chat/runtime/index.ts
+++ b/src/frontend/features/chat/runtime/index.ts
@@ -1,7 +1,9 @@
 export {
+  type AgentChatDraftHandoff,
   ChatProvider,
   useAgentChatActions,
   useAgentChatControls,
+  useAgentChatDraftHandoff,
   useAgentChatFork,
   useAgentChatSession,
 } from './ChatProvider';

--- a/src/frontend/features/chat/runtime/index.ts
+++ b/src/frontend/features/chat/runtime/index.ts
@@ -1,5 +1,5 @@
+export { type AgentChatDraftHandoff } from './agentChatDraftHandoff';
 export {
-  type AgentChatDraftHandoff,
   ChatProvider,
   useAgentChatActions,
   useAgentChatControls,


### PR DESCRIPTION
### What this PR does

Before this PR:

Sending the first message from a new Agent draft changed the route to its newly created Session. Because the page-level chat screen subscribed to route params and the composer key changed with the route identity, the update fJaneed through the whole chat page and remounted the composer.

After this PR:

The stable chat page frame no longer subscribes to chat route params. A focused content leaf handles Draft/Session route changes, while a one-shot Draft-to-Session handoff keeps the accepted draft attached to the same composer instance. Navigation to unrelated Drafts or Sessions still creates an isolated composer session.

### Screenshots or videos

N/A — this changes render and mount behavior without changing the static UI. Regression coverage records the page-frame render count and composer instance identity across the first-send transition.

### Why we need it and why it was done in this way

The Session ID remains the canonical route identity so deep links, back navigation, and restoration keep working. The volatile route subscription is moved to the smallest component that needs it, and the runtime publishes the originating Agent only for the accepted first-message handoff.

The following tradeoffs were made:

- The chat content still renders when its route identity changes; that update is required to display the new Session.
- The header may perform its own focused route-derived update, but the content subscription no longer fans out through the page shell.

The following alternatives were considered:

- Removing the Session ID from the route would weaken deep-link and restoration semantics.
- Creating an empty Session before the first message would change persistence behavior and could leave unused Sessions behind.

### Breaking changes

None.

### Special notes for your reviewer

Validation performed:

- pnpm format
- pnpm lint (0 errors; existing repository warnings remain)
- git diff --check

Tests, typecheck, builds, and simulator verification were not run because workspace policy requires explicit authorization for those checks.

### Checklist

- [x] Branch: This PR targets v0.2
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: No static UI changes; the non-visual render behavior is covered by regression tests
- [x] Code: The change keeps the route subscription and transition state scoped to their owners
- [x] Refactor: Duplicate header ownership was removed from the route resolver
- [x] Upgrade: No upgrade-flow impact
- [x] Documentation: The chat feature ownership notes were updated
- [x] Self-review: The final diff was reviewed against origin/v0.2

### Release note

```release-note
Fixed the chat page and composer refreshing after sending the first message in a new conversation.
```
