### PR TITLE
fix(chat-drawer): prevent content flicker when toggling drawer

### DIFF
--- a/patches/react-native-drawer-layout@4.2.4.patch
+++ b/patches/react-native-drawer-layout@4.2.4.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/module/views/Drawer.native.js b/lib/module/views/Drawer.native.js
+index 5fb761c4140881cbb19d40597e2d6e33e870748b..0b2b7966dd28dfcb6dcf830a0cd1f75999c4eaec 100644
+--- a/lib/module/views/Drawer.native.js
++++ b/lib/module/views/Drawer.native.js
+@@ -285,6 +285,7 @@ export function Drawer({
+             children: [/*#__PURE__*/_jsxs(Animated.View, {
+               style: [styles.content, contentAnimatedStyle],
+               children: [/*#__PURE__*/_jsx(View, {
++                collapsable: false,
+                 "aria-hidden": isOpen && drawerType !== 'permanent',
+                 style: styles.content,
+                 children: children
+diff --git a/src/views/Drawer.native.tsx b/src/views/Drawer.native.tsx
+index ff41791d2c3b4fa498dc3f22877d226db120f2f7..cc1e015ec40cc765ee92eb4f7f89c0c0ac37ab88 100644
+--- a/src/views/Drawer.native.tsx
++++ b/src/views/Drawer.native.tsx
+@@ -468,6 +468,7 @@ export function Drawer({
+             >
+               <Animated.View style={[styles.content, contentAnimatedStyle]}>
+                 <View
++                  collapsable={false}
+                   aria-hidden={isOpen && drawerType !== 'permanent'}
+                   style={styles.content}
+                 >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,7 @@ patchedDependencies:
   metro-runtime@0.84.4: 7f83ec93fe717bebba70d6301eac128b36bbb0b46d5db476fb5c43bac9daea6a
   metro@0.84.4: bc3c69aec12bccf391b5180caffd62a4043c81bcf5848949a4b50e79184be6f7
   ollama-ai-provider-v2@3.3.1: 4cb5921e69158814eeeed8d71c80621bd261f33d769b6afabba0db40931155eb
+  react-native-drawer-layout@4.2.4: 5d567d547b418913c11d2dfe413fc9c1caa72027b12a4a212d23447fc3efe934
   react-native-enriched-markdown@1.0.1: 6b4f6cd7cfebd01ee08d694a0afa28d1426d9f625b45b7717d2fffce02b6da00
   react-native-keyboard-controller@1.21.13: 6f5bed7a836aae55a44a2b0a97532e6d73d9dfb87032457499dfe3ff2c239186
   react-native-nitro-healthkit@1.0.0: c1231cd559844fba1fa13c5d09d4f9a84ecd4211707055a1ea2c3ba9930108e7
@@ -15483,7 +15484,7 @@ snapshots:
       react-fast-compare: 3.2.2
       react-is: 19.2.6
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
-      react-native-drawer-layout: 4.2.4(0f5cf51ddfe162994ec210b6e15e7656)
+      react-native-drawer-layout: 4.2.4(patch_hash=5d567d547b418913c11d2dfe413fc9c1caa72027b12a4a212d23447fc3efe934)(0f5cf51ddfe162994ec210b6e15e7656)
       react-native-safe-area-context: 5.7.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-screens: 4.25.2(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       server-only: 0.0.1
@@ -17884,7 +17885,7 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
       react-native-svg: 15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
 
-  react-native-drawer-layout@4.2.4(0f5cf51ddfe162994ec210b6e15e7656):
+  react-native-drawer-layout@4.2.4(patch_hash=5d567d547b418913c11d2dfe413fc9c1caa72027b12a4a212d23447fc3efe934)(0f5cf51ddfe162994ec210b6e15e7656):
     dependencies:
       color: 4.2.3
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,7 @@ patchedDependencies:
   react-native-keyboard-controller@1.21.13: patches/react-native-keyboard-controller@1.21.13.patch
   expo-router@57.0.6: patches/expo-router@57.0.6.patch
   react-native-enriched-markdown@1.0.1: patches/react-native-enriched-markdown@1.0.1.patch
+  react-native-drawer-layout@4.2.4: patches/react-native-drawer-layout@4.2.4.patch
 
 minimumReleaseAgeExclude:
   - '@expo/cli@57.0.3'

--- a/src/frontend/appShell/sidebar/__tests__/drawerNativePatch.test.ts
+++ b/src/frontend/appShell/sidebar/__tests__/drawerNativePatch.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const drawerPackageRoot = dirname(
+  require.resolve('react-native-drawer-layout/package.json', {
+    paths: [dirname(require.resolve('expo-router/package.json'))],
+  }),
+);
+
+// Guard the installed dependency's source and compiled entry. Changing aria-hidden
+// must not let Fabric flatten/unflatten the parent of the native chat screen.
+describe('drawer native content patch', () => {
+  test.each([
+    [
+      'src/views/Drawer.native.tsx',
+      /<View\s+collapsable=\{false\}\s+aria-hidden=\{isOpen && drawerType !== 'permanent'\}/,
+    ],
+    [
+      'lib/module/views/Drawer.native.js',
+      /_jsx\(View, \{\s+collapsable: false,\s+"aria-hidden": isOpen && drawerType !== 'permanent'/,
+    ],
+  ])('keeps the native content parent stable in %s', (file, contentWrapper) => {
+    expect(readFileSync(join(drawerPackageRoot, file), 'utf8')).toMatch(contentWrapper);
+  });
+});


### PR DESCRIPTION
### What this PR does

Before this PR, opening or closing the chat drawer briefly flashed the exposed chat content on the right. After this PR, the drawer's native content wrapper stays mounted throughout both transitions.

Patch `react-native-drawer-layout@4.2.4` with `collapsable={false}` on the content wrapper in both its TypeScript source and published JavaScript. Register the pnpm patch and add installed-dependency guards for both entries.

### Screenshots or videos

No recording was captured. The reporter installed the rebuilt Android preview APK on a physical device and confirmed that the flicker is gone.

### Why we need it and why it was done in this way

The wrapper toggles `aria-hidden` when the drawer opens and closes. Under Fabric, this can change whether React Native flattens that wrapper, forcing the native chat screen to move between parents. Keeping the wrapper non-collapsible stabilizes the native hierarchy while preserving the existing accessibility attributes, overlay, and gestures.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm lint` passed with existing warnings in unchanged files.
- `pnpm format`, `pnpm format:check`, and `git diff --check` passed.
- Local EAS Android preview build succeeded for `arm64-v8a`; physical-device verification passed as reported above.
- Automated tests and `pnpm typecheck` were intentionally not run under the contributor's verification policy. The latter also builds workspace packages. The new tests guard patch installation, while the physical-device check covers the visible regression.
- iOS device behavior has not been verified.

### Checklist

- [x] This PR targets `v0.2`.
- [x] The change has been self-reviewed and stays limited to the drawer patch.
- [ ] A screenshot or video is attached; physical-device confirmation is recorded above.
- [x] No user-guide update or migration is required.

### Release note

```release-note
Fix chat content briefly flashing when opening or closing the sidebar drawer.
```
