### PR TITLE
fix(design-system): correct mobile color semantics

### DIFF
--- a/packages/design-tokens/src/styles/shadcn.css
+++ b/packages/design-tokens/src/styles/shadcn.css
@@ -67,8 +67,8 @@
    * VBG：「Category series are monochrome by default. Reserve chromatic tokens
    * for meaning.」故改为灰阶。有意偏离之处：VBG 自己的 --vbg-chart-1..6 是
    * gray-1000/900/800 重复两轮，对 5 系列图表不可用，此处顺延到 700/600。
-   * 深色下 gray-700(0.65) 比 gray-800(0.59) 更亮，第 3/4 档亮度会反序 —— 目前
-   * 没有任何组件消费 chart-1..5（AiUsageWeeklyChart 用的是语义色），故不额外处理。 */
+   * 深色下 gray-700(0.65) 比 gray-800(0.59) 更亮，第 3/4 档亮度会反序；当前
+   * AiUsageWeeklyChart 只消费前三档，后两档保留给未来扩展。 */
   --chart-1: var(--gray-1000);
   --chart-2: var(--gray-900);
   --chart-3: var(--gray-800);

--- a/packages/ui/src/components/button/__tests__/button.test.tsx
+++ b/packages/ui/src/components/button/__tests__/button.test.tsx
@@ -222,7 +222,7 @@ describe('Button', () => {
       variant: 'ghost',
     },
     {
-      labelClassName: 'text-primary',
+      labelClassName: 'text-link',
       rootClassNames: ['bg-transparent', 'shadow-none', 'active:opacity-70'],
       variant: 'link',
     },
@@ -261,7 +261,7 @@ describe('Button', () => {
     expect(rootClassName).not.toContain('px-4');
     expect(rootClassName).not.toContain('py-2.5');
     expect(rootClassName).not.toContain('rounded-xl');
-    expect(labelClassName).toContain('text-primary');
+    expect(labelClassName).toContain('text-link');
     expect(labelClassName).toContain('underline');
   });
 

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -97,7 +97,7 @@ const variantStyles: Record<ButtonVariant, { label: string; root: string }> = {
     root: 'bg-transparent shadow-none active:bg-secondary',
   },
   link: {
-    label: 'text-primary underline',
+    label: 'text-link underline',
     root: 'bg-transparent shadow-none active:opacity-70',
   },
   outline: {

--- a/packages/ui/src/components/content-state/__tests__/content-state.test.tsx
+++ b/packages/ui/src/components/content-state/__tests__/content-state.test.tsx
@@ -188,7 +188,8 @@ describe('ContentState', () => {
     const title = text.find((node) => node.props.children === 'Load failed');
     const description = text.find((node) => node.props.children === 'Request timed out');
 
-    expect(title?.props.className).toContain('text-destructive-foreground');
+    expect(title?.props.className).toContain('text-error');
+    expect(title?.props.className).not.toContain('text-destructive-foreground');
     expect(title?.props.selectable).toBe(true);
     expect(description?.props.selectable).toBe(true);
     expect(tree.root.findAll((node) => node.props.accessibilityRole === 'button')).toHaveLength(0);

--- a/packages/ui/src/components/content-state/content-state.tsx
+++ b/packages/ui/src/components/content-state/content-state.tsx
@@ -84,7 +84,7 @@ function ContentStateFrame({
                 isCentered ? 'text-center' : 'text-left',
                 'font-semibold',
                 isProminent ? 'text-lg' : 'text-base',
-                kind === 'error' ? 'text-destructive-foreground' : 'text-foreground',
+                kind === 'error' ? 'text-error' : 'text-foreground',
               )}
               selectable={kind === 'error'}
             >

--- a/packages/ui/src/components/input/__tests__/input.test.tsx
+++ b/packages/ui/src/components/input/__tests__/input.test.tsx
@@ -125,6 +125,9 @@ describe('Input', () => {
 
     expect(input.props.isDisabled).toBe(true);
     expect(input.props.isInvalid).toBe(true);
+    expect(input.props.className).toContain('border-error');
+    expect(input.props.className).toContain('ios:outline-error');
+    expect(input.props.className).not.toContain('destructive');
   });
 
   test('uses a four-line adaptive viewport for multiline input', () => {

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -88,7 +88,7 @@ function NativeInput({
       ? 'min-h-10 rounded-lg border border-border py-2 text-base shadow-none ios:shadow-none ios:focus:outline-transparent android:border-border android:shadow-none android:focus:border-border'
       : 'min-h-10 rounded-lg border border-border py-0 text-(length:--text-base) shadow-none ios:shadow-none ios:focus:outline-transparent android:border-border android:shadow-none android:focus:border-border',
     invalid &&
-      'border-destructive ios:outline-danger ios:focus:outline-danger android:border-destructive android:focus:border-destructive',
+      'border-error ios:outline-error ios:focus:outline-error android:border-error android:focus:border-error',
   );
 
   return (
@@ -215,7 +215,7 @@ function PasswordInput({
         'min-h-10 flex-row items-stretch overflow-hidden rounded-lg border border-border shadow-none',
         isOnSurface ? 'bg-default' : 'bg-field',
         isDisabled && 'opacity-disabled',
-        isInvalid && 'border-destructive',
+        isInvalid && 'border-error',
       )}
       style={[styles.root, style]}
     >

--- a/packages/ui/src/components/message-part/__tests__/message-part.test.tsx
+++ b/packages/ui/src/components/message-part/__tests__/message-part.test.tsx
@@ -271,7 +271,7 @@ describe('MessagePart', () => {
     act(() => renderer!.root.findByProps({ testID: 'group-trigger' }).props.onPress());
     expect(findRenderedByTestId(renderer!, 'group-steps')).toHaveLength(0);
     expect(renderer!.root.findByProps({ children: '1 failed' }).props.className).toContain(
-      'text-destructive',
+      'text-error',
     );
   });
 
@@ -301,13 +301,13 @@ describe('MessagePart', () => {
     const warning = renderer!.root.findAllByProps({ testID: 'unknown' }).at(-1);
     expect(warning?.props.accessibilityLabel).toBe('Unknown Part');
     expect(warning?.props.className).toBe(
-      'flex-row items-center gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3',
+      'flex-row items-center gap-2 rounded-lg border border-warning-border bg-warning-subtle p-3',
     );
     expect(renderer!.root.findByProps({ testID: 'unknown-warning-icon' }).props.className).toBe(
-      'size-4 shrink-0 text-warning',
+      'size-4 shrink-0 text-warning-subtle-foreground',
     );
     expect(renderer!.root.findByProps({ children: 'Unknown Part' }).props.className).toBe(
-      'text-base text-warning',
+      'text-base text-warning-subtle-foreground',
     );
   });
 
@@ -359,6 +359,17 @@ describe('MessagePart', () => {
       renderer = create(<MessagePart.Error message="Could not complete." title="Quota exceeded" />);
     });
     expect(renderer!.root.findAllByProps({ accessibilityRole: 'button' })).toHaveLength(0);
+    expect(
+      renderer!.root.findByProps({
+        className: 'gap-1.5 rounded-lg border border-error-border bg-error-subtle p-3',
+      }),
+    ).toBeDefined();
+    expect(renderer!.root.findByProps({ children: 'Quota exceeded' }).props.className).toContain(
+      'text-error-subtle-foreground',
+    );
+    expect(renderer!.root.findByProps({ children: 'Could not complete.' }).props.className).toBe(
+      'text-base text-error-subtle-foreground',
+    );
 
     const onPress = jest.fn();
     act(() => {

--- a/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-disclosure.tsx
@@ -33,7 +33,7 @@ const disclosureIconMotion = {
 } as const;
 
 const toneClassName = {
-  danger: 'text-destructive',
+  danger: 'text-error',
   default: 'text-foreground-tertiary',
   warning: 'text-warning',
 } as const satisfies Record<MessagePartTone, string>;

--- a/packages/ui/src/components/message-part/components/message-part-feedback.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-feedback.tsx
@@ -4,7 +4,7 @@ import { Pressable, Text, View } from 'react-native';
 
 import type { MessagePartErrorProps } from '../message-part.types';
 
-const errorClassName = 'gap-1.5 rounded-lg border border-destructive bg-danger-soft p-3';
+const errorClassName = 'gap-1.5 rounded-lg border border-error-border bg-error-subtle p-3';
 
 export function MessagePartError({
   accessibilityHint,
@@ -15,13 +15,15 @@ export function MessagePartError({
   const content = (
     <>
       <View className="flex-row items-center gap-2">
-        <TriangleAlertIcon className="text-destructive" size={15} />
-        <Text className="flex-1 font-semibold text-destructive text-base" selectable>
+        <TriangleAlertIcon className="text-error-subtle-foreground" size={15} />
+        <Text className="flex-1 font-semibold text-base text-error-subtle-foreground" selectable>
           {title}
         </Text>
-        {onPress ? <ChevronRightIcon className="size-4 shrink-0 text-destructive" /> : null}
+        {onPress ? (
+          <ChevronRightIcon className="size-4 shrink-0 text-error-subtle-foreground" />
+        ) : null}
       </View>
-      <Text className="text-destructive text-base" selectable>
+      <Text className="text-base text-error-subtle-foreground" selectable>
         {message}
       </Text>
     </>

--- a/packages/ui/src/components/message-part/components/message-part-sections.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-sections.tsx
@@ -50,10 +50,10 @@ export function MessagePartTextSection({
   const textClassName =
     variant === 'code'
       ? tone === 'danger'
-        ? 'font-mono text-destructive text-sm'
+        ? 'font-mono text-error text-sm'
         : 'font-mono text-foreground text-sm'
       : tone === 'danger'
-        ? 'text-base text-destructive'
+        ? 'text-base text-error'
         : 'text-base text-foreground';
 
   return (

--- a/packages/ui/src/components/message-part/components/message-part-unknown.tsx
+++ b/packages/ui/src/components/message-part/components/message-part-unknown.tsx
@@ -7,11 +7,11 @@ export function MessagePartUnknown({ label, testID }: MessagePartUnknownProps) {
   return (
     <View
       accessibilityLabel={label}
-      className="flex-row items-center gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3"
+      className="flex-row items-center gap-2 rounded-lg border border-warning-border bg-warning-subtle p-3"
       testID={testID}
     >
-      <TriangleAlertIcon className="size-4 shrink-0 text-warning" />
-      <Text className="text-base text-warning">{label}</Text>
+      <TriangleAlertIcon className="size-4 shrink-0 text-warning-subtle-foreground" />
+      <Text className="text-base text-warning-subtle-foreground">{label}</Text>
     </View>
   );
 }

--- a/src/frontend/components/ModelPicker/components/ModelPickerList.tsx
+++ b/src/frontend/components/ModelPicker/components/ModelPickerList.tsx
@@ -253,7 +253,7 @@ const ModelPickerRow = memo(function ModelPickerRow({
           {item.model.name}
         </Text>
       </View>
-      {isSelected ? <CheckIcon className="size-5 shrink-0 text-success" /> : null}
+      {isSelected ? <CheckIcon className="size-5 shrink-0 text-foreground" /> : null}
     </Pressable>
   );
 });

--- a/src/frontend/features/agents/edit/components/AgentCapabilitiesSection.tsx
+++ b/src/frontend/features/agents/edit/components/AgentCapabilitiesSection.tsx
@@ -163,9 +163,7 @@ function permissionCaption(
           openSettings(scopes);
         }}
       >
-        <Text className="text-destructive text-sm">
-          {t('agent.capabilities.permission.denied')}
-        </Text>
+        <Text className="text-error text-sm">{t('agent.capabilities.permission.denied')}</Text>
       </Pressable>
     );
   }

--- a/src/frontend/features/agents/edit/components/AgentToolsSection.tsx
+++ b/src/frontend/features/agents/edit/components/AgentToolsSection.tsx
@@ -228,7 +228,7 @@ function statusCaption(
     return undefined;
   }
   return (
-    <Text className="text-destructive text-sm" selectable>
+    <Text className="text-error text-sm" selectable>
       {t(`${translationPrefix}.${status}`)}
     </Text>
   );

--- a/src/frontend/features/chat/components/ChatWorkspace/components/AssistantMessageToolbar.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/AssistantMessageToolbar.tsx
@@ -42,7 +42,7 @@ export const AssistantMessageToolbar = memo(function AssistantMessageToolbar({
           accessibilityLabel={t(isCopied ? 'chat.messageActions.copied' : 'common.copy')}
           icon={
             isCopied ? (
-              <CheckIcon className="text-primary" size={15} />
+              <CheckIcon className="text-success" size={15} />
             ) : (
               <CopyIcon className="text-muted-foreground" size={15} />
             )

--- a/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/AssistantMessageToolbar.test.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/AssistantMessageToolbar.test.tsx
@@ -14,7 +14,12 @@ jest.mock('expo-clipboard', () => ({
   setStringAsync: (text: string) => mockSetStringAsync(text),
 }));
 
-jest.mock('@cherrystudio/app-icons/icons/check', () => () => null);
+jest.mock('@cherrystudio/app-icons/icons/check', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockCheckIcon(props: object) {
+    return <View {...props} testID="copy-success-icon" />;
+  };
+});
 jest.mock('@cherrystudio/app-icons/icons/copy', () => () => null);
 jest.mock('@cherrystudio/app-icons/icons/git-fork', () => () => null);
 
@@ -98,6 +103,9 @@ describe('AssistantMessageToolbar', () => {
     expect(
       renderer?.root.findByProps({ testID: 'assistant-message-copy' }).props.accessibilityLabel,
     ).toBe('chat.messageActions.copied');
+    expect(renderer?.root.findByProps({ testID: 'copy-success-icon' }).props.className).toBe(
+      'text-success',
+    );
   });
 
   test('keeps the direct branch action reachable on a message with nothing to copy', () => {

--- a/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/AssistantMessageToolbar.test.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/AssistantMessageToolbar.test.tsx
@@ -14,12 +14,7 @@ jest.mock('expo-clipboard', () => ({
   setStringAsync: (text: string) => mockSetStringAsync(text),
 }));
 
-jest.mock('@cherrystudio/app-icons/icons/check', () => {
-  const { View } = jest.requireActual('react-native');
-  return function MockCheckIcon(props: object) {
-    return <View {...props} testID="copy-success-icon" />;
-  };
-});
+jest.mock('@cherrystudio/app-icons/icons/check', () => () => null);
 jest.mock('@cherrystudio/app-icons/icons/copy', () => () => null);
 jest.mock('@cherrystudio/app-icons/icons/git-fork', () => () => null);
 
@@ -103,9 +98,9 @@ describe('AssistantMessageToolbar', () => {
     expect(
       renderer?.root.findByProps({ testID: 'assistant-message-copy' }).props.accessibilityLabel,
     ).toBe('chat.messageActions.copied');
-    expect(renderer?.root.findByProps({ testID: 'copy-success-icon' }).props.className).toBe(
-      'text-success',
-    );
+    expect(
+      renderer?.root.findByProps({ testID: 'assistant-message-copy' }).props.icon.props.className,
+    ).toBe('text-success');
   });
 
   test('keeps the direct branch action reachable on a message with nothing to copy', () => {

--- a/src/frontend/features/home/aiUsage/components/AiUsageSectionState.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageSectionState.tsx
@@ -29,7 +29,7 @@ export function AiUsageSectionStatus({
     <Button
       accessibilityLabel={t('aiUsage.retry')}
       hitSlop={6}
-      icon={<RefreshCwIcon className="text-destructive" />}
+      icon={<RefreshCwIcon className="text-error" />}
       onPress={onRetry}
       shape="pill"
       size="sm"

--- a/src/frontend/features/home/aiUsage/components/AiUsageWeeklyChart.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageWeeklyChart.tsx
@@ -56,12 +56,12 @@ export function AiUsageWeeklyChart({
 }: AiUsageWeeklyChartProps) {
   const { t } = useTranslation();
   const { onLayout, ref: containerRef, width: containerWidth } = useMeasuredWidth();
-  const [info, warning, muted, separator, success, foreground] = useThemeColor([
-    'info',
-    'warning',
+  const [chart1, chart2, chart3, muted, separator, foreground] = useThemeColor([
+    'chart-1',
+    'chart-2',
+    'chart-3',
     'muted-foreground',
     'border-strong',
-    'success',
     'foreground',
   ]);
   const formatTokens = useMemo(() => createAiUsageTokenFormatter(locale), [locale]);
@@ -121,14 +121,14 @@ export function AiUsageWeeklyChart({
     }
 
     return data.series.map((series, index) => ({
-      color: getSeriesColor(series.isOther, index, success, info, warning, muted),
+      color: getSeriesColor(series.isOther, index, chart1, chart2, chart3, muted),
       key: series.key,
       label: series.isOther
         ? t('aiUsage.other')
         : displayAiUsageModelId(series.modelId) || t('aiUsage.unknownModel'),
       yKey: seriesValueKey(index),
     }));
-  }, [data.series, info, muted, success, t, warning]);
+  }, [chart1, chart2, chart3, data.series, muted, t]);
   const chartTheme = useMemo<CartesianChartTheme>(
     () => ({
       axis: 'transparent',
@@ -136,10 +136,10 @@ export function AiUsageWeeklyChart({
       grid: 'transparent',
       mutedText: muted,
       plotBackground: 'transparent',
-      series: chartSeries.map((series) => series.color ?? success),
+      series: chartSeries.map((series) => series.color ?? chart1),
       text: foreground,
     }),
-    [chartSeries, foreground, muted, success],
+    [chart1, chartSeries, foreground, muted],
   );
   const renderBar = useCallback(
     ({ bar, fill, radius }: BarChartRenderBarProps<ChartDatum>) => {
@@ -270,7 +270,7 @@ export function AiUsageWeeklyChart({
                   ))}
                   {hasAverage ? (
                     <Line
-                      stroke={success}
+                      stroke={foreground}
                       strokeDasharray="5 5"
                       strokeWidth={1.5}
                       testID="ai-usage-average-line"
@@ -344,7 +344,7 @@ export function AiUsageWeeklyChart({
                 ))}
                 {hasAverage ? (
                   <Text
-                    className="absolute left-1 font-medium text-success text-xs"
+                    className="absolute left-1 font-medium text-foreground text-xs"
                     numberOfLines={1}
                     style={[styles.axisLabel, { top: getAxisLabelTop(averageY) }]}
                     testID="ai-usage-average-label"
@@ -437,15 +437,15 @@ function WeeklyChartSkeleton() {
 function getSeriesColor(
   isOther: boolean,
   index: number,
-  success: string,
-  info: string,
-  warning: string,
+  chart1: string,
+  chart2: string,
+  chart3: string,
   muted: string,
 ): string {
   if (isOther) return muted;
-  if (index === 0) return success;
-  if (index === 1) return info;
-  if (index === 2) return warning;
+  if (index === 0) return chart1;
+  if (index === 1) return chart2;
+  if (index === 2) return chart3;
   return muted;
 }
 

--- a/src/frontend/features/paintings/components/PaintingAssistantMessage.tsx
+++ b/src/frontend/features/paintings/components/PaintingAssistantMessage.tsx
@@ -101,7 +101,9 @@ export function PaintingAssistantMessage({
     return (
       <View className="w-full">
         <View className="flex-row items-start gap-2 rounded-md border border-border bg-card p-3">
-          <CircleAlertIcon className="mt-0.5 size-5 text-destructive" />
+          <CircleAlertIcon
+            className={didFail ? 'mt-0.5 size-5 text-error' : 'mt-0.5 size-5 text-warning'}
+          />
           <View className="min-w-0 flex-1 items-start gap-2">
             <Text accessibilityRole="alert" className="font-medium text-foreground text-sm">
               {t(didFail ? 'painting.status.failed' : 'painting.status.interrupted')}

--- a/src/frontend/features/paintings/components/__tests__/PaintingAssistantMessage.test.tsx
+++ b/src/frontend/features/paintings/components/__tests__/PaintingAssistantMessage.test.tsx
@@ -4,7 +4,12 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { PaintingAssistantMessage } from '../PaintingAssistantMessage';
 
-jest.mock('@cherrystudio/app-icons/icons/circle-alert', () => () => null);
+jest.mock('@cherrystudio/app-icons/icons/circle-alert', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockCircleAlertIcon(props: object) {
+    return <View {...props} testID="painting-status-icon" />;
+  };
+});
 
 jest.mock('@cherrystudio/ui/components', () => {
   const React = jest.requireActual('react');
@@ -91,10 +96,33 @@ describe('PaintingAssistantMessage', () => {
     expect(text).toContain('painting.status.failed');
     expect(text).toContain('painting.status.failedHint');
     expect(text).not.toContain('Invalid JSON response from provider');
+    expect(
+      renderer?.root.findByProps({ testID: 'painting-status-icon' }).props.className,
+    ).toContain('text-error');
 
     const retry = renderer?.root.findByProps({ accessibilityLabel: 'painting.status.retry' });
     act(() => retry?.props.onPress());
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses warning feedback for an interrupted generation', () => {
+    act(() => {
+      renderer = create(
+        <PaintingAssistantMessage
+          aspectRatio={1}
+          error={null}
+          interruption={{ reason: 'interrupted' }}
+          outputs={[]}
+          prompt="Draw a cherry"
+          resolution="Auto"
+          status="idle"
+        />,
+      );
+    });
+
+    expect(
+      renderer?.root.findByProps({ testID: 'painting-status-icon' }).props.className,
+    ).toContain('text-warning');
   });
 
   it('distinguishes multiple generated outputs for assistive technology', () => {

--- a/src/frontend/features/settings/components/SettingsServiceRow/SettingsServiceRow.tsx
+++ b/src/frontend/features/settings/components/SettingsServiceRow/SettingsServiceRow.tsx
@@ -107,7 +107,7 @@ export const SettingsServiceRow = memo(function SettingsServiceRow({
               <Text
                 className={cn(
                   'shrink-0 text-xs',
-                  statusTone === 'danger' ? 'text-destructive' : 'text-foreground',
+                  statusTone === 'danger' ? 'text-error' : 'text-foreground',
                 )}
                 numberOfLines={1}
               >

--- a/src/frontend/features/settings/provider/components/ProviderForm/components/ProviderFormEndpoints.tsx
+++ b/src/frontend/features/settings/provider/components/ProviderForm/components/ProviderFormEndpoints.tsx
@@ -113,7 +113,7 @@ export function ProviderFormTextEndpoints() {
         </Text>
       ) : null}
       {meta.hasEditedEndpointUrls && !hasConfiguredEndpoint ? (
-        <Text className="text-destructive text-xs">
+        <Text className="text-error text-xs">
           {t('settings.provider.apiService.textEndpointRequired')}
         </Text>
       ) : null}

--- a/src/frontend/features/settings/provider/detail/modelAdd/ProviderModelAddScreen.tsx
+++ b/src/frontend/features/settings/provider/detail/modelAdd/ProviderModelAddScreen.tsx
@@ -476,7 +476,7 @@ function ProviderModelAddForm({
                   ))}
                 </View>
                 {endpointTypeError ? (
-                  <Text className="text-destructive text-xs">{endpointTypeError}</Text>
+                  <Text className="text-error text-xs">{endpointTypeError}</Text>
                 ) : null}
               </ProviderModelAddSection>
             ) : null}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -134,8 +134,8 @@
       --field-border: var(--input);
       --segment: var(--card);
       --segment-foreground: var(--card-foreground);
-      --danger: var(--destructive);
-      --danger-foreground: var(--destructive-foreground);
+      --danger: var(--error);
+      --danger-foreground: var(--constant-white);
       /* 黑色：success/warning 的实色底在两个主题里都够亮，压黑字。 */
       --success-foreground: oklch(0 0 0);
       --warning-foreground: oklch(0 0 0);
@@ -161,8 +161,8 @@
       --field-border: var(--input);
       --segment: var(--secondary);
       --segment-foreground: var(--secondary-foreground);
-      --danger: var(--destructive);
-      --danger-foreground: var(--destructive-foreground);
+      --danger: var(--error);
+      --danger-foreground: var(--constant-white);
       /* 黑色：success/warning 的实色底在两个主题里都够亮，压黑字。 */
       --success-foreground: oklch(0 0 0);
       --warning-foreground: oklch(0 0 0);


### PR DESCRIPTION
## Summary

- replace misused destructive, success, and primary colors with semantic error, warning, link, success, and neutral selection tokens
- use paired subtle feedback surface tokens and align the HeroUI danger bridge with the error role
- move AI usage category series to chart tokens and add regression assertions for the corrected states

## Validation

- pnpm format:check
- targeted oxlint on changed TypeScript files
- targeted Expo lint on changed TypeScript files
- pnpm lint (blocked by seven existing unresolved @cherrystudio/ai-core imports in unchanged backend files)

Tests, typecheck, builds, and device verification were not run because they require explicit authorization in this workspace.