### PR TITLE
docs(git-workflow): make stacked PRs explicit opt-in

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -15,6 +15,11 @@ actions, downloads, delegation, or external writes. Follow the user's instructio
 [Testing And CI](../../docs/guides/testing-and-ci.md); report unavailable evidence and skipped checks
 without claiming completion.
 
+- **Stacked PRs:** [gh-stack](gh-stack/SKILL.md) is explicit opt-in: use it only when the user
+  explicitly requests a stack workflow or layered PRs for the task. Default to a single branch and
+  PR. Task complexity, dependent concerns, reusable component work, incidental stack mentions, or
+  a checked-out stack do not opt in. This overrides the upstream skill's automatic activation
+  triggers. Follow [Git Workflow](../../docs/guides/git-workflow.md) after the user opts in.
 - **Diagnosis:** [diagnose-fix-loop](diagnose-fix-loop/SKILL.md) loads the project
   [diagnose](diagnose/SKILL.md) as its evidence phase; an activated loop does not need a second named
   invocation. Outside that dependency, `diagnose` remains explicit opt-in. Both skills are required

--- a/docs/guides/git-workflow.md
+++ b/docs/guides/git-workflow.md
@@ -15,22 +15,25 @@ such as `main` are not valid. Older unscoped commits are not precedents.
 
 ## Stacked Pull Requests
 
-Use the project [gh-stack skill](../../.agents/skills/gh-stack/SKILL.md) before implementation when
-one coherent story contains multiple dependent concerns that can be reviewed in sequence. Plan the layers first, put foundations at the
-bottom, and keep Conventional Commit messages in every layer.
+PR layering is the user's decision. Default to a single branch and PR for one coherent task. Use
+the project [gh-stack skill](../../.agents/skills/gh-stack/SKILL.md) and create layers only when the
+user explicitly requests a stack or layered PRs. Task size, dependent concerns, and reusable
+component work do not imply that request.
 
-Use one stack for one coherent story. Put unrelated features, bug fixes, or refactors in separate
-Conductor workspaces and separate stacks. A linear stack is not a container for parallel independent
-work.
+Once the user opts in, plan the layers before implementation, put foundations at the bottom, and
+keep Conventional Commit messages in every layer. Use one stack for one coherent story. Put
+unrelated features, bug fixes, or refactors in separate Conductor workspaces; the user chooses their
+PR structure independently. A linear stack is not a container for parallel independent work.
 
-When a feature needs a new reusable CherryUI component, place the component package change in its
-own bottom PR and the feature integration in the PR above it. See
-[UI Development](./ui-development.md).
+Within a user-requested stack, when a feature needs a new reusable CherryUI component, place the
+component package change in its own bottom PR and the feature integration in the PR above it.
+Otherwise, keep both changes in the same PR. See [UI Development](./ui-development.md).
 
 ## Pull Request Lifecycle
 
 1. Run the local gates in [Testing And CI](./testing-and-ci.md).
-2. Create a normal PR as a draft, or submit an entire stack with `gh stack submit --auto`.
+2. Create a normal PR as a draft. For a user-requested stack, submit all layers with
+   `gh stack submit --auto`.
 3. After successful PR or stack creation, release the workspace's simulators or emulators and
    allocated port range using [Parallel Device Testing](./parallel-device-testing.md).
 4. Rerun local gates after later draft changes, then mark the final head ready for review.

--- a/docs/guides/ui-development.md
+++ b/docs/guides/ui-development.md
@@ -17,8 +17,10 @@ Keep a component feature-local when its state, language, or interaction belongs 
 workflow. Move it into CherryUI only when it is reusable across independent features and fits the
 package's platform-neutral interaction ownership.
 
-When CherryUI lacks a qualifying reusable component, create it in an independent bottom PR before
-the feature integration PR. Use a `gh-stack` layer when the integration depends on that component.
+When CherryUI lacks a qualifying reusable component, implement it in CherryUI and keep the component
+and feature integration in the same PR by default. Only when the user explicitly requests a stack
+or layered PRs, place the component in a bottom PR and the dependent feature integration above it.
+Follow [Git Workflow](./git-workflow.md) for the opt-in stack workflow.
 
 When an implementation differs between iOS and Android, follow
 [Platform Variants](../references/naming-conventions.md#platform-variants): keep the full component


### PR DESCRIPTION
### What this PR does

Before this PR: dependent work automatically required stacked PRs, and new reusable CherryUI components had to be submitted in a separate bottom PR.

After this PR: a coherent task defaults to a single branch and PR. Only an explicit user request enables the gh-stack workflow and PR layering. Component and feature integration changes stay together by default.

### Screenshots or videos

N/A — repository documentation only; no product UI changes.

### Why we need it and why it was done in this way

PR structure should be the user's decision. Update the project skill usage rules, Git workflow, and UI guide together so automatic skill triggers and component guidance cannot implicitly require layering. Keep the upstream gh-stack skill unchanged and retain layer ordering rules for explicitly requested stacks.

### Breaking changes

None.

### Special notes for your reviewer

Validation:
- Passed: `pnpm format:check`, `pnpm docs:check-links`, and `pnpm skills:check`.
- `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider entry point in unchanged application files; warnings were also reported.
- Tests and builds were not run under the user's verification policy. `pnpm typecheck` was skipped because it runs package builds.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the resulting behavior.
- [x] Preview: Explained why screenshots are not applicable.
- [x] Self-review: Reviewed the complete three-file diff.

### Release note

```release-note
NONE
```
