### PR TITLE
fix(chat-workspace): constrain fork origin title width

### DIFF
--- a/src/backend/services/backgroundActivity/__tests__/expoWidgetsLiveActivityPatch.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/expoWidgetsLiveActivityPatch.test.ts
@@ -1,9 +1,0 @@
-import { readFileSync } from 'node:fs';
-
-describe('expo-widgets Live Activity patch', () => {
-  test('keeps the compact trailing content close to the Dynamic Island edge', () => {
-    const patch = readFileSync(`${process.cwd()}/patches/expo-widgets@57.0.8.patch`, 'utf8');
-
-    expect(patch).toContain('+      .contentMargins(.trailing, 0, for: .compactTrailing)');
-  });
-});

--- a/src/frontend/features/chat/components/ChatWorkspace/components/ChatForkOriginDivider.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/ChatForkOriginDivider.tsx
@@ -43,18 +43,26 @@ export function ChatForkOriginDivider({ sourceSessionId }: ChatForkOriginDivider
       testID="chat-fork-origin"
     >
       <View className="h-px flex-1 bg-border" />
-      <Text className="shrink text-muted-foreground text-sm" numberOfLines={1}>
-        {/*
-          The slot tag must not collide with an HTML void element — Trans parses
-          the translated string as markup, and a void name such as `source`
-          would close the tag before the title ever reached it.
-        */}
+      <View className="min-w-0 shrink flex-row items-center" testID="chat-fork-origin-label">
+        {/* Every translated fragment is wrapped in Text so the title remains an
+            independently constrained flex item without fixing the locale's word order. */}
         <Trans
-          components={{ origin: <Text className="text-foreground underline" /> }}
+          components={{
+            label: <Text className="shrink-0 text-muted-foreground text-sm" numberOfLines={1} />,
+            origin: (
+              <Text
+                className="min-w-0 max-w-56 shrink text-foreground text-sm underline"
+                numberOfLines={1}
+                testID="chat-fork-origin-title"
+              />
+            ),
+            suffix: <Text className="shrink-0 text-muted-foreground text-sm" numberOfLines={1} />,
+          }}
           i18nKey="chat.fork.origin"
+          parent={null}
           values={{ title }}
         />
-      </Text>
+      </View>
       <View className="h-px flex-1 bg-border" />
     </Pressable>
   );

--- a/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/ChatForkOriginDivider.test.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/ChatForkOriginDivider.test.tsx
@@ -40,10 +40,12 @@ describe('ChatForkOriginDivider', () => {
     // title must land *inside* its own slot: that slot is what carries the link
     // affordance, and an unparsed one silently degrades to plain text.
     const row = renderer!.root.findByProps({ testID: 'chat-fork-origin' });
-    const slot = renderer!.root.findAllByProps({ className: 'text-foreground underline' })[0];
+    const slot = renderer!.root.findByProps({ testID: 'chat-fork-origin-title' });
 
     expect(collectText(row)).toBe('Branched from Arithmetic drills');
     expect(collectText(slot)).toBe('Arithmetic drills');
+    expect(slot.props.className).toContain('max-w-56');
+    expect(slot.props.numberOfLines).toBe(1);
   });
 
   test('returns to the source session by swapping route params', async () => {

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -172,7 +172,7 @@
   "chat.errorPart.retryable": "The reply could not be completed. You can try again.",
   "chat.errorPart.title": "Error",
   "chat.fork.openSource": "Open the source chat",
-  "chat.fork.origin": "Branched from <origin>{{title}}</origin>",
+  "chat.fork.origin": "<label>Branched from </label><origin>{{title}}</origin>",
   "chat.fork.sessionTitle": "Branch - {{title}}",
   "chat.input.action.sendMessage": "Send message",
   "chat.input.action.stopGenerating": "Stop generating",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -171,7 +171,7 @@
   "chat.errorPart.retryable": "本次回复未能完成，可以重试。",
   "chat.errorPart.title": "错误",
   "chat.fork.openSource": "打开源对话",
-  "chat.fork.origin": "从 <origin>{{title}}</origin> 创建的分支对话",
+  "chat.fork.origin": "<label>从 </label><origin>{{title}}</origin><suffix> 创建的分支对话</suffix>",
   "chat.fork.sessionTitle": "分支 - {{title}}",
   "chat.input.action.sendMessage": "发送消息",
   "chat.input.action.stopGenerating": "停止生成",


### PR DESCRIPTION
### What this PR does

Before this PR:

Long source-session titles could consume the full fork-origin label, causing the localized context after the title to be truncated as part of the same text node.

After this PR:

The source title is an independently shrinking text item with a 224-point maximum width. Only the title ellipsizes, while the surrounding localized context remains visible and keeps each locale's word order.

The PR also removes the obsolete `expoWidgetsLiveActivityPatch` test left behind when #793 deleted the patch it exclusively guarded. Without that cleanup, the shared `v0.2` baseline makes every PR test job fail with `ENOENT`.

### Screenshots or videos

Not yet captured. This is a draft PR, and device verification was not run because workspace instructions require explicit authorization before launching a simulator or device workflow.

### Why we need it and why it was done in this way

The translated label now wraps every fragment in its own React Native `Text` component so flexbox can constrain only the source title. The `Trans` component still controls fragment order, preserving natural English and Chinese phrasing without splitting the sentence into order-dependent translation keys.

The following tradeoffs were made:

- The title uses the existing `max-w-56` layout scale and can shrink further on narrow screens.
- The translation markup is slightly more explicit so the surrounding copy remains outside the ellipsized title.

The following alternatives were considered:

- Constraining the original nested title text was rejected because inline nested text does not provide an independent flex layout boundary.
- Splitting the sentence into prefix and suffix translation keys was rejected because it would hard-code word order in the component.

### Breaking changes

None.

### Special notes for your reviewer

Verification completed:

- GitHub Actions: test, lint, and typecheck
- `pnpm format:check`
- Targeted Oxlint and Expo lint for the changed TypeScript files
- `git diff --check`

Local `pnpm lint` reached Expo lint but could not resolve the unbuilt workspace package `@cherrystudio/ai-core` from seven unrelated backend files. Package builds, type checks, tests, and device verification were not run locally because workspace instructions require explicit authorization for those actions; the complete remote CI run passed after the stale test was removed.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: An updated screenshot still needs to be captured during authorized device verification
- [x] Code: The change is focused and follows the existing layout scale
- [x] Refactor: No unrelated refactoring was included
- [x] Upgrade: No upgrade-flow impact
- [x] Documentation: No user-guide update is required for this layout correction
- [x] Self-review: The diff was reviewed before opening this PR

### Release note

```release-note
Improve the fork-origin divider layout for long source conversation titles.
```
