### PR TITLE
feat(database-schema): align compatible fields with desktop

### DIFF
--- a/migrations/sqlite-drizzle/0017_desktop-compatible-fields.sql
+++ b/migrations/sqlite-drizzle/0017_desktop-compatible-fields.sql
@@ -1,0 +1,165 @@
+ALTER TABLE `agent_session` RENAME COLUMN "title" TO "name";--> statement-breakpoint
+ALTER TABLE `agent_session` RENAME COLUMN "title_is_manual" TO "is_name_manually_edited";--> statement-breakpoint
+ALTER TABLE `mcp_server` RENAME COLUMN "endpoint_url" TO "base_url";--> statement-breakpoint
+ALTER TABLE `mcp_server` RENAME COLUMN "is_enabled" TO "is_active";--> statement-breakpoint
+ALTER TABLE `agent` RENAME COLUMN "model_id" TO "model";--> statement-breakpoint
+DROP INDEX `mcp_server_is_enabled_idx`;--> statement-breakpoint
+CREATE INDEX `mcp_server_is_active_idx` ON `mcp_server` (`is_active`);--> statement-breakpoint
+CREATE TABLE `__new_ai_usage_record` (
+	`id` text PRIMARY KEY NOT NULL,
+	`request_id` text NOT NULL,
+	`record_kind` text NOT NULL,
+	`request_count` integer NOT NULL,
+	`message_kind` text,
+	`message_id` text,
+	`provider_id` text,
+	`provider_name` text,
+	`model_id` text,
+	`model_name` text,
+	`source_type` text,
+	`source_id` text,
+	`source_name` text,
+	`source_icon` text,
+	`modality` text NOT NULL,
+	`api_key_id` text,
+	`api_key_label` text,
+	`api_key_masked` text,
+	`api_key_attribution` text NOT NULL,
+	`auth_method` text,
+	`input_tokens` integer,
+	`output_tokens` integer,
+	`total_tokens` integer,
+	`reasoning_tokens` integer,
+	`no_cache_tokens` integer,
+	`cache_read_tokens` integer,
+	`cache_write_tokens` integer,
+	`image_count` integer,
+	`cost` real,
+	`cost_currency` text,
+	`cost_source` text,
+	`cost_breakdown` text,
+	`pricing_snapshot` text,
+	`time_first_token_ms` integer,
+	`time_completion_ms` integer,
+	`time_thinking_ms` integer,
+	`created_at` integer NOT NULL,
+	CONSTRAINT "ai_usage_record_record_kind_check" CHECK("__new_ai_usage_record"."record_kind" IN ('invocation', 'legacy-aggregate')),
+	CONSTRAINT "ai_usage_record_message_kind_check" CHECK("__new_ai_usage_record"."message_kind" IN ('chat', 'agent-session')),
+	CONSTRAINT "ai_usage_record_source_type_check" CHECK("__new_ai_usage_record"."source_type" IN ('assistant', 'agent', 'mini-app')),
+	CONSTRAINT "ai_usage_record_modality_check" CHECK("__new_ai_usage_record"."modality" IN ('language', 'embedding', 'image', 'rerank')),
+	CONSTRAINT "ai_usage_record_attribution_check" CHECK("__new_ai_usage_record"."api_key_attribution" IN ('explicit', 'matched', 'auth', 'unknown')),
+	CONSTRAINT "ai_usage_record_auth_method_check" CHECK("__new_ai_usage_record"."auth_method" IN ('oauth', 'external-cli', 'iam-aws', 'api-key-aws', 'iam-gcp', 'iam-azure')),
+	CONSTRAINT "ai_usage_record_cost_source_check" CHECK("__new_ai_usage_record"."cost_source" IN ('provider', 'computed')),
+	CONSTRAINT "ai_usage_record_cost_currency_check" CHECK("__new_ai_usage_record"."cost_currency" IN ('USD', 'CNY')),
+	CONSTRAINT "ai_usage_record_kind_identity_check" CHECK((
+        "__new_ai_usage_record"."record_kind" = 'invocation'
+        AND "__new_ai_usage_record"."request_count" = 1
+        AND "__new_ai_usage_record"."provider_id" IS NOT NULL
+        AND "__new_ai_usage_record"."model_id" IS NOT NULL
+      ) OR (
+        "__new_ai_usage_record"."record_kind" = 'legacy-aggregate'
+        AND "__new_ai_usage_record"."request_count" >= 1
+        AND "__new_ai_usage_record"."message_kind" IS NOT NULL
+        AND "__new_ai_usage_record"."message_id" IS NOT NULL
+      )),
+	CONSTRAINT "ai_usage_record_message_identity_check" CHECK(("__new_ai_usage_record"."message_kind" IS NULL AND "__new_ai_usage_record"."message_id" IS NULL)
+        OR ("__new_ai_usage_record"."message_kind" IS NOT NULL AND "__new_ai_usage_record"."message_id" IS NOT NULL)),
+	CONSTRAINT "ai_usage_record_source_identity_check" CHECK((
+        "__new_ai_usage_record"."source_type" IS NULL
+        AND "__new_ai_usage_record"."source_id" IS NULL
+        AND "__new_ai_usage_record"."source_name" IS NULL
+        AND "__new_ai_usage_record"."source_icon" IS NULL
+      ) OR (
+        "__new_ai_usage_record"."source_type" IS NOT NULL
+        AND "__new_ai_usage_record"."source_id" IS NOT NULL
+      )),
+	CONSTRAINT "ai_usage_record_api_key_identity_check" CHECK((
+        "__new_ai_usage_record"."api_key_attribution" IN ('explicit', 'matched')
+        AND "__new_ai_usage_record"."api_key_id" IS NOT NULL
+        AND "__new_ai_usage_record"."auth_method" IS NULL
+      ) OR (
+        "__new_ai_usage_record"."api_key_attribution" = 'auth'
+        AND "__new_ai_usage_record"."api_key_id" IS NULL
+        AND "__new_ai_usage_record"."api_key_label" IS NULL
+        AND "__new_ai_usage_record"."api_key_masked" IS NULL
+        AND "__new_ai_usage_record"."auth_method" IS NOT NULL
+      ) OR (
+        "__new_ai_usage_record"."api_key_attribution" = 'unknown'
+        AND "__new_ai_usage_record"."api_key_id" IS NULL
+        AND "__new_ai_usage_record"."api_key_label" IS NULL
+        AND "__new_ai_usage_record"."api_key_masked" IS NULL
+        AND "__new_ai_usage_record"."auth_method" IS NULL
+      )),
+	CONSTRAINT "ai_usage_record_cost_tuple_check" CHECK((
+        "__new_ai_usage_record"."cost" IS NULL
+        AND "__new_ai_usage_record"."cost_currency" IS NULL
+        AND "__new_ai_usage_record"."cost_source" IS NULL
+        AND "__new_ai_usage_record"."cost_breakdown" IS NULL
+      ) OR (
+        "__new_ai_usage_record"."cost" IS NOT NULL
+        AND "__new_ai_usage_record"."cost_currency" IS NOT NULL
+        AND "__new_ai_usage_record"."cost_source" IS NOT NULL
+      )),
+	CONSTRAINT "ai_usage_record_image_count_check" CHECK((
+        "__new_ai_usage_record"."modality" = 'image'
+        AND "__new_ai_usage_record"."image_count" IS NOT NULL
+        AND "__new_ai_usage_record"."image_count" >= 0
+      ) OR (
+        "__new_ai_usage_record"."modality" <> 'image'
+        AND "__new_ai_usage_record"."image_count" IS NULL
+      )),
+	CONSTRAINT "ai_usage_record_nonnegative_check" CHECK(
+        ("__new_ai_usage_record"."input_tokens" IS NULL OR "__new_ai_usage_record"."input_tokens" >= 0)
+        AND ("__new_ai_usage_record"."output_tokens" IS NULL OR "__new_ai_usage_record"."output_tokens" >= 0)
+        AND ("__new_ai_usage_record"."total_tokens" IS NULL OR "__new_ai_usage_record"."total_tokens" >= 0)
+        AND ("__new_ai_usage_record"."reasoning_tokens" IS NULL OR "__new_ai_usage_record"."reasoning_tokens" >= 0)
+        AND ("__new_ai_usage_record"."no_cache_tokens" IS NULL OR "__new_ai_usage_record"."no_cache_tokens" >= 0)
+        AND ("__new_ai_usage_record"."cache_read_tokens" IS NULL OR "__new_ai_usage_record"."cache_read_tokens" >= 0)
+        AND ("__new_ai_usage_record"."cache_write_tokens" IS NULL OR "__new_ai_usage_record"."cache_write_tokens" >= 0)
+        AND ("__new_ai_usage_record"."cost" IS NULL OR "__new_ai_usage_record"."cost" >= 0)
+        AND ("__new_ai_usage_record"."time_first_token_ms" IS NULL OR "__new_ai_usage_record"."time_first_token_ms" >= 0)
+        AND ("__new_ai_usage_record"."time_completion_ms" IS NULL OR "__new_ai_usage_record"."time_completion_ms" >= 0)
+        AND ("__new_ai_usage_record"."time_thinking_ms" IS NULL OR "__new_ai_usage_record"."time_thinking_ms" >= 0)
+      ),
+	CONSTRAINT "ai_usage_record_integer_check" CHECK(
+        typeof("__new_ai_usage_record"."request_count") = 'integer'
+        AND ("__new_ai_usage_record"."input_tokens" IS NULL OR typeof("__new_ai_usage_record"."input_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."output_tokens" IS NULL OR typeof("__new_ai_usage_record"."output_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."total_tokens" IS NULL OR typeof("__new_ai_usage_record"."total_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."reasoning_tokens" IS NULL OR typeof("__new_ai_usage_record"."reasoning_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."no_cache_tokens" IS NULL OR typeof("__new_ai_usage_record"."no_cache_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."cache_read_tokens" IS NULL OR typeof("__new_ai_usage_record"."cache_read_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."cache_write_tokens" IS NULL OR typeof("__new_ai_usage_record"."cache_write_tokens") = 'integer')
+        AND ("__new_ai_usage_record"."image_count" IS NULL OR typeof("__new_ai_usage_record"."image_count") = 'integer')
+        AND ("__new_ai_usage_record"."time_first_token_ms" IS NULL OR typeof("__new_ai_usage_record"."time_first_token_ms") = 'integer')
+        AND ("__new_ai_usage_record"."time_completion_ms" IS NULL OR typeof("__new_ai_usage_record"."time_completion_ms") = 'integer')
+        AND ("__new_ai_usage_record"."time_thinking_ms" IS NULL OR typeof("__new_ai_usage_record"."time_thinking_ms") = 'integer')
+        AND typeof("__new_ai_usage_record"."created_at") = 'integer'
+      ),
+	CONSTRAINT "ai_usage_record_finite_cost_check" CHECK("__new_ai_usage_record"."cost" IS NULL OR "__new_ai_usage_record"."cost" <= 1.7976931348623157e308)
+);
+--> statement-breakpoint
+INSERT INTO `__new_ai_usage_record`("id", "request_id", "record_kind", "request_count", "message_kind", "message_id", "provider_id", "provider_name", "model_id", "model_name", "source_type", "source_id", "source_name", "source_icon", "modality", "api_key_id", "api_key_label", "api_key_masked", "api_key_attribution", "auth_method", "input_tokens", "output_tokens", "total_tokens", "reasoning_tokens", "no_cache_tokens", "cache_read_tokens", "cache_write_tokens", "image_count", "cost", "cost_currency", "cost_source", "cost_breakdown", "pricing_snapshot", "time_first_token_ms", "time_completion_ms", "time_thinking_ms", "created_at") SELECT "id", "request_id", "record_kind", "request_count", "message_kind", "message_id", "provider_id", "provider_name", "model_id", "model_name", "source_type", "source_id", "source_name", "source_icon", "modality", "api_key_id", "api_key_label", "api_key_masked", "api_key_attribution", "auth_method", "input_tokens", "output_tokens", "total_tokens", "reasoning_tokens", "no_cache_tokens", "cache_read_tokens", "cache_write_tokens", "image_count", "cost", "cost_currency", "cost_source", "cost_breakdown", "pricing_snapshot", "time_first_token_ms", "time_completion_ms", "time_thinking_ms", "created_at" FROM `ai_usage_record`;--> statement-breakpoint
+DROP TABLE `ai_usage_record`;--> statement-breakpoint
+ALTER TABLE `__new_ai_usage_record` RENAME TO `ai_usage_record`;--> statement-breakpoint
+CREATE UNIQUE INDEX `ai_usage_record_request_id_idx` ON `ai_usage_record` (`request_id`);--> statement-breakpoint
+CREATE INDEX `ai_usage_record_created_at_idx` ON `ai_usage_record` (`created_at`);--> statement-breakpoint
+CREATE INDEX `ai_usage_record_message_created_idx` ON `ai_usage_record` (`message_kind`,`message_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `ai_usage_record_provider_created_idx` ON `ai_usage_record` (`provider_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `ai_usage_record_model_created_idx` ON `ai_usage_record` (`model_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `ai_usage_record_api_key_created_idx` ON `ai_usage_record` (`api_key_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `ai_usage_record_source_created_idx` ON `ai_usage_record` (`source_type`,`source_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `__new_preference` (
+	`scope` text DEFAULT 'default' NOT NULL,
+	`key` text NOT NULL,
+	`value` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope`, `key`)
+);
+--> statement-breakpoint
+INSERT INTO `__new_preference`("scope", "key", "value", "created_at", "updated_at") SELECT 'default', "key", "value", "created_at", "updated_at" FROM `preference`;--> statement-breakpoint
+DROP TABLE `preference`;--> statement-breakpoint
+ALTER TABLE `__new_preference` RENAME TO `preference`;--> statement-breakpoint
+ALTER TABLE `job` ADD `cancel_requested_at` integer;--> statement-breakpoint
+ALTER TABLE `user_model` ADD `input_modalities_explicit` integer DEFAULT false NOT NULL;

--- a/migrations/sqlite-drizzle/meta/0017_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1810 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "57aa5d2a-ecdd-41ef-b07d-a49a7e4e25fe",
+  "prevId": "55e10680-041a-4c67-9fb1-26fc7c54c2e6",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        }
+      },
+      "indexes": {
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_approval_mode": {
+          "name": "tool_approval_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "disabled_capabilities": {
+          "name": "disabled_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_created_at_idx": {
+          "name": "agent_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "agent_order_key_idx": {
+          "name": "agent_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_model_user_model_id_fk": {
+          "name": "agent_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_tool_binding": {
+      "name": "agent_tool_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_tool_name": {
+          "name": "raw_tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "approval": {
+          "name": "approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "display_name_snapshot": {
+          "name": "display_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_tool_binding_agent_id_idx": {
+          "name": "agent_tool_binding_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_tool_binding_mcp_server_id_idx": {
+          "name": "agent_tool_binding_mcp_server_id_idx",
+          "columns": ["mcp_server_id"],
+          "isUnique": false
+        },
+        "agent_tool_binding_builtin_uniq": {
+          "name": "agent_tool_binding_builtin_uniq",
+          "columns": ["agent_id", "capability_id"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'builtin'"
+        },
+        "agent_tool_binding_mcp_server_default_uniq": {
+          "name": "agent_tool_binding_mcp_server_default_uniq",
+          "columns": ["agent_id", "mcp_server_id"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"raw_tool_name\" IS NULL"
+        },
+        "agent_tool_binding_mcp_tool_uniq": {
+          "name": "agent_tool_binding_mcp_tool_uniq",
+          "columns": ["agent_id", "mcp_server_id", "raw_tool_name"],
+          "isUnique": true,
+          "where": "\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"raw_tool_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "agent_tool_binding_agent_id_agent_id_fk": {
+          "name": "agent_tool_binding_agent_id_agent_id_fk",
+          "tableFrom": "agent_tool_binding",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_tool_binding_identity_check": {
+          "name": "agent_tool_binding_identity_check",
+          "value": "(\n        (\"agent_tool_binding\".\"source\" = 'builtin' AND \"agent_tool_binding\".\"capability_id\" IS NOT NULL AND length(\"agent_tool_binding\".\"capability_id\") > 0 AND \"agent_tool_binding\".\"mcp_server_id\" IS NULL AND \"agent_tool_binding\".\"raw_tool_name\" IS NULL)\n        OR\n        (\"agent_tool_binding\".\"source\" = 'mcp' AND \"agent_tool_binding\".\"capability_id\" IS NULL AND \"agent_tool_binding\".\"mcp_server_id\" IS NOT NULL AND length(\"agent_tool_binding\".\"mcp_server_id\") > 0 AND (\"agent_tool_binding\".\"raw_tool_name\" IS NULL OR length(\"agent_tool_binding\".\"raw_tool_name\") > 0))\n      )"
+        },
+        "agent_tool_binding_approval_check": {
+          "name": "agent_tool_binding_approval_check",
+          "value": "\"agent_tool_binding\".\"approval\" IN ('auto', 'ask', 'deny')"
+        }
+      }
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"kind\":\"local\"}'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "forked_from_session_id": {
+          "name": "forked_from_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fork_boundary_message_id": {
+          "name": "fork_boundary_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_agent_id_idx": {
+          "name": "agent_session_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_session_last_activity_at_idx": {
+          "name": "agent_session_last_activity_at_idx",
+          "columns": ["last_activity_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_forked_from_session_id_agent_session_id_fk": {
+          "name": "agent_session_forked_from_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent_session",
+          "columnsFrom": ["forked_from_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_checkpoint": {
+          "name": "context_checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_snapshot": {
+          "name": "message_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_created_idx": {
+          "name": "agent_session_message_session_created_idx",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        },
+        "agent_session_message_turn_id_idx": {
+          "name": "agent_session_message_turn_id_idx",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "agent_session_message_status_idx": {
+          "name": "agent_session_message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agent_session_message_active_turn_uniq": {
+          "name": "agent_session_message_active_turn_uniq",
+          "columns": ["session_id"],
+          "isUnique": true,
+          "where": "\"agent_session_message\".\"role\" = 'assistant' and \"agent_session_message\".\"status\" in ('pending', 'streaming')"
+        },
+        "agent_session_message_fts_rowid_uniq": {
+          "name": "agent_session_message_fts_rowid_uniq",
+          "columns": ["fts_rowid"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_message_model_id_user_model_id_fk": {
+          "name": "agent_session_message_model_id_user_model_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_session_message_role_check": {
+          "name": "agent_session_message_role_check",
+          "value": "\"agent_session_message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "agent_session_message_status_check": {
+          "name": "agent_session_message_status_check",
+          "value": "\"agent_session_message\".\"status\" IN ('pending', 'streaming', 'success', 'error', 'cancelled', 'interrupted')"
+        }
+      }
+    },
+    "ai_usage_record": {
+      "name": "ai_usage_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_kind": {
+          "name": "record_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_icon": {
+          "name": "source_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_label": {
+          "name": "api_key_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_masked": {
+          "name": "api_key_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_attribution": {
+          "name": "api_key_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_cache_tokens": {
+          "name": "no_cache_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_snapshot": {
+          "name": "pricing_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_first_token_ms": {
+          "name": "time_first_token_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_completion_ms": {
+          "name": "time_completion_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_thinking_ms": {
+          "name": "time_thinking_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usage_record_request_id_idx": {
+          "name": "ai_usage_record_request_id_idx",
+          "columns": ["request_id"],
+          "isUnique": true
+        },
+        "ai_usage_record_created_at_idx": {
+          "name": "ai_usage_record_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_message_created_idx": {
+          "name": "ai_usage_record_message_created_idx",
+          "columns": ["message_kind", "message_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_provider_created_idx": {
+          "name": "ai_usage_record_provider_created_idx",
+          "columns": ["provider_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_model_created_idx": {
+          "name": "ai_usage_record_model_created_idx",
+          "columns": ["model_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_api_key_created_idx": {
+          "name": "ai_usage_record_api_key_created_idx",
+          "columns": ["api_key_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_source_created_idx": {
+          "name": "ai_usage_record_source_created_idx",
+          "columns": ["source_type", "source_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_usage_record_record_kind_check": {
+          "name": "ai_usage_record_record_kind_check",
+          "value": "\"ai_usage_record\".\"record_kind\" IN ('invocation', 'legacy-aggregate')"
+        },
+        "ai_usage_record_message_kind_check": {
+          "name": "ai_usage_record_message_kind_check",
+          "value": "\"ai_usage_record\".\"message_kind\" IN ('chat', 'agent-session')"
+        },
+        "ai_usage_record_source_type_check": {
+          "name": "ai_usage_record_source_type_check",
+          "value": "\"ai_usage_record\".\"source_type\" IN ('assistant', 'agent', 'mini-app')"
+        },
+        "ai_usage_record_modality_check": {
+          "name": "ai_usage_record_modality_check",
+          "value": "\"ai_usage_record\".\"modality\" IN ('language', 'embedding', 'image', 'rerank')"
+        },
+        "ai_usage_record_attribution_check": {
+          "name": "ai_usage_record_attribution_check",
+          "value": "\"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched', 'auth', 'unknown')"
+        },
+        "ai_usage_record_auth_method_check": {
+          "name": "ai_usage_record_auth_method_check",
+          "value": "\"ai_usage_record\".\"auth_method\" IN ('oauth', 'external-cli', 'iam-aws', 'api-key-aws', 'iam-gcp', 'iam-azure')"
+        },
+        "ai_usage_record_cost_source_check": {
+          "name": "ai_usage_record_cost_source_check",
+          "value": "\"ai_usage_record\".\"cost_source\" IN ('provider', 'computed')"
+        },
+        "ai_usage_record_cost_currency_check": {
+          "name": "ai_usage_record_cost_currency_check",
+          "value": "\"ai_usage_record\".\"cost_currency\" IN ('USD', 'CNY')"
+        },
+        "ai_usage_record_kind_identity_check": {
+          "name": "ai_usage_record_kind_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"record_kind\" = 'invocation'\n        AND \"ai_usage_record\".\"request_count\" = 1\n        AND \"ai_usage_record\".\"provider_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"model_id\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"record_kind\" = 'legacy-aggregate'\n        AND \"ai_usage_record\".\"request_count\" >= 1\n        AND \"ai_usage_record\".\"message_kind\" IS NOT NULL\n        AND \"ai_usage_record\".\"message_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_message_identity_check": {
+          "name": "ai_usage_record_message_identity_check",
+          "value": "(\"ai_usage_record\".\"message_kind\" IS NULL AND \"ai_usage_record\".\"message_id\" IS NULL)\n        OR (\"ai_usage_record\".\"message_kind\" IS NOT NULL AND \"ai_usage_record\".\"message_id\" IS NOT NULL)"
+        },
+        "ai_usage_record_source_identity_check": {
+          "name": "ai_usage_record_source_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"source_type\" IS NULL\n        AND \"ai_usage_record\".\"source_id\" IS NULL\n        AND \"ai_usage_record\".\"source_name\" IS NULL\n        AND \"ai_usage_record\".\"source_icon\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"source_type\" IS NOT NULL\n        AND \"ai_usage_record\".\"source_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_api_key_identity_check": {
+          "name": "ai_usage_record_api_key_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched')\n        AND \"ai_usage_record\".\"api_key_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'auth'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'unknown'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      )"
+        },
+        "ai_usage_record_cost_tuple_check": {
+          "name": "ai_usage_record_cost_tuple_check",
+          "value": "(\n        \"ai_usage_record\".\"cost\" IS NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NULL\n        AND \"ai_usage_record\".\"cost_breakdown\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"cost\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_image_count_check": {
+          "name": "ai_usage_record_image_count_check",
+          "value": "(\n        \"ai_usage_record\".\"modality\" = 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NOT NULL\n        AND \"ai_usage_record\".\"image_count\" >= 0\n      ) OR (\n        \"ai_usage_record\".\"modality\" <> 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NULL\n      )"
+        },
+        "ai_usage_record_nonnegative_check": {
+          "name": "ai_usage_record_nonnegative_check",
+          "value": "\n        (\"ai_usage_record\".\"input_tokens\" IS NULL OR \"ai_usage_record\".\"input_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR \"ai_usage_record\".\"output_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR \"ai_usage_record\".\"total_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR \"ai_usage_record\".\"reasoning_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR \"ai_usage_record\".\"no_cache_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR \"ai_usage_record\".\"cache_read_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR \"ai_usage_record\".\"cache_write_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" >= 0)\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR \"ai_usage_record\".\"time_first_token_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR \"ai_usage_record\".\"time_completion_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR \"ai_usage_record\".\"time_thinking_ms\" >= 0)\n      "
+        },
+        "ai_usage_record_integer_check": {
+          "name": "ai_usage_record_integer_check",
+          "value": "\n        typeof(\"ai_usage_record\".\"request_count\") = 'integer'\n        AND (\"ai_usage_record\".\"input_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"input_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"output_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"total_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"reasoning_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"no_cache_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_read_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_write_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"image_count\" IS NULL OR typeof(\"ai_usage_record\".\"image_count\") = 'integer')\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_first_token_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_completion_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_thinking_ms\") = 'integer')\n        AND typeof(\"ai_usage_record\".\"created_at\") = 'integer'\n      "
+        },
+        "ai_usage_record_finite_cost_check": {
+          "name": "ai_usage_record_finite_cost_check",
+          "value": "\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" <= 1.7976931348623157e308"
+        }
+      }
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "painting": {
+      "name": "painting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"input\":[],\"output\":[]}'"
+        }
+      },
+      "indexes": {
+        "painting_order_key_idx": {
+          "name": "painting_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_modalities_explicit": {
+          "name": "input_modalities_explicit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "user_model_custom_config_check": {
+          "name": "user_model_custom_config_check",
+          "value": "\"user_model\".\"preset_model_id\" IS NOT NULL OR (\"user_model\".\"name\" IS NOT NULL AND \"user_model\".\"capabilities\" IS NOT NULL AND \"user_model\".\"supports_streaming\" IS NOT NULL)"
+        }
+      }
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {
+      "\"agent\".\"model_id\"": "\"agent\".\"model\"",
+      "\"agent_session\".\"title\"": "\"agent_session\".\"name\"",
+      "\"agent_session\".\"title_is_manual\"": "\"agent_session\".\"is_name_manually_edited\"",
+      "\"mcp_server\".\"endpoint_url\"": "\"mcp_server\".\"base_url\"",
+      "\"mcp_server\".\"is_enabled\"": "\"mcp_server\".\"is_active\""
+    }
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1788503757336,
       "tag": "0016_agent-message-stats",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1788511869009,
+      "tag": "0017_desktop-compatible-fields",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/universal/src/data/types/aiUsageRecord.ts
+++ b/packages/universal/src/data/types/aiUsageRecord.ts
@@ -72,7 +72,7 @@ export type ServingCredentialReceipt =
 export const AiUsageRecordModalitySchema = z.enum(['language', 'embedding', 'image', 'rerank']);
 export type AiUsageRecordModality = z.infer<typeof AiUsageRecordModalitySchema>;
 
-export const AiUsageRecordSourceTypeSchema = z.enum(['assistant', 'agent']);
+export const AiUsageRecordSourceTypeSchema = z.enum(['assistant', 'agent', 'mini-app']);
 export type AiUsageRecordSourceType = z.infer<typeof AiUsageRecordSourceTypeSchema>;
 
 export const AiUsageRecordEntrySchema = z.strictObject({

--- a/src/backend/data/PreferenceService.ts
+++ b/src/backend/data/PreferenceService.ts
@@ -1,6 +1,8 @@
+import { eq } from 'drizzle-orm';
+
 import { BaseService, DependsOn, Injectable } from '@/backend/core/lifecycle';
 import type { DbService } from '@/backend/data/db/DbService';
-import { preferenceTable } from '@/backend/data/db/schemas';
+import { DEFAULT_PREFERENCE_SCOPE, preferenceTable } from '@/backend/data/db/schemas';
 import {
   getDefaultValue,
   getPreferenceKeys,
@@ -67,7 +69,8 @@ export class PreferenceService extends BaseService implements PreferenceClient {
         key: preferenceTable.key,
         value: preferenceTable.value,
       })
-      .from(preferenceTable);
+      .from(preferenceTable)
+      .where(eq(preferenceTable.scope, DEFAULT_PREFERENCE_SCOPE));
 
     for (const row of rows) {
       if (isPreferenceKey(row.key)) {
@@ -239,8 +242,11 @@ export class PreferenceService extends BaseService implements PreferenceClient {
         // react-doctor-disable-next-line async-await-in-loop -- expo-sqlite 写事务内本质串行，并行化无收益
         await tx
           .insert(preferenceTable)
-          .values({ key, value })
-          .onConflictDoUpdate({ target: preferenceTable.key, set: { value } });
+          .values({ key, scope: DEFAULT_PREFERENCE_SCOPE, value })
+          .onConflictDoUpdate({
+            target: [preferenceTable.scope, preferenceTable.key],
+            set: { value },
+          });
       }
     });
   }

--- a/src/backend/data/__tests__/PreferenceService.test.ts
+++ b/src/backend/data/__tests__/PreferenceService.test.ts
@@ -3,16 +3,21 @@ import { PreferenceService } from '@/backend/data/PreferenceService';
 import { PreferenceDefaults } from '@/shared/data/preference';
 
 jest.mock('@/backend/data/db/schemas', () => ({
+  DEFAULT_PREFERENCE_SCOPE: 'default',
   preferenceTable: {
     key: 'key',
+    scope: 'scope',
     value: 'value',
   },
 }));
 
 type PreferenceRow = {
   key: string;
+  scope: string;
   value: unknown;
 };
+
+type PreferenceInputRow = Omit<PreferenceRow, 'scope'> & Partial<Pick<PreferenceRow, 'scope'>>;
 
 type FakeDbService = DbService & {
   failNextWrite: boolean;
@@ -76,6 +81,7 @@ describe('PreferenceService', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(dbService.rows.get('ui.font_size_step')).toMatchObject({
       key: 'ui.font_size_step',
+      scope: 'default',
       value: 1,
     });
   });
@@ -122,6 +128,7 @@ describe('PreferenceService', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(dbService.rows.get('agent.default_model_id')).toMatchObject({
       key: 'agent.default_model_id',
+      scope: 'default',
       value: 'provider:model',
     });
   });
@@ -206,8 +213,10 @@ describe('PreferenceService', () => {
   });
 });
 
-function createFakeDbService(rows: PreferenceRow[] = []) {
-  const rowMap = new Map(rows.map((row) => [row.key, row]));
+function createFakeDbService(rows: PreferenceInputRow[] = []) {
+  const rowMap = new Map(
+    rows.map((row) => [row.key, { ...row, scope: row.scope ?? 'default' } as PreferenceRow]),
+  );
   const writeWaiters: (() => void)[] = [];
 
   const db = {
@@ -224,7 +233,9 @@ function createFakeDbService(rows: PreferenceRow[] = []) {
       }),
     }),
     select: () => ({
-      from: () => Promise.resolve(Array.from(rowMap.values())),
+      from: () => ({
+        where: () => Promise.resolve(Array.from(rowMap.values())),
+      }),
     }),
   };
 

--- a/src/backend/data/db/__tests__/migrations.test.ts
+++ b/src/backend/data/db/__tests__/migrations.test.ts
@@ -63,14 +63,15 @@ describe('bundled SQLite migrations', () => {
       expect(columnNames(database, 'mcp_server')).toEqual([
         'id',
         'name',
-        'endpoint_url',
-        'is_enabled',
+        'base_url',
+        'is_active',
         'created_at',
         'updated_at',
         'disabled_tools',
         'headers',
       ]);
       expect(columnNames(database, 'preference')).toEqual([
+        'scope',
         'key',
         'value',
         'created_at',
@@ -105,7 +106,7 @@ describe('bundled SQLite migrations', () => {
         'name',
         'instructions',
         'avatar',
-        'model_id',
+        'model',
         'order_key',
         'created_at',
         'updated_at',
@@ -116,8 +117,8 @@ describe('bundled SQLite migrations', () => {
       expect(columnNames(database, 'agent_session')).toEqual([
         'id',
         'agent_id',
-        'title',
-        'title_is_manual',
+        'name',
+        'is_name_manually_edited',
         'execution_target',
         'last_activity_at',
         'created_at',
@@ -157,7 +158,9 @@ describe('bundled SQLite migrations', () => {
         'updated_at',
       ]);
 
-      expect(indexNames(database, 'mcp_server')).toEqual(['mcp_server_is_enabled_idx']);
+      expect(indexNames(database, 'mcp_server')).toEqual(['mcp_server_is_active_idx']);
+      expect(columnNames(database, 'job')).toContain('cancel_requested_at');
+      expect(columnNames(database, 'user_model')).toContain('input_modalities_explicit');
       expect(indexNames(database, 'user_model')).toEqual(
         expect.arrayContaining([
           'user_model_preset_idx',
@@ -425,6 +428,86 @@ describe('bundled SQLite migrations', () => {
     }
   });
 
+  test('preserves existing values while aligning desktop-compatible fields', () => {
+    const database = new DatabaseSync(':memory:');
+
+    try {
+      database.exec('PRAGMA foreign_keys = ON');
+      const entries = readMigrationEntries();
+      const alignmentMigrationIndex = entries.findIndex(
+        ({ tag }) => tag === '0017_desktop-compatible-fields',
+      );
+      expect(alignmentMigrationIndex).toBeGreaterThan(0);
+
+      for (const { sql } of entries.slice(0, alignmentMigrationIndex)) {
+        applyMigrationSql(database, sql);
+      }
+      database.exec(`
+        INSERT INTO user_provider (provider_id, name, order_key, created_at, updated_at)
+        VALUES ('provider', 'Provider', 'a0', 1, 1);
+        INSERT INTO user_model (
+          id, provider_id, model_id, preset_model_id, order_key, created_at, updated_at
+        ) VALUES ('provider::model', 'provider', 'model', 'model', 'a0', 1, 1);
+        INSERT INTO agent (id, name, model_id, order_key, created_at, updated_at)
+        VALUES ('agent-1', 'Agent', 'provider::model', 'a0', 1, 1);
+        INSERT INTO agent_session (
+          id, agent_id, title, title_is_manual, last_activity_at, created_at, updated_at
+        ) VALUES ('session-1', 'agent-1', 'Retained title', 1, 1, 1, 1);
+        INSERT INTO mcp_server (id, name, endpoint_url, is_enabled, created_at, updated_at)
+        VALUES ('server-1', 'Server', 'https://example.com/mcp', 1, 1, 1);
+        INSERT INTO preference (key, value, created_at, updated_at)
+        VALUES ('ui.theme_mode', '"dark"', 1, 1);
+        INSERT INTO job (id, type, status, queue, scheduled_at, input, created_at, updated_at)
+        VALUES ('job-1', 'test', 'running', 'test', 1, '{}', 1, 1);
+      `);
+
+      applyMigrationsAsDrizzleWould(database, entries.slice(alignmentMigrationIndex));
+
+      expect(database.prepare("SELECT model FROM agent WHERE id = 'agent-1'").get()).toEqual({
+        model: 'provider::model',
+      });
+      expect(
+        database
+          .prepare("SELECT name, is_name_manually_edited FROM agent_session WHERE id = 'session-1'")
+          .get(),
+      ).toEqual({ is_name_manually_edited: 1, name: 'Retained title' });
+      expect(
+        database.prepare("SELECT base_url, is_active FROM mcp_server WHERE id = 'server-1'").get(),
+      ).toEqual({ base_url: 'https://example.com/mcp', is_active: 1 });
+      expect(
+        database.prepare("SELECT scope, value FROM preference WHERE key = 'ui.theme_mode'").get(),
+      ).toEqual({ scope: 'default', value: '"dark"' });
+      expect(
+        database.prepare("SELECT cancel_requested_at FROM job WHERE id = 'job-1'").get(),
+      ).toEqual({ cancel_requested_at: null });
+      expect(
+        database
+          .prepare("SELECT input_modalities_explicit FROM user_model WHERE id = 'provider::model'")
+          .get(),
+      ).toEqual({ input_modalities_explicit: 0 });
+
+      database.exec(`
+        INSERT INTO preference (scope, key, value, created_at, updated_at)
+        VALUES ('desktop', 'ui.theme_mode', '"light"', 2, 2);
+        INSERT INTO ai_usage_record (
+          id, request_id, record_kind, request_count, provider_id, model_id,
+          source_type, source_id, modality, api_key_attribution, created_at
+        ) VALUES (
+          'usage-1', 'request-1', 'invocation', 1, 'provider', 'model',
+          'mini-app', 'mini-app-1', 'language', 'unknown', 2
+        );
+      `);
+      expect(
+        database
+          .prepare("SELECT count(*) AS count FROM preference WHERE key = 'ui.theme_mode'")
+          .get(),
+      ).toEqual({ count: 2 });
+      expect(database.prepare('PRAGMA foreign_key_check').all()).toEqual([]);
+    } finally {
+      database.close();
+    }
+  });
+
   test('labels only provable origins and leaves the rest unknown', () => {
     const database = new DatabaseSync(':memory:');
 
@@ -535,10 +618,10 @@ describe('bundled SQLite migrations', () => {
       expect(
         database
           .prepare(
-            "SELECT title, forked_from_session_id FROM agent_session WHERE id = 'legacy-session'",
+            "SELECT name, forked_from_session_id FROM agent_session WHERE id = 'legacy-session'",
           )
           .get(),
-      ).toEqual({ forked_from_session_id: null, title: 'Arithmetic drills' });
+      ).toEqual({ forked_from_session_id: null, name: 'Arithmetic drills' });
       expect(database.prepare('SELECT count(*) AS count FROM agent_session_message').get()).toEqual(
         { count: 1 },
       );

--- a/src/backend/data/db/migrations.ts
+++ b/src/backend/data/db/migrations.ts
@@ -15,6 +15,7 @@ import m0013 from '../../../../migrations/sqlite-drizzle/0013_agent-session-fork
 import m0014 from '../../../../migrations/sqlite-drizzle/0014_agent-disabled-capabilities.sql';
 import m0015 from '../../../../migrations/sqlite-drizzle/0015_agent-session-activity-and-fork-boundary.sql';
 import m0016 from '../../../../migrations/sqlite-drizzle/0016_agent-message-stats.sql';
+import m0017 from '../../../../migrations/sqlite-drizzle/0017_desktop-compatible-fields.sql';
 import journal from '../../../../migrations/sqlite-drizzle/meta/_journal.json';
 
 // Expo SQLite migrations must be bundled into JS; unlike the desktop main
@@ -41,5 +42,6 @@ export const migrations = {
     m0014,
     m0015,
     m0016,
+    m0017,
   },
 };

--- a/src/backend/data/db/schemas/agent.ts
+++ b/src/backend/data/db/schemas/agent.ts
@@ -33,7 +33,7 @@ export const agentTable = sqliteTable(
     avatar: text(),
     // Default model: FK to user_model(id) — UniqueModelId "providerId::modelId"
     // Legitimately nullable: NULL = "no model selected yet"
-    modelId: text().references(() => userModelTable.id, { onDelete: 'set null' }),
+    modelId: text('model').references(() => userModelTable.id, { onDelete: 'set null' }),
     // Per-Agent interactive approval preference. This does not enable tools.
     toolApprovalMode: text({ enum: ['default', 'auto'] })
       .$type<AgentToolApprovalMode>()

--- a/src/backend/data/db/schemas/agentSession.ts
+++ b/src/backend/data/db/schemas/agentSession.ts
@@ -24,9 +24,9 @@ export const agentSessionTable = sqliteTable(
       .notNull()
       .references(() => agentTable.id, { onDelete: 'restrict' }),
     // Protocol vocabulary (AgentSessionView.title), not a second synonym set
-    title: text().notNull().default(''),
+    title: text('name').notNull().default(''),
     // Whether the title was manually edited by user
-    titleIsManual: integer({ mode: 'boolean' }).notNull().default(false),
+    titleIsManual: integer('is_name_manually_edited', { mode: 'boolean' }).notNull().default(false),
     // Application intent (protocol AgentExecutionTarget), never a Runtime id
     executionTarget: text({ mode: 'json' })
       .$type<AgentExecutionTarget>()

--- a/src/backend/data/db/schemas/index.ts
+++ b/src/backend/data/db/schemas/index.ts
@@ -26,7 +26,7 @@ export * from './userProvider';
 
 export { appStateTable } from './appState';
 export { fileEntryTable } from './file';
-export { preferenceTable } from './preference';
+export { DEFAULT_PREFERENCE_SCOPE, preferenceTable } from './preference';
 
 export type AppStateRow = typeof appStateTable.$inferSelect;
 export type InsertAppStateRow = typeof appStateTable.$inferInsert;

--- a/src/backend/data/db/schemas/job.ts
+++ b/src/backend/data/db/schemas/job.ts
@@ -45,6 +45,9 @@ export const jobTable = sqliteTable(
     error: text({ mode: 'json' }).$type<JobError>(),
     parentId: text(),
     cancelRequested: integer({ mode: 'boolean' }).notNull().default(false),
+    // Set once at the first cancel request while the job is active, never moved.
+    // Read models use it as the cancel time; finishedAt keeps transition time.
+    cancelRequestedAt: integer(),
     metadata: text({ mode: 'json' }).$type<Record<string, unknown>>().notNull().default({}),
     timeoutMs: integer(),
     ...createUpdateTimestamps,

--- a/src/backend/data/db/schemas/mcpServer.ts
+++ b/src/backend/data/db/schemas/mcpServer.ts
@@ -23,9 +23,9 @@ export const mcpServerTable = sqliteTable(
   {
     id: uuidPrimaryKey(),
     name: text().notNull(),
-    endpointUrl: text().notNull(),
+    endpointUrl: text('base_url').notNull(),
     headers: text({ mode: 'json' }).$type<Record<string, string>>(),
-    isEnabled: integer({ mode: 'boolean' }).notNull().default(false),
+    isEnabled: integer('is_active', { mode: 'boolean' }).notNull().default(false),
     /**
      * Tool names this server may not offer, as the server reports them. The
      * server decides what exists; this is the user's say over what reaches the
@@ -36,7 +36,7 @@ export const mcpServerTable = sqliteTable(
 
     ...createUpdateTimestamps,
   },
-  (t) => [index('mcp_server_is_enabled_idx').on(t.isEnabled)],
+  (t) => [index('mcp_server_is_active_idx').on(t.isEnabled)],
 );
 
 export type InsertMcpServerRow = typeof mcpServerTable.$inferInsert;

--- a/src/backend/data/db/schemas/preference.ts
+++ b/src/backend/data/db/schemas/preference.ts
@@ -1,12 +1,20 @@
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 import { createUpdateTimestamps } from './_columnHelpers';
 
-export const preferenceTable = sqliteTable('preference', {
-  key: text().primaryKey(),
-  value: text({ mode: 'json' }),
-  ...createUpdateTimestamps,
-});
+export const DEFAULT_PREFERENCE_SCOPE = 'default';
+
+export const preferenceTable = sqliteTable(
+  'preference',
+  {
+    // Reserved for future use; mobile currently reads and writes only the default scope.
+    scope: text().notNull().default(DEFAULT_PREFERENCE_SCOPE),
+    key: text().notNull(),
+    value: text({ mode: 'json' }),
+    ...createUpdateTimestamps,
+  },
+  (t) => [primaryKey({ columns: [t.scope, t.key] })],
+);
 
 export type PreferenceRow = typeof preferenceTable.$inferSelect;
 export type InsertPreferenceRow = typeof preferenceTable.$inferInsert;

--- a/src/backend/data/db/schemas/userModel.ts
+++ b/src/backend/data/db/schemas/userModel.ts
@@ -80,6 +80,10 @@ export const userModelTable = sqliteTable(
     /** Supported input modalities (e.g., TEXT, VISION, AUDIO, VIDEO) */
     inputModalities: text({ mode: 'json' }).$type<Modality[]>(),
 
+    /** Whether inputModalities was explicitly supplied by the user. Historical empty arrays predate
+     *  this provenance bit and are treated as an implicit default. */
+    inputModalitiesExplicit: integer({ mode: 'boolean' }).notNull().default(false),
+
     /** Supported output modalities (e.g., TEXT, VISION, AUDIO, VIDEO, VECTOR) */
     outputModalities: text({ mode: 'json' }).$type<Modality[]>(),
 

--- a/src/backend/data/db/seeding/seeders/PreferenceSeeder.ts
+++ b/src/backend/data/db/seeding/seeders/PreferenceSeeder.ts
@@ -1,4 +1,6 @@
-import { preferenceTable } from '@/backend/data/db/schemas';
+import { eq } from 'drizzle-orm';
+
+import { DEFAULT_PREFERENCE_SCOPE, preferenceTable } from '@/backend/data/db/schemas';
 import { PreferenceDefaults } from '@/shared/data/preference';
 
 import { hashObject } from '../hashObject';
@@ -17,7 +19,8 @@ export class PreferenceSeeder implements DatabaseSeeder {
     const stored = await dbService
       .getDb()
       .select({ key: preferenceTable.key })
-      .from(preferenceTable);
+      .from(preferenceTable)
+      .where(eq(preferenceTable.scope, DEFAULT_PREFERENCE_SCOPE));
     const storedKeys = new Set(stored.map((preference) => preference.key));
     const missing = Object.entries(PreferenceDefaults).filter(([key]) => !storedKeys.has(key));
 
@@ -30,7 +33,10 @@ export class PreferenceSeeder implements DatabaseSeeder {
     await dbService.withWriteTx(async (tx) => {
       for (const [key, value] of missing) {
         // react-doctor-disable-next-line async-await-in-loop -- expo-sqlite 写事务内本质串行，并行化无收益
-        await tx.insert(preferenceTable).values({ key, value }).onConflictDoNothing();
+        await tx
+          .insert(preferenceTable)
+          .values({ key, scope: DEFAULT_PREFERENCE_SCOPE, value })
+          .onConflictDoNothing();
       }
     });
   }

--- a/src/backend/data/services/ContentSearchService.ts
+++ b/src/backend/data/services/ContentSearchService.ts
@@ -98,7 +98,7 @@ export class ContentSearchService {
           SELECT
             message.id,
             message.session_id AS "sessionId",
-            session.title AS "sessionTitle",
+            session.name AS "sessionTitle",
             session.agent_id AS "agentId",
             agent.name AS "agentName",
             message.role,

--- a/src/backend/data/services/JobService.ts
+++ b/src/backend/data/services/JobService.ts
@@ -1,5 +1,5 @@
 import { loggerService } from '@logger';
-import { and, asc, count, desc, eq, inArray, lte, type SQL } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, lte, type SQL, sql } from 'drizzle-orm';
 
 import { application } from '@/backend/core/application/Application';
 import type { Database } from '@/backend/data/db/DbService';

--- a/src/backend/data/services/JobService.ts
+++ b/src/backend/data/services/JobService.ts
@@ -59,6 +59,8 @@ function rowToSnapshot(row: JobRow): JobSnapshot {
   return {
     attempt: row.attempt,
     cancelRequested: row.cancelRequested,
+    cancelRequestedAt:
+      row.cancelRequestedAt === null ? null : timestampToISO(row.cancelRequestedAt),
     createdAt: timestampToISO(row.createdAt),
     error: validateError(row.id, row.error),
     finishedAt: row.finishedAt === null ? null : timestampToISO(row.finishedAt),
@@ -275,7 +277,23 @@ export class JobService {
   }
 
   async setCancelRequestedTx(tx: Database, id: string): Promise<void> {
-    await tx.update(jobTable).set({ cancelRequested: true }).where(eq(jobTable.id, id));
+    const now = Date.now();
+    const activeStatuses = sql.join(
+      ACTIVE_JOB_STATUSES.map((status) => sql`${status}`),
+      sql`, `,
+    );
+    await tx
+      .update(jobTable)
+      .set({
+        cancelRequested: true,
+        cancelRequestedAt: sql`CASE
+          WHEN ${jobTable.status} IN (${activeStatuses})
+          THEN COALESCE(${jobTable.cancelRequestedAt}, ${now})
+          ELSE ${jobTable.cancelRequestedAt}
+        END`,
+        updatedAt: now,
+      })
+      .where(eq(jobTable.id, id));
   }
 
   /** Caller passes the already-merged object. Fenced on `status='running'`. */

--- a/src/backend/data/services/ModelService.ts
+++ b/src/backend/data/services/ModelService.ts
@@ -127,7 +127,10 @@ function applyStoredFields(baseline: Model, row: UserModelRow): Model {
     ...(row.endpointTypes !== null ? { endpointTypes: row.endpointTypes } : {}),
     ...(row.group !== null ? { group: row.group } : {}),
     id: createUniqueModelId(row.providerId, row.modelId),
-    ...(row.inputModalities !== null ? { inputModalities: row.inputModalities } : {}),
+    ...(row.inputModalities !== null &&
+    (row.inputModalitiesExplicit || row.inputModalities.length > 0)
+      ? { inputModalities: row.inputModalities }
+      : {}),
     isDeprecated: row.isDeprecated,
     isEnabled: row.isEnabled,
     isHidden: row.isHidden,
@@ -198,6 +201,7 @@ function customInputToInsert(input: CreateModelInput): ModelInputWithoutOrderKey
     group: input.group ?? null,
     id: createUniqueModelId(input.providerId, input.modelId),
     inputModalities: input.inputModalities ?? null,
+    inputModalitiesExplicit: input.inputModalities !== undefined,
     isDeprecated: input.isDeprecated ?? false,
     isEnabled: input.isEnabled ?? true,
     isHidden: input.isHidden ?? false,
@@ -232,6 +236,9 @@ function presetDeltaToInsert(
     group: delta(input.group, baseline.group),
     id: createUniqueModelId(input.providerId, input.modelId),
     inputModalities: delta(input.inputModalities, baseline.inputModalities),
+    inputModalitiesExplicit:
+      input.inputModalities !== undefined &&
+      !deepEqual(input.inputModalities, baseline.inputModalities),
     isDeprecated: input.isDeprecated ?? baseline.isDeprecated ?? false,
     isEnabled: input.isEnabled ?? baseline.isEnabled,
     isHidden: input.isHidden ?? baseline.isHidden,
@@ -688,6 +695,9 @@ export class ModelService {
             : value
           : value;
       (updates as Record<string, unknown>)[dbKey] = storedValue;
+    }
+    if (dto.inputModalities !== undefined) {
+      updates.inputModalitiesExplicit = true;
     }
     return updates;
   }

--- a/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionMessageService.integration.test.ts
@@ -81,7 +81,7 @@ function insertSession(database: DatabaseSync, id: string): void {
   database
     .prepare(
       `INSERT INTO agent_session (
-        id, agent_id, title, title_is_manual, execution_target,
+        id, agent_id, name, is_name_manually_edited, execution_target,
         last_activity_at, created_at, updated_at
       ) VALUES (?, 'agent-1', '', 0, '{"kind":"local"}', 1, 1, 1)`,
     )

--- a/src/backend/data/services/__tests__/AgentSessionService.integration.test.ts
+++ b/src/backend/data/services/__tests__/AgentSessionService.integration.test.ts
@@ -77,7 +77,7 @@ function insertSession(
   database
     .prepare(
       `INSERT INTO agent_session (
-        id, agent_id, title, title_is_manual, execution_target,
+        id, agent_id, name, is_name_manually_edited, execution_target,
         last_activity_at, created_at, updated_at
       ) VALUES (?, ?, ?, 0, '{"kind":"local"}', ?, ?, ?)`,
     )

--- a/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
+++ b/src/backend/data/services/__tests__/AuxiliaryData.integration.test.ts
@@ -98,7 +98,7 @@ describe('auxiliary Data API integration', () => {
       .run(agentId, 'Needle Agent', 'a0', now, now);
     sqlite
       .prepare(
-        'INSERT INTO agent_session (id, agent_id, title, title_is_manual, last_activity_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO agent_session (id, agent_id, name, is_name_manually_edited, last_activity_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
       )
       .run(sessionId, agentId, 'Needle Session', 1, now, now, now);
     sqlite

--- a/src/backend/data/services/__tests__/JobService.writers.test.ts
+++ b/src/backend/data/services/__tests__/JobService.writers.test.ts
@@ -149,6 +149,29 @@ describe('JobService runtime writers', () => {
     });
   });
 
+  describe('setCancelRequestedTx', () => {
+    it('stamps the first active cancel request once and leaves terminal rows unstamped', async () => {
+      const now = jest.spyOn(Date, 'now').mockReturnValueOnce(100).mockReturnValueOnce(200);
+      const active = await insertJob({ status: 'running' });
+
+      await service.setCancelRequestedTx(tx, active.id);
+      await service.setCancelRequestedTx(tx, active.id);
+
+      expect(await service.getRowByIdTx(tx, active.id)).toMatchObject({
+        cancelRequested: true,
+        cancelRequestedAt: 100,
+      });
+
+      const terminal = await insertJob({ status: 'completed' });
+      await service.setCancelRequestedTx(tx, terminal.id);
+      expect(await service.getRowByIdTx(tx, terminal.id)).toMatchObject({
+        cancelRequested: true,
+        cancelRequestedAt: null,
+      });
+      now.mockRestore();
+    });
+  });
+
   describe('setMetadataTx', () => {
     it('writes only while the row is running', async () => {
       const running = await insertJob({ status: 'running' });

--- a/src/backend/data/services/__tests__/JobService.writers.test.ts
+++ b/src/backend/data/services/__tests__/JobService.writers.test.ts
@@ -151,10 +151,12 @@ describe('JobService runtime writers', () => {
 
   describe('setCancelRequestedTx', () => {
     it('stamps the first active cancel request once and leaves terminal rows unstamped', async () => {
-      const now = jest.spyOn(Date, 'now').mockReturnValueOnce(100).mockReturnValueOnce(200);
       const active = await insertJob({ status: 'running' });
+      const terminal = await insertJob({ status: 'completed' });
+      const now = jest.spyOn(Date, 'now').mockReturnValue(100);
 
       await service.setCancelRequestedTx(tx, active.id);
+      now.mockReturnValue(200);
       await service.setCancelRequestedTx(tx, active.id);
 
       expect(await service.getRowByIdTx(tx, active.id)).toMatchObject({
@@ -162,7 +164,6 @@ describe('JobService runtime writers', () => {
         cancelRequestedAt: 100,
       });
 
-      const terminal = await insertJob({ status: 'completed' });
       await service.setCancelRequestedTx(tx, terminal.id);
       expect(await service.getRowByIdTx(tx, terminal.id)).toMatchObject({
         cancelRequested: true,

--- a/src/backend/services/jobs/JobRuntime.ts
+++ b/src/backend/services/jobs/JobRuntime.ts
@@ -1125,6 +1125,7 @@ export class JobRuntime extends BaseService {
     return {
       attempt: 0,
       cancelRequested: true,
+      cancelRequestedAt: nowIso,
       createdAt: nowIso,
       error: { code: 'JOB_FINALIZE_TX_FAILED', message: cause.message, retryable: true },
       finishedAt: nowIso,

--- a/src/frontend/data/paintings/__tests__/usePaintingJobs.test.tsx
+++ b/src/frontend/data/paintings/__tests__/usePaintingJobs.test.tsx
@@ -12,6 +12,7 @@ function jobSnapshot(overrides: Partial<JobSnapshot>): JobSnapshot {
   return {
     attempt: 1,
     cancelRequested: false,
+    cancelRequestedAt: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     error: null,
     finishedAt: null,

--- a/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
+++ b/src/frontend/features/paintings/hooks/__tests__/usePaintingGeneration.test.tsx
@@ -30,6 +30,7 @@ function jobSnapshot(overrides: Partial<JobSnapshot>): JobSnapshot {
   return {
     attempt: 1,
     cancelRequested: false,
+    cancelRequestedAt: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     error: null,
     finishedAt: null,

--- a/src/shared/data/api/schemas/jobs.ts
+++ b/src/shared/data/api/schemas/jobs.ts
@@ -89,6 +89,7 @@ export const JobSnapshotSchema = z.strictObject({
   error: JobErrorSchema.nullable(),
   parentId: z.string().nullable(),
   cancelRequested: z.boolean(),
+  cancelRequestedAt: z.string().nullable(),
   metadata: z.record(z.string(), z.unknown()),
   timeoutMs: z.number().int().nullable(),
   createdAt: z.string(),


### PR DESCRIPTION
## Summary

- align compatible SQLite column names for Agent, Agent Session, and MCP records with Cherry Studio desktop
- add desktop-compatible preference scope, model input-modality provenance, job cancel-request timestamps, and mini-app AI usage attribution
- add the append-only `0017_desktop-compatible-fields` migration with historical-value and foreign-key retention coverage
- keep mobile runtime property names and mobile-only fields intact to avoid lossy behavior changes

## Validation

- `pnpm format:check` — passed
- targeted `oxlint` for changed files — passed
- `git diff --check` — passed
- `pnpm lint` — blocked by seven pre-existing unresolved `@cherrystudio/ai-core` imports because that workspace package is not built; no lint errors were reported in this change
- tests, typecheck, and builds were not run per workspace instructions requiring explicit authorization

## Compatibility notes

- desktop reference: `CherryHQ/cherry-studio` `origin/main` at `e88333eb75212d9d9405b872ee1df9f634604738`
- this intentionally does not force-align incompatible session workspace semantics, message lifecycle statuses, full multi-transport MCP storage, file/painting relationships, or job schedules
- physical desktop v7 backup compatibility remains blocked