### PR TITLE
fix(chat-header): refine Android overlay chrome

### DIFF
--- a/src/app/(drawer)/(chat)/_layout.tsx
+++ b/src/app/(drawer)/(chat)/_layout.tsx
@@ -11,7 +11,7 @@ import { isLiquidGlassAvailable } from '@/frontend/utils/constants';
  * only exist inside a native stack screen.
  */
 export default function ChatStackLayout() {
-  const [foregroundColor, chatBackgroundColor] = useThemeColor(['foreground', 'background']);
+  const [foregroundColor, chatBackgroundColor] = useThemeColor(['foreground', 'chat-background']);
 
   return (
     <Stack

--- a/src/frontend/appShell/header/MainHeader/MainHeader.android.tsx
+++ b/src/frontend/appShell/header/MainHeader/MainHeader.android.tsx
@@ -1,18 +1,24 @@
+import MaskedView from '@react-native-masked-view/masked-view';
+import { BlurView } from 'expo-blur';
 import { Stack } from 'expo-router';
-import { useState } from 'react';
-import { View } from 'react-native';
+import { type RefObject, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useUniwind } from 'uniwind';
 
 import { HeaderActionGroup } from '../components/HeaderActionGroup/HeaderActionGroup';
+import { mainHeaderRowHeight } from '../headerScreenOptions';
 import { MainHeaderAgentButton } from './MainHeaderAgentButton';
 import { useMainHeaderActions } from './useMainHeaderActions';
 import { useMainHeaderAgentPicker } from './useMainHeaderAgentPicker';
 
 const HEADER_HORIZONTAL_INSET = 16;
 const HEADER_TITLE_ACTION_GAP = 4;
+const HEADER_BLUR_INTENSITY = 24;
 
-export function MainHeader() {
+export function MainHeader({ blurTarget }: { blurTarget: RefObject<View | null> }) {
   const insets = useSafeAreaInsets();
+  const { theme } = useUniwind();
   const { agent, currentAgentId, leadingAction, rightActions } = useMainHeaderActions();
   const { agentPickerSheet, openAgentPicker } = useMainHeaderAgentPicker(currentAgentId);
   const [leadingActionsWidth, setLeadingActionsWidth] = useState(0);
@@ -25,13 +31,38 @@ export function MainHeader() {
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <View className="bg-background">
-        <View style={{ height: insets.top }} />
-        {/* 56dp row matches the native-stack toolbar height, so the 40dp action
+      <View className="absolute inset-x-0 top-0 z-20" pointerEvents="box-none">
+        <MaskedView
+          maskElement={
+            <View
+              style={[
+                StyleSheet.absoluteFill,
+                {
+                  experimental_backgroundImage:
+                    'linear-gradient(to bottom, black 0%, black 62%, transparent 100%)',
+                },
+              ]}
+            />
+          }
+          pointerEvents="none"
+          style={StyleSheet.absoluteFill}
+        >
+          <BlurView
+            blurMethod="dimezisBlurViewSdk31Plus"
+            blurReductionFactor={2}
+            blurTarget={blurTarget}
+            intensity={HEADER_BLUR_INTENSITY}
+            style={StyleSheet.absoluteFill}
+            tint={theme === 'dark' ? 'systemUltraThinMaterialDark' : 'systemUltraThinMaterialLight'}
+          />
+        </MaskedView>
+        <View pointerEvents="none" style={{ height: insets.top }} />
+        {/* 56dp row matches the native-stack toolbar height, so the 36dp action
             surfaces keep the same clearance as native-header screens. */}
         <View
-          className="relative h-14 flex-row items-center"
-          style={{ paddingHorizontal: HEADER_HORIZONTAL_INSET }}
+          className="relative flex-row items-center"
+          pointerEvents="box-none"
+          style={{ height: mainHeaderRowHeight, paddingHorizontal: HEADER_HORIZONTAL_INSET }}
         >
           {/* The chat route is currently a drawer root, so the route policy
               resolves this leading action to the sidebar button. */}

--- a/src/frontend/appShell/header/README.md
+++ b/src/frontend/appShell/header/README.md
@@ -25,16 +25,20 @@ This module owns Expo Router header adapters used by the app screens.
 - `components/HeaderActionGroup` is the platform gateway for adjacent top actions. Callers declare
   placement, tone, and actions without choosing a platform: iOS delegates the group surface to the
   native toolbar, while Android draws the Cherry fallback surface.
-- `MainHeader` keeps a thin platform adapter because Android draws the chat bar inside the scene,
-  while iOS uses the native transparent toolbar. Both adapters mount the same action lists from
+- `MainHeader` keeps a thin platform adapter because Android draws an ultra-thin blurred overlay
+  above the scrolling chat scene, while iOS uses the native transparent toolbar. Android 12 and
+  newer sample the chat surface through Expo Blur; older releases fall back to the material tint.
+  The Android blur fades to fully transparent at the lower edge so it does not split the header and
+  message canvas into separate visual surfaces. Both adapters mount the same action lists from
   `useMainHeaderActions`, so platform files only own how the surface is mounted.
 - `headerScreenOptions` owns native top-header invariants. Top headers are separator-free on both
   platforms, and self-drawn headers do not add bottom borders or elevation.
 - Top-bar controls share one Cherry action size and grouping contract. iOS lets the native toolbar
   draw its system background. Android supplies the matching fallback surface: one action forms a
   circle when it is an icon, while a label action and adjacent actions form a capsule. The visible
-  surface stays 40dp tall inside non-overlapping Android touch targets; short label targets keep a
-  64dp minimum width so their inset surface cannot collapse into a circle. Default surfaces use
-  theme tokens; inverse surfaces use constant contrast because they sit over uncontrolled media.
+  surface stays 36dp tall inside non-overlapping Android touch targets; short label targets keep a
+  64dp minimum width so their inset surface cannot collapse into a circle. Default surfaces use the
+  card token and a compact shadow so their complete outline remains visible against the header;
+  inverse surfaces use constant contrast because they sit over uncontrolled media.
 - `MainHeaderAgentButton` is the one exception to the black-icon rule: it carries the current
   Agent's avatar, so the chat identifies its Agent the same way the Agent list does.

--- a/src/frontend/appShell/header/components/HeaderActionGroup/HeaderActionGroup.android.tsx
+++ b/src/frontend/appShell/header/components/HeaderActionGroup/HeaderActionGroup.android.tsx
@@ -4,10 +4,10 @@ import { HeaderAction } from '../HeaderAction';
 import type { HeaderActionTone } from '../HeaderAction';
 import type { HeaderActionGroupProps } from './HeaderActionGroup';
 
-const GROUP_BASE_CLASS_NAME = 'absolute inset-1 rounded-full shadow-sm';
+const GROUP_BASE_CLASS_NAME = 'absolute inset-1.5 rounded-full';
 const GROUP_CLASS_NAMES: Record<HeaderActionTone, string> = {
-  default: `${GROUP_BASE_CLASS_NAME} bg-background`,
-  inverse: `${GROUP_BASE_CLASS_NAME} bg-constant-black/55`,
+  default: `${GROUP_BASE_CLASS_NAME} bg-card shadow-xs`,
+  inverse: `${GROUP_BASE_CLASS_NAME} bg-constant-black/55 shadow-sm`,
 };
 
 /** Draws the Android fallback for the shared surface supplied by the iOS native toolbar. */
@@ -19,7 +19,7 @@ export function HeaderActionGroup({ actions, tone = 'default' }: HeaderActionGro
   return (
     <View className="relative flex-row items-center">
       {/* Actions own adjacent, non-overlapping targets. The inset surface stays
-          40dp tall: one icon action forms a circle, while a short label action
+          36dp tall: one icon action forms a circle, while a short label action
           expands to a capsule instead of collapsing to the same geometry. */}
       <View className={GROUP_CLASS_NAMES[tone]} pointerEvents="none" />
       {actions.map((action) => (

--- a/src/frontend/appShell/header/components/HeaderActionGroup/__tests__/HeaderActionGroup.android.test.tsx
+++ b/src/frontend/appShell/header/components/HeaderActionGroup/__tests__/HeaderActionGroup.android.test.tsx
@@ -19,7 +19,7 @@ describe('HeaderActionGroup.android', () => {
     renderer = undefined;
   });
 
-  it('keeps adjacent actions in separate 48dp targets around the inset surface', () => {
+  it('keeps adjacent actions in separate 48dp targets around the 36dp inset surface', () => {
     const Icon = () => null;
 
     act(() => {
@@ -52,7 +52,8 @@ describe('HeaderActionGroup.android', () => {
       (node) => typeof node.type === 'string' && node.props.accessibilityRole === 'button',
     );
 
-    expect(surface.props.className).toContain('absolute inset-1');
+    expect(surface.props.className).toContain('absolute inset-1.5');
+    expect(surface.props.className).toContain('bg-card shadow-xs');
     expect(actions).toHaveLength(2);
     actions.forEach((action) => {
       expect(action.props.className.split(' ')).toContain('size-12');

--- a/src/frontend/appShell/header/headerScreenOptions.ts
+++ b/src/frontend/appShell/header/headerScreenOptions.ts
@@ -1,3 +1,5 @@
+export const mainHeaderRowHeight = 56;
+
 /** Invariants shared by every native top header in the app. */
 export const headerScreenOptions = {
   headerBackVisible: false,

--- a/src/frontend/appShell/header/index.ts
+++ b/src/frontend/appShell/header/index.ts
@@ -5,7 +5,7 @@ export {
   type HeaderActionGroupProps,
 } from './components/HeaderActionGroup/HeaderActionGroup';
 export { HeaderChrome } from './components/HeaderChrome';
-export { headerScreenOptions } from './headerScreenOptions';
+export { headerScreenOptions, mainHeaderRowHeight } from './headerScreenOptions';
 export { MainHeader } from './MainHeader/MainHeader';
 export {
   RouteHeader,

--- a/src/frontend/appShell/navigation/README.md
+++ b/src/frontend/appShell/navigation/README.md
@@ -7,7 +7,8 @@ domains.
 
 - `NavigationThemeProvider` supplies the app-wide navigation theme.
 - `ContextMenuLink` and `ContextMenuLinkItem` define the shared link-with-context-menu adapter.
-- `resolveHeaderContentInset` normalizes platform header insets for full-screen content.
+- `resolveHeaderContentInset` normalizes native and custom-overlay header insets for full-screen
+  content.
 - `providerSetupHref`, `readProviderSetupReturnTo`, and `useOpenProviderSetup` carry a requesting
   internal href through provider setup without introducing a global workflow coordinator.
 - `getRootHeaderStyle`, `getTransparentHeaderStyle`, and `paintingViewerHeaderShown` expose the

--- a/src/frontend/appShell/navigation/headerContentInset/headerContentInset.android.ts
+++ b/src/frontend/appShell/navigation/headerContentInset/headerContentInset.android.ts
@@ -1,3 +1,3 @@
-export function resolveHeaderContentInset(_headerHeight: number) {
-  return 0;
+export function resolveHeaderContentInset(_headerHeight: number, overlayHeaderHeight = 0) {
+  return overlayHeaderHeight;
 }

--- a/src/frontend/appShell/navigation/headerContentInset/headerContentInset.ios.ts
+++ b/src/frontend/appShell/navigation/headerContentInset/headerContentInset.ios.ts
@@ -1,3 +1,3 @@
-export function resolveHeaderContentInset(headerHeight: number) {
+export function resolveHeaderContentInset(headerHeight: number, _overlayHeaderHeight = 0) {
   return headerHeight;
 }

--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -3,7 +3,9 @@ import {
   ContentState,
   getComposerKeyboardStickyOffset,
 } from '@cherrystudio/ui/components';
+import { BlurTargetView } from 'expo-blur';
 import { useIsPreview, useLocalSearchParams } from 'expo-router';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -31,12 +33,14 @@ import { useAgentChatDraftHandoff } from './runtime';
 const PREVIEW_CONTENT_BOTTOM_INSET = 12;
 
 export function ChatScreen() {
+  const blurTargetRef = useRef<View>(null);
+
   return (
     <>
-      <MainHeader />
-      <View className="flex-1">
+      <BlurTargetView ref={blurTargetRef} style={{ flex: 1 }}>
         <ChatRouteContent />
-      </View>
+      </BlurTargetView>
+      <MainHeader blurTarget={blurTargetRef} />
     </>
   );
 }

--- a/src/frontend/features/chat/components/ChatWorkspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/ChatWorkspace.tsx
@@ -3,7 +3,9 @@ import { useHeaderHeight } from 'expo-router/react-navigation';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { mainHeaderRowHeight } from '@/frontend/appShell/header';
 import { resolveHeaderContentInset } from '@/frontend/appShell/navigation';
 import { MessageList, type MessageListItem } from '@/frontend/components/Message';
 import type { AgentMessageHistoryWindow } from '@/frontend/hooks/agent';
@@ -58,6 +60,7 @@ export function ChatWorkspace({
   const live = useAgentChatSession(sessionId);
   const client = useAgentChatActions();
   const headerHeight = useHeaderHeight();
+  const { top: safeAreaTop } = useSafeAreaInsets();
   const { t } = useTranslation();
   const { toast } = useToast();
   useEffect(() => {
@@ -175,7 +178,10 @@ export function ChatWorkspace({
     renderGateKey: sessionId,
     requiresInitialHistoryLayout,
   });
-  const contentTopInset = resolveHeaderContentInset(headerHeight);
+  const contentTopInset = resolveHeaderContentInset(
+    headerHeight,
+    safeAreaTop + mainHeaderRowHeight,
+  );
 
   if (error && !isLoadingInitial && listMessages.length === 0) {
     return (

--- a/src/frontend/features/chat/components/ChatWorkspace/__tests__/ChatWorkspace.test.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/__tests__/ChatWorkspace.test.tsx
@@ -41,6 +41,14 @@ jest.mock('expo-router/react-navigation', () => ({
   useHeaderHeight: () => 52,
 }));
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 24 }),
+}));
+
+jest.mock('@/frontend/appShell/header', () => ({
+  mainHeaderRowHeight: 56,
+}));
+
 jest.mock('@cherrystudio/app-icons/icons/check', () => () => null);
 jest.mock('@cherrystudio/app-icons/icons/copy', () => () => null);
 jest.mock('@cherrystudio/app-icons/icons/ellipsis', () => () => null);


### PR DESCRIPTION
## Summary

- reduce Android header action surfaces to 36dp while preserving 48dp touch targets
- render the Android chat header as an overlay so messages can scroll underneath with the correct safe-area inset
- add a theme-aware, progressively masked blur that fades into the chat canvas without a hard visual boundary

## Validation

- `pnpm lint` (passes; existing repository warnings remain)
- `pnpm format:check`
- not run: tests, typecheck, build, or device verification (not authorized for this task)