### PR TITLE
fix(message-list): remove extra bottom space after sending

### DIFF
--- a/src/frontend/components/Message/MessageList.tsx
+++ b/src/frontend/components/Message/MessageList.tsx
@@ -1,5 +1,5 @@
 import { ContextMenuScrollBoundary, ScrollToBottomButton } from '@cherrystudio/ui/components';
-import { KeyboardAwareLegendList, useKeyboardScrollToEnd } from '@legendapp/list/keyboard';
+import { KeyboardAwareLegendList } from '@legendapp/list/keyboard';
 import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +35,6 @@ export function MessageList({
 }: MessageListProps) {
   const { t } = useTranslation();
   const listRef = useRef<LegendListRef | null>(null);
-  const { freeze, scrollMessageToEnd } = useKeyboardScrollToEnd({ listRef });
   const {
     handleContentSizeChange,
     handleDisclosureToggle,
@@ -56,7 +55,6 @@ export function MessageList({
     listRef,
     messages,
     onReady,
-    scrollMessageToEnd,
   });
   const isAtBottom = useSharedValue(true);
   const contentHeightRef = useRef({ dataKey, height: 0 });
@@ -155,7 +153,6 @@ export function MessageList({
               estimatedItemSize={300}
               estimatedHeaderSize={contentTopInset}
               extraData={extraData}
-              freeze={freeze}
               getItemType={getMessageRowType}
               keyExtractor={messageKeyExtractor}
               keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}

--- a/src/frontend/components/Message/README.md
+++ b/src/frontend/components/Message/README.md
@@ -221,8 +221,9 @@ bootstrap once, and the controller adopts following mode without issuing a secon
 
 Keyboard lift remains `whenAtEnd`: focusing the composer must not move a viewport that is reading
 history. The keyboard controller is a platform geometry adapter; it never transitions the product
-following/reading state. A local send uses its keyboard-aware scroll helper once so keyboard
-dismissal and the animated return to the live edge share one operation.
+following/reading state. A local send keeps keyboard geometry updates active while awaiting
+dismissal, then scrolls to the live edge after the keyboard inset clears. A dataset switch or
+committed drag during dismissal cancels that pending scroll.
 
 User message rows visually separate managed file parts from the text bubble: a right-aligned,
 horizontally scrollable attachment strip sits above the optional bubble. This is a presentation

--- a/src/frontend/components/Message/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/Message/list/__tests__/MessageList.test.tsx
@@ -1,6 +1,7 @@
 import type { LegendListRef } from '@legendapp/list/react-native';
 import type { ReactNode, Ref } from 'react';
 import { Platform, Pressable, type LayoutChangeEvent } from 'react-native';
+import { KeyboardController } from 'react-native-keyboard-controller';
 import type { SharedValue } from 'react-native-reanimated';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
@@ -47,8 +48,9 @@ type MockLegendListProps = {
 };
 
 let mockLatestListProps: MockLegendListProps | undefined;
-const mockFreeze = { get: jest.fn(), set: jest.fn(), value: false };
-const mockScrollMessageToEnd = jest.fn(async () => undefined);
+const mockKeyboardDismiss = KeyboardController.dismiss as jest.MockedFunction<
+  typeof KeyboardController.dismiss
+>;
 const mockListScrollToEnd = jest.fn(async () => undefined);
 const mockListScrollToIndex = jest.fn(async () => undefined);
 let mockListState = {
@@ -123,10 +125,6 @@ jest.mock('@legendapp/list/keyboard', () => {
         </View>
       );
     },
-    useKeyboardScrollToEnd: () => ({
-      freeze: mockFreeze,
-      scrollMessageToEnd: mockScrollMessageToEnd,
-    }),
   };
 });
 
@@ -584,13 +582,17 @@ describe('MessageList scroll-controller ownership', () => {
     });
   });
 
