### PR TITLE
style(chat-messages): redesign token usage summary and details

### DIFF
--- a/src/frontend/features/chat/components/ChatWorkspace/components/AssistantMessageUsage.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/AssistantMessageUsage.tsx
@@ -1,4 +1,3 @@
-import InfoIcon from '@cherrystudio/app-icons/icons/info';
 import { Button } from '@cherrystudio/ui/components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,23 +8,26 @@ import type { MessageListItem } from '@/frontend/components/Message';
 import { getMessageDurationMs, getMessageTokenUsage } from '../utils/messageUsage';
 import { MessageUsageDetail } from './MessageUsageDetail';
 
+// Keep the compact unit consistent across UI languages (27k instead of 2.7万).
+const TOKEN_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
 export function AssistantMessageUsage({ message }: { message: MessageListItem }) {
   const { t, i18n } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
   if (message.status === 'pending') return null;
 
-  const locale = i18n.resolvedLanguage;
+  const locale = i18n.resolvedLanguage ?? i18n.language;
   const { totalTokens } = getMessageTokenUsage(message.stats);
   const durationMs = getMessageDurationMs(message.stats);
   const tokens =
     totalTokens === undefined
       ? undefined
       : t('chat.messageUsage.tokensValue', {
-          value: new Intl.NumberFormat(locale, {
-            notation: 'compact',
-            maximumFractionDigits: 1,
-          }).format(totalTokens),
+          value: TOKEN_NUMBER_FORMATTER.format(totalTokens).replace('K', 'k'),
         });
   const duration =
     durationMs === undefined
@@ -42,14 +44,13 @@ export function AssistantMessageUsage({ message }: { message: MessageListItem })
       <Button
         accessibilityLabel={summary}
         accessibilityHint={t('chat.messageUsage.openHint')}
-        hitSlop={6}
-        icon={<InfoIcon className="text-muted-foreground" size={14} />}
+        hitSlop={9}
         onPress={() => setIsOpen(true)}
-        size="sm"
+        size="inline"
         testID="assistant-message-usage"
         variant="ghost"
       >
-        <Text className="shrink text-muted-foreground text-xs tabular-nums">{summary}</Text>
+        <Text className="min-w-0 shrink text-muted-foreground text-xs tabular-nums">{summary}</Text>
       </Button>
       {isOpen ? <MessageUsageDetail message={message} onClose={() => setIsOpen(false)} /> : null}
     </>

--- a/src/frontend/features/chat/components/ChatWorkspace/components/ChatMessage.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/ChatMessage.tsx
@@ -63,9 +63,11 @@ function renderChatAssistantMessage(
       </View>
       <AssistantMessage isTextSelectionEnabled={isTextSelectionEnabled} message={message}>
         {message.status !== 'pending' ? (
-          <View className="w-full flex-row flex-wrap items-center justify-between gap-x-3">
+          <View className="w-full flex-row flex-wrap items-center gap-x-3 gap-y-1">
             <AssistantMessageToolbar message={message} />
-            <AssistantMessageUsage message={message} />
+            <View className="min-w-0 max-w-full flex-1 items-end">
+              <AssistantMessageUsage message={message} />
+            </View>
           </View>
         ) : null}
       </AssistantMessage>

--- a/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
@@ -2,12 +2,13 @@ import { Button, ContentState, MessagePart, Spinner } from '@cherrystudio/ui/com
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
 
+import { ModelAvatar } from '@/frontend/components/Avatar';
 import type { MessageListItem } from '@/frontend/components/Message';
 
 import { useMessageUsageRecords } from '../hooks/useMessageUsageRecords';
 import { formatMessageUsageCost, getMessageUsageDetails } from '../utils/messageUsage';
 
-const DETAIL_SIZES = ['compact', 'large'] as const;
+const DETAIL_SIZES = ['medium', 'large'] as const;
 
 export function MessageUsageDetail({
   message,
@@ -37,34 +38,19 @@ export function MessageUsageDetail({
   const formatDuration = (value: number | undefined) =>
     value === undefined ? undefined : seconds.format(value / 1000);
   const createdAt = message.createdAt ? new Date(message.createdAt) : undefined;
-  const metadata = {
-    ...(detail.requestCount !== undefined
-      ? {
-          [t('chat.messageUsage.requests')]: numbers.format(detail.requestCount),
-        }
-      : {}),
-    ...(message.model
-      ? {
-          [t('chat.messageUsage.model')]: message.model.name,
-          [t('chat.messageUsage.provider')]:
-            records.find((record) => record.providerId === message.model?.providerId)
-              ?.providerName ?? message.model.providerId,
-        }
-      : {}),
-    ...(createdAt && Number.isFinite(createdAt.getTime())
-      ? {
-          [t('chat.messageUsage.createdAt')]: new Intl.DateTimeFormat(locale, {
-            dateStyle: 'medium',
-            timeStyle: 'medium',
-          }).format(createdAt),
-        }
-      : {}),
-  };
-  const tokenDetails = [
+  const providerName = message.model
+    ? (records.find((record) => record.providerId === message.model?.providerId)?.providerName ??
+      message.model.providerId)
+    : undefined;
+  const tokenSum =
+    detail.inputTokens !== undefined && detail.outputTokens !== undefined
+      ? detail.inputTokens + detail.outputTokens
+      : 0;
+  const hasTokenDistribution = Number.isFinite(tokenSum) && tokenSum > 0;
+  const inputDetails = [
     ['chat.messageUsage.noCache', detail.noCacheTokens],
     ['chat.messageUsage.cacheRead', detail.cacheReadTokens],
     ['chat.messageUsage.cacheWrite', detail.cacheWriteTokens],
-    ['chat.messageUsage.reasoning', detail.reasoningTokens],
   ] as const;
   const performance = [
     ['chat.messageUsage.totalDuration', formatDuration(detail.durationMs)],
@@ -74,6 +60,23 @@ export function MessageUsageDetail({
     ['chat.messageUsage.toolDuration', formatDuration(detail.toolDurationMs)],
     ['chat.messageUsage.approvalDuration', formatDuration(detail.approvalDurationMs)],
   ] as const;
+  const visiblePerformance = performance.filter(([, value]) => value !== undefined);
+  const metadata = [
+    [
+      'chat.messageUsage.requests',
+      detail.requestCount === undefined ? undefined : numbers.format(detail.requestCount),
+    ],
+    [
+      'chat.messageUsage.createdAt',
+      createdAt && Number.isFinite(createdAt.getTime())
+        ? new Intl.DateTimeFormat(locale, {
+            dateStyle: 'medium',
+            timeStyle: 'medium',
+          }).format(createdAt)
+        : undefined,
+    ],
+  ] as const;
+  const visibleMetadata = metadata.filter(([, value]) => value !== undefined);
 
   return (
     <MessagePart.Detail
@@ -82,89 +85,201 @@ export function MessageUsageDetail({
       testID="message-usage-detail"
       title={t('chat.messageUsage.title')}
     >
-      <MessagePart.ValueSection title={t('chat.messageUsage.message')} value={metadata} />
-      <MessagePart.ValueSection
-        title={t('chat.messageUsage.tokens')}
-        value={{
-          [t('chat.messageUsage.input')]: formatTokens(detail.inputTokens),
-          [t('chat.messageUsage.output')]: formatTokens(detail.outputTokens),
-          [t('chat.messageUsage.total')]: formatTokens(detail.totalTokens),
-          ...Object.fromEntries(
-            tokenDetails
-              .filter(([, value]) => value !== undefined)
-              .map(([key, value]) => [t(key), formatTokens(value)]),
-          ),
-        }}
-      />
-      <MessagePart.ValueSection
-        title={t('chat.messageUsage.performance')}
-        value={Object.fromEntries(
-          performance
-            .filter(([, value]) => value !== undefined)
-            .map(([key, value]) => [t(key), value]),
-        )}
-      />
-      <Text className="text-muted-foreground text-xs">{t('chat.messageUsage.durationHint')}</Text>
-      <View className="gap-2">
-        <MessagePart.SectionTitle title={t('chat.messageUsage.cost')} />
-        {detail.costs.map((cost) => {
-          const sourceKey =
-            cost.providerReportedRequestCount > 0
-              ? cost.computedRequestCount > 0
-                ? 'chat.messageUsage.costMixed'
-                : 'chat.messageUsage.costBilled'
-              : cost.computedRequestCount > 0
-                ? 'chat.messageUsage.costEstimated'
-                : 'chat.messageUsage.cost';
-          return (
-            <View
-              className="flex-row flex-wrap items-center justify-between gap-2"
-              key={cost.currency}
-            >
-              <Text className="text-muted-foreground text-sm">
-                {t(sourceKey)} ({cost.currency})
-              </Text>
-              <Text className="text-foreground text-sm tabular-nums" selectable>
-                {formatMessageUsageCost(cost.amount, cost.currency, locale)}
-              </Text>
+      <View className="gap-8 px-1 pt-2 pb-4">
+        <View className="gap-6">
+          {message.model ? (
+            <View className="flex-row items-center gap-2.5">
+              <ModelAvatar model={message.model} size={28} />
+              <View className="min-w-0 flex-1 gap-0.5">
+                <Text className="font-medium text-foreground text-sm" selectable>
+                  {message.model.name}
+                </Text>
+                <Text className="text-muted-foreground text-xs" selectable>
+                  {providerName}
+                </Text>
+              </View>
             </View>
-          );
-        })}
-        {!isLoading && !error && detail.costs.length === 0 ? (
-          <Text className="text-muted-foreground text-sm">{unavailable}</Text>
+          ) : null}
+          <View className="gap-1">
+            <Text className="text-muted-foreground text-sm">
+              {t('chat.messageUsage.totalTokens')}
+            </Text>
+            <Text
+              adjustsFontSizeToFit
+              className="font-semibold text-4xl text-foreground tabular-nums"
+              minimumFontScale={0.6}
+              numberOfLines={1}
+              selectable
+            >
+              {detail.totalTokens === undefined ? '—' : numbers.format(detail.totalTokens)}
+            </Text>
+            {detail.totalTokens === undefined ? (
+              <Text className="text-muted-foreground text-xs">{unavailable}</Text>
+            ) : null}
+          </View>
+          <View className="gap-4">
+            {hasTokenDistribution ? (
+              <View
+                accessibilityElementsHidden
+                className="h-1.5 flex-row gap-1 overflow-hidden rounded-full"
+                importantForAccessibility="no-hide-descendants"
+              >
+                {detail.inputTokens ? (
+                  <View
+                    className="rounded-full bg-foreground"
+                    style={{ flex: detail.inputTokens / tokenSum }}
+                  />
+                ) : null}
+                {detail.outputTokens ? (
+                  <View
+                    className="rounded-full bg-muted-foreground"
+                    style={{ flex: detail.outputTokens / tokenSum }}
+                  />
+                ) : null}
+              </View>
+            ) : null}
+            <View className="flex-row flex-wrap gap-x-6 gap-y-5">
+              <View className="min-w-32 flex-1 gap-3">
+                <View className="gap-1">
+                  <View className="flex-row items-center gap-1.5">
+                    <View className="size-1.5 rounded-full bg-foreground" />
+                    <Text className="text-muted-foreground text-sm">
+                      {t('chat.messageUsage.input')}
+                    </Text>
+                  </View>
+                  <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                    {formatTokens(detail.inputTokens)}
+                  </Text>
+                </View>
+                <View className="gap-2">
+                  {inputDetails.map(([key, value]) =>
+                    value === undefined ? null : (
+                      <MessageUsageRow key={key} label={t(key)} value={numbers.format(value)} />
+                    ),
+                  )}
+                </View>
+              </View>
+              <View className="min-w-32 flex-1 gap-3">
+                <View className="gap-1">
+                  <View className="flex-row items-center gap-1.5">
+                    <View className="size-1.5 rounded-full bg-muted-foreground" />
+                    <Text className="text-muted-foreground text-sm">
+                      {t('chat.messageUsage.output')}
+                    </Text>
+                  </View>
+                  <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                    {formatTokens(detail.outputTokens)}
+                  </Text>
+                </View>
+                {detail.reasoningTokens !== undefined ? (
+                  <MessageUsageRow
+                    label={t('chat.messageUsage.reasoning')}
+                    value={numbers.format(detail.reasoningTokens)}
+                  />
+                ) : null}
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View className="gap-3">
+          <MessagePart.SectionTitle title={t('chat.messageUsage.cost')} />
+          {detail.costs.map((cost) => {
+            const sourceKey =
+              cost.providerReportedRequestCount > 0
+                ? cost.computedRequestCount > 0
+                  ? 'chat.messageUsage.costMixed'
+                  : 'chat.messageUsage.costBilled'
+                : cost.computedRequestCount > 0
+                  ? 'chat.messageUsage.costEstimated'
+                  : 'chat.messageUsage.cost';
+            return (
+              <View
+                className="flex-row flex-wrap items-baseline justify-between gap-x-4 gap-y-1"
+                key={cost.currency}
+              >
+                <View className="min-w-0 shrink flex-row flex-wrap items-baseline gap-2">
+                  <Text className="font-medium text-foreground text-sm">{cost.currency}</Text>
+                  <Text className="text-muted-foreground text-xs">{t(sourceKey)}</Text>
+                </View>
+                <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                  {formatMessageUsageCost(cost.amount, cost.currency, locale)}
+                </Text>
+              </View>
+            );
+          })}
+          {detail.costs.length === 0 ? (
+            <Text className="text-muted-foreground text-sm">{unavailable}</Text>
+          ) : null}
+          {detail.hasUnpricedRecords && detail.costs.length > 0 ? (
+            <Text className="text-muted-foreground text-xs">
+              {t('chat.messageUsage.partialCost')}
+            </Text>
+          ) : null}
+        </View>
+
+        {visiblePerformance.length > 0 ? (
+          <View className="gap-4">
+            <MessagePart.SectionTitle title={t('chat.messageUsage.performance')} />
+            <View className="flex-row flex-wrap gap-x-6 gap-y-5">
+              {visiblePerformance.map(([key, value]) => (
+                <View className="min-w-32 flex-1 gap-1" key={key}>
+                  <Text className="text-muted-foreground text-xs">{t(key)}</Text>
+                  <Text className="font-medium text-foreground text-lg tabular-nums" selectable>
+                    {value}
+                  </Text>
+                </View>
+              ))}
+            </View>
+            <Text className="text-muted-foreground text-xs">
+              {t('chat.messageUsage.durationHint')}
+            </Text>
+          </View>
         ) : null}
-        {detail.hasUnpricedRecords && detail.costs.length > 0 ? (
-          <Text className="text-muted-foreground text-xs">
-            {t('chat.messageUsage.partialCost')}
-          </Text>
+
+        {visibleMetadata.length > 0 ? (
+          <View className="gap-3">
+            <MessagePart.SectionTitle title={t('chat.messageUsage.message')} />
+            {visibleMetadata.map(([key, value]) =>
+              value === undefined ? null : (
+                <MessageUsageRow key={key} label={t(key)} value={value} />
+              ),
+            )}
+          </View>
+        ) : null}
+
+        {error ? (
+          <ContentState.Error
+            primaryAction={{ children: t('common.retry'), onPress: () => void refresh() }}
+            title={t('chat.messageUsage.loadError')}
+          />
+        ) : isLoading ? (
+          <View className="flex-row items-center gap-2">
+            <Spinner accessibilityLabel={t('chat.messageUsage.loading')} size="sm" />
+            <Text className="text-muted-foreground text-xs">{t('chat.messageUsage.loading')}</Text>
+          </View>
+        ) : records.length === 0 ? (
+          <View className="flex-row flex-wrap items-center justify-between gap-x-3 gap-y-1">
+            <Text className="min-w-0 shrink text-muted-foreground text-xs">
+              {t('chat.messageUsage.noRecords')}
+            </Text>
+            <Button onPress={() => void refresh()} size="inline" variant="ghost">
+              <Text className="font-medium text-foreground text-xs">{t('common.retry')}</Text>
+            </Button>
+          </View>
         ) : null}
       </View>
-      {error ? (
-        <ContentState.Error
-          primaryAction={{
-            children: t('common.retry'),
-            onPress: () => {
-              void refresh();
-            },
-          }}
-          title={t('chat.messageUsage.loadError')}
-        />
-      ) : isLoading ? (
-        <Spinner accessibilityLabel={t('chat.messageUsage.loading')} size="sm" />
-      ) : records.length === 0 ? (
-        <View className="gap-1">
-          <Text className="text-muted-foreground text-xs">{t('chat.messageUsage.noRecords')}</Text>
-          <Button
-            onPress={() => {
-              void refresh();
-            }}
-            size="sm"
-            variant="ghost"
-          >
-            {t('common.retry')}
-          </Button>
-        </View>
-      ) : null}
     </MessagePart.Detail>
+  );
+}
+
+function MessageUsageRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-row flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+      <Text className="text-muted-foreground text-xs">{label}</Text>
+      <Text className="min-w-0 shrink text-foreground text-xs tabular-nums" selectable>
+        {value}
+      </Text>
+    </View>
   );
 }

--- a/src/frontend/features/chat/components/ChatWorkspace/components/README.md
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/README.md
@@ -33,6 +33,18 @@ Missing measurements stay unavailable, while an image call without token fields 
 reported language usage. Total throughput includes tool execution and approval waits and is not
 labelled as model generation speed.
 
+The usage summary aligns to the right of the footer, separate from the message actions on the left.
+It uses plain secondary text with a middle dot between tokens and elapsed time, without a persistent
+surface, border, or extra icon. Token counts use a locale-independent compact number with its unit,
+such as `27k Tokens`. The entire summary remains tappable.
+
+The detail sheet retains localized exact counts. It opens at medium height and expands to large,
+leading with the model and total tokens, then grouping input/cache and output/reasoning measurements
+into two columns. A neutral segmented bar
+shows the relative input/output counts only when both are known and their sum is positive. Costs,
+performance, and message metadata follow as separate typographic groups, using theme tokens and
+scalable text. Missing counts stay unavailable and a measured zero remains visible.
+
 The usage button uses CherryUI's release-time press action under the existing message context menu.
 Scrolling, a committed long press, and system cancellation must cancel that tap; accessibility
 activation opens the same detail. The maintained sheet owns scrolling and dismissal. No feature-local

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -308,6 +308,7 @@
   "chat.messageUsage.total": "Total",
   "chat.messageUsage.totalDuration": "Total time",
   "chat.messageUsage.totalSpeed": "Overall speed",
+  "chat.messageUsage.totalTokens": "Total tokens",
   "chat.messageUsage.unavailable": "Not available",
   "chat.media.photos": "Photos",
   "chat.model.select": "Select model",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -306,6 +306,7 @@
   "chat.messageUsage.total": "总计",
   "chat.messageUsage.totalDuration": "总耗时",
   "chat.messageUsage.totalSpeed": "整体响应速度",
+  "chat.messageUsage.totalTokens": "总 Token 用量",
   "chat.messageUsage.unavailable": "暂无数据",
   "chat.media.photos": "照片",
   "chat.model.select": "选择模型",


### PR DESCRIPTION
### What this PR does

Before this PR, per-message usage uses an info-icon button and locale-specific compact notation, while the detail sheet presents most measurements in equally weighted key/value rows.

After this PR:

- A quiet text summary stays right-aligned, separate from the message actions on the left. Token counts use lowercase `k` across UI languages and retain the unit, for example `27k Tokens`.
- The detail sheet opens at medium height, leads with the model and total tokens, and groups input/cache and output/reasoning measurements into two columns with a neutral proportion bar.
- Costs, performance, and message metadata have distinct typography and spacing. Exact counts, measured zeroes, missing data, per-currency costs, and retry actions remain available.

### Screenshots or videos

Pending. Light/dark device acceptance and screenshot capture were not performed under the repository owner's verification policy.

### Why we need it and why it was done in this way

The footer should read as secondary message information, while the detail sheet should make total usage easy to find. The change reuses CherryUI's button and detail sheet, existing semantic theme tokens, and the current usage data and calculation helpers. Ledger queries still mount only while the detail sheet is open.

### Breaking changes

None. No dependency, schema, backend calculation, or shared component API changes.

### Special notes for your reviewer

Validation:

- `pnpm lint` passed with existing warnings in unchanged files.
- `pnpm format:check` passed.
- Changed-file Oxlint and Expo ESLint passed.
- `git diff --check` passed.
- Builds, type checks, tests, and device acceptance were intentionally not run under the repository owner's verification policy. Automated CI and light/dark visual acceptance remain pending.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description covers the final behavior and validation limitations
- [ ] Preview: Light/dark screenshots or video are attached
- [x] Code: Changes stay within chat presentation and existing UI/data contracts
- [x] Upgrade: No migration or dependency change is needed
- [x] Documentation: The chat workspace README describes the updated presentation
- [x] Self-review: The local diff was reviewed
- [ ] Device acceptance is complete

### Release note

```release-note
Refine message usage with a right-aligned compact token summary and a redesigned detail sheet for tokens, costs, and response performance.
```
