### PR TITLE
fix(chat-workspace): simplify usage details and add full-height sheet

### DIFF
--- a/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
@@ -37,7 +37,6 @@ export function MessageUsageDetail({
       : t('chat.messageUsage.speedValue', { value: decimals.format(value) });
   const formatDuration = (value: number | undefined) =>
     value === undefined ? undefined : seconds.format(value / 1000);
-  const createdAt = message.createdAt ? new Date(message.createdAt) : undefined;
   const providerName = message.model
     ? (records.find((record) => record.providerId === message.model?.providerId)?.providerName ??
       message.model.providerId)
@@ -61,22 +60,6 @@ export function MessageUsageDetail({
     ['chat.messageUsage.approvalDuration', formatDuration(detail.approvalDurationMs)],
   ] as const;
   const visiblePerformance = performance.filter(([, value]) => value !== undefined);
-  const metadata = [
-    [
-      'chat.messageUsage.requests',
-      detail.requestCount === undefined ? undefined : numbers.format(detail.requestCount),
-    ],
-    [
-      'chat.messageUsage.createdAt',
-      createdAt && Number.isFinite(createdAt.getTime())
-        ? new Intl.DateTimeFormat(locale, {
-            dateStyle: 'medium',
-            timeStyle: 'medium',
-          }).format(createdAt)
-        : undefined,
-    ],
-  ] as const;
-  const visibleMetadata = metadata.filter(([, value]) => value !== undefined);
 
   return (
     <MessagePart.Detail
@@ -117,7 +100,86 @@ export function MessageUsageDetail({
               <Text className="text-muted-foreground text-xs">{unavailable}</Text>
             ) : null}
           </View>
+          <View className="gap-4">
+            {hasTokenDistribution ? (
+              <View
+                accessibilityElementsHidden
+                className="h-1.5 flex-row gap-1 overflow-hidden rounded-full"
+                importantForAccessibility="no-hide-descendants"
+              >
+                {detail.inputTokens ? (
+                  <View
+                    className="rounded-full bg-foreground"
+                    style={{ flex: detail.inputTokens / tokenSum }}
+                  />
+                ) : null}
+                {detail.outputTokens ? (
+                  <View
+                    className="rounded-full bg-muted-foreground"
+                    style={{ flex: detail.outputTokens / tokenSum }}
+                  />
+                ) : null}
+              </View>
+            ) : null}
+            <View className="flex-row flex-wrap gap-x-6 gap-y-5">
+              <View className="min-w-32 flex-1 gap-3">
+                <View className="gap-1">
+                  <View className="flex-row items-center gap-1.5">
+                    <View className="size-1.5 rounded-full bg-foreground" />
+                    <Text className="text-muted-foreground text-sm">
+                      {t('chat.messageUsage.input')}
+                    </Text>
+                  </View>
+                  <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                    {formatTokens(detail.inputTokens)}
+                  </Text>
+                </View>
+                <View className="gap-2">
+                  {inputDetails.map(([key, value]) =>
+                    value === undefined ? null : (
+                      <MessageUsageRow key={key} label={t(key)} value={numbers.format(value)} />
+                    ),
+                  )}
+                </View>
+              </View>
+              <View className="min-w-32 flex-1 gap-3">
+                <View className="gap-1">
+                  <View className="flex-row items-center gap-1.5">
+                    <View className="size-1.5 rounded-full bg-muted-foreground" />
+                    <Text className="text-muted-foreground text-sm">
+                      {t('chat.messageUsage.output')}
+                    </Text>
+                  </View>
+                  <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                    {formatTokens(detail.outputTokens)}
+                  </Text>
+                </View>
+                {detail.reasoningTokens !== undefined ? (
+                  <MessageUsageRow
+                    label={t('chat.messageUsage.reasoning')}
+                    value={numbers.format(detail.reasoningTokens)}
+                  />
+                ) : null}
+              </View>
+            </View>
+          </View>
         </View>
+
+        {visiblePerformance.length > 0 ? (
+          <View className="gap-4">
+            <MessagePart.SectionTitle title={t('chat.messageUsage.performance')} />
+            <View className="flex-row flex-wrap gap-x-6 gap-y-5">
+              {visiblePerformance.map(([key, value]) => (
+                <View className="min-w-32 flex-1 gap-1" key={key}>
+                  <Text className="text-muted-foreground text-xs">{t(key)}</Text>
+                  <Text className="font-medium text-foreground text-lg tabular-nums" selectable>
+                    {value}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
 
         <View className="gap-3">
           <MessagePart.SectionTitle title={t('chat.messageUsage.cost')} />
@@ -154,100 +216,6 @@ export function MessageUsageDetail({
             </Text>
           ) : null}
         </View>
-
-        {visiblePerformance.length > 0 ? (
-          <View className="gap-4">
-            <MessagePart.SectionTitle title={t('chat.messageUsage.performance')} />
-            <View className="flex-row flex-wrap gap-x-6 gap-y-5">
-              {visiblePerformance.map(([key, value]) => (
-                <View className="min-w-32 flex-1 gap-1" key={key}>
-                  <Text className="text-muted-foreground text-xs">{t(key)}</Text>
-                  <Text className="font-medium text-foreground text-lg tabular-nums" selectable>
-                    {value}
-                  </Text>
-                </View>
-              ))}
-            </View>
-            <Text className="text-muted-foreground text-xs">
-              {t('chat.messageUsage.durationHint')}
-            </Text>
-          </View>
-        ) : null}
-
-        <View className="gap-4">
-          {hasTokenDistribution ? (
-            <View
-              accessibilityElementsHidden
-              className="h-1.5 flex-row gap-1 overflow-hidden rounded-full"
-              importantForAccessibility="no-hide-descendants"
-            >
-              {detail.inputTokens ? (
-                <View
-                  className="rounded-full bg-foreground"
-                  style={{ flex: detail.inputTokens / tokenSum }}
-                />
-              ) : null}
-              {detail.outputTokens ? (
-                <View
-                  className="rounded-full bg-muted-foreground"
-                  style={{ flex: detail.outputTokens / tokenSum }}
-                />
-              ) : null}
-            </View>
-          ) : null}
-          <View className="flex-row flex-wrap gap-x-6 gap-y-5">
-            <View className="min-w-32 flex-1 gap-3">
-              <View className="gap-1">
-                <View className="flex-row items-center gap-1.5">
-                  <View className="size-1.5 rounded-full bg-foreground" />
-                  <Text className="text-muted-foreground text-sm">
-                    {t('chat.messageUsage.input')}
-                  </Text>
-                </View>
-                <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
-                  {formatTokens(detail.inputTokens)}
-                </Text>
-              </View>
-              <View className="gap-2">
-                {inputDetails.map(([key, value]) =>
-                  value === undefined ? null : (
-                    <MessageUsageRow key={key} label={t(key)} value={numbers.format(value)} />
-                  ),
-                )}
-              </View>
-            </View>
-            <View className="min-w-32 flex-1 gap-3">
-              <View className="gap-1">
-                <View className="flex-row items-center gap-1.5">
-                  <View className="size-1.5 rounded-full bg-muted-foreground" />
-                  <Text className="text-muted-foreground text-sm">
-                    {t('chat.messageUsage.output')}
-                  </Text>
-                </View>
-                <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
-                  {formatTokens(detail.outputTokens)}
-                </Text>
-              </View>
-              {detail.reasoningTokens !== undefined ? (
-                <MessageUsageRow
-                  label={t('chat.messageUsage.reasoning')}
-                  value={numbers.format(detail.reasoningTokens)}
-                />
-              ) : null}
-            </View>
-          </View>
-        </View>
-
-        {visibleMetadata.length > 0 ? (
-          <View className="gap-3">
-            <MessagePart.SectionTitle title={t('chat.messageUsage.message')} />
-            {visibleMetadata.map(([key, value]) =>
-              value === undefined ? null : (
-                <MessageUsageRow key={key} label={t(key)} value={value} />
-              ),
-            )}
-          </View>
-        ) : null}
 
         {error ? (
           <ContentState.Error

--- a/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
@@ -86,22 +86,37 @@ export function MessageUsageDetail({
       title={t('chat.messageUsage.title')}
     >
       <View className="gap-8 px-1 pt-2 pb-4">
-        <View className="gap-1">
-          <Text className="text-muted-foreground text-sm">
-            {t('chat.messageUsage.totalTokens')}
-          </Text>
-          <Text
-            adjustsFontSizeToFit
-            className="font-semibold text-4xl text-foreground tabular-nums"
-            minimumFontScale={0.6}
-            numberOfLines={1}
-            selectable
-          >
-            {detail.totalTokens === undefined ? '—' : numbers.format(detail.totalTokens)}
-          </Text>
-          {detail.totalTokens === undefined ? (
-            <Text className="text-muted-foreground text-xs">{unavailable}</Text>
+        <View className="gap-6">
+          {message.model ? (
+            <View className="flex-row items-center gap-2.5">
+              <ModelAvatar model={message.model} size={28} />
+              <View className="min-w-0 flex-1 gap-0.5">
+                <Text className="font-medium text-foreground text-sm" selectable>
+                  {message.model.name}
+                </Text>
+                <Text className="text-muted-foreground text-xs" selectable>
+                  {providerName}
+                </Text>
+              </View>
+            </View>
           ) : null}
+          <View className="gap-1">
+            <Text className="text-muted-foreground text-sm">
+              {t('chat.messageUsage.totalTokens')}
+            </Text>
+            <Text
+              adjustsFontSizeToFit
+              className="font-semibold text-4xl text-foreground tabular-nums"
+              minimumFontScale={0.6}
+              numberOfLines={1}
+              selectable
+            >
+              {detail.totalTokens === undefined ? '—' : numbers.format(detail.totalTokens)}
+            </Text>
+            {detail.totalTokens === undefined ? (
+              <Text className="text-muted-foreground text-xs">{unavailable}</Text>
+            ) : null}
+          </View>
         </View>
 
         <View className="gap-3">
@@ -223,22 +238,9 @@ export function MessageUsageDetail({
           </View>
         </View>
 
-        {message.model || visibleMetadata.length > 0 ? (
+        {visibleMetadata.length > 0 ? (
           <View className="gap-3">
             <MessagePart.SectionTitle title={t('chat.messageUsage.message')} />
-            {message.model ? (
-              <View className="flex-row items-center gap-2.5">
-                <ModelAvatar model={message.model} size={28} />
-                <View className="min-w-0 flex-1 gap-0.5">
-                  <Text className="font-medium text-foreground text-sm" selectable>
-                    {message.model.name}
-                  </Text>
-                  <Text className="text-muted-foreground text-xs" selectable>
-                    {providerName}
-                  </Text>
-                </View>
-              </View>
-            ) : null}
             {visibleMetadata.map(([key, value]) =>
               value === undefined ? null : (
                 <MessageUsageRow key={key} label={t(key)} value={value} />

--- a/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
@@ -8,7 +8,7 @@ import type { MessageListItem } from '@/frontend/components/Message';
 import { useMessageUsageRecords } from '../hooks/useMessageUsageRecords';
 import { formatMessageUsageCost, getMessageUsageDetails } from '../utils/messageUsage';
 
-const DETAIL_SIZES = ['medium', 'large'] as const;
+const DETAIL_SIZES = ['medium', 'large', 'full'] as const;
 
 export function MessageUsageDetail({
   message,
@@ -86,100 +86,22 @@ export function MessageUsageDetail({
       title={t('chat.messageUsage.title')}
     >
       <View className="gap-8 px-1 pt-2 pb-4">
-        <View className="gap-6">
-          {message.model ? (
-            <View className="flex-row items-center gap-2.5">
-              <ModelAvatar model={message.model} size={28} />
-              <View className="min-w-0 flex-1 gap-0.5">
-                <Text className="font-medium text-foreground text-sm" selectable>
-                  {message.model.name}
-                </Text>
-                <Text className="text-muted-foreground text-xs" selectable>
-                  {providerName}
-                </Text>
-              </View>
-            </View>
+        <View className="gap-1">
+          <Text className="text-muted-foreground text-sm">
+            {t('chat.messageUsage.totalTokens')}
+          </Text>
+          <Text
+            adjustsFontSizeToFit
+            className="font-semibold text-4xl text-foreground tabular-nums"
+            minimumFontScale={0.6}
+            numberOfLines={1}
+            selectable
+          >
+            {detail.totalTokens === undefined ? '—' : numbers.format(detail.totalTokens)}
+          </Text>
+          {detail.totalTokens === undefined ? (
+            <Text className="text-muted-foreground text-xs">{unavailable}</Text>
           ) : null}
-          <View className="gap-1">
-            <Text className="text-muted-foreground text-sm">
-              {t('chat.messageUsage.totalTokens')}
-            </Text>
-            <Text
-              adjustsFontSizeToFit
-              className="font-semibold text-4xl text-foreground tabular-nums"
-              minimumFontScale={0.6}
-              numberOfLines={1}
-              selectable
-            >
-              {detail.totalTokens === undefined ? '—' : numbers.format(detail.totalTokens)}
-            </Text>
-            {detail.totalTokens === undefined ? (
-              <Text className="text-muted-foreground text-xs">{unavailable}</Text>
-            ) : null}
-          </View>
-          <View className="gap-4">
-            {hasTokenDistribution ? (
-              <View
-                accessibilityElementsHidden
-                className="h-1.5 flex-row gap-1 overflow-hidden rounded-full"
-                importantForAccessibility="no-hide-descendants"
-              >
-                {detail.inputTokens ? (
-                  <View
-                    className="rounded-full bg-foreground"
-                    style={{ flex: detail.inputTokens / tokenSum }}
-                  />
-                ) : null}
-                {detail.outputTokens ? (
-                  <View
-                    className="rounded-full bg-muted-foreground"
-                    style={{ flex: detail.outputTokens / tokenSum }}
-                  />
-                ) : null}
-              </View>
-            ) : null}
-            <View className="flex-row flex-wrap gap-x-6 gap-y-5">
-              <View className="min-w-32 flex-1 gap-3">
-                <View className="gap-1">
-                  <View className="flex-row items-center gap-1.5">
-                    <View className="size-1.5 rounded-full bg-foreground" />
-                    <Text className="text-muted-foreground text-sm">
-                      {t('chat.messageUsage.input')}
-                    </Text>
-                  </View>
-                  <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
-                    {formatTokens(detail.inputTokens)}
-                  </Text>
-                </View>
-                <View className="gap-2">
-                  {inputDetails.map(([key, value]) =>
-                    value === undefined ? null : (
-                      <MessageUsageRow key={key} label={t(key)} value={numbers.format(value)} />
-                    ),
-                  )}
-                </View>
-              </View>
-              <View className="min-w-32 flex-1 gap-3">
-                <View className="gap-1">
-                  <View className="flex-row items-center gap-1.5">
-                    <View className="size-1.5 rounded-full bg-muted-foreground" />
-                    <Text className="text-muted-foreground text-sm">
-                      {t('chat.messageUsage.output')}
-                    </Text>
-                  </View>
-                  <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
-                    {formatTokens(detail.outputTokens)}
-                  </Text>
-                </View>
-                {detail.reasoningTokens !== undefined ? (
-                  <MessageUsageRow
-                    label={t('chat.messageUsage.reasoning')}
-                    value={numbers.format(detail.reasoningTokens)}
-                  />
-                ) : null}
-              </View>
-            </View>
-          </View>
         </View>
 
         <View className="gap-3">
@@ -237,9 +159,86 @@ export function MessageUsageDetail({
           </View>
         ) : null}
 
-        {visibleMetadata.length > 0 ? (
+        <View className="gap-4">
+          {hasTokenDistribution ? (
+            <View
+              accessibilityElementsHidden
+              className="h-1.5 flex-row gap-1 overflow-hidden rounded-full"
+              importantForAccessibility="no-hide-descendants"
+            >
+              {detail.inputTokens ? (
+                <View
+                  className="rounded-full bg-foreground"
+                  style={{ flex: detail.inputTokens / tokenSum }}
+                />
+              ) : null}
+              {detail.outputTokens ? (
+                <View
+                  className="rounded-full bg-muted-foreground"
+                  style={{ flex: detail.outputTokens / tokenSum }}
+                />
+              ) : null}
+            </View>
+          ) : null}
+          <View className="flex-row flex-wrap gap-x-6 gap-y-5">
+            <View className="min-w-32 flex-1 gap-3">
+              <View className="gap-1">
+                <View className="flex-row items-center gap-1.5">
+                  <View className="size-1.5 rounded-full bg-foreground" />
+                  <Text className="text-muted-foreground text-sm">
+                    {t('chat.messageUsage.input')}
+                  </Text>
+                </View>
+                <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                  {formatTokens(detail.inputTokens)}
+                </Text>
+              </View>
+              <View className="gap-2">
+                {inputDetails.map(([key, value]) =>
+                  value === undefined ? null : (
+                    <MessageUsageRow key={key} label={t(key)} value={numbers.format(value)} />
+                  ),
+                )}
+              </View>
+            </View>
+            <View className="min-w-32 flex-1 gap-3">
+              <View className="gap-1">
+                <View className="flex-row items-center gap-1.5">
+                  <View className="size-1.5 rounded-full bg-muted-foreground" />
+                  <Text className="text-muted-foreground text-sm">
+                    {t('chat.messageUsage.output')}
+                  </Text>
+                </View>
+                <Text className="font-medium text-foreground text-xl tabular-nums" selectable>
+                  {formatTokens(detail.outputTokens)}
+                </Text>
+              </View>
+              {detail.reasoningTokens !== undefined ? (
+                <MessageUsageRow
+                  label={t('chat.messageUsage.reasoning')}
+                  value={numbers.format(detail.reasoningTokens)}
+                />
+              ) : null}
+            </View>
+          </View>
+        </View>
+
+        {message.model || visibleMetadata.length > 0 ? (
           <View className="gap-3">
             <MessagePart.SectionTitle title={t('chat.messageUsage.message')} />
+            {message.model ? (
+              <View className="flex-row items-center gap-2.5">
+                <ModelAvatar model={message.model} size={28} />
+                <View className="min-w-0 flex-1 gap-0.5">
+                  <Text className="font-medium text-foreground text-sm" selectable>
+                    {message.model.name}
+                  </Text>
+                  <Text className="text-muted-foreground text-xs" selectable>
+                    {providerName}
+                  </Text>
+                </View>
+              </View>
+            ) : null}
             {visibleMetadata.map(([key, value]) =>
               value === undefined ? null : (
                 <MessageUsageRow key={key} label={t(key)} value={value} />

--- a/src/frontend/features/chat/components/ChatWorkspace/components/README.md
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/README.md
@@ -39,11 +39,12 @@ surface, border, or extra icon. Token counts use a locale-independent compact nu
 such as `27k Tokens`. The entire summary remains tappable.
 
 The detail sheet retains localized exact counts. It opens at medium height and expands through
-large to full height. The model and provider remain at the top, followed by total tokens, costs,
-and performance. Input/cache and output/reasoning measurements follow in two columns. A neutral
-segmented bar shows the relative input/output counts only when both are known and their sum is
-positive. Message metadata appears last. The groups retain their theme tokens and scalable text.
-Missing counts stay unavailable and a measured zero remains visible.
+large to full height. The model and provider remain at the top, followed by total tokens and the
+input/cache and output/reasoning measurements in two columns. A neutral segmented bar shows the
+relative input/output counts only when both are known and their sum is positive. Performance
+measurements follow without an explanatory paragraph, and costs appear last. The message metadata
+section is omitted. The groups retain their theme tokens and scalable text. Missing counts stay
+unavailable and a measured zero remains visible.
 
 Message rows do not register a long-press copy menu. Copy is an explicit assistant toolbar action.
 The usage button uses CherryUI's release-time press action.

--- a/src/frontend/features/chat/components/ChatWorkspace/components/README.md
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/README.md
@@ -38,12 +38,12 @@ It uses plain secondary text with a middle dot between tokens and elapsed time, 
 surface, border, or extra icon. Token counts use a locale-independent compact number with its unit,
 such as `27k Tokens`. The entire summary remains tappable.
 
-The detail sheet retains localized exact counts. It opens at medium height and expands to large,
-leading with the model and total tokens, then grouping input/cache and output/reasoning measurements
-into two columns. A neutral segmented bar
-shows the relative input/output counts only when both are known and their sum is positive. Costs,
-performance, and message metadata follow as separate typographic groups, using theme tokens and
-scalable text. Missing counts stay unavailable and a measured zero remains visible.
+The detail sheet retains localized exact counts. It opens at medium height and expands through
+large to full height, leading with total tokens, costs, and performance. Input/cache and
+output/reasoning measurements follow in two columns. A neutral segmented bar shows the relative
+input/output counts only when both are known and their sum is positive. Model, provider, and
+message metadata appear last. The groups retain their theme tokens and scalable text. Missing
+counts stay unavailable and a measured zero remains visible.
 
 Message rows do not register a long-press copy menu. Copy is an explicit assistant toolbar action.
 The usage button uses CherryUI's release-time press action.

--- a/src/frontend/features/chat/components/ChatWorkspace/components/README.md
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/README.md
@@ -39,11 +39,11 @@ surface, border, or extra icon. Token counts use a locale-independent compact nu
 such as `27k Tokens`. The entire summary remains tappable.
 
 The detail sheet retains localized exact counts. It opens at medium height and expands through
-large to full height, leading with total tokens, costs, and performance. Input/cache and
-output/reasoning measurements follow in two columns. A neutral segmented bar shows the relative
-input/output counts only when both are known and their sum is positive. Model, provider, and
-message metadata appear last. The groups retain their theme tokens and scalable text. Missing
-counts stay unavailable and a measured zero remains visible.
+large to full height. The model and provider remain at the top, followed by total tokens, costs,
+and performance. Input/cache and output/reasoning measurements follow in two columns. A neutral
+segmented bar shows the relative input/output counts only when both are known and their sum is
+positive. Message metadata appears last. The groups retain their theme tokens and scalable text.
+Missing counts stay unavailable and a measured zero remains visible.
 
 Message rows do not register a long-press copy menu. Copy is an explicit assistant toolbar action.
 The usage button uses CherryUI's release-time press action.


### PR DESCRIPTION
### What this PR does

Before this PR: Message usage details placed costs ahead of performance, included a timing explanation and message metadata section, and expanded only from medium to large height.

After this PR: The model avatar, model name, provider, total tokens, and input/output breakdown retain their original layout at the top. Timing and speed measurements follow, with costs last. The timing explanation and message metadata section are removed. The sheet opens at medium height and expands through large to full height.

### Screenshots or videos

Not captured. Device and manual UI verification were not run for this change.

### Why we need it and why it was done in this way

Token usage and timing take priority over costs, while removing secondary information reduces the amount to read. The change preserves the existing typography, colors, and usage calculations and reuses the shared sheet's existing `full` size. The component documentation reflects the final layout and heights.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm format:check` and `git diff --check`.
- `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider entry point in unchanged backend files, plus existing warnings. No diagnostics were reported for the changed component.
- Tests, typecheck, builds, and device/UI acceptance were not run, per the task's verification constraints.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the resulting behavior and validation limits.
- [ ] Preview: Screenshots or video are attached for this user-facing change.
- [x] Code: The change reuses existing components and presentation styles.
- [x] Upgrade: No schema, dependency, or migration changes.
- [x] Documentation: Updated the component README; a user-guide update is not needed for this layout adjustment.
- [x] Self-review: Reviewed the complete diff before publication.

### Release note

```release-note
Message usage details prioritize tokens and timing, place costs last, and omit the timing explanation and message metadata. Model information keeps its original position at the top, and the details sheet can expand to full height.
```
