### PR TITLE
fix(navigation-header): correct iOS sidebar blur and glass theme updates

### DIFF
--- a/src/frontend/appShell/header/MainHeader/MainHeader.ios.tsx
+++ b/src/frontend/appShell/header/MainHeader/MainHeader.ios.tsx
@@ -22,6 +22,13 @@ export function MainHeader() {
           ...headerScreenOptions,
           title: '',
           headerTransparent: true,
+          unstable_nativeProps: {
+            headerConfig: {
+              // Uniwind owns the window appearance. Native-stack's light/dark
+              // override cannot update the visible iOS header dynamically.
+              experimental_userInterfaceStyle: 'unspecified',
+            },
+          },
         }}
       />
       {agent ? (

--- a/src/frontend/appShell/sidebar/components/SidebarBody.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarBody.tsx
@@ -49,12 +49,7 @@ export function SidebarBody({ children }: PropsWithChildren) {
 
   return (
     <View className="flex-1">
-      <ScrollShadow
-        className="flex-1"
-        color={backgroundColor}
-        size={appSidebar.scrollShadowSize}
-        visibility="top"
-      >
+      <ScrollShadow className="flex-1" color={backgroundColor} size={headerInset} visibility="top">
         <ContextMenuScrollBoundary>
           {(scrollHandlers) => (
             <ScrollView

--- a/src/frontend/appShell/sidebar/components/SidebarHeader.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarHeader.tsx
@@ -15,10 +15,12 @@ import { SidebarFade } from './SidebarFade/SidebarFade';
  */
 export function SidebarHeader() {
   const insets = useSafeAreaInsets();
+  const headerInset = insets.top + appSidebar.headerRowHeight + appSidebar.headerGapY * 2;
 
   return (
     <View className="absolute top-0 right-0 left-0" pointerEvents="box-none">
-      <SidebarFade edge="top" size={appSidebar.headerBlurSize} />
+      {/* Match the body's top inset so the first resting row stays outside the blur. */}
+      <SidebarFade edge="top" size={headerInset} />
       <View
         className="absolute right-0 left-0 flex-row items-center gap-2 px-5"
         style={{ height: appSidebar.headerRowHeight, top: insets.top + appSidebar.headerGapY }}

--- a/src/frontend/utils/constants.ts
+++ b/src/frontend/utils/constants.ts
@@ -83,7 +83,5 @@ export const appSidebar = {
   dockMinInset: 16, // floor for the dock's concentric inset (see SidebarDock)
   headerRowHeight: 40, // brand row's height below the status bar; the body scrolls under it
   headerGapY: 8, // header's breathing room above and below the brand row
-  scrollShadowSize: 112, // ScrollShadow's top dissolve depth below the header
-  headerBlurSize: 124, // progressive-blur depth behind the fixed header controls
   recentSessionLimit: 10, // most-recent sessions shown before the "view all" row
 } as const;


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `v0.2`

### What this PR does

Before this PR: Fixed-height sidebar blur and fade regions could overlap the first menu row, while the iOS chat header's glass could retain its previous appearance after a system theme change.

After this PR: Both sidebar effects stop at the safe-area-aware header inset, and the iOS chat navigation bar inherits the window appearance managed by Uniwind.

### Screenshots or videos

Pending — device verification and screenshots not authorized for this task

### Why we need it and why it was done in this way

- Tradeoffs: retain the existing progressive sidebar blur and native chat toolbar; remove the two fixed fade-height constants
- Alternatives considered: another fixed height or remounting navigation on theme changes; shared inset geometry and native appearance inheritance keep the change local
- Native API limitation: [`experimental_userInterfaceStyle` does not support dynamic changes on the visible screen](https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#experimental_userinterfacestyle-ios-only)

### Breaking changes

None

### Special notes for your reviewer

- Passed: changed-file Oxlint and ESLint, full `pnpm format:check`, and `git diff --check`
- Blocked: full `pnpm lint` reports seven `@cherrystudio/ai-core` import-resolution errors in unchanged backend files, alongside existing warnings
- Not run under task authorization: builds, typecheck, tests, and light/dark device acceptance

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Preview: Screenshots or video demonstrating the user-facing changes
- [x] Code: Keep the implementation readable and simple
- [x] Refactor: Remove obsolete fixed-height constants without unrelated refactoring
- [x] Upgrade: No persistence or dependency changes
- [x] Documentation: No user-guide update needed for these visual bug fixes
- [x] Self-review: Reviewed the complete diff against `origin/v0.2`

### Release note

```release-note
Fix sidebar glass blurring the first menu item and update the iOS chat header glass when switching system themes.
```
