### PR TITLE
feat(file-preview): unify attachment and library cards

### DIFF
--- a/docs/references/file-preview-and-viewer.md
+++ b/docs/references/file-preview-and-viewer.md
@@ -71,7 +71,7 @@ under system bars. Images use constant black/white chrome; text uses theme surfa
 gesture is disabled while an image is zoomed, matching the existing painting viewer. Android
 system back remains native navigation.
 
-Every resolved file has a primary Share action and an Open with action in the overflow menu.
+Every resolved file has Share and Open with actions in the overflow menu.
 Images also have Save to Photos, using the add-only permission flow shared with the painting viewer.
 
 ### Image

--- a/docs/references/file-preview-and-viewer.md
+++ b/docs/references/file-preview-and-viewer.md
@@ -45,17 +45,20 @@ exported `openFilePreview` remains the platform primitive: Quick Look on iOS, ap
 
 | Surface | Images | Other files |
 | --- | --- | --- |
-| Composer and user-message strips | Existing square preview | Existing platform fallback |
+| Composer | Square thumbnail with removal control | Compact file-type icon above a multiline title |
+| User-message strips | Existing square preview | Existing platform fallback |
 | Assistant deliverables | Image itself at message width | Full-width filename/type row |
-| File library | Bounded WebP thumbnail | Existing platform fallback |
+| File library | Bounded WebP thumbnail | Title-first card with file-type icon at the bottom |
 
 Assistant images use the existing backend thumbnail query. Until dimensions load, the image
 reserves a square. The rendered aspect ratio matches the asset, with a height cap of 1.25 times
 its width and contain fitting for taller images. A thumbnail failure leaves the filename and an
 accessible open action. Opening always resolves the original file.
 
-Raster derivatives stay in the backend file-preview pipeline. Text excerpt cards are deferred;
-iOS keeps Quick Look thumbnails and Android keeps extension cards for those files.
+Raster derivatives stay in the backend file-preview pipeline. The composer and library share
+CherryUI's extension-to-icon presets and theme colors; icon routing never controls opening.
+Generated-file badges fit inside library cards. Text excerpt cards are deferred; the default
+`thumbnail` variant keeps iOS Quick Look thumbnails and Android extension cards.
 
 ## Viewer
 

--- a/packages/app-icons/src/icons/file-code-2.tsx
+++ b/packages/app-icons/src/icons/file-code-2.tsx
@@ -1,0 +1,11 @@
+import { createDesktopIcon } from '../create-desktop-icon';
+import { createIcon } from '../create-icon';
+
+const Icon = createDesktopIcon([
+  ['path', { d: 'M4 22h14a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v4', key: '1pf5j1' }],
+  ['path', { d: 'M14 2v4a2 2 0 0 0 2 2h4', key: 'tnqrlb' }],
+  ['path', { d: 'm5 12-3 3 3 3', key: 'oke12k' }],
+  ['path', { d: 'm9 18 3-3-3-3', key: '112psh' }],
+] as const);
+
+export default createIcon(Icon, 'FileCode2Icon');

--- a/packages/app-icons/src/icons/file-json.tsx
+++ b/packages/app-icons/src/icons/file-json.tsx
@@ -1,0 +1,17 @@
+import { createDesktopIcon } from '../create-desktop-icon';
+import { createIcon } from '../create-icon';
+
+const Icon = createDesktopIcon([
+  ['path', { d: 'M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z', key: '1rqfz7' }],
+  ['path', { d: 'M14 2v4a2 2 0 0 0 2 2h4', key: 'tnqrlb' }],
+  [
+    'path',
+    { d: 'M10 12a1 1 0 0 0-1 1v1a1 1 0 0 1-1 1 1 1 0 0 1 1 1v1a1 1 0 0 0 1 1', key: '1oajmo' },
+  ],
+  [
+    'path',
+    { d: 'M14 18a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1 1 1 0 0 1-1-1v-1a1 1 0 0 0-1-1', key: 'mpwhp6' },
+  ],
+] as const);
+
+export default createIcon(Icon, 'FileJsonIcon');

--- a/packages/app-icons/src/icons/file-spreadsheet.tsx
+++ b/packages/app-icons/src/icons/file-spreadsheet.tsx
@@ -1,0 +1,13 @@
+import { createDesktopIcon } from '../create-desktop-icon';
+import { createIcon } from '../create-icon';
+
+const Icon = createDesktopIcon([
+  ['path', { d: 'M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z', key: '1rqfz7' }],
+  ['path', { d: 'M14 2v4a2 2 0 0 0 2 2h4', key: 'tnqrlb' }],
+  ['path', { d: 'M8 13h2', key: 'yr2amv' }],
+  ['path', { d: 'M14 13h2', key: 'un5t4a' }],
+  ['path', { d: 'M8 17h2', key: '2yhykz' }],
+  ['path', { d: 'M14 17h2', key: '10kma7' }],
+] as const);
+
+export default createIcon(Icon, 'FileSpreadsheetIcon');

