### PR TITLE
fix(paintings): keep generated images visible and out of the input draft

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -151,6 +151,7 @@ function RootStack() {
           // in both themes. `PaintingViewerChrome` paints the same pair.
           contentStyle: { backgroundColor: constantBlack },
           headerShown: paintingViewerHeaderShown,
+          headerStyle: { backgroundColor: constantBlack },
           headerTintColor: constantWhite,
           headerTransparent: true,
           title: '',

--- a/src/frontend/features/paintings/components/PaintingAssistantMessage.tsx
+++ b/src/frontend/features/paintings/components/PaintingAssistantMessage.tsx
@@ -93,7 +93,11 @@ export function PaintingAssistantMessage({
     resultOpacity.set(1);
     completeFade();
   }, [completeFade, resultOpacity]);
-  const resultStyle = useAnimatedStyle(() => ({ opacity: resultOpacity.get() }));
+  // A persisted-file refresh can end the transition before onDisplay fires.
+  // Keep owning opacity: detaching an animated style leaves its native value.
+  const resultStyle = useAnimatedStyle(() => ({
+    opacity: animateOutput && !isFadeComplete ? resultOpacity.get() : 1,
+  }));
 
   if (status !== 'generating' && (error || interruption)) {
     const didFail = Boolean(error) || interruption?.reason === 'failed';
@@ -204,7 +208,7 @@ export function PaintingAssistantMessage({
           ) : null
         ) : null}
         {results.length > 0 ? (
-          <Animated.View className="w-full gap-3" style={animateOutput ? resultStyle : undefined}>
+          <Animated.View className="w-full gap-3" style={resultStyle} testID="painting-results">
             {results}
           </Animated.View>
         ) : null}

--- a/src/frontend/features/paintings/components/PaintingComposer.tsx
+++ b/src/frontend/features/paintings/components/PaintingComposer.tsx
@@ -196,28 +196,11 @@ export function PaintingComposer({
   );
   const { contentBottomInset, handleInputHeightChange, inputHeightShared, keyboardOffset } =
     useComposerDockLayout();
-  const composerKey = firstOutput?.fileEntryId ?? 'painting-composer';
-  const composerInitialAttachments = firstOutput
-    ? [
-        {
-          fileEntryId: firstOutput.fileEntryId,
-          id: `painting-file:${firstOutput.fileEntryId}`,
-          kind: 'image' as const,
-          mediaType: firstOutput.mediaType,
-          name: firstOutput.name,
-          size: firstOutput.size,
-          status: 'ready' as const,
-          uri: firstOutput.uri,
-        },
-      ]
-    : initialAttachments.length > 0
-      ? initialAttachments
-      : receiptId
-        ? initialFiles.inputs
-        : [];
-  const composerInitialDraft = firstOutput
-    ? ''
-    : initialDraft || (receiptId ? (painting?.prompt ?? '') : '');
+  // Results belong to the message list. Only an explicit handoff or an
+  // unfinished receipt seeds the draft; finishing a job must not remount it.
+  const composerInitialAttachments =
+    initialAttachments.length > 0 ? initialAttachments : receiptId ? initialFiles.inputs : [];
+  const composerInitialDraft = initialDraft || (receiptId ? (painting?.prompt ?? '') : '');
 
   return (
     <View className="flex-1">
@@ -234,7 +217,6 @@ export function PaintingComposer({
       <ComposerSessionProvider
         initialAttachments={composerInitialAttachments}
         initialDraft={composerInitialDraft}
-        key={composerKey}
       >
         <ComposerDock onHeightChange={handleInputHeightChange}>
           <PaintingInput

--- a/src/frontend/features/paintings/components/__tests__/PaintingAssistantMessage.test.tsx
+++ b/src/frontend/features/paintings/components/__tests__/PaintingAssistantMessage.test.tsx
@@ -37,6 +37,7 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('react-native-reanimated', () => {
+  const { useState } = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
 
   return {
@@ -48,13 +49,16 @@ jest.mock('react-native-reanimated', () => {
     useAnimatedStyle: (factory: () => object) => factory(),
     useReducedMotion: () => true,
     useSharedValue: (initial: number) => {
-      let value = initial;
-      return {
-        get: () => value,
-        set: (next: number) => {
-          value = next;
-        },
-      };
+      const [sharedValue] = useState(() => {
+        let value = initial;
+        return {
+          get: () => value,
+          set: (next: number) => {
+            value = next;
+          },
+        };
+      });
+      return sharedValue;
     },
     withTiming: (value: number) => value,
   };
@@ -155,5 +159,47 @@ describe('PaintingAssistantMessage', () => {
         'painting.outputAccessibility:{"count":2,"index":2,"prompt":"Draw a cherry"}',
       ]),
     );
+  });
+
+  it('makes the result visible when persisted files end its fade before the image displays', () => {
+    const props = {
+      aspectRatio: 1,
+      error: null,
+      interruption: null,
+      paintingId: 'painting-1',
+      prompt: 'Draw a cherry',
+      resolution: '1024 x 1024',
+    };
+    const outputs = [{ fileEntryId: 'output-1', uri: 'file:///one.png' }];
+    act(() => {
+      renderer = create(<PaintingAssistantMessage {...props} outputs={[]} status="generating" />);
+    });
+    act(() => {
+      renderer?.update(
+        <PaintingAssistantMessage {...props} animateOutput outputs={outputs} status="idle" />,
+      );
+    });
+    expect(renderer?.root.findByProps({ testID: 'painting-results' }).props.style).toEqual({
+      opacity: 0,
+    });
+
+    // Query synchronization can turn off the fade before the native onDisplay event.
+    act(() => {
+      renderer?.update(
+        <PaintingAssistantMessage
+          {...props}
+          animateOutput={false}
+          outputs={outputs}
+          status="idle"
+        />,
+      );
+    });
+    expect(renderer?.root.findByProps({ testID: 'painting-results' }).props.style).toEqual({
+      opacity: 1,
+    });
+    expect(
+      renderer?.root.findByProps({ testID: 'painting-output-output-1' }).props.pointerEvents,
+    ).toBe('auto');
+    expect(renderer?.root.findAllByProps({ testID: 'painting-generation-loader' })).toHaveLength(0);
   });
 });

--- a/src/frontend/features/paintings/components/__tests__/PaintingComposer.test.tsx
+++ b/src/frontend/features/paintings/components/__tests__/PaintingComposer.test.tsx
@@ -115,6 +115,7 @@ let mockMessageListProps: MessageListProps | undefined;
 let mockProviderProps:
   | { initialAttachments?: readonly unknown[]; initialDraft?: string }
   | undefined;
+let mockProviderMounts = 0;
 let mockUuid = 0;
 
 jest.mock('expo-crypto', () => ({
@@ -144,6 +145,10 @@ jest.mock('@cherrystudio/ui/components', () => ({
 jest.mock('@/frontend/components/Composer', () => ({
   ComposerDock: ({ children }: { children: React.ReactNode }) => children,
   ComposerSessionProvider: ({ children, ...props }: { children: React.ReactNode }) => {
+    const { useEffect } = jest.requireActual('react');
+    useEffect(() => {
+      mockProviderMounts += 1;
+    }, []);
     mockProviderProps = props;
     return children;
   },
@@ -201,6 +206,7 @@ describe('PaintingComposer', () => {
     mockMessageListUnmounts = 0;
     mockMessageListProps = undefined;
     mockProviderProps = undefined;
+    mockProviderMounts = 0;
     mockUuid = 0;
     mockGeneration.aspectRatio = 16 / 9;
     mockGeneration.error = null;
@@ -228,7 +234,7 @@ describe('PaintingComposer', () => {
     });
   }
 
-  it('projects a completed painting and seeds its first output for follow-up editing', () => {
+  it('shows completed outputs in the message list without attaching them to the draft', () => {
     renderComposer();
 
     expect(mockMessageListProps?.messages.map((message) => message.role)).toEqual([
@@ -251,16 +257,16 @@ describe('PaintingComposer', () => {
       status: 'idle',
     });
     expect(mockProviderProps).toMatchObject({
-      initialAttachments: [files.outputs[0]],
+      initialAttachments: [],
       initialDraft: '',
     });
   });
 
-  it('passes one-shot handoff params into the painting input', () => {
+  it('seeds the input image and params when explicitly handed off for editing', () => {
     act(() => {
       renderer = create(
         <PaintingComposer
-          initialAttachments={[]}
+          initialAttachments={[files.outputs[0]]}
           initialDraft="Change the aspect ratio"
           initialFiles={{ inputs: [], outputAspectRatio: 1, outputs: [] }}
           initialParamValues={{ aspectRatio: '16:9' }}
@@ -271,6 +277,10 @@ describe('PaintingComposer', () => {
     });
 
     expect(mockInputProps?.initialParamValues).toEqual({ aspectRatio: '16:9' });
+    expect(mockProviderProps).toMatchObject({
+      initialAttachments: [files.outputs[0]],
+      initialDraft: 'Change the aspect ratio',
+    });
   });
 
   it('replaces the persisted turn with a pending request and then its result', async () => {
@@ -312,6 +322,8 @@ describe('PaintingComposer', () => {
     });
     expect(mockMessageListMounts).toBe(1);
     expect(mockMessageListUnmounts).toBe(0);
+    expect(mockProviderMounts).toBe(1);
+    expect(mockProviderProps?.initialAttachments).toEqual([]);
   });
 
   it('restores the previous painting after attachment rejection and lets the submit surface explain it', async () => {


### PR DESCRIPTION
### What this PR does

Before this PR, finishing image generation remounted the composer and automatically attached the first output to the next draft. This could unexpectedly switch model compatibility to image editing. A persisted-file refresh could also leave the message image transparent, and the image viewer header could retain a light background above its black canvas.

After this PR, generated images stay in the message list without resetting or seeding the next draft. Explicit edit/resize handoffs and unfinished-receipt recovery still seed the composer. Result opacity is explicitly restored when its fade ends, and the viewer header uses the same black background as its canvas.

### Screenshots or videos

Post-change screenshots and light/dark device acceptance are pending. Device verification was not run under the task's verification constraints.

### Why we need it and why it was done in this way

Generation results and the next input draft have separate ownership. Removing output-driven composer remounting preserves that boundary without changing the shared composer. Keeping the animated opacity style attached also prevents a stale native opacity value when persisted files disable the fade before the image-display callback.

Regression coverage was updated for completed outputs, explicit editing handoffs, composer lifetime, and the interrupted fade transition.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: formatting and both lint tools on the changed files; full `pnpm format:check`; `git diff --check`.
- Full `pnpm lint` fails with 7 unresolved imports of `@cherrystudio/ai-core` and its provider entry in unchanged files. The package exports point to `dist`, which is absent in this workspace. Existing lint warnings are also present.
- Regression tests, type checking, builds, and device acceptance were not run under the task's verification constraints. The repository's full type-check command builds workspace packages.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the behavior and validation limits
- [ ] Preview: Post-change screenshots or video uploaded
- [x] Code: Changes are limited to the painting workflow and viewer header
- [x] Upgrade: No persistence or migration changes
- [x] Documentation: No user-guide update is needed for these bug fixes
- [x] Self-review: Reviewed the complete diff before opening the draft

### Release note

```release-note
Fixed generated drawing images being automatically added to the next input draft, results remaining invisible after generation, and the image viewer showing a light header above its black background.
```
