### PR TITLE
fix(chat-input): keep composer visible above the keyboard

### DIFF
--- a/packages/ui/src/components/composer/__tests__/composer-dock.test.tsx
+++ b/packages/ui/src/components/composer/__tests__/composer-dock.test.tsx
@@ -7,6 +7,10 @@ import { useComposerDockLayout } from '../hooks/use-composer-dock-layout';
 
 let mockBottomInset = 34;
 
+jest.mock('uniwind', () => ({
+  withUniwind: (component: unknown) => component,
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: mockBottomInset, left: 0, right: 0, top: 0 }),
 }));
@@ -76,6 +80,8 @@ describe('Composer.Dock', () => {
     const stickyView = renderer!.root.findByProps({ testID: 'keyboard-sticky-view' });
     const layoutEvent = { nativeEvent: { layout: { height: 126 } } };
 
+    // A stationary native wrapper would clip the lifted input under Android's blur target.
+    expect(renderer!.toJSON()).toMatchObject({ props: { testID: 'keyboard-sticky-view' } });
     expect(container.props.style).toEqual({ paddingBottom: 38, paddingHorizontal: 16 });
     expect(stickyView.props.offset).toEqual({ opened: 26 });
 

--- a/packages/ui/src/components/composer/__tests__/composer.test.tsx
+++ b/packages/ui/src/components/composer/__tests__/composer.test.tsx
@@ -14,6 +14,7 @@ jest.mock('heroui-native/utils', () => {
 });
 
 jest.mock('uniwind', () => ({
+  withUniwind: (component: unknown) => component,
   useResolveClassNames: jest.fn((className: string) =>
     className.includes('text-foreground')
       ? { color: '#111827', fontSize: 16 }

--- a/packages/ui/src/components/composer/components/composer-dock.tsx
+++ b/packages/ui/src/components/composer/components/composer-dock.tsx
@@ -1,13 +1,16 @@
 import { type PropsWithChildren, type RefObject, useCallback } from 'react';
-import { type LayoutChangeEvent, View } from 'react-native';
+import type { LayoutChangeEvent, View } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { withUniwind } from 'uniwind';
 
 import {
   composerHorizontalScreenInset,
   getComposerBottomPadding,
   getComposerKeyboardStickyOffset,
 } from '../utils/composer-dock-layout';
+
+const StyledKeyboardStickyView = withUniwind(KeyboardStickyView);
 
 export type ComposerDockProps = PropsWithChildren<{
   containerRef?: RefObject<View | null>;
@@ -37,10 +40,14 @@ export function ComposerDock({
     [onHeightChange, onLayout],
   );
 
+  // Move the dock boundary with its content: Android BlurTargetView clips
+  // children to their own bounds, so a stationary wrapper hides the lifted input.
   return (
-    <View
+    <StyledKeyboardStickyView
       ref={containerRef}
       className={layoutMode === 'flow' ? 'z-10 shrink-0' : 'absolute right-0 bottom-0 left-0 z-10'}
+      enabled={keyboardTrackingEnabled}
+      offset={{ opened: getComposerKeyboardStickyOffset(bottom) }}
       onLayout={onHeightChange || onLayout ? handleLayout : undefined}
       pointerEvents="box-none"
       style={{
@@ -48,12 +55,7 @@ export function ComposerDock({
         paddingHorizontal: composerHorizontalScreenInset,
       }}
     >
-      <KeyboardStickyView
-        enabled={keyboardTrackingEnabled}
-        offset={{ opened: getComposerKeyboardStickyOffset(bottom) }}
-      >
-        {children}
-      </KeyboardStickyView>
-    </View>
+      {children}
+    </StyledKeyboardStickyView>
   );
 }


### PR DESCRIPTION
### What this PR does

Before this PR: opening the Android keyboard could make the chat composer disappear. The input moved outside a stationary dock wrapper, where the chat screen's native blur target could clip it.

After this PR: the keyboard-following view is the dock's outermost native container, so its boundary moves with the input. Existing safe-area spacing, floating/flow layouts, keyboard tracking controls, refs, and height callbacks are preserved.

### Screenshots or videos

After-change device capture is pending. The reported Android screenshots show the message list moving above the keyboard while the composer disappears. Device verification was not performed, per the user's verification policy.

### Why we need it and why it was done in this way

Move the existing `KeyboardStickyView` to the dock boundary and use `withUniwind` to retain its layout classes. This removes the stationary wrapper without changing the keyboard controller or the screen's blur implementation. Add a structural regression assertion for the moving root and update the existing Uniwind mocks.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm lint` passed with existing warnings.
- `pnpm format:check` and `git diff --check` passed.
- Tests, type checking, builds, and device verification were intentionally not run, per user instructions. The structural assertion does not replace native clipping acceptance.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the problem and change
- [ ] Preview: After-change screenshots or video are attached
- [x] Code: The change is limited to the composer boundary and related tests
- [x] Upgrade: No migration or dependency change is required
- [x] Documentation: No user-guide update is needed for this bug fix
- [x] Self-review: The complete local diff has been reviewed

### Release note

```release-note
Fix the chat input disappearing when the keyboard opens on Android.
```
