### PR TITLE
chore(app-config): update application identifiers

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -26,13 +26,13 @@ Use the platform's application identifier:
 ```bash
 # iOS
 maestro --device "$DEVICE_ID" test \
-  -e APP_ID=com.cherry-ai.cherry-studio-app \
+  -e APP_ID=com.cherryai.cherrystudio-app.dev \
   -e DEV_CLIENT_URL="$DEV_CLIENT_URL" \
   .maestro/flows
 
 # Android
 maestro --device "$DEVICE_ID" test \
-  -e APP_ID=com.cherry_ai.cherry_studio_app \
+  -e APP_ID=com.cherryai.cherrystudio_app.dev \
   -e DEV_CLIENT_URL="$DEV_CLIENT_URL" \
   .maestro/flows
 ```

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ values are rejected.
 | `preview` | Cherry Studio Preview | `.preview` | `cherrystudio-preview` |
 | `production` | Cherry Studio | none | `cherrystudio` |
 
-The base IDs remain `com.cherry-ai.cherry-studio-app` (iOS) and
-`com.cherry_ai.cherry_studio_app` (Android). Widget identifiers and iOS App Groups follow the selected
-variant. Each variant has independent app data; existing installations retain the original identity
-and their data is not automatically migrated to the new development or preview app.
+The base IDs are `com.cherryai.cherrystudio-app` (iOS) and
+`com.cherryai.cherrystudio_app` (Android). Widget identifiers and iOS App Groups follow the selected
+variant. Each variant has independent app data; existing installations retain their previous identity
+and their data is not automatically migrated to apps using the new IDs.
 
 The `dev`, `start`, Storybook, `ios`, and `android` scripts select `PROFILE=development`. The `prebuild`
 script also defaults to development, while preserving an explicitly set `PROFILE` (for example,
@@ -59,9 +59,10 @@ same explicit `PROFILE` when building or starting Metro. When switching variants
 `ios` or `android` directories, regenerate them with `PROFILE=<profile> pnpm exec expo prebuild --clean`
 before building; this replaces generated native projects, including any manual native edits.
 
-These identity changes require new native builds. The first iOS development/preview build also needs
+These identity changes require new native builds. Each iOS variant needs
 matching Apple app identifiers, widget identifiers, App Groups, and provisioning profiles. The EAS
-project ID and production App Store submission target stay unchanged.
+project ID stays unchanged. Before production submission, check that `submit.production.ios.ascAppId`
+in `eas.json` points to an App Store Connect app matching the new production bundle identifier.
 
 ## Validate
 

--- a/app.json
+++ b/app.json
@@ -9,11 +9,11 @@
     "userInterfaceStyle": "automatic",
     "ios": {
       "icon": "./assets/icon.png",
-      "bundleIdentifier": "com.cherry-ai.cherry-studio-app",
+      "bundleIdentifier": "com.cherryai.cherrystudio-app",
       "appleTeamId": "87242QY66T",
       "entitlements": {
         "com.apple.developer.healthkit": true,
-        "com.apple.security.application-groups": ["group.com.cherry-ai.cherry-studio-app"]
+        "com.apple.security.application-groups": ["group.com.cherryai.cherrystudio-app"]
       },
       "infoPlist": {
         "NSCalendarsWriteOnlyAccessUsageDescription": "Allow Cherry Studio to add and update calendar events when you ask the assistant.",
@@ -27,7 +27,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#F65D5D"
       },
-      "package": "com.cherry_ai.cherry_studio_app",
+      "package": "com.cherryai.cherrystudio_app",
       "predictiveBackGestureEnabled": false,
       "permissions": [
         "android.permission.READ_EXTERNAL_STORAGE",
@@ -148,11 +148,9 @@
               "appExtensions": [
                 {
                   "targetName": "ExpoWidgetsTarget",
-                  "bundleIdentifier": "com.cherry-ai.cherry-studio-app.ExpoWidgetsTarget",
+                  "bundleIdentifier": "com.cherryai.cherrystudio-app.ExpoWidgetsTarget",
                   "entitlements": {
-                    "com.apple.security.application-groups": [
-                      "group.com.cherry-ai.cherry-studio-app"
-                    ]
+                    "com.apple.security.application-groups": ["group.com.cherryai.cherrystudio-app"]
                   }
                 }
               ]

--- a/docs/guides/parallel-device-testing.md
+++ b/docs/guides/parallel-device-testing.md
@@ -291,7 +291,7 @@ pnpm dev --port "$CONDUCTOR_PORT"
 Use a workspace-unique session, explicit simulator, and explicit Metro hint:
 
 ```bash
-agent-device open com.cherry-ai.cherry-studio-app.dev --session "$CONDUCTOR_WORKSPACE_NAME" --platform ios --device "iPhone 17 Pro ($CONDUCTOR_WORKSPACE_NAME)" --metro-host 127.0.0.1 --metro-port "$CONDUCTOR_PORT" --relaunch
+agent-device open com.cherryai.cherrystudio-app.dev --session "$CONDUCTOR_WORKSPACE_NAME" --platform ios --device "iPhone 17 Pro ($CONDUCTOR_WORKSPACE_NAME)" --metro-host 127.0.0.1 --metro-port "$CONDUCTOR_PORT" --relaunch
 ```
 
 For Android, relaunch the installed development client on the dedicated emulator, then open the
@@ -300,7 +300,7 @@ URL from another workspace. Opening that URL through `agent-device` configures A
 reachability for its Metro port.
 
 ```bash
-agent-device open com.cherry_ai.cherry_studio_app.dev --session "${CONDUCTOR_WORKSPACE_NAME}-android" --platform android --serial "$ANDROID_SERIAL" --relaunch
+agent-device open com.cherryai.cherrystudio_app.dev --session "${CONDUCTOR_WORKSPACE_NAME}-android" --platform android --serial "$ANDROID_SERIAL" --relaunch
 agent-device open "$DEV_CLIENT_URL" --session "${CONDUCTOR_WORKSPACE_NAME}-android" --platform android --serial "$ANDROID_SERIAL"
 ```
 


### PR DESCRIPTION
Update the iOS base bundle identifier to `com.cherryai.cherrystudio-app` and the Android package to `com.cherryai.cherrystudio_app`. Existing variant selection continues to append `.dev` and `.preview`; iOS widget and App Group identifiers follow the new base. Update documentation and development-device command examples accordingly.

New native builds and matching Apple identifiers and provisioning profiles are required. Existing app data is not automatically migrated to the new identities. The configured App Store Connect target (`ascAppId: 6754246754`) remains unchanged and must be verified against the new production bundle identifier before submission; account compliance review currently blocks that verification.

Validation: `pnpm lint` passed with warnings in unchanged source files; `pnpm format:check` and `git diff --check` passed. Builds, typecheck (which builds workspace packages), tests, and device/UI checks were not run, per the user's verification policy.
