### PR TITLE
test(e2e): establish mobile selector baseline and Maestro smoke flows

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,52 @@
+# Maestro End-to-End Flows
+
+These flows are the first deterministic end-to-end checks for Cherry Studio Mobile. They use
+accessibility identifiers rather than translated labels and run independently from a fresh app
+state.
+
+## Prerequisites
+
+- Install a compatible development build on the target simulator or emulator.
+- Start the workspace's Metro session and copy the exact development-client URL it prints.
+- Install the Maestro CLI and select the intended device explicitly when more than one is running.
+
+Follow [Parallel Device Testing](../docs/guides/parallel-device-testing.md) when running flows from a
+Conductor workspace. In particular, do not reuse another workspace's simulator, emulator, Metro
+session, or writable app data.
+
+## Run
+
+Set `DEVICE_ID` to the dedicated simulator UDID or emulator serial. Set `DEV_CLIENT_URL` to the
+exact URL printed by this workspace's Metro process; keep it quoted because it contains URL query
+characters. For a newly installed development client, include Expo's `disableOnboarding=1` query
+parameter so its own launcher onboarding does not hide the product onboarding under test.
+
+Use the platform's application identifier:
+
+```bash
+# iOS
+maestro --device "$DEVICE_ID" test \
+  -e APP_ID=com.cherry-ai.cherry-studio-app \
+  -e DEV_CLIENT_URL="$DEV_CLIENT_URL" \
+  .maestro/flows
+
+# Android
+maestro --device "$DEVICE_ID" test \
+  -e APP_ID=com.cherry_ai.cherry_studio_app \
+  -e DEV_CLIENT_URL="$DEV_CLIENT_URL" \
+  .maestro/flows
+```
+
+Run one flow by passing its file path instead of the directory. Both current flows clear application
+state, then reconnect the development client through `DEV_CLIENT_URL`. They delete data in the
+selected test installation and must never target a primary user installation.
+
+## Scope
+
+- `onboarding-skip.yaml` verifies the fresh-install path from onboarding to the chat composer.
+- `appearance-persistence.yaml` verifies selecting the dark theme and retaining that preference
+  after a full app restart.
+
+A provider-backed chat flow is intentionally absent. It requires deterministic development-only
+fixture preparation; the current seed data does not provide a mock provider, and a successful app
+launch must not be treated as proof that credentials or external model calls work.

--- a/.maestro/flows/appearance-persistence.yaml
+++ b/.maestro/flows/appearance-persistence.yaml
@@ -1,0 +1,72 @@
+appId: ${APP_ID}
+name: Appearance selection persists after restart
+---
+- clearState
+- openLink:
+    link: ${DEV_CLIENT_URL}
+- runFlow:
+    when:
+      visible: "Open|打开"
+    commands:
+      - tapOn: "Open|打开"
+- extendedWaitUntil:
+    visible:
+      id: onboarding-welcome
+    timeout: 30000
+- tapOn:
+    id: onboarding-skip
+- extendedWaitUntil:
+    visible:
+      id: chat-composer
+    timeout: 30000
+- tapOn:
+    id: main-header-open-sidebar
+- extendedWaitUntil:
+    visible:
+      id: sidebar-settings
+    timeout: 10000
+- tapOn:
+    id: sidebar-settings
+- extendedWaitUntil:
+    visible:
+      id: settings-appearance
+    timeout: 10000
+- tapOn:
+    id: settings-appearance
+- extendedWaitUntil:
+    visible:
+      id: theme-preview-dark
+    timeout: 10000
+- tapOn:
+    id: theme-preview-dark
+- assertVisible:
+    id: theme-preview-dark
+    checked: true
+- stopApp
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: chat-composer
+    timeout: 30000
+- tapOn:
+    id: main-header-open-sidebar
+- extendedWaitUntil:
+    visible:
+      id: sidebar-settings
+    timeout: 10000
+- tapOn:
+    id: sidebar-settings
+- extendedWaitUntil:
+    visible:
+      id: settings-appearance
+    timeout: 10000
+- tapOn:
+    id: settings-appearance
+- extendedWaitUntil:
+    visible:
+      id: theme-preview-dark
+      checked: true
+    timeout: 10000
+- assertVisible:
+    id: theme-preview-dark
+    checked: true

