### PR TITLE
fix(chat-input): dismiss focus on outside interactions

### DIFF
--- a/packages/ui/src/components/composer/components/morph-menu/morph-menu.tsx
+++ b/packages/ui/src/components/composer/components/morph-menu/morph-menu.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 import {
+  Keyboard,
   type LayoutChangeEvent,
   Pressable,
   StyleSheet,
@@ -150,6 +151,10 @@ function MorphMenuRoot({
       setAnchor(null);
     }
   }, [isReducedMotion, progress]);
+  const handleBackdropPress = useCallback(() => {
+    close();
+    Keyboard.dismiss();
+  }, [close]);
   const toggle = () => {
     if (isOpen) {
       close();
@@ -280,7 +285,7 @@ function MorphMenuRoot({
           <Pressable
             accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"
-            onPress={close}
+            onPress={handleBackdropPress}
             pointerEvents={isOpen ? 'auto' : 'none'}
             style={StyleSheet.absoluteFill}
             testID={testID ? `${testID}-backdrop` : undefined}

--- a/src/frontend/appShell/header/MainHeader/MainHeaderAgentButton.tsx
+++ b/src/frontend/appShell/header/MainHeader/MainHeaderAgentButton.tsx
@@ -1,7 +1,7 @@
 import ChevronDownIcon from '@cherrystudio/app-icons/icons/chevron-down';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback } from 'react';
-import { Pressable, Text } from 'react-native';
+import { Keyboard, Pressable, Text } from 'react-native';
 
 import {
   type ChatRouteParamsInput,
@@ -31,12 +31,14 @@ export function useMainHeaderAgent() {
       return;
     }
 
+    Keyboard.dismiss();
     router.push({
       params: { agentId: currentAgentId },
       pathname: '/sessions',
     });
   }, [currentAgentId, router]);
   const openNewSession = useCallback(() => {
+    Keyboard.dismiss();
     if (agent) {
       router.setParams(chatRouteParams({ agentId: agent.id, kind: 'draft' }));
       return;

--- a/src/frontend/appShell/header/MainHeader/useMainHeaderAgentPicker.tsx
+++ b/src/frontend/appShell/header/MainHeader/useMainHeaderAgentPicker.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Keyboard } from 'react-native';
 
 import { MainHeaderAgentPickerSheet } from './MainHeaderAgentPickerSheet';
 
@@ -13,6 +14,9 @@ export function useMainHeaderAgentPicker(currentAgentId: string | undefined) {
         open={isOpen}
       />
     ),
-    openAgentPicker: () => setIsOpen(true),
+    openAgentPicker: () => {
+      Keyboard.dismiss();
+      setIsOpen(true);
+    },
   };
 }

--- a/src/frontend/appShell/header/RouteHeader/useOpenDrawer.ts
+++ b/src/frontend/appShell/header/RouteHeader/useOpenDrawer.ts
@@ -1,6 +1,7 @@
 import { useNavigation } from 'expo-router';
 import { DrawerActions } from 'expo-router/react-navigation';
 import { useCallback } from 'react';
+import { Keyboard } from 'react-native';
 
 // Dispatched rather than called on a typed drawer prop: the header can sit any
 // number of stack levels below the drawer navigator, and the action bubbles up
@@ -8,5 +9,8 @@ import { useCallback } from 'react';
 export function useOpenDrawer() {
   const navigation = useNavigation();
 
-  return useCallback(() => navigation.dispatch(DrawerActions.openDrawer()), [navigation]);
+  return useCallback(() => {
+    Keyboard.dismiss();
+    navigation.dispatch(DrawerActions.openDrawer());
+  }, [navigation]);
 }

--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -7,7 +7,7 @@ import { BlurTargetView } from 'expo-blur';
 import { useIsPreview, useLocalSearchParams } from 'expo-router';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { View } from 'react-native';
+import { Keyboard, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { MainHeader } from '@/frontend/appShell/header';
@@ -92,38 +92,42 @@ function ResolvedChatContent({ target }: { target: ChatTarget }) {
       !messageWindow.error ? (
         <SessionReadReceipt sessionId={sessionId} />
       ) : null}
-      {sessionId && session.error ? (
-        <View className="flex-1 justify-center px-8 py-16">
-          <ContentState.Error
-            primaryAction={{
-              children: t('agent.actions.retry'),
-              onPress: () => void session.refetch(),
-            }}
-            prominence="prominent"
-            title={t('navigation.chatsLoadFailed')}
+      {/* Dismiss after the outside touch ends so the keyboard cannot move a
+          message action before release. The composer is outside this boundary. */}
+      <View className="flex-1" onTouchEnd={Keyboard.dismiss}>
+        {sessionId && session.error ? (
+          <View className="flex-1 justify-center px-8 py-16">
+            <ContentState.Error
+              primaryAction={{
+                children: t('agent.actions.retry'),
+                onPress: () => void session.refetch(),
+              }}
+              prominence="prominent"
+              title={t('navigation.chatsLoadFailed')}
+            />
+          </View>
+        ) : isSessionAvailable && sessionId ? (
+          <ChatWorkspace
+            assistantAvatarUri={agent.agent?.avatarUri}
+            assistantName={agent.agent?.name}
+            isAssistantToolbarEnabled={!isPreview}
+            contentBottomInset={contentBottomInset}
+            forkBoundaryMessageId={session.data?.forkBoundaryMessageId ?? undefined}
+            forkedFromSessionId={session.data?.forkedFromSessionId ?? undefined}
+            keyboardOffset={keyboardOffset}
+            messageWindow={messageWindow}
+            sessionId={sessionId}
           />
-        </View>
-      ) : isSessionAvailable && sessionId ? (
-        <ChatWorkspace
-          assistantAvatarUri={agent.agent?.avatarUri}
-          assistantName={agent.agent?.name}
-          isAssistantToolbarEnabled={!isPreview}
-          contentBottomInset={contentBottomInset}
-          forkBoundaryMessageId={session.data?.forkBoundaryMessageId ?? undefined}
-          forkedFromSessionId={session.data?.forkedFromSessionId ?? undefined}
-          keyboardOffset={keyboardOffset}
-          messageWindow={messageWindow}
-          sessionId={sessionId}
-        />
-      ) : target.kind === 'draft' ? (
-        <ChatDraftState
-          assistantAvatarUri={agent.agent?.avatarUri}
-          assistantName={agent.agent?.name}
-          contentBottomInset={contentBottomInset}
-        />
-      ) : (
-        <ChatEmptyState contentBottomInset={contentBottomInset} />
-      )}
+        ) : target.kind === 'draft' ? (
+          <ChatDraftState
+            assistantAvatarUri={agent.agent?.avatarUri}
+            assistantName={agent.agent?.name}
+            contentBottomInset={contentBottomInset}
+          />
+        ) : (
+          <ChatEmptyState contentBottomInset={contentBottomInset} />
+        )}
+      </View>
       {hasComposer ? (
         <ComposerSessionProvider key={composerSession.key}>
           <ComposerDock layoutMode="flow">

--- a/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortOverlay.tsx
+++ b/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortOverlay.tsx
@@ -2,7 +2,7 @@ import { Portal, TextAnimation } from '@cherrystudio/ui/components';
 import { easing } from '@cherrystudio/ui/motion';
 import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
+import { Keyboard, Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { OverKeyboardView, useKeyboardState } from 'react-native-keyboard-controller';
 import Animated, {
@@ -103,6 +103,11 @@ export function ChatInputEffortOverlay({
       }),
     );
   }, [layout, progress, reducedMotion]);
+
+  const handleBackdropPress = useCallback(() => {
+    close();
+    Keyboard.dismiss();
+  }, [close]);
 
   const open = useCallback(
     (gaugeFrame: ChatInputEffortFrame) => {
@@ -224,7 +229,7 @@ export function ChatInputEffortOverlay({
       <Pressable
         accessibilityElementsHidden
         importantForAccessibility="no-hide-descendants"
-        onPress={close}
+        onPress={handleBackdropPress}
         style={{
           height: viewportHeight,
           left: 0,


### PR DESCRIPTION
### What this PR does

Before this PR: touching chat content, dismissing composer overlays, or using header actions could leave the input focused and the keyboard visible.

After this PR:

- Touches ending in the message or empty-state area dismiss input focus.
- Tapping outside the attachment menu or reasoning-effort panel closes the overlay and dismisses focus.
- Opening the sidebar, agent picker, history, or a new chat dismisses focus before proceeding.

### Screenshots or videos

Pending. Device verification and capture were not authorized for this task; this PR remains a draft.

### Why we need it and why it was done in this way

Use the existing `Keyboard.dismiss()` integration at the interaction boundaries. The chat content boundary excludes the composer and dismisses on touch end so keyboard movement does not reposition a message action before release. Opening composer menus still preserves the editing context.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: lint for all six changed files, `pnpm format:check`, and `git diff --check`.
- `pnpm lint` failed with seven import-resolution errors in unchanged files because `packages/ai-core/dist` is absent. Existing warnings were also reported.
- Builds, type checking, tests, and device verification were not run under the task's verification constraints.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the behavior change and validation limits.
- [ ] Preview: Screenshots or a video demonstrate the fix.
- [x] Self-review: Reviewed the complete diff.

### Release note

```release-note
Fix chat input remaining focused after outside interactions, closing composer overlays, or using chat navigation actions.
```
