### PR TITLE
refactor(file-preview): let application callers control file opening

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -21,9 +21,9 @@ import PlusIcon from '@cherrystudio/app-icons/icons/plus';
 `Image` wraps `expo-image` with Uniwind `className` support while preserving the underlying image
 API.
 
-`FilePreview` renders and opens a business-neutral file descriptor. The caller supplies display
+`FilePreview` renders a business-neutral file descriptor and delegates presses to its caller. The caller supplies display
 metadata, the file's kind, localized unavailable/opening labels, and an error callback; the
-component owns the frame, the press target, unavailable states, system opening, and iOS Quick Look
+component owns the frame, the press target, unavailable states, and iOS Quick Look
 thumbnail caching. Loading placeholders belong to the caller because it owns the loading lifecycle:
 
 ```tsx
@@ -38,6 +38,7 @@ thumbnail caching. Loading placeholders belong to the caller because it owns the
   }}
   labels={{ openWith: 'Open with', unavailable: 'Unavailable' }}
   onError={(error, operation) => reportPreviewError(error, operation)}
+  onPress={openBrief}
 />;
 ```
 
@@ -56,7 +57,7 @@ const previewPlugins = [{ component: PdfPreview, kind: 'pdf' }];
 ```
 
 A plugin receives `FilePreviewComponentProps` — the file, the resolved size, and the same `onError`
-— and draws the preview only. The frame, press target, and system opening stay with `FilePreview`,
+— and draws the preview only. The frame and press target stay with `FilePreview`,
 so a plugin cannot diverge on interaction. Providers nest: an inner one overrides the kinds it
 names and inherits the rest, including the platform fallback.
 
@@ -65,12 +66,13 @@ beyond `file.uri` and a platform API, as `image` and the iOS Quick Look thumbnai
 parses a format or calls a service is product code and registers through the provider; see
 `src/frontend/components/FileEntryPreview/README.md` for that path.
 
-`onError` distinguishes `open` from `thumbnail`, allowing product code to alert for a failed open
-while treating thumbnail generation as a recoverable fallback. CherryUI carries no file database,
+`openFilePreview` is the exported platform-opening primitive. The caller chooses when to use it
+and handles its rejected promise. `onError` reports thumbnail failures; the shared operation type
+also includes `open` for callers that use one error reporter for both operations. CherryUI carries no file database,
 logging, or translation dependency.
 
-`FileAttachmentPreview` is the compact horizontal result variant. It keeps the same platform file
-opening and error contract while showing a filename and caller-supplied category label; square
+`FileAttachmentPreview` is the compact horizontal result variant. It requires the same `onPress`
+callback while showing a filename and caller-supplied category label; square
 thumbnail callers continue to use `FilePreview`.
 
 `MarkdownText` is the shared GitHub-flavored Markdown renderer. Static content uses the enriched

--- a/packages/ui/src/components/file-preview/__tests__/file-attachment-preview.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-attachment-preview.test.tsx
@@ -3,11 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { FileAttachmentPreview } from '../components/file-attachment-preview';
 import type { FilePreviewFile } from '../file-preview.types';
 
-const mockOpenFilePreview = jest.fn();
-
-jest.mock('../utils/open-file/open-file', () => ({
-  openFilePreview: (input: unknown) => mockOpenFilePreview(input),
-}));
+const onPress = jest.fn();
 
 const file: FilePreviewFile = {
   displayName: 'release-notes.md',
@@ -21,45 +17,48 @@ const labels = { openWith: 'Open with', unavailable: 'Unavailable' };
 
 describe('FileAttachmentPreview', () => {
   beforeEach(() => {
-    mockOpenFilePreview.mockReset();
-    mockOpenFilePreview.mockResolvedValue(undefined);
+    onPress.mockReset();
   });
 
   it('shows the filename stem and document metadata', () => {
     const renderer = render(
-      <FileAttachmentPreview categoryLabel="Document" file={file} labels={labels} />,
+      <FileAttachmentPreview
+        categoryLabel="Document"
+        file={file}
+        labels={labels}
+        onPress={onPress}
+      />,
     );
     const text = renderer.root.findAllByType('Text').flatMap((node) => node.props.children);
 
     expect(text).toEqual(['release-notes', 'Document · MD']);
   });
 
-  it('opens the original file and reports failures', async () => {
-    const error = new Error('open failed');
-    const onError = jest.fn();
-    mockOpenFilePreview.mockRejectedValue(error);
+  it('delegates a valid press to the caller', () => {
     const renderer = render(
       <FileAttachmentPreview
         categoryLabel="Document"
         file={file}
         labels={labels}
-        onError={onError}
+        onPress={onPress}
       />,
     );
-
     const pressable = renderer.root.findByProps({ accessibilityRole: 'button' });
-    await act(async () => pressable.props.onPress());
+    act(() => pressable.props.onPress());
 
-    expect(mockOpenFilePreview).toHaveBeenCalledWith({ file, labels });
-    expect(onError).toHaveBeenCalledWith(error, 'open');
+    expect(onPress).toHaveBeenCalledTimes(1);
   });
 
   it('renders a disabled unavailable state without opening', () => {
-    const renderer = render(<FileAttachmentPreview categoryLabel="Document" labels={labels} />);
+    const renderer = render(
+      <FileAttachmentPreview categoryLabel="Document" labels={labels} onPress={onPress} />,
+    );
     const pressable = renderer.root.findByProps({ accessibilityRole: 'button' });
 
     expect(pressable.props.disabled).toBe(true);
     expect(pressable.props.accessibilityLabel).toBe('Unavailable');
+    act(() => pressable.props.onPress());
+    expect(onPress).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/file-preview/__tests__/file-preview.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview.test.tsx
@@ -5,11 +5,8 @@ import { FilePreview } from '../components/file-preview';
 import { FilePreviewPluginProvider } from '../components/file-preview-plugin-provider';
 import type { FilePreviewFile, FilePreviewKind, FilePreviewPlugin } from '../file-preview.types';
 
-const mockOpenFilePreview = jest.fn();
+const onPress = jest.fn();
 
-jest.mock('../utils/open-file/open-file', () => ({
-  openFilePreview: (input: unknown) => mockOpenFilePreview(input),
-}));
 jest.mock('../default-plugins/default-plugins', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   return {
@@ -41,18 +38,17 @@ const compactPdfPlugins: readonly FilePreviewPlugin[] = [
 
 describe('FilePreview', () => {
   beforeEach(() => {
-    mockOpenFilePreview.mockReset();
-    mockOpenFilePreview.mockResolvedValue(undefined);
+    onPress.mockReset();
   });
 
   it('renders the plugin registered for the file kind', () => {
-    const renderer = render(<FilePreview file={file('image')} labels={labels} />);
+    const renderer = render(<FilePreview file={file('image')} labels={labels} onPress={onPress} />);
 
     expect(renderer.root.findAllByType('BuiltInImage')).toHaveLength(1);
   });
 
   it('falls back to the platform renderer for a kind no plugin claims', () => {
-    const renderer = render(<FilePreview file={file('pdf')} labels={labels} />);
+    const renderer = render(<FilePreview file={file('pdf')} labels={labels} onPress={onPress} />);
 
     expect(renderer.root.findAllByType('DefaultFallback')).toHaveLength(1);
   });
@@ -60,7 +56,13 @@ describe('FilePreview', () => {
   it('passes the resolved size and error reporter to the plugin', () => {
     const onError = jest.fn();
     const renderer = render(
-      <FilePreview file={file('pdf')} labels={labels} onError={onError} size={0} />,
+      <FilePreview
+        file={file('pdf')}
+        labels={labels}
+        onPress={onPress}
+        onError={onError}
+        size={0}
+      />,
     );
 
     expect(renderer.root.findByType('DefaultFallback').props).toMatchObject({ onError, size: 1 });
@@ -69,9 +71,9 @@ describe('FilePreview', () => {
   it('lets a provider claim a kind and inherit the rest', () => {
     const renderer = render(
       <FilePreviewPluginProvider plugins={pdfPlugins}>
-        <FilePreview file={file('pdf')} labels={labels} />
-        <FilePreview file={file('image')} labels={labels} />
-        <FilePreview file={file('text')} labels={labels} />
+        <FilePreview file={file('pdf')} labels={labels} onPress={onPress} />
+        <FilePreview file={file('image')} labels={labels} onPress={onPress} />
+        <FilePreview file={file('text')} labels={labels} onPress={onPress} />
       </FilePreviewPluginProvider>,
     );
 
@@ -84,7 +86,7 @@ describe('FilePreview', () => {
     const renderer = render(
       <FilePreviewPluginProvider plugins={pdfPlugins}>
         <FilePreviewPluginProvider plugins={compactPdfPlugins}>
-          <FilePreview file={file('pdf')} labels={labels} />
+          <FilePreview file={file('pdf')} labels={labels} onPress={onPress} />
         </FilePreviewPluginProvider>
       </FilePreviewPluginProvider>,
     );
@@ -93,23 +95,21 @@ describe('FilePreview', () => {
     expect(renderer.root.findAllByType('PdfPreview')).toHaveLength(0);
   });
 
-  it('opens the file through the platform module and reports failures', async () => {
-    const error = new Error('open failed');
-    const onError = jest.fn();
-    mockOpenFilePreview.mockRejectedValue(error);
-    const renderer = render(<FilePreview file={file('pdf')} labels={labels} onError={onError} />);
+  it('delegates a valid press to the caller', () => {
+    const renderer = render(<FilePreview file={file('pdf')} labels={labels} onPress={onPress} />);
 
-    await act(async () => renderer.root.findByType('FilePreviewFrame').props.onPress());
+    act(() => renderer.root.findByType('FilePreviewFrame').props.onPress());
 
-    expect(mockOpenFilePreview).toHaveBeenCalledWith({ file: file('pdf'), labels });
-    expect(onError).toHaveBeenCalledWith(error, 'open');
+    expect(onPress).toHaveBeenCalledTimes(1);
   });
 
   it('disables the frame when no file resolved', () => {
-    const renderer = render(<FilePreview labels={labels} />);
+    const renderer = render(<FilePreview labels={labels} onPress={onPress} />);
 
     expect(renderer.root.findAllByType('FilePreviewUnavailable')).toHaveLength(1);
     expect(renderer.root.findByType('FilePreviewFrame').props.disabled).toBe(true);
+    act(() => renderer.root.findByType('FilePreviewFrame').props.onPress());
+    expect(onPress).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/file-preview/components/file-attachment-preview.tsx
+++ b/packages/ui/src/components/file-preview/components/file-attachment-preview.tsx
@@ -3,20 +3,17 @@ import { Text, View } from 'react-native';
 import { Pressable } from 'react-native-gesture-handler';
 
 import type { FileAttachmentPreviewProps } from '../file-preview.types';
-import { openFilePreview } from '../utils/open-file/open-file';
 
 export function FileAttachmentPreview({
   categoryLabel,
   file,
   labels,
-  onError,
+  onPress,
 }: FileAttachmentPreviewProps) {
   const handlePress = () => {
     if (!file) return;
 
-    void openFilePreview({ file, labels }).catch((error) => {
-      onError?.(toError(error), 'open');
-    });
+    onPress();
   };
 
   return (
@@ -59,8 +56,4 @@ export function FileAttachmentPreview({
 function filenameStem(filename: string): string {
   const extensionIndex = filename.lastIndexOf('.');
   return extensionIndex > 0 ? filename.slice(0, extensionIndex) : filename;
-}
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/ui/src/components/file-preview/components/file-preview.tsx
+++ b/packages/ui/src/components/file-preview/components/file-preview.tsx
@@ -1,3 +1,5 @@
+import { createElement } from 'react';
+
 import type { FilePreviewProps } from '../file-preview.types';
 import { useFilePreviewPlugins } from '../hooks/use-file-preview-plugins';
 import { FilePreviewUnavailable } from './fallback-preview';
@@ -37,4 +39,3 @@ export function FilePreview({
     </FilePreviewFrame>
   );
 }
-import { createElement } from 'react';

--- a/packages/ui/src/components/file-preview/components/file-preview.tsx
+++ b/packages/ui/src/components/file-preview/components/file-preview.tsx
@@ -1,21 +1,24 @@
 import type { FilePreviewProps } from '../file-preview.types';
 import { useFilePreviewPlugins } from '../hooks/use-file-preview-plugins';
-import { openFilePreview } from '../utils/open-file/open-file';
 import { FilePreviewUnavailable } from './fallback-preview';
 import { FilePreviewFrame } from './file-preview-frame';
 
 const defaultSize = 112;
 
-export function FilePreview({ file, labels, onError, size = defaultSize }: FilePreviewProps) {
+export function FilePreview({
+  file,
+  labels,
+  onError,
+  onPress,
+  size = defaultSize,
+}: FilePreviewProps) {
   const resolvedSize = Math.max(1, size);
   const { resolve } = useFilePreviewPlugins();
   const handlePress = () => {
     if (!file) {
       return;
     }
-    void openFilePreview({ file, labels }).catch((error) => {
-      onError?.(toError(error), 'open');
-    });
+    onPress();
   };
   const Preview = file ? resolve(file.kind) : undefined;
 
@@ -27,14 +30,11 @@ export function FilePreview({ file, labels, onError, size = defaultSize }: FileP
       size={resolvedSize}
     >
       {file && Preview ? (
-        <Preview file={file} onError={onError} size={resolvedSize} />
+        createElement(Preview, { file, onError, size: resolvedSize })
       ) : (
         <FilePreviewUnavailable label={labels.unavailable} size={resolvedSize} />
       )}
     </FilePreviewFrame>
   );
 }
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}
+import { createElement } from 'react';

--- a/packages/ui/src/components/file-preview/file-preview.types.ts
+++ b/packages/ui/src/components/file-preview/file-preview.types.ts
@@ -33,8 +33,8 @@ export type FilePreviewLabels = {
 
 /**
  * What every renderer receives, built-in or registered. A renderer draws the
- * preview only: the frame, press target, and system opening stay with
- * `FilePreview` so a plugin cannot diverge on interaction.
+ * preview only: `FilePreview` owns the press target and delegates opening to
+ * the caller, so a plugin cannot diverge on interaction.
  */
 export type FilePreviewComponentProps = {
   file: FilePreviewFile;
@@ -53,6 +53,7 @@ export type FilePreviewProps = {
   file?: FilePreviewFile | null;
   labels: FilePreviewLabels;
   onError?: (error: Error, operation: FilePreviewOperation) => void;
+  onPress: () => void;
   size?: number;
 };
 

--- a/packages/ui/src/components/file-preview/index.ts
+++ b/packages/ui/src/components/file-preview/index.ts
@@ -1,6 +1,7 @@
 export { FileAttachmentPreview } from './components/file-attachment-preview';
 export { FilePreview } from './components/file-preview';
 export { FilePreviewPluginProvider } from './components/file-preview-plugin-provider';
+export { openFilePreview } from './utils/open-file/open-file';
 export type {
   BuiltInFilePreviewKind,
   FileAttachmentPreviewProps,

--- a/packages/ui/stories/message-parts/playground.stories.tsx
+++ b/packages/ui/stories/message-parts/playground.stories.tsx
@@ -9,6 +9,7 @@ import { MessagePartStoryFrame } from './story-frame';
 const onLinkPress = fn();
 const onSourcePress = fn();
 const onFileError = fn();
+const onFilePress = fn();
 
 const fileLabels = {
   openWith: 'Open with',
@@ -148,6 +149,7 @@ export const AllStates: Story = {
                 <FilePreview
                   file={imageFile}
                   labels={fileLabels}
+                  onPress={onFilePress}
                   onError={onFileError}
                   size={104}
                 />
@@ -156,12 +158,13 @@ export const AllStates: Story = {
                 <FilePreview
                   file={documentFile}
                   labels={fileLabels}
+                  onPress={onFilePress}
                   onError={onFileError}
                   size={104}
                 />
               </StoryExample>
               <StoryExample title="Unavailable">
-                <FilePreview labels={fileLabels} size={104} />
+                <FilePreview labels={fileLabels} onPress={onFilePress} size={104} />
               </StoryExample>
             </View>
           </StoryGroup>

--- a/src/frontend/components/FileEntryPreview/FileEntryPreview.test.tsx
+++ b/src/frontend/components/FileEntryPreview/FileEntryPreview.test.tsx
@@ -8,6 +8,7 @@ const mockAlertShow = jest.fn();
 const mockFileAttachmentPreview = jest.fn((_props: Record<string, unknown>) => null);
 const mockFilePreview = jest.fn((_props: Record<string, unknown>) => null);
 const mockLoggerWarn = jest.fn();
+const mockOpenFilePreview = jest.fn();
 const mockSkeleton = jest.fn((_props: Record<string, unknown>) => null);
 const mockUseResolvedFile = jest.fn();
 
@@ -15,6 +16,7 @@ jest.mock('@cherrystudio/ui/components', () => ({
   FileAttachmentPreview: (props: Record<string, unknown>) => mockFileAttachmentPreview(props),
   FilePreview: (props: Record<string, unknown>) => mockFilePreview(props),
   Skeleton: (props: Record<string, unknown>) => mockSkeleton(props),
+  openFilePreview: (input: unknown) => mockOpenFilePreview(input),
   useAlert: () => ({ alert: { show: mockAlertShow } }),
 }));
 jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -40,6 +42,7 @@ const entry = FileEntrySchema.parse({
 describe('FileEntryPreview', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOpenFilePreview.mockResolvedValue(undefined);
     mockUseResolvedFile.mockReturnValue({
       data: { entry, uri: 'file:///documents/image.png' },
       isLoading: false,
@@ -140,6 +143,24 @@ describe('FileEntryPreview', () => {
         labels: expect.objectContaining({ unavailable: 'filePreview.unavailable' }),
       }),
     );
+  });
+
+  it('opens original bytes and reports a rejected system open', async () => {
+    const error = new Error('No application can open this file');
+    mockOpenFilePreview.mockRejectedValueOnce(error);
+    act(() => {
+      create(<FileEntryPreview entryId={entry.id} />);
+    });
+    const onPress = mockFilePreview.mock.calls[0]?.[0].onPress as () => void;
+
+    await act(async () => onPress());
+
+    expect(mockOpenFilePreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: expect.objectContaining({ uri: 'file:///documents/image.png' }),
+      }),
+    );
+    expect(mockAlertShow).toHaveBeenCalledWith({ title: 'filePreview.openFailed' });
   });
 
   it('logs all preview errors and alerts only when opening fails', () => {

--- a/src/frontend/components/FileEntryPreview/FileEntryPreview.tsx
+++ b/src/frontend/components/FileEntryPreview/FileEntryPreview.tsx
@@ -1,7 +1,9 @@
 import {
   FileAttachmentPreview,
   FilePreview,
+  type FilePreviewFile,
   type FilePreviewOperation,
+  openFilePreview,
   useAlert,
 } from '@cherrystudio/ui/components';
 import { useCallback } from 'react';
@@ -70,16 +72,18 @@ function EntryPreview({
   size?: number;
   uri: string | undefined;
 }) {
-  const { handleError, t } = useFileEntryPreviewError(entryId);
+  const { handleError, openFile, t } = useFileEntryPreviewError(entryId);
+  const file = entry && uri ? toFilePreviewFile(entry, uri, previewUri) : null;
 
   return (
     <FilePreview
-      file={entry && uri ? toFilePreviewFile(entry, uri, previewUri) : null}
+      file={file}
       labels={{
         openWith: t('filePreview.openWith'),
         unavailable: t('filePreview.unavailable'),
       }}
       onError={handleError}
+      onPress={() => openFile(file)}
       size={size}
     />
   );
@@ -94,17 +98,19 @@ function EntryAttachment({
   entryId: FileEntryId;
   uri: string | undefined;
 }) {
-  const { handleError, t } = useFileEntryPreviewError(entryId);
+  const { handleError, openFile, t } = useFileEntryPreviewError(entryId);
+  const file = entry && uri ? toFilePreviewFile(entry, uri) : null;
 
   return (
     <FileAttachmentPreview
       categoryLabel={t('filePreview.document')}
-      file={entry && uri ? toFilePreviewFile(entry, uri) : null}
+      file={file}
       labels={{
         openWith: t('filePreview.openWith'),
         unavailable: t('filePreview.unavailable'),
       }}
       onError={handleError}
+      onPress={() => openFile(file)}
     />
   );
 }
@@ -122,5 +128,18 @@ function useFileEntryPreviewError(entryId: FileEntryId) {
     [alert, entryId, t],
   );
 
-  return { handleError, t };
+  const openFile = (file: FilePreviewFile | null) => {
+    if (!file) return;
+    void openFilePreview({
+      file,
+      labels: {
+        openWith: t('filePreview.openWith'),
+        unavailable: t('filePreview.unavailable'),
+      },
+    }).catch((error: unknown) => {
+      handleError(error instanceof Error ? error : new Error(String(error)), 'open');
+    });
+  };
+
+  return { handleError, openFile, t };
 }

--- a/src/frontend/components/FileEntryPreview/README.md
+++ b/src/frontend/components/FileEntryPreview/README.md
@@ -1,8 +1,8 @@
 # FileEntryPreview
 
 Application adapter from a managed `FileEntryId` to CherryUI's business-neutral `FilePreview`.
-It resolves the entry and local URI, classifies the file, injects translations, logs preview
-failures, and presents an Alert when the system viewer cannot open a file.
+It resolves the entry and local URI, classifies the file, injects translations, owns the press
+callback and system opening, logs preview failures, and presents an Alert when opening fails.
 
 `LoadedFileEntryPreview` is the same adapter for a caller that already holds the `FileEntry` — a
 list page, say — and accepts original and preview URIs resolved in the same batch as its peers.


### PR DESCRIPTION
### What this PR does

Before this PR, CherryUI's file preview components opened files directly through the platform viewer, so application callers could not route supported files into an in-app reader.

After this PR, `FilePreview` and `FileAttachmentPreview` require an `onPress` callback. The application owns opening and error feedback, and `openFilePreview` remains available through the public component API for system opening. Existing application callers, component tests, stories, and documentation are updated together.

This is the foundation layer for the file viewer feature in the next PR. It preserves the existing system-opening behavior on its own.

### Screenshots or videos

N/A: this layer changes callback ownership without an intended visual change.

### Why we need it and why it was done in this way

The application knows the managed-file identity and available routes; CherryUI owns the preview surface and press behavior. An explicit callback keeps navigation policy at that application boundary while preserving the shared system-opening primitive.

### Breaking changes

Internal component API change: callers of `FilePreview` and `FileAttachmentPreview` must provide `onPress`. All repository callers are migrated in this PR.

### Special notes for your reviewer

Validation on the final local stack head:

- `pnpm format:check`: passed.
- `git diff --check`: passed.
- Changed-file formatting and lint checks passed during implementation.
- `pnpm lint`: blocked by 7 existing `import/no-unresolved` errors for `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` in unchanged files; workspace package build outputs are absent.
- Tests were updated but not executed. Type checking, builds, and device verification were not run under the current task's verification restrictions.

### Checklist

- [x] Branch: this foundation PR targets `v0.2`.
- [x] PR: the description explains the behavior and ownership change.
- [x] Preview: no visible change is intended in this layer.
- [x] Documentation: the component README describes the callback contract.
- [ ] Verification: automated tests and type checking are pending.

### Release note

```release-note
NONE
```
