### PR TITLE
refactor(chat-input): unify file picking and preview visuals

### DIFF
--- a/docs/references/file-preview-and-viewer.md
+++ b/docs/references/file-preview-and-viewer.md
@@ -47,7 +47,7 @@ exported `openFilePreview` remains the platform primitive: Quick Look on iOS, ap
 | --- | --- | --- |
 | Composer | Square thumbnail with removal control | Compact file-type icon above a multiline title |
 | Chat file picker | Square thumbnail | Compact file-type icon beside the filename metadata |
-| User-message strips | Existing square preview | Existing platform fallback |
+| User-message strips | Square thumbnail | Compact file-type icon above a multiline title |
 | Assistant deliverables | Image itself at message width | Full-width filename/type row |
 | File library | Bounded WebP thumbnail | Title-first card with file-type icon at the bottom |
 

--- a/docs/references/file-preview-and-viewer.md
+++ b/docs/references/file-preview-and-viewer.md
@@ -46,6 +46,7 @@ exported `openFilePreview` remains the platform primitive: Quick Look on iOS, ap
 | Surface | Images | Other files |
 | --- | --- | --- |
 | Composer | Square thumbnail with removal control | Compact file-type icon above a multiline title |
+| Chat file picker | Square thumbnail | Compact file-type icon beside the filename metadata |
 | User-message strips | Existing square preview | Existing platform fallback |
 | Assistant deliverables | Image itself at message width | Full-width filename/type row |
 | File library | Bounded WebP thumbnail | Title-first card with file-type icon at the bottom |

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -75,10 +75,12 @@ logging, or translation dependency.
 callback while showing a filename and caller-supplied category label; square
 thumbnail callers continue to use `FilePreview`.
 
-`FilePreview` has three explicit visual variants. The default `thumbnail` uses the plugin and
-platform rendering described above. `attachment` puts a file-type icon above a multiline filename
-on a compact neutral tile; `card` puts the filename first and the icon at the bottom on a roomier
-surface. Both card variants retain image thumbnails and caller-controlled opening. An
+`FilePreview` has four explicit visual variants. The default `thumbnail` uses the plugin and
+platform rendering described above. `icon` keeps image thumbnails but represents other files with
+only their type icon, for rows that already show the filename. `attachment` puts a file-type icon
+above a multiline filename on a compact neutral tile; `card` puts the filename first and the icon
+at the bottom on a roomier surface. The `icon`, `attachment`, and `card` variants retain image
+thumbnails and caller-controlled opening. An
 optional `badge` slot sits beside the document icon or over an image; callers own its meaning and
 localized content. The complete filename remains the accessible label when its extension is
 omitted from the visible title.

--- a/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
@@ -1,20 +1,15 @@
+import { View } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { FilePreviewFrame } from '../components/file-preview-frame';
 
