### PR TITLE
fix(paintings): align Gemini controls and Kolors precision

### DIFF
--- a/packages/ai-runtime/src/provider/custom/__tests__/gatewayImageModel.test.ts
+++ b/packages/ai-runtime/src/provider/custom/__tests__/gatewayImageModel.test.ts
@@ -1,6 +1,10 @@
 import type { ImageModelV3CallOptions, LanguageModelV3 } from '@ai-sdk/provider';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { splitParamValues } from '../../../utils/imageOptions';
+import { buildVendorProviderOptions } from '../wire/buildImageRequest';
+import { DEFAULT_DIFFUSION_REGISTRATION } from '../wire/wireProfile';
+
 const baseImageModel = vi.fn();
 const languageModel = vi.fn();
 
@@ -89,7 +93,59 @@ describe('createGatewayGeminiImageModel', () => {
     });
   });
 
-  it('preserves other provider options and deep-merges existing imageConfig', async () => {
+  it.each(['1K', '2K', '4K'])(
+    'sends the selected %s resolution to Google while preserving Gateway routing',
+    async (imageResolution) => {
+      const doGenerate = vi.fn().mockResolvedValue({
+        content: [{ type: 'file', mediaType: 'image/png', data: 'IMG' }],
+        finishReason: 'stop',
+        usage: {},
+        response: { headers: {} },
+      });
+      const model = createGatewayGeminiImageModel(
+        fakeLanguageModel(doGenerate),
+        'google/gemini-3.1-flash-image',
+      );
+      const paramValues = { imageResolution };
+      const { vendorBag } = splitParamValues(paramValues);
+      const providerOptions = buildVendorProviderOptions(
+        'gateway',
+        paramValues,
+        DEFAULT_DIFFUSION_REGISTRATION,
+        vendorBag,
+      );
+      providerOptions.gateway.only = ['google'];
+
+      await model.doGenerate(callOptions({ providerOptions }));
+
+      const sent = doGenerate.mock.calls[0][0];
+      expect(sent.providerOptions.gateway).toEqual({ only: ['google'] });
+      expect(sent.providerOptions.google.imageConfig).toEqual({ imageSize: imageResolution });
+    },
+  );
+
+  it('omits automatic resolution from both Google and Gateway options', async () => {
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [{ type: 'file', mediaType: 'image/png', data: 'IMG' }],
+      finishReason: 'stop',
+      usage: {},
+      response: { headers: {} },
+    });
+    const model = createGatewayGeminiImageModel(
+      fakeLanguageModel(doGenerate),
+      'google/gemini-3.1-flash-image',
+    );
+
+    await model.doGenerate(
+      callOptions({ providerOptions: { gateway: { imageResolution: 'auto' } } }),
+    );
+
+    expect(doGenerate.mock.calls[0][0].providerOptions).toEqual({
+      google: { responseModalities: ['IMAGE'] },
+    });
+  });
+
+  it('preserves explicit Google imageSize over the inherited Gateway resolution', async () => {
     const doGenerate = vi.fn().mockResolvedValue({
       content: [{ type: 'file', mediaType: 'image/png', data: 'IMG' }],
       finishReason: 'stop',
@@ -105,7 +161,7 @@ describe('createGatewayGeminiImageModel', () => {
       callOptions({
         aspectRatio: '16:9',
         providerOptions: {
-          gateway: { only: ['google'] },
+          gateway: { imageResolution: '4K', only: ['google'] },
           google: { imageConfig: { imageSize: '2K' } },
         },
       }),

--- a/packages/ai-runtime/src/provider/custom/gateway/gatewayImageModel.ts
+++ b/packages/ai-runtime/src/provider/custom/gateway/gatewayImageModel.ts
@@ -112,9 +112,14 @@ export function createGatewayGeminiImageModel(
       // Augment only the `google` namespace; keep every other caller option
       // (e.g. `gateway` routing: order/only/BYOK) intact, and deep-merge
       // imageConfig so an existing imageSize survives an added aspectRatio.
+      const { gateway: rawGateway, ...otherProviderOptions } = providerOptions ?? {};
+      const { imageResolution, ...gateway } = (rawGateway ?? {}) as Record<string, JSONValue>;
       const existingGoogle = (providerOptions?.google ?? {}) as Record<string, JSONValue>;
       const existingImageConfig = (existingGoogle.imageConfig ?? {}) as Record<string, JSONValue>;
       const imageConfig: Record<string, JSONValue> = {
+        ...(typeof imageResolution === 'string' && imageResolution !== 'auto'
+          ? { imageSize: imageResolution }
+          : {}),
         ...existingImageConfig,
         ...(aspectRatio ? { aspectRatio } : {}),
       };
@@ -129,7 +134,11 @@ export function createGatewayGeminiImageModel(
         ...(seed != null ? { seed } : {}),
         ...(headers ? { headers } : {}),
         ...(abortSignal ? { abortSignal } : {}),
-        providerOptions: { ...providerOptions, google },
+        providerOptions: {
+          ...otherProviderOptions,
+          ...(Object.keys(gateway).length > 0 ? { gateway } : {}),
+          google,
+        },
       });
 
       const images: string[] = [];

--- a/packages/provider-registry/README.md
+++ b/packages/provider-registry/README.md
@@ -6,6 +6,17 @@ Bundled AI provider and model catalog for Cherry Studio: static JSON data files 
 
 > **Contributing?** The `data/*.json` files are **generated** — never hand-edit them. Edit `src/creators/` / `src/providers/` and run `pnpm generate`. See [CLAUDE.md](CLAUDE.md) and [docs/architecture.md](docs/architecture.md).
 
+For a change limited to specific creator models, update only their generated base-model rows:
+
+```bash
+pnpm exec tsx scripts/generate-catalog.ts --write --model=gemini-3-1-flash-image --model=kolors
+pnpm exec oxfmt data/models.json
+```
+
+Repeat `--model=<canonical-id>` for each model. This still enriches the selected rows from upstream,
+preserves all other bundled rows, and updates the model catalog's content version. Provider overrides,
+provider definitions, and reasoning patterns stay untouched; changes to those require full generation.
+
 ## Data Files
 
 ```

--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -8724,6 +8724,42 @@
       "contextWindow": 131072,
       "family": "gemini-flash",
       "id": "gemini-3-1-flash-image",
+      "imageGeneration": {
+        "modes": {
+          "generate": {
+            "supports": {
+              "aspectRatio": {
+                "default": "auto",
+                "options": [
+                  "auto",
+                  "ASPECT_1_1",
+                  "ASPECT_1_4",
+                  "ASPECT_1_8",
+                  "ASPECT_2_3",
+                  "ASPECT_3_2",
+                  "ASPECT_3_4",
+                  "ASPECT_4_1",
+                  "ASPECT_4_3",
+                  "ASPECT_4_5",
+                  "ASPECT_5_4",
+                  "ASPECT_8_1",
+                  "ASPECT_9_16",
+                  "ASPECT_16_9",
+                  "ASPECT_21_9"
+                ],
+                "render": "chips",
+                "type": "enum"
+              },
+              "imageResolution": {
+                "default": "auto",
+                "options": ["auto", "1K", "2K", "4K"],
+                "render": "chips",
+                "type": "enum"
+              }
+            }
+          }
+        }
+      },
       "inputModalities": ["text", "image", "video"],
       "maxOutputTokens": 65536,
       "metadata": {},
@@ -11738,6 +11774,7 @@
                 "default": 4.5,
                 "max": 20,
                 "min": 1,
+                "step": 0.1,
                 "type": "range"
               },
               "negativePrompt": {
@@ -22621,5 +22658,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "ea9e5ee3d7b53cc9"
+  "version": "1d23d6c15f3d3be3"
 }

--- a/packages/provider-registry/scripts/__tests__/merge-selected-models.test.ts
+++ b/packages/provider-registry/scripts/__tests__/merge-selected-models.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeSelectedModels } from '../merge-selected-models';
+
+describe('mergeSelectedModels', () => {
+  it('updates the selected model without refreshing or deleting unrelated models', () => {
+    const retained = { id: 'retained', price: 1 };
+    const absentUpstream = { id: 'absent-upstream', price: 2 };
+    const selected = { id: 'selected', price: 3 };
+
+    expect(
+      mergeSelectedModels(
+        [retained, absentUpstream, { id: 'selected', price: 0 }],
+        [selected, { id: 'retained', price: 100 }, { id: 'new-upstream', price: 4 }],
+        ['selected'],
+      ),
+    ).toEqual([retained, absentUpstream, selected]);
+  });
+
+  it('adds an explicitly selected new model once', () => {
+    expect(mergeSelectedModels([{ id: 'existing' }], [{ id: 'new' }], ['new', 'new'])).toEqual([
+      { id: 'existing' },
+      { id: 'new' },
+    ]);
+  });
+
+  it('rejects unknown selections instead of removing a bundled model', () => {
+    expect(() => mergeSelectedModels([{ id: 'missing' }], [], ['missing'])).toThrow(
+      'Cannot regenerate unknown model: missing',
+    );
+  });
+});

--- a/packages/provider-registry/scripts/generate-catalog.ts
+++ b/packages/provider-registry/scripts/generate-catalog.ts
@@ -8,6 +8,7 @@
  *     OPENROUTER_IMAGE_CACHE=/tmp/or-images.json \
  *     tsx scripts/generate-catalog.ts            # dry run (prints summary)
  *     tsx scripts/generate-catalog.ts --write    # write both JSON files
+ *     tsx scripts/generate-catalog.ts --write --model=kolors # update only this base model
  *     tsx scripts/generate-catalog.ts --report   # also dump /tmp/gen-*.txt review files
  */
 import { createHash } from 'node:crypto';
@@ -31,6 +32,7 @@ import { ReasoningFamilyRuleSchema } from '../src/schemas/model';
 import { stripHostReprefix } from '../src/utils/normalize';
 import { deriveLegacyReasoningFields } from '../src/utils/reasoningControls';
 import { canonOf, prefixHit } from './canonicalize';
+import { mergeSelectedModels } from './merge-selected-models';
 import {
   type CherryMeta,
   finalizeMeta,
@@ -57,6 +59,9 @@ const REASONING_FAMILIES_GEN_PATH = path.join(
 const WRITE = process.argv.includes('--write');
 const REPORT = process.argv.includes('--report');
 const PROVIDERS_ONLY = process.argv.includes('--providers-only');
+const SELECTED_MODEL_IDS = process.argv
+  .filter((argument) => argument.startsWith('--model='))
+  .map((argument) => argument.slice('--model='.length));
 // Each artifact's `version` is a hash of its own (version-less, key-sorted) content: equal content ⇒
 // equal version, ANY content change ⇒ new version. Seeders (`PresetProviderSeeder` via `SeedRunner`)
 // skip when the journal version matches, so a date stamp would let a same-day regeneration change
@@ -146,6 +151,7 @@ const sortKeys = (v: any): any =>
 
 /** Load an upstream source (cache file or live URL) and validate its top-level shape with zod. */
 async function load<T>(env: string, url: string, schema: ZodType<T>): Promise<T> {
+  // eslint-disable-next-line expo/no-dynamic-env-var -- This Node generator reads cache paths at runtime.
   const cache = process.env[env];
   let raw: unknown;
   if (cache) {
@@ -533,6 +539,9 @@ function buildProviderModels(
 }
 
 void (async () => {
+  if (SELECTED_MODEL_IDS.length > 0 && PROVIDERS_ONLY) {
+    throw new Error('--model cannot be combined with --providers-only');
+  }
   if (PROVIDERS_ONLY) {
     const providers = buildProviders();
     if (!WRITE) {
@@ -586,7 +595,15 @@ void (async () => {
     return;
   }
 
-  const list = [...models.values()]
+  const modelsToWrite =
+    SELECTED_MODEL_IDS.length > 0
+      ? mergeSelectedModels(
+          JSON.parse(fs.readFileSync(MODELS_PATH, 'utf8')).models,
+          [...models.values()],
+          SELECTED_MODEL_IDS,
+        )
+      : [...models.values()];
+  const list = modelsToWrite
     .sort((a, b) => {
       const aKey = `${a.ownedBy ?? ''}\0${a.id}`;
       const bKey = `${b.ownedBy ?? ''}\0${b.id}`;
@@ -598,6 +615,8 @@ void (async () => {
     });
   fs.writeFileSync(MODELS_PATH, stampAndSerialize({ models: list }));
   console.log(`\nWROTE ${MODELS_PATH} (${list.length} models).`);
+
+  if (SELECTED_MODEL_IDS.length > 0) return;
 
   const providers = buildProviders();
   fs.writeFileSync(PROVIDERS_PATH, stampAndSerialize({ providers }));

--- a/packages/provider-registry/scripts/merge-selected-models.ts
+++ b/packages/provider-registry/scripts/merge-selected-models.ts
@@ -1,0 +1,18 @@
+/** Update selected generated models while retaining the rest of the bundled catalog. */
+export function mergeSelectedModels<T extends { id: string }>(
+  existing: readonly T[],
+  generated: readonly T[],
+  selectedIds: readonly string[],
+): T[] {
+  const selected = new Set(selectedIds);
+  const generatedById = new Map(generated.map((model) => [model.id, model]));
+  const replacements = [...selected].map((id) => {
+    const model = generatedById.get(id);
+    if (!model) {
+      throw new Error(`Cannot regenerate unknown model: ${id}`);
+    }
+    return model;
+  });
+
+  return [...existing.filter((model) => !selected.has(model.id)), ...replacements];
+}

--- a/packages/provider-registry/src/__tests__/catalog-invariants.test.ts
+++ b/packages/provider-registry/src/__tests__/catalog-invariants.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest';
 
 import { canonOf, prefixHit } from '../../scripts/canonicalize';
 import { CREATORS } from '../creators';
-import { ModelListSchema } from '../schemas/model';
+import { type ImageGenerationSupport, ModelListSchema } from '../schemas/model';
 import { ProviderListSchema } from '../schemas/provider';
 import { ProviderModelListSchema } from '../schemas/provider-models';
 import { ReasoningWireProfileSchema } from '../schemas/reasoningWire';
@@ -30,6 +30,7 @@ const models = modelsRaw.models as Array<{
   inputModalities?: string[];
   outputModalities?: string[];
   ownedBy?: string;
+  imageGeneration?: ImageGenerationSupport;
 }>;
 const overrides = providerModelsRaw.overrides as Array<{
   providerId: string;
@@ -64,6 +65,53 @@ describe('catalog invariants (data/*.json)', () => {
       });
     },
   );
+
+  it('keeps smart aspect ratios and resolution controls for Nano Banana 2', () => {
+    const supports = models.find((model) => model.id === 'gemini-3-1-flash-image')?.imageGeneration
+      ?.modes.generate?.supports;
+
+    expect(supports?.aspectRatio).toEqual({
+      default: 'auto',
+      options: [
+        'auto',
+        'ASPECT_1_1',
+        'ASPECT_1_4',
+        'ASPECT_1_8',
+        'ASPECT_2_3',
+        'ASPECT_3_2',
+        'ASPECT_3_4',
+        'ASPECT_4_1',
+        'ASPECT_4_3',
+        'ASPECT_4_5',
+        'ASPECT_5_4',
+        'ASPECT_8_1',
+        'ASPECT_9_16',
+        'ASPECT_16_9',
+        'ASPECT_21_9',
+      ],
+      render: 'chips',
+      type: 'enum',
+    });
+    expect(supports?.imageResolution).toEqual({
+      default: 'auto',
+      options: ['auto', '1K', '2K', '4K'],
+      render: 'chips',
+      type: 'enum',
+    });
+  });
+
+  it('keeps fractional guidance scale controls for Kolors', () => {
+    const supports = models.find((model) => model.id === 'kolors')?.imageGeneration?.modes.generate
+      ?.supports;
+
+    expect(supports?.guidanceScale).toEqual({
+      default: 4.5,
+      max: 20,
+      min: 1,
+      step: 0.1,
+      type: 'range',
+    });
+  });
 
   it('base model ids are unique', () => {
     expect(ids.filter((id, i) => ids.indexOf(id) !== i)).toEqual([]);

--- a/packages/provider-registry/src/creators/google.ts
+++ b/packages/provider-registry/src/creators/google.ts
@@ -509,6 +509,57 @@ export default defineCreator({
       },
     },
     {
+      id: 'gemini-3-1-flash-image',
+      name: 'Nano Banana 2',
+      family: 'gemini-flash',
+      capabilities: [
+        'reasoning',
+        'image-recognition',
+        'image-generation',
+        'video-recognition',
+        'structured-output',
+        'file-input',
+      ],
+      inputModalities: ['text', 'image', 'video'],
+      outputModalities: ['text', 'image'],
+      imageGeneration: {
+        modes: {
+          generate: {
+            supports: {
+              aspectRatio: {
+                default: 'auto',
+                options: [
+                  'auto',
+                  'ASPECT_1_1',
+                  'ASPECT_1_4',
+                  'ASPECT_1_8',
+                  'ASPECT_2_3',
+                  'ASPECT_3_2',
+                  'ASPECT_3_4',
+                  'ASPECT_4_1',
+                  'ASPECT_4_3',
+                  'ASPECT_4_5',
+                  'ASPECT_5_4',
+                  'ASPECT_8_1',
+                  'ASPECT_9_16',
+                  'ASPECT_16_9',
+                  'ASPECT_21_9',
+                ],
+                render: 'chips',
+                type: 'enum',
+              },
+              imageResolution: {
+                default: 'auto',
+                options: ['auto', '1K', '2K', '4K'],
+                render: 'chips',
+                type: 'enum',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
       id: 'gemini-3-1-flash-image-preview',
       name: 'Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)',
       family: 'gemini-flash',

--- a/packages/provider-registry/src/creators/kling.ts
+++ b/packages/provider-registry/src/creators/kling.ts
@@ -78,6 +78,7 @@ export default defineCreator({
                 default: 4.5,
                 max: 20,
                 min: 1,
+                step: 0.1,
                 type: 'range',
               },
               negativePrompt: {

--- a/src/frontend/features/paintings/utils/imageGenerationLabels.ts
+++ b/src/frontend/features/paintings/utils/imageGenerationLabels.ts
@@ -54,11 +54,13 @@ const PARAM_LABEL_KEYS = {
 } as const satisfies Record<CanonicalParamKey, string>;
 
 const OPTION_LABEL_KEYS: Partial<Record<CanonicalParamKey, Record<string, string>>> = {
+  aspectRatio: { auto: 'painting.settings.option.auto' },
   background: {
     auto: 'painting.settings.option.auto',
     opaque: 'painting.settings.option.opaque',
     transparent: 'painting.settings.option.transparent',
   },
+  imageResolution: { auto: 'painting.settings.option.auto' },
   moderation: {
     auto: 'painting.settings.option.auto',
     low: 'painting.settings.option.low',


### PR DESCRIPTION
### What this PR does

Before this PR, Gemini image requests through AI Gateway dropped the selected resolution, the stable Nano Banana 2 model lacked aspect-ratio and resolution controls, and Kolors guidance scale fell back to integer slider steps despite its 4.5 default.

After this PR:

- Gateway maps the selected 1K/2K/4K resolution to Google's `imageConfig.imageSize`, omits automatic resolution, and preserves routing options and explicit Google configuration precedence.
- The stable Nano Banana 2 model exposes automatic and explicit aspect ratios and resolutions, with localized automatic-option labels.
- Kolors guidance scale uses a 0.1 step.

### Screenshots or videos

Pending. These changes affect existing painting settings; device/UI acceptance and screenshot capture were not performed under the author's verification instructions.

### Why we need it and why it was done in this way

Ports the relevant behavior from desktop [CherryHQ/cherry-studio#18817](https://github.com/CherryHQ/cherry-studio/pull/18817) and [CherryHQ/cherry-studio#19256](https://github.com/CherryHQ/cherry-studio/pull/19256) through the existing mobile provider adapter and catalog sources.

The catalog generator now accepts repeatable `--model=<id>` arguments so a focused model correction can regenerate its entries while retaining unrelated bundled metadata. This PR regenerated only `gemini-3-1-flash-image` and `kolors` and the model catalog content version. The generator usage is documented in the provider-registry README.

### Breaking changes

None.

### Special notes for your reviewer

- Regression cases cover Gateway resolution mapping, automatic-value omission, routing preservation, explicit configuration precedence, catalog controls, and selective generation safeguards.
- Passed: full `pnpm format:check` and changed-file formatting/static lint checks.
- Full `pnpm lint` did not pass: ESLint reported seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider subpath in unchanged files. This checkout has no `packages/ai-core/dist`, which those package exports require. Workspace packages were not built under the author's verification instructions. Oxlint reported 20 warnings; ESLint reported 15 warnings in addition to those seven errors.
- Tests, type checking, builds, and device/UI acceptance were not run, per the author's explicit verification policy. The selective-generation tooling tests also remain unexecuted.
- The read-only desktop sync audit reported no selected invariant failures. Its overall check remains unsuccessful because the provider-registry source hash has drifted and five selected domains lack baselines; no synchronization baseline was advanced.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the resulting behavior and implementation scope
- [ ] Preview: Screenshots or a video demonstrate the settings changes
- [x] Code: Changes use the existing provider adaptation and catalog boundaries
- [x] Upgrade: The regenerated catalog includes its updated content version
- [x] Documentation: Generator usage is documented; a separate user-guide update is not required for these bug fixes
- [x] Self-review: The complete local diff was reviewed before submission

### Release note

```release-note
Fix Gemini image resolution selection through AI Gateway, restore aspect-ratio and resolution controls for the stable Nano Banana 2 model, and allow fractional Kolors guidance-scale adjustments.
```
