### PR TITLE
fix(sidebar): hide unset username placeholder

### DIFF
--- a/src/frontend/appShell/sidebar/components/SidebarDock.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarDock.tsx
@@ -24,7 +24,7 @@ export function SidebarDock({ onNewChatPress, onSettingsPress }: SidebarDockProp
   const [userName] = usePreference('app.user.name');
   const primaryForegroundColor = useThemeColor('sidebar-primary-foreground');
   const { bottomPadding, inset } = useDockMetrics();
-  const displayName = userName.trim() || t('settings.profile.userName');
+  const displayName = userName.trim();
 
   return (
     // Ends of the sidebar, not a huddle in the corner: the chat pill anchors the
@@ -68,13 +68,18 @@ export function SidebarDock({ onNewChatPress, onSettingsPress }: SidebarDockProp
             paddingHorizontal: 10,
           })}
         >
-          <ProfileAvatarImage accessibilityLabel={displayName} size={32} />
-          <Text
-            className="min-w-0 max-w-20 shrink font-medium text-[15px] text-sidebar-foreground"
-            numberOfLines={1}
-          >
-            {displayName}
-          </Text>
+          <ProfileAvatarImage
+            accessibilityLabel={displayName || t('settings.profile.avatar')}
+            size={32}
+          />
+          {displayName ? (
+            <Text
+              className="min-w-0 max-w-20 shrink font-medium text-[15px] text-sidebar-foreground"
+              numberOfLines={1}
+            >
+              {displayName}
+            </Text>
+          ) : null}
         </Pressable>
       </View>
     </View>


### PR DESCRIPTION
## Summary

- hide the username label in the sidebar dock when the profile name is blank
- preserve the existing avatar and username layout when a name is configured
- keep a translated accessibility label for the avatar in the unnamed state

## Verification

- `pnpm exec oxfmt --no-error-on-unmatched-pattern src/frontend/appShell/sidebar/components/SidebarDock.tsx`
- `pnpm exec oxlint src/frontend/appShell/sidebar/components/SidebarDock.tsx`
- `pnpm exec expo lint src/frontend/appShell/sidebar/components/SidebarDock.tsx`
- `pnpm format:check`
- `pnpm lint` *(blocked by seven pre-existing unresolved `@cherrystudio/ai-core` imports because workspace packages are not built)*
- Not run: tests or typecheck, per workspace verification constraints; the repository typecheck invokes package builds.