### PR TITLE
fix(agent-session): use app language for automatic naming

### DIFF
--- a/src/backend/ai/agent/host/AgentHostDependencies.ts
+++ b/src/backend/ai/agent/host/AgentHostDependencies.ts
@@ -92,6 +92,7 @@ export class AgentHostDependencies extends BaseService implements MobileAgentHos
   naming(signal: AbortSignal): MobileAgentHostNaming {
     return new AgentSessionNaming({
       ai: this.aiService,
+      appLanguage: () => this.appLanguage(),
       model: modelService,
       preference: this.preferenceService,
       provider: providerService,

--- a/src/backend/ai/agent/host/AgentSessionNaming.ts
+++ b/src/backend/ai/agent/host/AgentSessionNaming.ts
@@ -10,6 +10,7 @@ import type { ModelService } from '@/backend/data/services/ModelService';
 import type { ProviderService } from '@/backend/data/services/ProviderService';
 import type { AgentInputPart, AgentMessagePart, AgentSessionView } from '@/shared/contracts/agent';
 import { loggerService } from '@/shared/core/logger/LoggerService';
+import type { LanguageVarious } from '@/shared/data/preference';
 import { isUniqueModelId, parseUniqueModelId, type UniqueModelId } from '@/shared/data/types/model';
 
 import type { AgentSessionStore } from '../sessionStore/AgentSessionStore';
@@ -21,6 +22,7 @@ const FALLBACK_PROMPT =
 
 type AgentSessionNamingDependencies = {
   ai: Pick<AiService, 'generateText'>;
+  appLanguage: () => LanguageVarious;
   model: Pick<ModelService, 'getById'>;
   preference: Pick<PreferenceService, 'get'>;
   provider: Pick<ProviderService, 'getByProviderId'>;
@@ -212,7 +214,7 @@ export class AgentSessionNaming {
 
   private async resolveNamingPrompt(): Promise<string> {
     const configuredPrompt = await this.dependencies.preference.get('agent.session_naming.prompt');
-    const language = (await this.dependencies.preference.get('app.language')) || 'en-us';
+    const language = this.dependencies.appLanguage();
     return (configuredPrompt || FALLBACK_PROMPT).replaceAll('{{language}}', language);
   }
 }

--- a/src/backend/ai/agent/host/__tests__/AgentSessionNaming.test.ts
+++ b/src/backend/ai/agent/host/__tests__/AgentSessionNaming.test.ts
@@ -2,6 +2,7 @@ import type { AiService } from '@/backend/ai/AiService';
 import type { PreferenceService } from '@/backend/data/PreferenceService';
 import type { ModelService } from '@/backend/data/services/ModelService';
 import type { ProviderService } from '@/backend/data/services/ProviderService';
+import type { LanguageVarious } from '@/shared/data/preference';
 
 import { InMemoryAgentSessionStore } from '../../sessionStore/InMemoryAgentSessionStore';
 import { AgentSessionNaming } from '../AgentSessionNaming';
@@ -17,6 +18,7 @@ function deferred<TValue>() {
 }
 
 function createNaming(input: {
+  appLanguage?: LanguageVarious;
   defaultModelId?: string | null;
   generateText?: AiService['generateText'];
   namingModelId?: string | null;
@@ -33,12 +35,12 @@ function createNaming(input: {
       if (key === 'agent.session_naming.model_id') return input.namingModelId ?? null;
       if (key === 'agent.default_model_id') return defaultModelId;
       if (key === 'agent.session_naming.prompt') return '';
-      if (key === 'app.language') return 'en-us';
       return null;
     }),
   } as unknown as PreferenceService;
   const naming = new AgentSessionNaming({
     ai: { generateText } as Pick<AiService, 'generateText'>,
+    appLanguage: () => input.appLanguage ?? 'en-US',
     model: { getById: jest.fn(async () => ({})) } as unknown as Pick<ModelService, 'getById'>,
     preference,
     provider: {
@@ -88,6 +90,27 @@ describe('AgentSessionNaming', () => {
       }),
     );
     expect(generateText.mock.calls[0]?.[0]).not.toHaveProperty('reasoningEffort');
+  });
+
+  test('uses the effective App language in the summary naming prompt', async () => {
+    const { generateText, naming, store } = createNaming({ appLanguage: 'zh-CN' });
+    const session = await store.createEmptySession({ agentId: 'agent-1' });
+    const userParts = [{ type: 'text' as const, text: 'Explain lunar eclipses' }];
+    await naming.maybeRenameFromFirstUserMessage(session.id, userParts);
+
+    await naming.maybeRenameFromConversationSummary({
+      assistantParts: [
+        { id: 'text-1', state: 'done', text: 'Earth blocks the sunlight.', type: 'text' },
+      ],
+      sessionId: session.id,
+      userParts,
+    });
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining('title in zh-CN'),
+      }),
+    );
   });
 
   test('keeps the first-message title when no usable naming model is configured', async () => {


### PR DESCRIPTION
## Summary

- reuse the Agent Host’s resolved app language for automatic session naming
- honor the device-language fallback when the app language preference is unset
- add regression coverage verifying that `zh-CN` reaches the naming system prompt

## Validation

- `pnpm format`
- `pnpm exec oxlint src/backend/ai/agent/host/AgentSessionNaming.ts src/backend/ai/agent/host/AgentHostDependencies.ts src/backend/ai/agent/host/__tests__/AgentSessionNaming.test.ts`
- `pnpm exec expo lint src/backend/ai/agent/host/AgentSessionNaming.ts src/backend/ai/agent/host/AgentHostDependencies.ts src/backend/ai/agent/host/__tests__/AgentSessionNaming.test.ts`
- `git diff --check`

## Verification not run

- Unit tests, typecheck, and builds were not run per repository workspace instructions.
- Full `pnpm lint` reached Expo lint but could not complete because this workspace cannot resolve the unbuilt `@cherrystudio/ai-core` package imports (7 unrelated `import/no-unresolved` errors). Building packages was intentionally skipped per repository instructions.