### PR TITLE
fix(ios-submission): add HealthKit purpose string and update app ID

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,7 @@
       "infoPlist": {
         "NSCalendarsWriteOnlyAccessUsageDescription": "Allow Cherry Studio to add and update calendar events when you ask the assistant.",
         "NSHealthShareUsageDescription": "Allow Cherry Studio to read selected health and fitness data when you ask the assistant.",
+        "NSHealthUpdateUsageDescription": "Cherry Studio reads selected Apple Health data to answer your health and fitness questions. It does not save or modify data in Apple Health.",
         "UIBackgroundModes": ["audio"],
         "ITSAppUsesNonExemptEncryption": false
       }

--- a/eas.json
+++ b/eas.json
@@ -49,7 +49,7 @@
   "submit": {
     "production": {
       "ios": {
-        "ascAppId": "6754246754"
+        "ascAppId": "6809783714"
       }
     }
   }


### PR DESCRIPTION
### What this PR does

Before this PR: iOS upload validation fails with HTTP 409 because `CherryStudio.app` is missing `NSHealthUpdateUsageDescription`, and the EAS production submission profile targets App Store Connect app `6754246754`.

After this PR: Expo's iOS Info.plist configuration includes the missing key, with wording that accurately describes the current read-only Apple Health integration. Runtime authorization remains read-only. The EAS production submission profile targets App Store Connect app `6809783714`.

### Screenshots or videos

N/A — native permission metadata only; no UI flow changes.

### Why we need it and why it was done in this way

The bundled HealthKit dependency includes native write APIs even though the app only reads health data. Adding the missing declaration is the smallest change addressing the reported validation error. Removing unused native write APIs would require a separate dependency change.

The submission app ID is updated to the user-supplied App Store Connect destination. This changes the submission target without changing the bundle identifier or build profiles.

### Breaking changes

None. A new iOS binary is required for the metadata change to take effect.

### Special notes for your reviewer

- Confirmed that the existing 1.0.0 (2) IPA lacks this key.
- `pnpm format` and `pnpm format:check` passed.
- `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its `/provider` export in unchanged TypeScript files, plus existing warnings.
- Build, typecheck (which builds workspace packages), tests, and device verification were intentionally skipped per the user's instructions.
- Upload validation and Apple's acceptance of the purpose wording have not been verified with a rebuilt IPA.
- The new App Store Connect app ID was supplied by the user; its association with the bundle identifier has not been independently verified.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the change and its limits
- [x] Preview: No visible UI change; screenshots are not applicable
- [x] Code: The change is limited to one Info.plist entry and the submission app ID
- [x] Upgrade: A new native binary is required
- [x] Self-review: Reviewed the local diff

### Release note

```release-note
NONE
```
