### PR TITLE
feat(navigation): reveal a strip of chat beside the open drawer

### DIFF
--- a/src/app/(drawer)/_layout.tsx
+++ b/src/app/(drawer)/_layout.tsx
@@ -23,7 +23,10 @@ export default function DrawerLayout() {
       <Drawer
         drawerContent={renderSidebar}
         screenOptions={{
-          drawerStyle: { width },
+          // The sidebar stops short of the right edge so a dimmed strip of chat
+          // stays visible: it tells the user where they came from and closes the
+          // drawer on tap.
+          drawerStyle: { width: width - appSidebar.sceneRevealWidth },
           // The chat surface is stable context; the sidebar is a temporary
           // surface that slides over it as the only moving plane.
           drawerType: 'front',

--- a/src/frontend/appShell/sidebar/hooks/useDockMetrics.ts
+++ b/src/frontend/appShell/sidebar/hooks/useDockMetrics.ts
@@ -10,7 +10,8 @@ import { appSidebar } from '@/frontend/utils/constants';
  * `inset` makes the dock's corners concentric with the display's: a rounded
  * rect nested in another only looks right when the two share a center, which
  * means the gap has to equal the difference of their radii. Anything less and
- * the pill's corner visibly tightens against the screen's.
+ * the pill's corner visibly tightens against the screen's. The drawer's right
+ * edge is straight, so there the same inset is plain symmetry.
  */
 export function useDockMetrics() {
   const insets = useSafeAreaInsets();

--- a/src/frontend/utils/constants.ts
+++ b/src/frontend/utils/constants.ts
@@ -70,6 +70,7 @@ export const paintingViewer = {
 } as const;
 
 export const appSidebar = {
+  sceneRevealWidth: 64, // chat strip left visible beside the open drawer (as in ChatGPT); tap to close
   fallbackCornerRadius: 55, // surface radius when the device is missing from expo-screen-corner-radius' table
   dockHeight: 48, // floating bottom dock's button height, shared by both buttons
   dockMinInset: 16, // floor for the dock's concentric inset (see SidebarDock)


### PR DESCRIPTION
## Summary

- The chat drawer no longer covers the whole screen. Like ChatGPT's mobile sidebar it stops short of the right edge and leaves a dimmed strip of the chat surface visible.
- The strip is a fixed 64pt (`appSidebar.sceneRevealWidth`) rather than a screen ratio, so it stays a comfortable tap target for closing the drawer on narrow phones.
- The full-width open swipe, scrim, and tap-to-close behaviour are unchanged. The dock's concentric inset now reads as symmetric padding on the drawer's straight right edge; only the comment changed.

## Test plan

- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck` pass on the final head
- [x] iOS simulator (iPhone 17 Pro): open the sidebar from the chat header, confirm a dimmed strip of chat stays visible on the right, tap the strip and confirm the drawer closes
- [ ] Android emulator: same flow, confirm the open swipe still coexists with system edge back

🤖 Generated with [Claude Code](https://claude.com/claude-code)