--- a/packages/app-icons/src/icons/file-type-2.tsx
+++ b/packages/app-icons/src/icons/file-type-2.tsx
@@ -1,0 +1,12 @@
+import { createDesktopIcon } from '../create-desktop-icon';
+import { createIcon } from '../create-icon';
+
+const Icon = createDesktopIcon([
+  ['path', { d: 'M4 22h14a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v4', key: '1pf5j1' }],
+  ['path', { d: 'M14 2v4a2 2 0 0 0 2 2h4', key: 'tnqrlb' }],
+  ['path', { d: 'M2 13v-1h6v1', key: '1dh9dg' }],
+  ['path', { d: 'M5 12v6', key: '150t9c' }],
+  ['path', { d: 'M4 18h2', key: '1xrofg' }],
+] as const);
+
+export default createIcon(Icon, 'FileType2Icon');

--- a/packages/app-icons/src/icons/presentation.tsx
+++ b/packages/app-icons/src/icons/presentation.tsx
@@ -1,0 +1,5 @@
+import Icon from 'lucide-react-native/icons/presentation';
+
+import { createIcon } from '../create-icon';
+
+export default createIcon(Icon, 'PresentationIcon');

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -75,6 +75,19 @@ logging, or translation dependency.
 callback while showing a filename and caller-supplied category label; square
 thumbnail callers continue to use `FilePreview`.
 
+`FilePreview` has three explicit visual variants. The default `thumbnail` uses the plugin and
+platform rendering described above. `attachment` puts a file-type icon above a multiline filename
+on a compact neutral tile; `card` puts the filename first and the icon at the bottom on a roomier
+surface. Both card variants retain image thumbnails and caller-controlled opening. An
+optional `badge` slot sits beside the document icon or over an image; callers own its meaning and
+localized content. The complete filename remains the accessible label when its extension is
+omitted from the visible title.
+
+`file-preview/utils/file-presentation.ts` owns extension-to-icon routing and categorical theme
+colors. Its icon choices follow desktop's `composer/tokenView/fileTokenPresentation.tsx`. The
+file-specific adapters in `@cherrystudio/app-icons` retain the desktop Lucide 0.525.0 vector paths
+where the current native Lucide version has renamed or redrawn them. They need no raster assets.
+
 `MarkdownText` is the shared GitHub-flavored Markdown renderer. Static content uses the enriched
 native renderer. A part that has streamed keeps the streaming renderer for its full mounted
 lifetime, including terminal state, so completion does not remount its native subtree. Both receive