--- a/.maestro/flows/onboarding-skip.yaml
+++ b/.maestro/flows/onboarding-skip.yaml
@@ -1,0 +1,23 @@
+appId: ${APP_ID}
+name: Fresh install skips onboarding
+---
+- clearState
+- openLink:
+    link: ${DEV_CLIENT_URL}
+- runFlow:
+    when:
+      visible: "Open|打开"
+    commands:
+      - tapOn: "Open|打开"
+- extendedWaitUntil:
+    visible:
+      id: onboarding-welcome
+    timeout: 30000
+- tapOn:
+    id: onboarding-skip
+- extendedWaitUntil:
+    visible:
+      id: chat-composer
+    timeout: 30000
+- assertVisible:
+    id: chat-composer-input

--- a/src/frontend/appShell/header/MainHeader/useMainHeaderActions.tsx
+++ b/src/frontend/appShell/header/MainHeader/useMainHeaderActions.tsx
@@ -17,6 +17,7 @@ export function useMainHeaderActions() {
       icon: NewConversationIcon,
       key: 'new-chat',
       onPress: openNewSession,
+      testID: 'main-header-new-chat',
       type: 'icon',
     },
   ];
@@ -27,6 +28,7 @@ export function useMainHeaderActions() {
       icon: HistoryIcon,
       key: 'agent-history',
       onPress: openAgentHistory,
+      testID: 'main-header-agent-history',
       type: 'icon',
     });
   }

--- a/src/frontend/appShell/header/RouteHeader/useRouteHeaderLeadingAction.ts
+++ b/src/frontend/appShell/header/RouteHeader/useRouteHeaderLeadingAction.ts
@@ -40,6 +40,7 @@ export function useRouteHeaderLeadingAction(onBack?: () => void): HeaderToolbarA
             icon: SidebarExpandIcon,
             key: 'route-leading',
             onPress: openDrawer,
+            testID: 'main-header-open-sidebar',
             type: 'icon',
           }
         : action === 'close'
@@ -48,6 +49,7 @@ export function useRouteHeaderLeadingAction(onBack?: () => void): HeaderToolbarA
               icon: XIcon,
               key: 'route-leading',
               onPress: goBack,
+              testID: 'route-header-close',
               type: 'icon',
             }
           : {
@@ -55,6 +57,7 @@ export function useRouteHeaderLeadingAction(onBack?: () => void): HeaderToolbarA
               icon: ArrowLeftIcon,
               key: 'route-leading',
               onPress: goBack,
+              testID: 'route-header-back',
               type: 'icon',
             },
     [action, goBack, openDrawer, t],

