### PR TITLE
fix(composer): align toolbar action visuals

### DIFF
--- a/packages/ui/src/components/composer/components/composer-send.tsx
+++ b/packages/ui/src/components/composer/components/composer-send.tsx
@@ -48,10 +48,10 @@ export function ComposerSend({ testID }: ComposerSendProps) {
       <Icon
         className={cn(
           isStopping
-            ? 'size-5 text-destructive'
+            ? 'size-8 text-destructive'
             : isActive
-              ? 'size-[22px] text-primary'
-              : 'size-[22px] text-foreground-disabled',
+              ? 'size-8 text-primary'
+              : 'size-8 text-foreground-disabled',
         )}
       />
     </ComposerAction>

--- a/packages/ui/src/components/composer/components/morph-menu/morph-menu.tsx
+++ b/packages/ui/src/components/composer/components/morph-menu/morph-menu.tsx
@@ -25,6 +25,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { useResolveClassNames } from 'uniwind';
 
 import { Portal } from '../../../portal';
 import { SurfaceFrame } from '../../../surface/surface-frame';
@@ -107,6 +108,13 @@ function MorphMenuRoot({
   const panelWidth = useSharedValue(minPanelWidth);
   const footprintRef = useRef<View>(null);
   const portalName = useId();
+  // The closed trigger shares the toolbar actions' circular fill. Once the
+  // menu is portalled, `anchor` stays set through the closing animation, so
+  // the expanded panel keeps its popover surface until it is fully collapsed.
+  const surfaceClassName = anchor ? 'bg-popover' : 'bg-secondary';
+  const surfaceFill = useResolveClassNames(surfaceClassName);
+  const tintColor =
+    typeof surfaceFill.backgroundColor === 'string' ? surfaceFill.backgroundColor : undefined;
   const triggerFootprint = useMemo(
     () => ({ height: triggerSize, width: triggerSize }),
     [triggerSize],
@@ -220,7 +228,12 @@ function MorphMenuRoot({
         {/* The panel stays inside the surface: an empty `GlassView` draws no
             material at all, so the two cannot be split into siblings to fade
             them separately. */}
-        <SurfaceFrame className="bg-popover" cornerRadius={openRadius} style={fillStyle}>
+        <SurfaceFrame
+          className={surfaceClassName}
+          cornerRadius={openRadius}
+          style={fillStyle}
+          tintColor={tintColor}
+        >
           <Animated.View
             onLayout={handlePanelLayout}
             pointerEvents={isOpen ? 'auto' : 'none'}


### PR DESCRIPTION
<!-- Template adapted from https://github.com/CherryHQ/cherry-studio/blob/main/.github/pull_request_template.md -->
<!-- Thanks for sending a pull request! Consider creating this PR as a draft while it is still in progress. -->

> ### Branch strategy
>
> - Active development targets `v0.2`.

### What this PR does

Before this PR: The composer send/stop glyph was visibly smaller than adjacent toolbar controls, and the add trigger could disappear into the composer surface without a circular fill.

After this PR: Composer send/stop glyphs use the full 32pt action footprint, while the closed add trigger uses the shared secondary fill and the expanded menu retains its popover surface with Liquid Glass tint support.

### Screenshots or videos

Not attached because device or simulator verification was not authorized for this task.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Retain the current desktop-aligned send glyph instead of replacing its visual language
- Switch the morph surface by lifecycle state so the trigger and expanded panel keep their respective semantic roles
- Resolve semantic colors for the native Liquid Glass tint instead of introducing literal colors

The following alternatives were considered:

- A permanently secondary menu surface, which would weaken the expanded popover hierarchy
- A separate animated circle behind the trigger, which would duplicate overlapping material layers

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- Validation: `pnpm format`, `pnpm lint` (0 errors; existing unrelated warnings only), and `git diff --check origin/v0.2...HEAD`
- Not run per workspace policy: typecheck, automated tests, builds, or device/simulator visual verification

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: For a user-facing change, I uploaded screenshots or a video so reviewers can quickly verify the effect; otherwise, I explained why it is not applicable
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: I have [left the code cleaner than I found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: The impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (for example, with `gh pr diff` or the GitHub UI) before requesting review from others

### Release note

```release-note
Aligned the composer send and add controls for consistent sizing and visible circular backgrounds
```