-  test('a local send owns one keyboard-aware animated scroll', async () => {
+  test('a local send keeps keyboard insets active and waits for dismissal before scrolling', async () => {
     const messages = [createMessage('user-1', 'user')];
     act(() => {
       renderer = create(<MessageList {...listProps(messages)} />);
     });
     await loadList();
     mockListScrollToEnd.mockClear();
+    let finishDismiss!: () => void;
+    mockKeyboardDismiss.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (finishDismiss = resolve)),
+    );
 
     const nextMessages = [...messages, createMessage('user-2', 'user')];
     act(() => {
@@ -600,13 +602,58 @@ describe('MessageList scroll-controller ownership', () => {
     });
     act(flushAnimationFrames);
 
-    expect(mockScrollMessageToEnd).toHaveBeenCalledTimes(1);
-    expect(mockScrollMessageToEnd).toHaveBeenCalledWith({
-      animated: true,
-      closeKeyboard: true,
-    });
+    expect(mockLatestListProps?.freeze).toBeUndefined();
+    expect(mockKeyboardDismiss).toHaveBeenCalledTimes(1);
     expect(mockListScrollToEnd).not.toHaveBeenCalled();
+
+    await act(async () => finishDismiss());
+
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
+    expect(mockListScrollToEnd).toHaveBeenCalledWith({ animated: true });
   });
+
+  test.each(['drag', 'dataset switch'] as const)(
+    'cancels the pending send scroll when a %s occurs during keyboard dismissal',
+    async (interruption) => {
+      const messages = [createMessage('user-1', 'user')];
+      act(() => {
+        renderer = create(<MessageList {...listProps(messages)} />);
+      });
+      await loadList();
+      mockListScrollToEnd.mockClear();
+      let finishDismiss!: () => void;
+      mockKeyboardDismiss.mockImplementationOnce(
+        () => new Promise<void>((resolve) => (finishDismiss = resolve)),
+      );
+
+      const nextMessages = [...messages, createMessage('user-2', 'user')];
+      act(() => {
+        renderer?.update(
+          <MessageList {...listProps(nextMessages, { enteringMessageId: 'user-2' })} />,
+        );
+      });
+      act(flushAnimationFrames);
+
+      act(() => {
+        if (interruption === 'drag') {
+          mockLatestListProps?.onScrollBeginDrag?.();
+        } else {
+          renderer?.update(
+            <MessageList
+              {...listProps([createMessage('other-user', 'user')], {
+                dataKey: 'session-2',
+                initialLayoutReady: false,
+              })}
+            />,
+          );
+        }
+      });
+      await act(async () => finishDismiss());
+      act(flushAnimationFrames);
+
+      expect(mockListScrollToEnd).not.toHaveBeenCalled();
+    },
+  );
 
   test('the explicit scroll button returns reading mode to the live edge', async () => {
     const messages = [createMessage('user-1', 'user')];

--- a/src/frontend/components/Message/list/useMessageListScrollController.ts
+++ b/src/frontend/components/Message/list/useMessageListScrollController.ts
@@ -2,6 +2,7 @@ import type { LegendListRef } from '@legendapp/list/react-native';
 import type { RefObject } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { KeyboardController } from 'react-native-keyboard-controller';
 
 import { cacheService } from '@/frontend/data/CacheService';
 import { loggerService } from '@/shared/core/logger/LoggerService';
@@ -18,8 +19,6 @@ import {
 const SAVE_THROTTLE_MS = 200;
 const scrollLog = loggerService.withContext('ChatScroll');
 
-type ScrollMessageToEnd = (options: { animated: boolean; closeKeyboard: boolean }) => Promise<void>;
-
 type MessageListScrollControllerInputs = {
   dataKey: string | undefined;
   enteringMessageId: string | undefined;
@@ -27,7 +26,6 @@ type MessageListScrollControllerInputs = {
   listRef: RefObject<LegendListRef | null>;
   messages: readonly MessageListItem[];
   onReady: (() => void) | undefined;
-  scrollMessageToEnd: ScrollMessageToEnd;
 };
 
 type ObservedScrollAnchor = Readonly<{
@@ -107,17 +105,21 @@ export function useMessageListScrollController(inputs: MessageListScrollControll
 
   const scrollToLiveEdge = useCallback(
     async (reason: FollowingReason, options: { animated: boolean; closeKeyboard: boolean }) => {
-      const current = inputsRef.current;
+      const generation = restoreGenerationRef.current;
       follow.enterFollowing(reason);
       clearStoredAnchor();
       liveEdgeScrollCountRef.current += 1;
 
       try {
         if (options.closeKeyboard) {
-          await current.scrollMessageToEnd(options);
-        } else {
-          await current.listRef.current?.scrollToEnd({ animated: options.animated });
+          // Keep keyboard geometry updates active so dismissal clears its bottom
+          // inset before we resolve the list's new live edge.
+          await KeyboardController.dismiss();
+          if (generation !== restoreGenerationRef.current || !follow.isFollowing()) {
+            return;
+          }
         }
+        await inputsRef.current.listRef.current?.scrollToEnd({ animated: options.animated });
       } catch (error) {
         scrollLog.warn('[SCROLL] liveEdgeScroll failed', error as Error, { reason });
       } finally {


### PR DESCRIPTION
### What this PR does

Before this PR: Sending a message with the keyboard open froze the list's keyboard geometry during dismissal, which could leave keyboard-sized blank space below the messages.

After this PR: Keyboard inset updates remain active during dismissal. Once the keyboard closes, the list scrolls to the latest message using the updated layout. Switching conversations or dragging the list while dismissal is pending cancels that pending scroll.

### Screenshots or videos

Not captured. Device/UI verification was not requested for this task; visual acceptance remains pending.

### Why we need it and why it was done in this way

The scroll controller now awaits `KeyboardController.dismiss()` before scrolling, replacing the helper that freezes keyboard geometry. This lets the existing keyboard integration clear its bottom inset without adding spacing overrides or changing dependencies.

The tradeoff is that the animated scroll starts after keyboard dismissal completes. Existing follow-to-bottom behavior is retained. Regression cases cover dismissal ordering and cancellation during a drag or conversation switch, and the message-list documentation reflects the new sequence.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: formatting and focused lint checks for the changed TypeScript files; repository-wide `pnpm format:check`.
- `pnpm lint` failed with 7 `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider entry in unchanged backend files. The package exports point to `packages/ai-core/dist`, which is absent in this workspace. The check also reported warnings in unchanged files.
- Tests, type checking, builds, and device/UI acceptance were not run under the task's verification restrictions. The new regression cases have not been executed.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description explains the behavior and validation status
- [ ] Preview: Screenshots or a video demonstrate the result
- [x] Code: The change is limited to message-list keyboard dismissal and scrolling
- [x] Upgrade: No dependency, schema, or migration changes
- [x] Documentation: Updated the message-list behavior documentation; no user-guide update is needed for this fix
- [x] Self-review: Reviewed the complete diff

### Release note

```release-note
Fix extra blank space below chat messages after sending with the keyboard open.
```