-jest.mock('uniwind', () => ({
-  useResolveClassNames: (className: string) => ({
-    borderRadius: className === 'rounded-4xl' ? 26 : 18,
-  }),
-}));
-
 describe('FilePreviewFrame', () => {
   test.each([
-    ['default', undefined, 112, 18],
-    ['library card', 'card', 160, 26],
+    ['default', undefined, 112, 'rounded-2xl'],
+    ['library card', 'card', 160, 'rounded-4xl'],
   ] as const)(
-    'clips %s previews to the resolved continuous corners',
-    (_, variant, size, radius) => {
+    'clips %s preview content at the shared corner boundary',
+    (_, variant, size, cornerClassName) => {
       let renderer: ReactTestRenderer | undefined;
 
       act(() => {
@@ -33,13 +28,18 @@ describe('FilePreviewFrame', () => {
       expect(renderer?.toJSON()).toMatchObject({
         props: {
           style: {
-            borderCurve: 'continuous',
-            borderRadius: radius,
             height: size,
-            overflow: 'hidden',
             width: size,
           },
         },
+      });
+
+      const clippingView = renderer?.root
+        .findAllByType(View)
+        .find((node) => node.props.className?.includes('overflow-hidden'));
+      expect(clippingView?.props).toMatchObject({
+        className: `size-full overflow-hidden ${cornerClassName}`,
+        style: { borderCurve: 'continuous' },
       });
     },
   );

--- a/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview-frame.test.tsx
@@ -2,36 +2,45 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { FilePreviewFrame } from '../components/file-preview-frame';
 
-jest.mock('heroui-native/utils', () => {
-  const { twMerge } = jest.requireActual('tailwind-merge');
-
-  return {
-    cn: (...values: unknown[]) => twMerge(values.filter(Boolean).join(' ')),
-  };
-});
+jest.mock('uniwind', () => ({
+  useResolveClassNames: (className: string) => ({
+    borderRadius: className === 'rounded-4xl' ? 26 : 18,
+  }),
+}));
 
 describe('FilePreviewFrame', () => {
-  it('clips previews to continuous rounded corners', () => {
-    let renderer: ReactTestRenderer | undefined;
+  test.each([
+    ['default', undefined, 112, 18],
+    ['library card', 'card', 160, 26],
+  ] as const)(
+    'clips %s previews to the resolved continuous corners',
+    (_, variant, size, radius) => {
+      let renderer: ReactTestRenderer | undefined;
 
-    act(() => {
-      renderer = create(
-        <FilePreviewFrame accessibilityLabel="Attachment" onPress={jest.fn()} size={112}>
-          <></>
-        </FilePreviewFrame>,
-      );
-    });
+      act(() => {
+        renderer = create(
+          <FilePreviewFrame
+            accessibilityLabel="Attachment"
+            onPress={jest.fn()}
+            size={size}
+            variant={variant}
+          >
+            <></>
+          </FilePreviewFrame>,
+        );
+      });
 
-    expect(renderer?.toJSON()).toMatchObject({
-      props: {
-        className: expect.stringContaining('rounded-2xl'),
-        style: {
-          borderCurve: 'continuous',
-          height: 112,
-          overflow: 'hidden',
-          width: 112,
+      expect(renderer?.toJSON()).toMatchObject({
+        props: {
+          style: {
+            borderCurve: 'continuous',
+            borderRadius: radius,
+            height: size,
+            overflow: 'hidden',
+            width: size,
+          },
         },
-      },
-    });
-  });
+      });
+    },
+  );
 });

--- a/packages/ui/src/components/file-preview/__tests__/file-preview.test.tsx
+++ b/packages/ui/src/components/file-preview/__tests__/file-preview.test.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
+import { FileCardPreview } from '../components/file-card-preview';
 import { FilePreview } from '../components/file-preview';
 import { FilePreviewPluginProvider } from '../components/file-preview-plugin-provider';
 import type { FilePreviewFile, FilePreviewKind, FilePreviewPlugin } from '../file-preview.types';
@@ -35,7 +36,6 @@ jest.mock('../components/fallback-preview', () => {
     FilePreviewUnavailable: (props: object) => React.createElement('FilePreviewUnavailable', props),
   };
 });
-
 const labels = { openWith: 'Open with', unavailable: 'Unavailable' };
 const pdfPlugins: readonly FilePreviewPlugin[] = [
   { component: (props) => createElement('PdfPreview', props), kind: 'pdf' },
@@ -59,6 +59,24 @@ describe('FilePreview', () => {
     const renderer = render(<FilePreview file={file('pdf')} labels={labels} onPress={onPress} />);
 
     expect(renderer.root.findAllByType('DefaultFallback')).toHaveLength(1);
+  });
+
+  it('uses the shared icon artwork instead of a platform thumbnail when requested', () => {
+    const renderer = render(
+      <FilePreview file={file('pdf')} labels={labels} onPress={onPress} variant="icon" />,
+    );
+
+    expect(renderer.root.findByType(FileCardPreview).props.variant).toBe('icon');
+    expect(renderer.root.findAllByType('DefaultFallback')).toHaveLength(0);
+  });
+
+  it('keeps image thumbnails in the icon variant', () => {
+    const renderer = render(
+      <FilePreview file={file('image')} labels={labels} onPress={onPress} variant="icon" />,
+    );
+
+    expect(renderer.root.findAllByType('BuiltInImage')).toHaveLength(1);
+    expect(renderer.root.findAllByType(FileCardPreview)).toHaveLength(0);
   });
 
   it('passes the resolved size and error reporter to the plugin', () => {

--- a/packages/ui/src/components/file-preview/components/file-card-preview.tsx
+++ b/packages/ui/src/components/file-preview/components/file-card-preview.tsx
@@ -16,6 +16,20 @@ export function FileCardPreview({
   variant: Exclude<FilePreviewVariant, 'thumbnail'>;
 }) {
   const { icon: Icon, iconClassName } = fileVisualPreset(file);
+
+  if (variant === 'icon') {
+    return (
+      <View className="flex-1 items-center justify-center bg-secondary">
+        <Icon className={cn('size-6 shrink-0', iconClassName)} />
+        {badge ? (
+          <View className="absolute right-1 bottom-1 max-w-3/4" pointerEvents="none">
+            {badge}
+          </View>
+        ) : null}
+      </View>
+    );
+  }
+
   const filename = (
     <Text
       className={cn('w-full shrink text-foreground', variant === 'card' ? 'text-base' : 'text-sm')}

--- a/packages/ui/src/components/file-preview/components/file-preview-frame.tsx
+++ b/packages/ui/src/components/file-preview/components/file-preview-frame.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
+import { View } from 'react-native';
 import { Pressable } from 'react-native-gesture-handler';
-import { useResolveClassNames } from 'uniwind';
 
 import type { FilePreviewVariant } from '../file-preview.types';
 
@@ -19,7 +19,10 @@ export function FilePreviewFrame({
   size: number;
   variant?: FilePreviewVariant;
 }) {
-  const cornerStyle = useResolveClassNames(variant === 'card' ? 'rounded-4xl' : 'rounded-2xl');
+  const clippingClassName =
+    variant === 'card'
+      ? 'size-full overflow-hidden rounded-4xl'
+      : 'size-full overflow-hidden rounded-2xl';
 
   return (
     <Pressable
@@ -30,14 +33,13 @@ export function FilePreviewFrame({
       disabled={disabled}
       onPress={onPress}
       style={{
-        ...cornerStyle,
-        borderCurve: 'continuous',
         height: size,
-        overflow: 'hidden',
         width: size,
       }}
     >
-      {children}
+      <View className={clippingClassName} style={{ borderCurve: 'continuous' }}>
+        {children}
+      </View>
     </Pressable>
   );
 }

--- a/packages/ui/src/components/file-preview/components/file-preview-frame.tsx
+++ b/packages/ui/src/components/file-preview/components/file-preview-frame.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Pressable } from 'react-native-gesture-handler';
+import { useResolveClassNames } from 'uniwind';
 
-import { cn } from '../../../utils';
 import type { FilePreviewVariant } from '../file-preview.types';
 
 export function FilePreviewFrame({
@@ -19,15 +19,18 @@ export function FilePreviewFrame({
   size: number;
   variant?: FilePreviewVariant;
 }) {
+  const cornerStyle = useResolveClassNames(variant === 'card' ? 'rounded-4xl' : 'rounded-2xl');
+
   return (
     <Pressable
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
       accessibilityState={disabled ? { disabled: true } : undefined}
-      className={cn('active:opacity-70', variant === 'card' ? 'rounded-4xl' : 'rounded-2xl')}
+      className="active:opacity-70"
       disabled={disabled}
       onPress={onPress}
       style={{
+        ...cornerStyle,
         borderCurve: 'continuous',
         height: size,
         overflow: 'hidden',

--- a/packages/ui/src/components/file-preview/file-preview.types.ts
+++ b/packages/ui/src/components/file-preview/file-preview.types.ts
@@ -16,8 +16,8 @@ export type FilePreviewKind = BuiltInFilePreviewKind | (string & {});
 
 export type FilePreviewOperation = 'open' | 'thumbnail';
 
-/** Native/content thumbnail, compact attachment, or title-first library card. */
-export type FilePreviewVariant = 'thumbnail' | 'attachment' | 'card';
+/** Native/content thumbnail, icon tile, compact attachment, or title-first library card. */
+export type FilePreviewVariant = 'thumbnail' | 'icon' | 'attachment' | 'card';
 
 export type FilePreviewFile = {
   displayName: string;

--- a/src/frontend/components/Composer/README.md
+++ b/src/frontend/components/Composer/README.md
@@ -49,8 +49,8 @@ plus `allowEmptySend` and `isSendEnabled` — see `canSend` below.
 - `ComposerMenu` — the ＋ menu. `children` are extra `Composer.Menu.Item`s
   appended below a separator. `onPickFiles` can replace the files destination;
   the menu still settles input dismissal before calling it.
-- `useComposerDocumentPicker` — opens the system document picker through the
-  shared input-replacement action and stages the chosen files as library uploads.
+- `useComposerDocumentPicker` — composes the app-wide file-upload picker with
+  the shared input-replacement action and stages the chosen files as library uploads.
 - `ComposerModelPill` — the model button. Its `icon` is a composed `ModelPickerIcon`, and
   `children` trail the label inside the pill.
 - `ComposerSessionProvider` / `useComposerState` / `useComposerActions` — one
@@ -86,7 +86,7 @@ walk to verify it.
   `components/ComposerModelPill.tsx`: the parts.
 - `components/ComposerMenu.tsx`: the ＋ menu. Camera and photos hand off to
   `expo-image-picker`. Files use the caller's destination when supplied and
-  otherwise open the system document picker.
+  otherwise use the shared file-upload picker through the Composer adapter.
 - `components/ComposerAttachmentStrip.tsx`: internal to `ComposerAttachments`;
   shows import progress, then delegates ready files to `FileEntryPreview`.
 - `components/ComposerSessionProvider.tsx` and

--- a/src/frontend/components/Composer/hooks/useComposerDocumentPicker.ts
+++ b/src/frontend/components/Composer/hooks/useComposerDocumentPicker.ts
@@ -1,29 +1,27 @@
-import * as DocumentPicker from 'expo-document-picker';
 import { useCallback } from 'react';
+
+import { useFileUploadPicker } from '@/frontend/hooks/file';
 
 import { useComposerActions, useComposerPresentationActions } from '../context/ComposerProvider';
 import { createDocumentAttachmentDraft } from '../utils/composerAttachments';
 
 /**
- * System document upload shared by the menu and the chat library picker. The
- * chosen files are staged in the composer at once and uploaded to the library
- * from there; see `createDocumentAttachmentDraft` for their ownership.
+ * Composer adapter over the shared file-upload picker. It owns the input
+ * replacement and stages chosen files as attachments; the shared picker owns
+ * the native selection contract.
  */
 export function useComposerDocumentPicker() {
   const { addAttachments } = useComposerActions();
   const { runInputReplacement } = useComposerPresentationActions();
+  const pickFiles = useFileUploadPicker();
 
   return useCallback(async () => {
     await runInputReplacement(async () => {
-      const result = await DocumentPicker.getDocumentAsync({
-        copyToCacheDirectory: true,
-        multiple: true,
-        type: '*/*',
-      });
+      const files = await pickFiles();
 
-      if (!result.canceled) {
-        addAttachments(result.assets.map(createDocumentAttachmentDraft));
+      if (files.length > 0) {
+        addAttachments(files.map(createDocumentAttachmentDraft));
       }
     });
-  }, [addAttachments, runInputReplacement]);
+  }, [addAttachments, pickFiles, runInputReplacement]);
 }

--- a/src/frontend/components/Composer/utils/__tests__/composerAttachments.test.ts
+++ b/src/frontend/components/Composer/utils/__tests__/composerAttachments.test.ts
@@ -52,8 +52,7 @@ describe('composer attachments', () => {
   test('classifies document picker images as image attachments', () => {
     expect(
       createDocumentAttachmentDraft({
-        lastModified: 0,
-        mimeType: 'image/png',
+        mediaType: 'image/png',
         name: 'screen.png',
         uri: 'file://screen.png',
       }),
@@ -104,7 +103,6 @@ describe('composer attachments', () => {
   test('classifies image documents by filename when media type is missing', () => {
     expect(
       createDocumentAttachmentDraft({
-        lastModified: 0,
         name: 'photo.webp',
         uri: 'file://photo.webp',
       }),
@@ -120,8 +118,7 @@ describe('composer attachments', () => {
     expect(
       isComposerAttachmentSupported(
         createDocumentAttachmentDraft({
-          lastModified: 0,
-          mimeType: 'image/heic',
+          mediaType: 'image/heic',
           name: 'photo.heic',
           uri: 'file://photo.heic',
         }),
@@ -132,8 +129,7 @@ describe('composer attachments', () => {
   test('classifies non-image documents as file attachments', () => {
     expect(
       createDocumentAttachmentDraft({
-        lastModified: 0,
-        mimeType: 'application/pdf',
+        mediaType: 'application/pdf',
         name: 'brief.pdf',
         uri: 'file://brief.pdf',
       }),

--- a/src/frontend/components/Composer/utils/composerAttachments.ts
+++ b/src/frontend/components/Composer/utils/composerAttachments.ts
@@ -1,5 +1,4 @@
-import type { DocumentPickerAsset } from 'expo-document-picker';
-
+import type { FileUploadSelection } from '@/frontend/hooks/file';
 import { type FileEntryId, fileEntryUrl } from '@/shared/data/types/file';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 import { withCherryMeta } from '@/shared/data/types/uiParts';
@@ -137,9 +136,9 @@ export function createCameraAttachmentDraft(photo: CameraPhotoInput): ComposerAt
 }
 
 export function createDocumentAttachmentDraft(
-  asset: DocumentPickerAsset,
+  asset: FileUploadSelection,
 ): ComposerAttachmentSource {
-  const mediaType = resolveDocumentImportMediaType(asset.name, asset.mimeType);
+  const mediaType = resolveDocumentImportMediaType(asset.name, asset.mediaType);
   const isImage = isComposerImageMediaType(mediaType) || isComposerImageFileName(asset.name);
   const extension = asset.name.trim().split('.').pop()?.toLowerCase();
   const resolvedMediaType =

--- a/src/frontend/components/FileEntryPreview/README.md
+++ b/src/frontend/components/FileEntryPreview/README.md
@@ -37,7 +37,10 @@ Product-specific parsing or backend calls remain in this adapter family. Add a n
 only with explicit card and opening behavior; the CherryUI plugin vocabulary itself stays open.
 Do not infer a second classification from filenames at individual surfaces.
 
-The default `thumbnail` variant keeps the platform fallback for text and unsupported documents.
+Rows that already render filename metadata use the explicit `icon` variant: images retain their
+thumbnail, while other files use the same type-icon presentation as Composer and the library.
+The default `thumbnail` variant keeps Quick Look on iOS and the Android extension-card fallback for
+text and unsupported documents.
 The composer's `attachment` and library's `card` variants use the shared file icon/title layout.
 Extension-based icon routing changes artwork only; it never changes product classification or
 opening. Text excerpts remain a separate follow-up.

--- a/src/frontend/components/Message/parts/FilePart.tsx
+++ b/src/frontend/components/Message/parts/FilePart.tsx
@@ -10,5 +10,5 @@ type FilePartProps = {
 export function FilePart({ part }: FilePartProps) {
   const fileEntryId = readCherryMeta(part)?.fileEntryId as FileEntryId | undefined;
 
-  return fileEntryId ? <FileEntryPreview entryId={fileEntryId} /> : null;
+  return fileEntryId ? <FileEntryPreview entryId={fileEntryId} variant="attachment" /> : null;
 }

--- a/src/frontend/components/Message/parts/__tests__/FilePart.test.tsx
+++ b/src/frontend/components/Message/parts/__tests__/FilePart.test.tsx
@@ -22,9 +22,10 @@ describe('FilePart', () => {
     };
     const renderer = render(<FilePart part={part} />);
 
-    expect(renderer.root.findByType('FileEntryPreview').props.entryId).toBe(
-      '00000000-0000-7000-8000-000000000001',
-    );
+    expect(renderer.root.findByType('FileEntryPreview').props).toMatchObject({
+      entryId: '00000000-0000-7000-8000-000000000001',
+      variant: 'attachment',
+    });
   });
 
   test('does not render unmanaged attachments', () => {

--- a/src/frontend/features/chat/components/ChatInput/components/FilePickerBottomSheet.tsx
+++ b/src/frontend/features/chat/components/ChatInput/components/FilePickerBottomSheet.tsx
@@ -229,13 +229,14 @@ function FilePickerRow({
         pointerEvents="none"
       >
         {item.uri && isComposerImageMediaType(item.entry.mediaType) && !item.previewUri ? (
-          <FileEntrySkeleton size={PREVIEW_SIZE} />
+          <FileEntrySkeleton size={PREVIEW_SIZE} variant="icon" />
         ) : (
           <LoadedFileEntryPreview
             entry={item.entry}
             previewUri={item.previewUri}
             size={PREVIEW_SIZE}
             uri={item.uri}
+            variant="icon"
           />
         )}
       </View>

--- a/src/frontend/hooks/file/__tests__/useFileUploadPicker.test.tsx
+++ b/src/frontend/hooks/file/__tests__/useFileUploadPicker.test.tsx
@@ -1,0 +1,104 @@
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { type FileUploadSelection, useFileUploadPicker } from '../useFileUploadPicker';
+
+const mockGetDocument = jest.fn();
+let pickFiles: ReturnType<typeof useFileUploadPicker> | undefined;
+let renderer: ReactTestRenderer | undefined;
+
+jest.mock('expo-document-picker', () => ({
+  getDocumentAsync: (...args: unknown[]) => mockGetDocument(...args),
+}));
+
+describe('useFileUploadPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    pickFiles = undefined;
+  });
+
+  afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('opens the shared multi-file picker and normalizes its selections', async () => {
+    mockGetDocument.mockResolvedValue({
+      assets: [
+        {
+          lastModified: 1_757_241_600_000,
+          mimeType: 'application/pdf',
+          name: 'notes.pdf',
+          size: 512,
+          uri: 'file:///source/notes.pdf',
+        },
+        {
+          lastModified: 1_757_241_600_001,
+          name: 'plain.txt',
+          uri: 'file:///source/plain.txt',
+        },
+      ],
+      canceled: false,
+    });
+    renderHook();
+
+    let selections: FileUploadSelection[] | undefined;
+    await act(async () => {
+      selections = await getPicker()();
+    });
+
+    expect(mockGetDocument).toHaveBeenCalledWith({
+      copyToCacheDirectory: true,
+      multiple: true,
+      type: '*/*',
+    });
+    expect(selections).toEqual([
+      {
+        mediaType: 'application/pdf',
+        name: 'notes.pdf',
+        size: 512,
+        uri: 'file:///source/notes.pdf',
+      },
+      {
+        name: 'plain.txt',
+        uri: 'file:///source/plain.txt',
+      },
+    ]);
+  });
+
+  it('returns no selections when the system picker is cancelled', async () => {
+    mockGetDocument.mockResolvedValue({ canceled: true });
+    renderHook();
+
+    let selections: FileUploadSelection[] | undefined;
+    await act(async () => {
+      selections = await getPicker()();
+    });
+
+    expect(selections).toEqual([]);
+  });
+});
+
+function Probe() {
+  const picker = useFileUploadPicker();
+
+  useEffect(() => {
+    pickFiles = picker;
+  }, [picker]);
+
+  return null;
+}
+
+function renderHook() {
+  act(() => {
+    renderer = create(<Probe />);
+  });
+}
+
+function getPicker() {
+  if (!pickFiles) {
+    throw new Error('File upload picker did not mount');
+  }
+
+  return pickFiles;
+}

--- a/src/frontend/hooks/file/index.ts
+++ b/src/frontend/hooks/file/index.ts
@@ -1,1 +1,2 @@
 export { type ResolvedFileEntry, useFileEntryPages } from './useFileEntryPages';
+export { type FileUploadSelection, useFileUploadPicker } from './useFileUploadPicker';

--- a/src/frontend/hooks/file/useFileUploadPicker.ts
+++ b/src/frontend/hooks/file/useFileUploadPicker.ts
@@ -1,0 +1,35 @@
+import * as DocumentPicker from 'expo-document-picker';
+import { useCallback } from 'react';
+
+export type FileUploadSelection = {
+  mediaType?: string;
+  name: string;
+  size?: number;
+  uri: string;
+};
+
+/**
+ * The app-wide system entry point for choosing files to import. Consumers own
+ * what happens after selection: the composer stages attachments, while a file
+ * library surface can import the same normalized sources directly.
+ */
+export function useFileUploadPicker() {
+  return useCallback(async (): Promise<FileUploadSelection[]> => {
+    const result = await DocumentPicker.getDocumentAsync({
+      copyToCacheDirectory: true,
+      multiple: true,
+      type: '*/*',
+    });
+
+    if (result.canceled) {
+      return [];
+    }
+
+    return result.assets.map((asset) => ({
+      ...(asset.mimeType === undefined ? {} : { mediaType: asset.mimeType }),
+      name: asset.name,
+      ...(asset.size === undefined ? {} : { size: asset.size }),
+      uri: asset.uri,
+    }));
+  }, []);
+}


### PR DESCRIPTION
## Summary

- extract the system document picker into a shared file-upload hook and keep Composer as a thin attachment adapter
- add an explicit icon-only `FilePreview` variant for metadata rows and use it in the chat file picker
- align user-message attachments with the shared attachment-card visual while retaining image thumbnails
- resolve shared preview corner tokens into native clipping styles so Composer, file picker, message, and library previews keep their rounded corners
- preserve the platform-specific thumbnail fallback boundary and document the unified visual contract

## Validation

- `pnpm lint` (passes with existing repository warnings)
- `pnpm format:check`
- targeted `oxfmt`, `oxlint`, and Expo lint for changed files
- `git diff --check`

Not run per repository agent policy: tests, typecheck, builds, UI boundary checks, or device verification.