--- a/src/frontend/appShell/header/components/HeaderAction/HeaderAction.tsx
+++ b/src/frontend/appShell/header/components/HeaderAction/HeaderAction.tsx
@@ -20,7 +20,11 @@ export function HeaderAction({
 
   switch (action.type) {
     case 'custom':
-      return <View className={iconActionClassName}>{action.element}</View>;
+      return (
+        <View className={iconActionClassName} testID={action.testID}>
+          {action.element}
+        </View>
+      );
 
     case 'menu': {
       const Icon = action.icon;
@@ -33,6 +37,7 @@ export function HeaderAction({
             accessibilityState={{ disabled: action.disabled }}
             className={cn(iconActionClassName, action.disabled && 'opacity-50')}
             pointerEvents={action.disabled ? 'none' : 'auto'}
+            testID={action.testID}
           >
             <Icon className={cn('size-[18px]', contentClassName)} />
           </View>
@@ -54,6 +59,7 @@ export function HeaderAction({
           )}
           disabled={action.disabled}
           onPress={action.onPress}
+          testID={action.testID}
         >
           <Text className={cn('font-semibold text-base', contentClassName)}>{action.label}</Text>
         </Pressable>
@@ -68,6 +74,7 @@ export function HeaderAction({
           disabled={action.disabled}
           onPress={action.onPress}
           targetSize={targetSize}
+          testID={action.testID}
         >
           <Icon className={cn('size-[18px]', contentClassName)} />
         </HeaderIconButton>

--- a/src/frontend/appShell/header/components/HeaderAction/HeaderAction.types.ts
+++ b/src/frontend/appShell/header/components/HeaderAction/HeaderAction.types.ts
@@ -11,6 +11,7 @@ export type HeaderActionTargetSize = 'surface' | 'touch-target';
 
 type HeaderActionBase = {
   key: string;
+  testID?: string;
 };
 
 export type HeaderToolbarAction =

--- a/src/frontend/appShell/sidebar/components/Sidebar.tsx
+++ b/src/frontend/appShell/sidebar/components/Sidebar.tsx
@@ -55,7 +55,7 @@ function SidebarRoot({ children, navigation }: SidebarProps) {
 
   return (
     <SidebarActionsContext value={actions}>
-      <View className="flex-1">
+      <View className="flex-1" testID="sidebar">
         {children ?? (
           <>
             <SidebarBody />

--- a/src/frontend/appShell/sidebar/components/SidebarBody.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarBody.tsx
@@ -95,16 +95,23 @@ function SidebarBodyDefault({
     <>
       {/* No home row: that surface moves under settings. */}
       <View className="pb-1">
-        <SidebarNavRow icon={FolderIcon} label={t('navigation.library')} onPress={openLibrary} />
+        <SidebarNavRow
+          icon={FolderIcon}
+          label={t('navigation.library')}
+          onPress={openLibrary}
+          testID="sidebar-library"
+        />
         <SidebarNavRow
           icon={MousePointerClickIcon}
           label={t('navigation.agents')}
           onPress={navigateAgents}
+          testID="sidebar-agents"
         />
         <SidebarNavRow
           icon={PaletteIcon}
           label={t('navigation.paintings')}
           onPress={openPaintings}
+          testID="sidebar-paintings"
         />
       </View>
 

--- a/src/frontend/appShell/sidebar/components/SidebarDock.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarDock.tsx
@@ -46,6 +46,7 @@ export function SidebarDock({ onNewChatPress, onSettingsPress }: SidebarDockProp
             opacity: pressed ? 0.6 : 1,
             paddingHorizontal: 16,
           })}
+          testID="sidebar-new-chat"
         >
           <NewConversationIcon color={primaryForegroundColor} size={18} />
           <Text className="font-medium text-[15px] text-sidebar-primary-foreground">
@@ -67,6 +68,7 @@ export function SidebarDock({ onNewChatPress, onSettingsPress }: SidebarDockProp
             opacity: pressed ? 0.6 : 1,
             paddingHorizontal: 10,
           })}
+          testID="sidebar-settings"
         >
           <ProfileAvatarImage
             accessibilityLabel={displayName || t('settings.profile.avatar')}

--- a/src/frontend/appShell/sidebar/components/SidebarNavRow.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarNavRow.tsx
@@ -7,6 +7,7 @@ type SidebarNavRowProps = {
   icon: ComponentType<LucideIconProps>;
   label: string;
   onPress: () => void;
+  testID: string;
 };
 
 // Gesture Handler's Pressable, not React Native's: these rows sit inside the
@@ -16,12 +17,13 @@ type SidebarNavRowProps = {
 // The press state is an `active:` class rather than a function `style`, because
 // a function style replaces whatever the className resolved to — which silently
 // drops the row's own layout.
-export function SidebarNavRow({ icon: Icon, label, onPress }: SidebarNavRowProps) {
+export function SidebarNavRow({ icon: Icon, label, onPress, testID }: SidebarNavRowProps) {
   return (
     <Pressable
       accessibilityRole="button"
       className="w-full active:bg-sidebar-accent"
       onPress={onPress}
+      testID={testID}
     >
       <View className="flex-row items-center gap-4 px-5 py-3">
         <Icon className="size-[18px] text-sidebar-foreground" strokeWidth={1.6} />

--- a/src/frontend/appShell/sidebar/components/SidebarRecents.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarRecents.tsx
@@ -182,6 +182,7 @@ function SidebarRecentSessionList({ registerEndReachedHandler }: SidebarRecentsP
           accessibilityRole="button"
           className="w-full active:bg-sidebar-accent"
           onPress={handleViewAllPress}
+          testID="sidebar-sessions-view-all"
         >
           <Text className="px-5 py-2.5 text-muted-foreground text-sm">
             {t('session.list.viewAll')}
@@ -247,6 +248,7 @@ function SidebarAgentRow({ agent }: { agent: Agent }) {
         className="w-full active:bg-sidebar-accent"
         disabled={isResolvingSession}
         onPress={closeDrawer}
+        testID={`sidebar-agent-${agent.id}`}
       >
         <View className="flex-row items-center gap-3 px-5 py-2.5">
           <AgentAvatar
@@ -295,6 +297,7 @@ function SidebarSessionRow({ onCloseDrawer, onDelete, onRename, session }: Sideb
         accessibilityRole="link"
         className="w-full active:bg-sidebar-accent"
         onPress={onCloseDrawer}
+        testID={`sidebar-session-${session.id}`}
       >
         <Text className="px-5 py-2.5 text-base text-sidebar-foreground" numberOfLines={1}>
           {session.title || t('session.list.untitled')}

--- a/src/frontend/components/Composer/components/ComposerField.tsx
+++ b/src/frontend/components/Composer/components/ComposerField.tsx
@@ -17,9 +17,12 @@ import { createPastedImageAttachmentDraft } from '../utils/composerAttachments';
  * decide for itself: what a pasted image means, and what a link means. Holds the
  * ref that input-replacing surfaces blur and that the ＋ menu inserts through.
  */
-type ComposerFieldProps = Pick<ComposerInputProps, 'onBlur' | 'onFocus' | 'placeholder' | 'style'>;
+type ComposerFieldProps = Pick<
+  ComposerInputProps,
+  'onBlur' | 'onFocus' | 'placeholder' | 'style' | 'testID'
+>;
 
-export function ComposerField({ onBlur, onFocus, placeholder, style }: ComposerFieldProps) {
+export function ComposerField({ onBlur, onFocus, placeholder, style, testID }: ComposerFieldProps) {
   const { t } = useTranslation();
   const { addAttachments } = useComposerActions();
   const { inputRef } = useComposerMeta();
@@ -62,6 +65,7 @@ export function ComposerField({ onBlur, onFocus, placeholder, style }: ComposerF
       placeholder={placeholder ?? t('chat.inputPlaceholder')}
       ref={inputRef}
       style={style}
+      testID={testID}
     />
   );
 }

--- a/src/frontend/components/Composer/components/ComposerSurface.tsx
+++ b/src/frontend/components/Composer/components/ComposerSurface.tsx
@@ -34,6 +34,7 @@ type ComposerSurfaceProps = PropsWithChildren<{
   onSend: (payload: ComposerSendPayload) => Promise<void>;
   onStop: () => void;
   streaming: boolean;
+  testID?: string;
 }>;
 
 /**
@@ -53,6 +54,7 @@ export function ComposerSurface({
   onSend,
   onStop,
   streaming,
+  testID,
 }: ComposerSurfaceProps) {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -140,6 +142,7 @@ export function ComposerSurface({
       onSend={handleSend}
       onStop={onStop}
       streaming={streaming}
+      testID={testID}
       value={draft}
     >
       {children}

--- a/src/frontend/components/Message/MessageList.tsx
+++ b/src/frontend/components/Message/MessageList.tsx
@@ -134,7 +134,7 @@ export function MessageList({
 
   return (
     <MessageListDisclosureProvider onDisclosureToggle={handleDisclosureToggle}>
-      <View className="flex-1">
+      <View className="flex-1" testID="chat-message-list">
         <ContextMenuScrollBoundary
           onMomentumScrollBegin={handleMomentumScrollBegin}
           onMomentumScrollEnd={handleMomentumScrollEnd}

--- a/src/frontend/features/chat/components/ChatInput/ChatInput.tsx
+++ b/src/frontend/features/chat/components/ChatInput/ChatInput.tsx
@@ -252,12 +252,17 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
               onSend={handleSendPress}
               onStop={() => void cancel()}
               streaming={isBusy}
+              testID="chat-composer"
             >
               <ComposerAttachments />
               <Animated.View className="relative overflow-hidden" style={morphFrameStyle}>
                 <Animated.View className="absolute top-0 overflow-hidden" style={fieldFrameStyle}>
                   <View className="absolute top-0 right-0 left-0" onLayout={handleFieldLayout}>
-                    <ComposerField onBlur={handleInputBlur} onFocus={handleInputFocus} />
+                    <ComposerField
+                      onBlur={handleInputBlur}
+                      onFocus={handleInputFocus}
+                      testID="chat-composer-input"
+                    />
                   </View>
                 </Animated.View>
                 <Animated.View
@@ -299,7 +304,7 @@ export function ChatInput({ agentId, dismissKeyboardOnSend, sessionId }: ChatInp
                         {effortGauge}
                       </Animated.View>
                     ) : null}
-                    <Composer.Send />
+                    <Composer.Send testID={isBusy ? 'chat-composer-stop' : 'chat-composer-send'} />
                   </View>
                 </Animated.View>
               </Animated.View>

--- a/src/frontend/features/chat/components/ChatWorkspace/components/ChatMessage.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/ChatMessage.tsx
@@ -117,7 +117,7 @@ export const ChatMessage = memo(function ChatMessage({
 
   return (
     <ContextMenu items={menuItems}>
-      <View className="w-full" collapsable={false}>
+      <View className="w-full" collapsable={false} testID={`chat-message-${message.id}`}>
         {message.role === 'user' ? (
           <UserMessage message={message} />
         ) : (

--- a/src/frontend/features/onboarding/OnboardingScreen.tsx
+++ b/src/frontend/features/onboarding/OnboardingScreen.tsx
@@ -61,6 +61,7 @@ export function OnboardingScreen() {
     <View
       className="flex-1 bg-background"
       style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      testID="onboarding-welcome"
     >
       <ScrollView
         contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
@@ -82,10 +83,22 @@ export function OnboardingScreen() {
         </View>
       </ScrollView>
       <View className="gap-3 px-6 pb-4">
-        <Button disabled={isSkipping} loading={isStarting} onPress={connect} size="lg">
+        <Button
+          disabled={isSkipping}
+          loading={isStarting}
+          onPress={connect}
+          size="lg"
+          testID="onboarding-connect"
+        >
           {t('onboarding.welcome.connect')}
         </Button>
-        <Button disabled={isStarting} loading={isSkipping} onPress={skip} variant="ghost">
+        <Button
+          disabled={isStarting}
+          loading={isSkipping}
+          onPress={skip}
+          testID="onboarding-skip"
+          variant="ghost"
+        >
           {t('onboarding.welcome.skip')}
         </Button>
         <Text className="text-center text-xs text-muted-foreground">

--- a/src/frontend/features/onboarding/model/OnboardingModelScreen.tsx
+++ b/src/frontend/features/onboarding/model/OnboardingModelScreen.tsx
@@ -103,6 +103,7 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
         behavior="padding"
         keyboardVerticalOffset={headerHeight}
         style={{ flex: 1 }}
+        testID="onboarding-model"
       >
         <View className="gap-2 px-4 pt-5 pb-4">
           {providerId ? (
@@ -134,6 +135,7 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
                 onChangeText={setManualId}
                 placeholder={t('onboarding.model.manualPlaceholder')}
                 returnKeyType="done"
+                testID="onboarding-model-manual-input"
                 value={manualId}
                 onSubmitEditing={start}
               />
@@ -232,8 +234,10 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
                   }
                   onPress={() => setSelectedId(item.id)}
                   selected={item.id === selectedModel?.id}
+                  testID={`onboarding-model-${item.id}`}
                 />
               )}
+              testID="onboarding-model-list"
             />
           </>
         )}
@@ -248,6 +252,7 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
                 loading={isBusy}
                 onPress={start}
                 size="lg"
+                testID="onboarding-model-start"
               >
                 {t(
                   phase === 'checking'
@@ -260,7 +265,7 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
             </>
           ) : null}
           {isBusy ? (
-            <Button onPress={cancel} variant="ghost">
+            <Button onPress={cancel} testID="onboarding-model-cancel" variant="ghost">
               {t('common.cancel')}
             </Button>
           ) : providerId &&
@@ -268,6 +273,7 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
             <Button
               disabled={!data.provider || Boolean(data.error)}
               onPress={() => setSelectionMode(selectionMode === 'manual' ? 'catalog' : 'manual')}
+              testID="onboarding-model-mode-toggle"
               variant="ghost"
             >
               {t(
@@ -277,7 +283,7 @@ function OnboardingModelSelection({ providerId }: { providerId?: string }) {
               )}
             </Button>
           ) : providerId && !data.isLoading && data.items.length === 0 ? (
-            <Button onPress={data.retry} variant="ghost">
+            <Button onPress={data.retry} testID="onboarding-model-reload" variant="ghost">
               {t('onboarding.model.reload')}
             </Button>
           ) : null}

--- a/src/frontend/features/settings/SettingsScreen.tsx
+++ b/src/frontend/features/settings/SettingsScreen.tsx
@@ -106,6 +106,7 @@ export default function SettingsScreen() {
               label={t('settings.appearance.title')}
               leading={<PaletteIcon className="size-4 text-foreground" />}
               onPress={() => router.push('/settings/appearance')}
+              testID="settings-appearance"
             />
           </Section>
           <Section>

--- a/src/frontend/features/settings/components/SettingsServiceRow/SettingsServiceRow.tsx
+++ b/src/frontend/features/settings/components/SettingsServiceRow/SettingsServiceRow.tsx
@@ -26,6 +26,7 @@ export type SettingsServiceRowProps = {
   statusLabel?: string;
   statusTone?: 'danger' | 'default' | 'success';
   subtitle?: string;
+  testID?: string;
   trailingAction?: ReactNode;
 };
 
@@ -45,6 +46,7 @@ export const SettingsServiceRow = memo(function SettingsServiceRow({
   statusLabel,
   statusTone = 'default',
   subtitle,
+  testID,
   trailingAction,
 }: SettingsServiceRowProps) {
   const accessibilityLabel = [name, statusLabel, subtitle].filter(Boolean).join(', ');
@@ -92,6 +94,7 @@ export const SettingsServiceRow = memo(function SettingsServiceRow({
           onPressedChange?.(id, false);
         }}
         showChevron={false}
+        testID={testID}
         trailing={
           <View className="flex-row items-center gap-2">
             {statusLabel && statusTone === 'success' ? (

--- a/src/frontend/features/settings/provider/ProviderListScreen.tsx
+++ b/src/frontend/features/settings/provider/ProviderListScreen.tsx
@@ -170,6 +170,7 @@ export default function ProviderListScreen() {
           isEnabled: provider.isEnabled,
           name: provider.name,
           onPress: () => openProvider(provider),
+          testID: `provider-row-${provider.id}`,
         };
       }),
     [isPreparing, listedProviders, openProvider, pendingProviderStates, t, toggleProviderEnabled],
@@ -228,6 +229,7 @@ export default function ProviderListScreen() {
         icon: PlusIcon,
         key: 'open-provider-catalog',
         onPress: openProviderCatalog,
+        testID: 'provider-catalog-open',
         type: 'icon',
       },
     ],
@@ -260,6 +262,7 @@ export default function ProviderListScreen() {
                 showsVerticalScrollIndicator={false}
                 stickySectionHeadersEnabled={false}
                 style={styles.list}
+                testID="provider-list"
               />
             </View>
           </View>

--- a/src/frontend/features/settings/provider/catalog/ProviderCatalogScreen.tsx
+++ b/src/frontend/features/settings/provider/catalog/ProviderCatalogScreen.tsx
@@ -75,6 +75,7 @@ function ProviderCatalogRow({
       statusLabel={entry.isInstalled ? t('settings.provider.catalog.installed') : undefined}
       statusTone="success"
       subtitle={onChoose ? entry.description : entry.id}
+      testID={`provider-catalog-entry-${entry.id}`}
       trailingAction={
         onChoose ? (
           isPendingEntry ? (
@@ -110,8 +111,9 @@ function CustomProviderCatalogRow({ onCreate }: { onCreate: () => void }) {
       id={CUSTOM_PROVIDER_ITEM_ID}
       name={name}
       subtitle={t('settings.provider.catalog.customDescription')}
+      testID="provider-catalog-entry-custom"
       trailingAction={
-        <Button onPress={onCreate} size="xs" variant="secondary">
+        <Button onPress={onCreate} size="xs" testID="provider-catalog-custom" variant="secondary">
           {t('settings.provider.catalog.create')}
         </Button>
       }
@@ -331,6 +333,7 @@ export default function ProviderCatalogScreen({
           name={item.name}
           onPress={() => openProviderSetup(item)}
           subtitle={t('onboarding.provider.continue')}
+          testID={`provider-catalog-entry-${item.id}`}
         />
       ) : (
         <ProviderCatalogRow
@@ -372,7 +375,10 @@ export default function ProviderCatalogScreen({
           <Text className="text-base text-foreground">{t('onboarding.provider.description')}</Text>
         </View>
       ) : null}
-      <View className="min-h-0 flex-1 gap-3 px-4 pb-5">
+      <View
+        className="min-h-0 flex-1 gap-3 px-4 pb-5"
+        testID={intent === 'chat' ? 'onboarding-provider' : 'provider-catalog'}
+      >
         {intent !== 'chat' && registryUpdateQuery.data?.status === 'available' ? (
           <ProviderRegistryUpdateNotice
             isUpdating={applyRegistryUpdateMutation.isPending}
@@ -408,11 +414,20 @@ export default function ProviderCatalogScreen({
                 intent === 'chat' ? (
                   <View className="gap-3 px-4 py-5">
                     {!query && !showsAllProviders ? (
-                      <Button variant="ghost" onPress={() => setShowsAllProviders(true)}>
+                      <Button
+                        onPress={() => setShowsAllProviders(true)}
+                        testID="onboarding-provider-show-all"
+                        variant="ghost"
+                      >
                         {t('onboarding.provider.showAll')}
                       </Button>
                     ) : null}
-                    <Button disabled={importPending} onPress={openCustomProvider} variant="outline">
+                    <Button
+                      disabled={importPending}
+                      onPress={openCustomProvider}
+                      testID="onboarding-provider-custom"
+                      variant="outline"
+                    >
                       {t('settings.provider.catalog.custom')}
                     </Button>
                   </View>
@@ -426,6 +441,7 @@ export default function ProviderCatalogScreen({
               showsVerticalScrollIndicator={false}
               stickySectionHeadersEnabled={false}
               style={styles.list}
+              testID={intent === 'chat' ? 'onboarding-provider-list' : 'provider-catalog-list'}
             />
           </View>
         )}

--- a/src/frontend/features/settings/provider/components/ProviderForm/components/ProviderFormEndpoints.tsx
+++ b/src/frontend/features/settings/provider/components/ProviderForm/components/ProviderFormEndpoints.tsx
@@ -162,6 +162,7 @@ function ProviderFormTextEndpointField({ endpoint }: { endpoint: CustomProviderT
         keyboardType="url"
         onChangeText={(next) => actions.setEndpointUrl(endpoint, next)}
         placeholder={t('settings.provider.apiService.baseUrlPlaceholder')}
+        testID={`provider-endpoint-${endpoint}-input`}
         value={value}
       />
       {requestUrl ? (
@@ -199,6 +200,7 @@ function ProviderFormEndpointField({ endpoint, label }: { endpoint: EndpointType
         keyboardType="url"
         onChangeText={(next) => actions.setEndpointUrl(endpoint, next)}
         placeholder={label}
+        testID="provider-base-url-input"
         value={value}
       />
     </TextField>

--- a/src/frontend/features/settings/provider/components/ProviderForm/components/ProviderFormFields.tsx
+++ b/src/frontend/features/settings/provider/components/ProviderForm/components/ProviderFormFields.tsx
@@ -18,6 +18,7 @@ export function ProviderFormName() {
         disabled={meta.isSubmitting}
         onChangeText={actions.setName}
         placeholder={t('settings.provider.add.name')}
+        testID="provider-name-input"
         value={state.name}
       />
     </TextField>
@@ -44,6 +45,7 @@ export function ProviderFormApiKey({ autoFocus = false }: { autoFocus?: boolean 
         placeholder={t('settings.provider.apiService.apiKey')}
         returnKeyType="done"
         scrollEnabled={false}
+        testID="provider-api-key-input"
         type="password"
         value={state.apiKey}
         visibilityAccessibilityLabels={{

--- a/src/frontend/features/settings/provider/new/components/ProviderCreationForm.tsx
+++ b/src/frontend/features/settings/provider/new/components/ProviderCreationForm.tsx
@@ -140,6 +140,7 @@ export function ProviderNewFormContent({
       keyboardShouldPersistTaps="handled"
       mode="layout"
       showsVerticalScrollIndicator={false}
+      testID="provider-form"
     >
       {issue || disabledKeys ? (
         <View className="gap-3 px-4 py-3">
@@ -169,7 +170,13 @@ export function ProviderNewFormContent({
         )}
       </ProviderForm>
       <View className="px-4 pb-8">
-        <Button disabled={!canSave} loading={isSaving} onPress={onSave} size="lg">
+        <Button
+          disabled={!canSave}
+          loading={isSaving}
+          onPress={onSave}
+          size="lg"
+          testID="provider-save"
+        >
           {t(isSaving ? 'settings.provider.setup.preparing' : 'settings.provider.setup.next')}
         </Button>
       </View>

--- a/src/frontend/features/settings/provider/new/components/ProviderSetupFormContent.tsx
+++ b/src/frontend/features/settings/provider/new/components/ProviderSetupFormContent.tsx
@@ -49,6 +49,7 @@ export function ProviderSetupFormContent({
       behavior="padding"
       keyboardVerticalOffset={headerHeight}
       style={{ flex: 1 }}
+      testID="onboarding-connection"
     >
       <ScrollView
         keyboardDismissMode="on-drag"
@@ -66,7 +67,13 @@ export function ProviderSetupFormContent({
         <ProviderForm value={form}>{children}</ProviderForm>
       </ScrollView>
       <View className="gap-2 px-4 pt-3" style={{ paddingBottom: Math.max(bottom, 16) }}>
-        <Button disabled={!canSave} loading={form.meta.isSubmitting} onPress={onSave} size="lg">
+        <Button
+          disabled={!canSave}
+          loading={form.meta.isSubmitting}
+          onPress={onSave}
+          size="lg"
+          testID="onboarding-connection-next"
+        >
           {t('settings.provider.setup.next')}
         </Button>
         {!canSave && !form.meta.isSubmitting ? (
@@ -179,6 +186,7 @@ export function ProviderSetupCustomFields() {
           keyboardType="url"
           onChangeText={(value) => actions.setEndpointUrl(endpoint, value)}
           placeholder={t('settings.provider.apiService.baseUrlPlaceholder')}
+          testID="provider-base-url-input"
           value={baseUrl}
         />
         <TextField.Error>
@@ -189,6 +197,7 @@ export function ProviderSetupCustomFields() {
         accessibilityLabel={t('onboarding.connection.protocol')}
         disabled={meta.isSubmitting}
         onPress={() => setIsProtocolPickerOpen(true)}
+        testID="provider-protocol-select"
       >
         <SelectField.Label>{t('onboarding.connection.protocol')}</SelectField.Label>
         <SelectField.Value>


### PR DESCRIPTION
### What this PR does

Before this PR:

Core mobile journeys had uneven `testID` coverage. Onboarding, the chat composer, sidebar navigation, and provider setup depended partly on translated accessibility labels or had no stable selector, and the repository had no checked-in end-to-end smoke flows.

After this PR:

- Adds stable accessibility identifiers across onboarding, chat input and messages, sidebar navigation, provider setup, and related header/actions.
- Adds two independent Maestro smoke flows for skipping onboarding and verifying appearance persistence across a full restart.
- Documents the platform app IDs, explicit device targeting, workspace-specific development-client URL, destructive state reset, and Conductor workspace isolation requirements.
- Keeps provider-backed chat out of the deterministic suite until development-only fixture preparation exists.

### Screenshots or videos

N/A — this adds test infrastructure and accessibility identifiers without changing visible UI behavior.

### Why we need it and why it was done in this way

Stable accessibility IDs make black-box mobile automation independent of localization and reduce coupling to layout coordinates. The flows accept `APP_ID` and `DEV_CLIENT_URL` at runtime so the same definitions work on iOS and Android while reconnecting to the exact Metro session owned by the active workspace after app state is cleared.

The following tradeoffs were made:

- The initial suite covers only deterministic, offline behavior.
- EAS profiles and CI wiring are deferred until both flows have been exercised and stabilized on dedicated iOS and Android devices.
- A provider-backed chat flow is deferred because the repository does not yet provide a deterministic mock-provider fixture.

The following alternatives were considered:

- Translated text selectors were rejected because they are unstable across locales.
- Real model calls were rejected because network availability, account balance, credentials, and nondeterministic output make them unsuitable for a smoke gate.

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- `pnpm format:check`
- `pnpm exec oxlint <changed TypeScript files>`
- `pnpm exec expo lint <changed TypeScript files>`
- YAML syntax parsing for both Maestro flows
- `git diff --check`

Full `pnpm lint` is currently blocked by seven unresolved `@cherrystudio/ai-core` imports in unchanged backend files because the local workspace package outputs are not built. Package builds, `pnpm typecheck`, Jest, Maestro execution, native builds, and device verification were not run under the current task authorization.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Preview: N/A; this PR has no visible UI changes
- [x] Code: The changes are focused and use existing component contracts
- [x] Upgrade: No upgrade-flow impact is expected
- [x] Documentation: Repository-local E2E usage documentation is included
- [x] Self-review: The complete diff and changed-file validation were reviewed before opening this PR

### Release note

```release-note
NONE
```