--- a/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
@@ -16,9 +16,9 @@ describe('FilePreviewFrame', () => {
 
     expect(renderer?.toJSON()).toMatchObject({
       props: {
+        className: expect.stringContaining('rounded-2xl'),
         style: {
           borderCurve: 'continuous',
-          borderRadius: 16,
           height: 112,
           overflow: 'hidden',
           width: 112,

--- a/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
@@ -2,6 +2,14 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { FilePreviewFrame } from '../components/file-preview-frame';
 
+jest.mock('heroui-native/utils', () => {
+  const { twMerge } = jest.requireActual('tailwind-merge');
+
+  return {
+    cn: (...values: unknown[]) => twMerge(values.filter(Boolean).join(' ')),
+  };
+});
+
 describe('FilePreviewFrame', () => {
   it('clips previews to continuous rounded corners', () => {
     let renderer: ReactTestRenderer | undefined;

--- a/packages/ui/src/components/file-preview/__tests__/file-preview.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview.test.tsx
@@ -7,6 +7,14 @@ import type { FilePreviewFile, FilePreviewKind, FilePreviewPlugin } from '../fil
 
 const onPress = jest.fn();
 
+jest.mock('heroui-native/utils', () => {
+  const { twMerge } = jest.requireActual('tailwind-merge');
+
+  return {
+    cn: (...values: unknown[]) => twMerge(values.filter(Boolean).join(' ')),
+  };
+});
+
 jest.mock('../default-plugins/default-plugins', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   return {

--- a/packages/ui/src/components/file-preview/components/file-card-preview.tsx
+++ b/packages/ui/src/components/file-preview/components/file-card-preview.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+import { Text, View } from 'react-native';
+
+import { cn } from '../../../utils';
+import type { FilePreviewFile, FilePreviewVariant } from '../file-preview.types';
+import { fileDisplayStem, fileVisualPreset } from '../utils/file-presentation';
+
+/** Shared document artwork; FilePreview delegates the press to its caller. */
+export function FileCardPreview({
+  badge,
+  file,
+  variant,
+}: {
+  badge?: ReactNode;
+  file: FilePreviewFile;
+  variant: Exclude<FilePreviewVariant, 'thumbnail'>;
+}) {
+  const { icon: Icon, iconClassName } = fileVisualPreset(file);
+  const filename = (
+    <Text
+      className={cn('w-full shrink text-foreground', variant === 'card' ? 'text-base' : 'text-sm')}
+      ellipsizeMode="tail"
+      numberOfLines={3}
+    >
+      {fileDisplayStem(file.displayName)}
+    </Text>
+  );
+  const icon = (
+    <View className="w-full shrink-0 flex-row items-center justify-between gap-2">
+      <Icon className={cn('shrink-0', iconClassName, variant === 'card' ? 'size-7' : 'size-6')} />
+      {badge ? <View className="min-w-0 shrink">{badge}</View> : null}
+    </View>
+  );
+
+  return (
+    <View
+      className={cn(
+        'flex-1 items-start justify-between gap-1',
+        variant === 'card' ? 'bg-card p-4' : 'bg-secondary p-3',
+      )}
+    >
+      {variant === 'card' ? filename : icon}
+      {variant === 'card' ? icon : filename}
+    </View>
+  );
+}

--- a/packages/ui/src/components/file-preview/components/file-preview-frame.tsx
+++ b/packages/ui/src/components/file-preview/components/file-preview-frame.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import { Pressable } from 'react-native-gesture-handler';
 
-const frameRadius = 16;
+import { cn } from '../../../utils';
+import type { FilePreviewVariant } from '../file-preview.types';
 
 export function FilePreviewFrame({
   accessibilityLabel,
@@ -9,24 +10,25 @@ export function FilePreviewFrame({
   disabled,
   onPress,
   size,
+  variant = 'thumbnail',
 }: {
   accessibilityLabel: string;
   children: ReactNode;
   disabled?: boolean;
   onPress: () => void;
   size: number;
+  variant?: FilePreviewVariant;
 }) {
   return (
     <Pressable
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
       accessibilityState={disabled ? { disabled: true } : undefined}
-      className="active:opacity-70"
+      className={cn('active:opacity-70', variant === 'card' ? 'rounded-4xl' : 'rounded-2xl')}
       disabled={disabled}
       onPress={onPress}
       style={{
         borderCurve: 'continuous',
-        borderRadius: frameRadius,
         height: size,
         overflow: 'hidden',
         width: size,

--- a/packages/ui/src/components/file-preview/components/file-preview.tsx
+++ b/packages/ui/src/components/file-preview/components/file-preview.tsx
@@ -1,18 +1,22 @@
 import { createElement } from 'react';
+import { View } from 'react-native';
 
 import type { FilePreviewProps } from '../file-preview.types';
 import { useFilePreviewPlugins } from '../hooks/use-file-preview-plugins';
 import { FilePreviewUnavailable } from './fallback-preview';
+import { FileCardPreview } from './file-card-preview';
 import { FilePreviewFrame } from './file-preview-frame';
 
 const defaultSize = 112;
 
 export function FilePreview({
+  badge,
   file,
   labels,
   onError,
   onPress,
   size = defaultSize,
+  variant = 'thumbnail',
 }: FilePreviewProps) {
   const resolvedSize = Math.max(1, size);
   const { resolve } = useFilePreviewPlugins();
@@ -30,9 +34,21 @@ export function FilePreview({
       disabled={!file}
       onPress={handlePress}
       size={resolvedSize}
+      variant={variant}
     >
       {file && Preview ? (
-        createElement(Preview, { file, onError, size: resolvedSize })
+        variant !== 'thumbnail' && file.kind !== 'image' ? (
+          <FileCardPreview badge={badge} file={file} variant={variant} />
+        ) : (
+          <>
+            {createElement(Preview, { file, onError, size: resolvedSize })}
+            {badge ? (
+              <View className="absolute right-3 bottom-3 max-w-3/4" pointerEvents="none">
+                {badge}
+              </View>
+            ) : null}
+          </>
+        )
       ) : (
         <FilePreviewUnavailable label={labels.unavailable} size={resolvedSize} />
       )}

--- a/packages/ui/src/components/file-preview/file-preview.types.ts
+++ b/packages/ui/src/components/file-preview/file-preview.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 /**
  * The kinds CherryUI classifies for callers that want a shared vocabulary. Only
@@ -15,6 +15,9 @@ export type BuiltInFilePreviewKind = 'document' | 'image' | 'pdf' | 'text';
 export type FilePreviewKind = BuiltInFilePreviewKind | (string & {});
 
 export type FilePreviewOperation = 'open' | 'thumbnail';
+
+/** Native/content thumbnail, compact attachment, or title-first library card. */
+export type FilePreviewVariant = 'thumbnail' | 'attachment' | 'card';
 
 export type FilePreviewFile = {
   displayName: string;
@@ -50,13 +53,15 @@ export type FilePreviewPlugin = {
 };
 
 export type FilePreviewProps = {
+  badge?: ReactNode;
   file?: FilePreviewFile | null;
   labels: FilePreviewLabels;
   onError?: (error: Error, operation: FilePreviewOperation) => void;
   onPress: () => void;
   size?: number;
+  variant?: FilePreviewVariant;
 };
 
-export type FileAttachmentPreviewProps = Omit<FilePreviewProps, 'size'> & {
+export type FileAttachmentPreviewProps = Omit<FilePreviewProps, 'badge' | 'size' | 'variant'> & {
   categoryLabel: string;
 };

--- a/packages/ui/src/components/file-preview/index.ts
+++ b/packages/ui/src/components/file-preview/index.ts
@@ -13,4 +13,5 @@ export type {
   FilePreviewOperation,
   FilePreviewPlugin,
   FilePreviewProps,
+  FilePreviewVariant,
 } from './file-preview.types';

--- a/packages/ui/src/components/file-preview/utils/file-presentation.ts
+++ b/packages/ui/src/components/file-preview/utils/file-presentation.ts
@@ -1,0 +1,106 @@
+import FileIcon from '@cherrystudio/app-icons/icons/file';
+import FileCode2Icon from '@cherrystudio/app-icons/icons/file-code-2';
+import FileJsonIcon from '@cherrystudio/app-icons/icons/file-json';
+import FileSpreadsheetIcon from '@cherrystudio/app-icons/icons/file-spreadsheet';
+import FileTextIcon from '@cherrystudio/app-icons/icons/file-text';
+import FileType2Icon from '@cherrystudio/app-icons/icons/file-type-2';
+import PresentationIcon from '@cherrystudio/app-icons/icons/presentation';
+
+import type { FilePreviewFile } from '../file-preview.types';
+
+// Icon choices and extension groups follow desktop's composer/tokenView/
+// fileTokenPresentation.tsx. Category colors use Mobile's theme-aware tokens.
+const fileVisualPresets = {
+  word: {
+    icon: FileType2Icon,
+    iconClassName: 'text-tag-blue-foreground',
+    extensions: ['doc', 'docx'],
+  },
+  excel: {
+    icon: FileSpreadsheetIcon,
+    iconClassName: 'text-tag-green-foreground',
+    extensions: ['csv', 'xls', 'xlsx'],
+  },
+  powerpoint: {
+    icon: PresentationIcon,
+    iconClassName: 'text-tag-amber-foreground',
+    extensions: ['ppt', 'pptx'],
+  },
+  pdf: {
+    icon: FileTextIcon,
+    iconClassName: 'text-tag-red-foreground',
+    extensions: ['pdf'],
+  },
+  markdown: {
+    icon: FileTextIcon,
+    iconClassName: 'text-muted-foreground',
+    extensions: ['markdown', 'md', 'mdx'],
+  },
+  json: {
+    icon: FileJsonIcon,
+    iconClassName: 'text-tag-blue-foreground',
+    extensions: ['json', 'jsonl'],
+  },
+  code: {
+    icon: FileCode2Icon,
+    iconClassName: 'text-tag-blue-foreground',
+    extensions: [
+      'css',
+      'go',
+      'html',
+      'java',
+      'js',
+      'jsx',
+      'py',
+      'rs',
+      'ts',
+      'tsx',
+      'xml',
+      'yaml',
+      'yml',
+    ],
+  },
+  text: {
+    icon: FileTextIcon,
+    iconClassName: 'text-tag-blue-foreground',
+    extensions: ['log', 'text', 'txt'],
+  },
+  document: {
+    icon: FileTextIcon,
+    iconClassName: 'text-muted-foreground',
+    extensions: [],
+  },
+  fallback: {
+    icon: FileIcon,
+    iconClassName: 'text-muted-foreground',
+    extensions: [],
+  },
+} as const;
+
+type FileVisualPreset = (typeof fileVisualPresets)[keyof typeof fileVisualPresets];
+
+const fileVisualPresetByExtension = new Map<string, FileVisualPreset>(
+  Object.values(fileVisualPresets).flatMap((preset) =>
+    preset.extensions.map((extension) => [extension, preset] as const),
+  ),
+);
+
+export function fileVisualPreset(file: FilePreviewFile): FileVisualPreset {
+  const extensionIndex = file.displayName.lastIndexOf('.');
+  const extension =
+    extensionIndex > 0 ? file.displayName.slice(extensionIndex + 1) : file.extensionLabel;
+
+  const preset = fileVisualPresetByExtension.get(extension.toLowerCase());
+  if (preset) return preset;
+  if (file.kind === 'pdf') return fileVisualPresets.pdf;
+  if (file.kind === 'markdown') return fileVisualPresets.markdown;
+  if (file.kind === 'html') return fileVisualPresets.code;
+  if (file.kind === 'text') return fileVisualPresets.text;
+  if (file.kind === 'document') return fileVisualPresets.document;
+  return fileVisualPresets.fallback;
+}
+
+export function fileDisplayStem(filename: string): string {
+  const extensionIndex = filename.lastIndexOf('.');
+  return extensionIndex > 0 ? filename.slice(0, extensionIndex) : filename;
+}

--- a/src/frontend/components/Composer/components/ComposerAttachmentStrip.tsx
+++ b/src/frontend/components/Composer/components/ComposerAttachmentStrip.tsx
@@ -27,8 +27,9 @@ export function ComposerAttachmentStrip({
   return (
     <ScrollView
       alwaysBounceHorizontal={false}
-      contentContainerClassName="gap-3 pr-1"
+      contentContainerClassName="gap-2 pr-1"
       horizontal
+      keyboardShouldPersistTaps="handled"
       showsHorizontalScrollIndicator={false}
     >
       {attachments.map((attachment) =>
@@ -59,7 +60,7 @@ function ManagedAttachmentTile({
 }) {
   return (
     <View accessibilityLabel={attachment.name}>
-      <FileEntryPreview entryId={attachment.fileEntryId} />
+      <FileEntryPreview entryId={attachment.fileEntryId} variant="attachment" />
       <RemoveBadge onPress={onRemove} />
     </View>
   );
@@ -78,14 +79,14 @@ function ImportingAttachmentTile({
         accessibilityLabel={attachment.name}
         accessibilityState={{ busy: true }}
         accessible
-        className="size-28 items-center justify-center gap-2 overflow-hidden rounded-2xl border border-border bg-secondary p-2"
+        className="size-28 items-start justify-between gap-1 overflow-hidden rounded-2xl bg-secondary p-3"
       >
         <Spinner
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
           size="sm"
         />
-        <Text className="text-center text-base text-muted-foreground" numberOfLines={2}>
+        <Text className="w-full shrink text-sm text-muted-foreground" numberOfLines={3}>
           {attachment.name}
         </Text>
       </View>

--- a/src/frontend/components/FileEntryPreview/FileEntryPreview.test.tsx
+++ b/src/frontend/components/FileEntryPreview/FileEntryPreview.test.tsx
@@ -132,7 +132,8 @@ describe('FileEntryPreview', () => {
 
     expect(mockFilePreview).not.toHaveBeenCalled();
     expect(mockSkeleton).toHaveBeenCalledWith({
-      style: { borderRadius: 16, height: 96, width: 96 },
+      className: 'rounded-2xl',
+      style: { height: 96, width: 96 },
     });
   });
 

--- a/src/frontend/components/FileEntryPreview/FileEntryPreview.tsx
+++ b/src/frontend/components/FileEntryPreview/FileEntryPreview.tsx
@@ -2,8 +2,9 @@ import {
   FileAttachmentPreview,
   FilePreview,
   type FilePreviewOperation,
+  type FilePreviewVariant,
 } from '@cherrystudio/ui/components';
-import { useCallback } from 'react';
+import { type ReactNode, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { loggerService } from '@/shared/core/logger/LoggerService';
@@ -18,14 +19,30 @@ import { fileEntryPreviewKind, toFilePreviewFile } from './utils/fileEntryPresen
 const logger = loggerService.withContext('FileEntryPreview');
 
 /** Reads the entry by id, then its URI. */
-export function FileEntryPreview({ entryId, size }: { entryId: FileEntryId; size?: number }) {
+export function FileEntryPreview({
+  entryId,
+  size,
+  variant,
+}: {
+  entryId: FileEntryId;
+  size?: number;
+  variant?: FilePreviewVariant;
+}) {
   const { data, isLoading } = useResolvedFile(entryId);
 
   if (isLoading) {
-    return <FileEntrySkeleton size={size} />;
+    return <FileEntrySkeleton size={size} variant={variant} />;
   }
 
-  return <EntryPreview entry={data?.entry} entryId={entryId} size={size} uri={data?.uri} />;
+  return (
+    <EntryPreview
+      entry={data?.entry}
+      entryId={entryId}
+      size={size}
+      uri={data?.uri}
+      variant={variant}
+    />
+  );
 }
 
 /** Assistant artifacts render images directly; other files retain their result row. */
@@ -47,33 +64,49 @@ export function FileEntryAttachment({ entryId }: { entryId: FileEntryId }) {
  * Same preview for a caller that already holds the entry and its resolved URI.
  */
 export function LoadedFileEntryPreview({
+  badge,
   entry,
   previewUri,
   size,
   uri,
+  variant,
 }: {
+  badge?: ReactNode;
   entry: FileEntry;
   previewUri: string | undefined;
   size?: number;
   uri: string | undefined;
+  variant?: FilePreviewVariant;
 }) {
   return (
-    <EntryPreview entry={entry} entryId={entry.id} previewUri={previewUri} size={size} uri={uri} />
+    <EntryPreview
+      badge={badge}
+      entry={entry}
+      entryId={entry.id}
+      previewUri={previewUri}
+      size={size}
+      uri={uri}
+      variant={variant}
+    />
   );
 }
 
 function EntryPreview({
+  badge,
   entry,
   entryId,
   previewUri,
   size,
   uri,
+  variant,
 }: {
+  badge?: ReactNode;
   entry: FileEntry | undefined;
   entryId: FileEntryId;
   previewUri?: string;
   size?: number;
   uri: string | undefined;
+  variant?: FilePreviewVariant;
 }) {
   const { handleError, t } = useFileEntryPreviewError(entryId);
   const { openFileEntry } = useOpenFileEntry();
@@ -81,6 +114,7 @@ function EntryPreview({
 
   return (
     <FilePreview
+      badge={badge}
       file={file}
       labels={{
         openWith: t('filePreview.openWith'),
@@ -91,6 +125,7 @@ function EntryPreview({
         if (entry && uri) openFileEntry({ entry, uri });
       }}
       size={size}
+      variant={variant}
     />
   );
 }

--- a/src/frontend/components/FileEntryPreview/FileEntrySkeleton.tsx
+++ b/src/frontend/components/FileEntryPreview/FileEntrySkeleton.tsx
@@ -1,14 +1,20 @@
-import { Skeleton } from '@cherrystudio/ui/components';
+import { type FilePreviewVariant, Skeleton } from '@cherrystudio/ui/components';
 
 const defaultSize = 112;
 
-export function FileEntrySkeleton({ size = defaultSize }: { size?: number }) {
+export function FileEntrySkeleton({
+  size = defaultSize,
+  variant = 'thumbnail',
+}: {
+  size?: number;
+  variant?: FilePreviewVariant;
+}) {
   const resolvedSize = Math.max(1, size);
 
   return (
     <Skeleton
+      className={variant === 'card' ? 'rounded-4xl' : 'rounded-2xl'}
       style={{
-        borderRadius: 16,
         height: resolvedSize,
         width: resolvedSize,
       }}

--- a/src/frontend/components/FileEntryPreview/README.md
+++ b/src/frontend/components/FileEntryPreview/README.md
@@ -20,6 +20,12 @@ logging, and the single opening policy shared by the composer, messages, and fil
 Opening failures report a toast. Thumbnail failures are logged and keep the existing fallback.
 The image thumbnail query uses the same resolved-entry shape and query key as the file library.
 
+The adapters forward CherryUI's `variant`: the composer uses `attachment` (icon above the file
+title), and the library uses `card` (title above the icon). Images keep their thumbnails. Both
+variants share the file icon/color presets in CherryUI, while the default `thumbnail` retains
+plugin and platform preview rendering. `LoadedFileEntryPreview` also forwards a caller-owned
+`badge`, used for the library's generated-file provenance without reserving empty metadata rows.
+
 ## Renderer Boundary
 
 CherryUI requires `onPress` and owns the frame, press target, unavailable state, plugin registry,
@@ -31,8 +37,10 @@ Product-specific parsing or backend calls remain in this adapter family. Add a n
 only with explicit card and opening behavior; the CherryUI plugin vocabulary itself stays open.
 Do not infer a second classification from filenames at individual surfaces.
 
-Cards keep the current platform fallback for text and unsupported documents. Text excerpts are a
-separate follow-up; this implementation prioritizes opening and using the file.
+The default `thumbnail` variant keeps the platform fallback for text and unsupported documents.
+The composer's `attachment` and library's `card` variants use the shared file icon/title layout.
+Extension-based icon routing changes artwork only; it never changes product classification or
+opening. Text excerpts remain a separate follow-up.
 
 The viewer and export behavior are documented in
 [File Preview And Viewer](../../../../docs/references/file-preview-and-viewer.md).

--- a/src/frontend/features/files/components/FileViewerHeader.tsx
+++ b/src/frontend/features/files/components/FileViewerHeader.tsx
@@ -50,32 +50,35 @@ export function FileViewerHeader({
     }
   };
 
-  const menuItems: MenuItem[] = [...items];
-  if (isImage) {
-    menuItems.push({
-      id: 'save-to-photos',
-      label: t('fileViewer.saveToPhotos'),
-      onPress: () => void saveToPhotos(),
-    });
-  }
-  menuItems.push({
-    id: 'open-with',
-    label: t('filePreview.openWith'),
-    onPress: () => void openFileEntryWithSystem(file),
-  });
+  const menuItems: MenuItem[] = [
+    ...items,
+    {
+      disabled: isSharing,
+      id: 'share',
+      label: t('fileViewer.share'),
+      onPress: () => void share(),
+    },
+    ...(isImage
+      ? [
+          {
+            id: 'save-to-photos',
+            label: t('fileViewer.saveToPhotos'),
+            onPress: () => void saveToPhotos(),
+          },
+        ]
+      : []),
+    {
+      id: 'open-with',
+      label: t('filePreview.openWith'),
+      onPress: () => void openFileEntryWithSystem(file),
+    },
+  ];
 
   return (
     <HeaderChrome
       actionTone={isImage ? 'inverse' : 'default'}
       leftActions={[leadingAction]}
       rightActions={[
-        {
-          disabled: isSharing,
-          key: 'share',
-          label: t('fileViewer.share'),
-          onPress: () => void share(),
-          type: 'label',
-        },
         {
           accessibilityLabel: t('common.more'),
           icon: EllipsisIcon,

--- a/src/frontend/features/library/components/FileLibraryList.tsx
+++ b/src/frontend/features/library/components/FileLibraryList.tsx
@@ -57,8 +57,7 @@ export function FileLibraryList({
   const tileSize =
     (windowWidth - fileLibraryGrid.pageEdge * 2 - fileLibraryGrid.tileGap) /
     fileLibraryGrid.columns;
-  const estimatedItemSize =
-    tileSize + fileLibraryGrid.tileMetadataEstimatedHeight + fileLibraryGrid.tileGap;
+  const estimatedItemSize = tileSize + fileLibraryGrid.tileGap;
 
   const contentContainerStyle = useMemo(
     () => ({
@@ -153,39 +152,32 @@ const FileTile = memo(function FileTile({ item, size }: { item: FileLibraryEntry
 
   return (
     <View
-      className="gap-2"
       style={{
         paddingBottom: fileLibraryGrid.tileGap,
         paddingHorizontal: fileLibraryGrid.tileGap / 2,
       }}
     >
       {fileEntryPreviewKind(item.entry) === 'image' && !item.previewUri ? (
-        <FileEntrySkeleton size={size} />
+        <FileEntrySkeleton size={size} variant="card" />
       ) : (
         <LoadedFileEntryPreview
+          badge={
+            isGenerated ? (
+              <View className="flex-row items-center gap-1 rounded-full bg-card/95 px-2 py-1">
+                <SparklesIcon className="size-3.5 text-muted-foreground" />
+                <Text className="shrink text-xs text-muted-foreground" numberOfLines={1}>
+                  {t('library.provenance.generated')}
+                </Text>
+              </View>
+            ) : undefined
+          }
           entry={item.entry}
           previewUri={item.previewUri}
           size={size}
           uri={item.uri}
+          variant="card"
         />
       )}
-      <View className="min-w-0 gap-0.5 px-0.5">
-        <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
-          {item.entry.filename}
-        </Text>
-        {/* Held open whether or not the badge shows, so a labelled tile does not
-            make its whole grid row taller than its neighbours. */}
-        <View className="flex-row items-center gap-1" style={styles.provenance}>
-          {isGenerated ? (
-            <>
-              <SparklesIcon className="size-3.5 text-muted-foreground" />
-              <Text className="text-xs text-muted-foreground" numberOfLines={1}>
-                {t('library.provenance.generated')}
-              </Text>
-            </>
-          ) : null}
-        </View>
-      </View>
     </View>
   );
 });
@@ -196,8 +188,5 @@ const styles = StyleSheet.create({
   },
   header: {
     marginHorizontal: fileLibraryGrid.tileGap / 2,
-  },
-  provenance: {
-    height: fileLibraryGrid.tileProvenanceHeight,
   },
 });

--- a/src/frontend/features/library/components/FileLibrarySkeleton.tsx
+++ b/src/frontend/features/library/components/FileLibrarySkeleton.tsx
@@ -1,5 +1,4 @@
-import { Skeleton } from '@cherrystudio/ui/components';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { FileEntrySkeleton } from '@/frontend/components/FileEntryPreview';
 
@@ -15,28 +14,15 @@ export function FileLibrarySkeleton({ count, tileSize }: { count: number; tileSi
     <View className="flex-row flex-wrap" testID="file-library-skeleton">
       {Array.from({ length: count }, (_, index) => (
         <View
-          className="gap-2"
           key={index}
           style={{
             paddingBottom: fileLibraryGrid.tileGap,
             paddingHorizontal: fileLibraryGrid.tileGap / 2,
           }}
         >
-          <FileEntrySkeleton size={tileSize} />
-          <View className="gap-0.5 px-0.5">
-            <Skeleton className="h-5 w-3/4 rounded-sm" />
-            {/* The origin badge is absent on most tiles, so the placeholder
-                reserves its line rather than promising one. */}
-            <View style={styles.provenance} />
-          </View>
+          <FileEntrySkeleton size={tileSize} variant="card" />
         </View>
       ))}
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  provenance: {
-    height: fileLibraryGrid.tileProvenanceHeight,
-  },
-});

--- a/src/frontend/features/library/utils/constants.ts
+++ b/src/frontend/features/library/utils/constants.ts
@@ -4,8 +4,6 @@ export const fileLibraryGrid = {
   pageEdge: 16, // page margin outside the outermost tiles
   skeletonTiles: 6, // placeholder tiles shown while a page is in flight
   tileGap: 12, // gap between tiles, horizontally and vertically
-  tileProvenanceHeight: 16, // origin badge line, reserved whether or not it fills
-  tileMetadataEstimatedHeight: 46, // preview gap, filename, and the badge line
 } as const;
 
 /**


### PR DESCRIPTION
### What this PR does

Before this PR, document attachments used platform-dependent thumbnails or extension cards, and the file library placed filenames and a reserved metadata row below each preview.

After this PR:

- The chat composer shows compact rounded cards with a file-type icon, multiline filename, and the existing remove control.
- The file library shows title-first cards with the file-type icon and generated-file badge inside the card. Image thumbnails remain available.
- Shared file presentation presets select the desktop file icons and Mobile's theme colors for Word, spreadsheets, presentations, PDF, text, Markdown, JSON, and code.

### Screenshots or videos

Pending light/dark device acceptance. Screenshots were not captured because device verification is user-owned for this task.

### Why we need it and why it was done in this way

The composer and library need a consistent, readable file presentation. Explicit `attachment` and `card` variants extend the existing CherryUI `FilePreview`, keeping icon selection, layout, and optional badge placement together. The default `thumbnail` variant and application-owned opening callbacks continue to support existing callers and the new file viewer.

File-specific icon adapters retain the desktop Lucide vector paths where the installed native version has renamed or redrawn them. Existing categorical theme tokens provide light/dark colors. Matching skeleton geometry and library row estimates remove the old empty metadata space.

### Breaking changes

None. The new visual variants and badge slot are optional.

### Special notes for your reviewer

- Passed: `pnpm format:check`, changed-file Oxlint and Expo lint, and `git diff --check`.
- Full `pnpm lint` was attempted. It reports 7 import-resolution errors in unchanged backend files because this workspace has no `packages/ai-core/dist` build output; the package exports point into that directory. Unrelated existing warnings are also reported.
- Local builds, type checks, automated tests, specialized validation commands, and device acceptance were not run under the task's user-owned verification policy.
- Remote [PR CI](https://github.com/CherryHQ/cherry-studio-app/actions/runs/34086751098) passed all test, lint, and typecheck jobs for `94914a921`. The file-preview suites use the existing HeroUI utility mock pattern to avoid loading untransformed ESM dependencies in Jest.
- Light/dark device acceptance and screenshots remain pending.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the resulting behavior and validation limits
- [ ] Preview: Light/dark screenshots or a video are attached
- [x] Code: The composer and library share file presentation ownership
- [x] Documentation: Component and file-viewer references are updated
- [x] Self-review: The local diff was reviewed before submission

### Release note

```release-note
File attachments now use consistent type icons and readable card layouts in the chat composer and file library.
```
