### PR TITLE
fix(message-attachments): align sent files and remove processing notices

### DIFF
--- a/src/frontend/components/Message/parts/MessageFileStrip.tsx
+++ b/src/frontend/components/Message/parts/MessageFileStrip.tsx
@@ -10,7 +10,7 @@ type MessageFilePart = Extract<CherryMessagePart, { type: 'file' }>;
 const FILE_CARD_SIZE = 112;
 
 /**
- * A run of managed files laid out as one horizontally scrolling row.
+ * User attachments laid out as one right-aligned, horizontally scrolling row.
  *
  * Files are the one part type that arrives several at a time, and stacking
  * full-size cards down a phone screen buries the rest of the message. The row
@@ -22,7 +22,7 @@ export function MessageFileStrip({ parts }: { parts: readonly MessageFilePart[] 
     <ScrollView
       alwaysBounceHorizontal={false}
       className="max-w-full"
-      contentContainerClassName="gap-2"
+      contentContainerClassName="grow justify-end gap-2"
       horizontal
       showsHorizontalScrollIndicator={false}
       style={styles.strip}

--- a/src/frontend/components/Message/rows/UserMessageAttachments.tsx
+++ b/src/frontend/components/Message/rows/UserMessageAttachments.tsx
@@ -1,7 +1,4 @@
-import { useTranslation } from 'react-i18next';
-import { Text, View } from 'react-native';
-
-import { fileAttachmentNoticeKeys } from '@/frontend/utils/fileAttachmentFeedback';
+import { View } from 'react-native';
 
 import { MessageFileStrip } from '../parts/MessageFileStrip';
 import type { UserMessageAttachmentPart } from './partitionUserMessageParts';
@@ -10,23 +7,11 @@ type UserMessageAttachmentsProps = {
   attachments: readonly UserMessageAttachmentPart[];
 };
 
-/** Files and their send-time processing notices stay together above the user's bubble. */
+/** Attached files sit above the user's bubble. */
 export function UserMessageAttachments({ attachments }: UserMessageAttachmentsProps) {
-  const { t } = useTranslation();
   return (
-    <View className="max-w-full gap-2 self-end">
+    <View className="max-w-full self-end">
       <MessageFileStrip parts={attachments.map(({ part }) => part)} />
-      {attachments.map(({ index, part, report }) => {
-        const notices = fileAttachmentNoticeKeys(report);
-        return notices.length > 0 ? (
-          <Text className="text-sm text-muted-foreground" key={`${part.url}:${index}`}>
-            {t('attachments.notice.withFilename', {
-              name: part.filename ?? t('chat.media.file'),
-              notice: notices.map((key) => t(key)).join(' '),
-            })}
-          </Text>
-        ) : null;
-      })}
     </View>
   );
 }


### PR DESCRIPTION
### What this PR does

Before this PR: Sent attachments could display on the left with processing descriptions such as “Extracted text sent; document images and layout are not included.”

After this PR: Sent attachments align to the right above the user's text bubble and display without processing descriptions. Multiple attachments retain horizontal scrolling.

### Screenshots or videos

Pending device verification. No after-change screenshots were captured because UI verification was not authorized for this task.

### Why we need it and why it was done in this way

Keep sent attachments visually grouped with the user's message. Remove the notice rendering and let the attachment strip's content grow to its viewport width with trailing alignment.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: formatting and lint for both changed files, full `pnpm format:check`, and `git diff --check`.
- Full `pnpm lint` failed with seven existing module-resolution errors for `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` in unrelated backend files. The changed files have no lint errors.
- Tests, typecheck, builds, and device verification were not run under the task's verification restrictions. Light/dark appearance and multi-attachment scrolling still need device verification.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the final change
- [ ] Preview: Screenshots or video demonstrate the result
- [x] Code: The change is limited to the two attachment presentation components
- [x] Documentation: A user-guide update is not required for this display fix
- [x] Self-review: Reviewed the complete diff

### Release note

```release-note
Fixed sent attachments appearing on the left and removed processing descriptions beneath attachment cards.
```
