### PR TITLE
feat(agent-editor): auto-save edits with debounced text fields

### DIFF
--- a/src/frontend/features/agents/README.md
+++ b/src/frontend/features/agents/README.md
@@ -19,6 +19,11 @@ surfaces.
 - The editor exposes the Agent definition fields (avatar, name, default model, and instructions),
   its two-mode tool-approval preference, and Agent-specific MCP extensions. Inference parameters
   and system capability switches are not part of the Agent editor surface.
+- Existing agents save edits automatically without a Save action. Name and instructions wait for
+  600 ms of idle input, then save; blur, leaving the page, and backgrounding flush pending text.
+  Other fields save immediately. Writes run in order and retain only the latest queued change per
+  field. Failed writes keep the draft and offer Retry. A blank name remains invalid and never
+  replaces the stored name. New agents still require an explicit Save to create the record.
 - Calendar, reminders, health, location, and file capabilities are injected uniformly by the Host
   when their system gates pass. The frontend keeps web search as a Session-scoped composer
   selection; image generation is selected for one submission. Neither is saved on the Agent.
@@ -27,8 +32,9 @@ surfaces.
   system permission and managed-resource checks.
 - The avatar is a managed file, not a mutable Agent field, so it has its own endpoint
   (`PUT /agents/:id/avatar`) and is written after the record lands — on create, only once the POST
-  returns an id. Picking one only updates the draft; Save commits it. An avatar can be set and
-  replaced but not cleared. Unset avatars render the name's first character over a generated colour,
+  returns an id. Picking one saves immediately when editing; on create, Save commits the draft.
+  An avatar can be set and replaced but not cleared. Unset avatars render the name's first character
+  over a generated colour,
   falling back to a neutral badge while the name is still blank.
 
 ## Organization

--- a/src/frontend/features/agents/edit/AgentEditScreen.tsx
+++ b/src/frontend/features/agents/edit/AgentEditScreen.tsx
@@ -28,7 +28,6 @@ import { usePreference } from '@/frontend/data/hooks';
 import {
   useAgentApiById,
   useAgentMutations,
-  useAgentToolBindingMutations,
   useAgentToolBindingsApi,
 } from '@/frontend/hooks/agent';
 import { useMcpServersApi } from '@/frontend/hooks/mcp/useMcpServers';
@@ -44,6 +43,7 @@ import { type AgentFormState, buildAgentDto, createAgentFormState } from './agen
 import { createAgentToolBindingDraft } from './agentToolSettings';
 import { AgentCapabilitiesSection } from './components/AgentCapabilitiesSection';
 import { AgentToolsSection } from './components/AgentToolsSection';
+import { useAgentAutoSave } from './useAgentAutoSave';
 
 const agentFormAvatarSize = 104;
 const agentFormContentPadding = 20;
@@ -130,9 +130,8 @@ function AgentEditForm({
   const { alert } = useAlert();
   const { toast } = useToast();
   const isEditing = Boolean(agentId);
-  const { createAgent, isCreating, isSettingAvatar, isUpdating, setAgentAvatar, updateAgent } =
-    useAgentMutations();
-  const { isReplacing, replaceAgentToolBindings } = useAgentToolBindingMutations();
+  const { createAgent, isCreating, isSettingAvatar, setAgentAvatar } = useAgentMutations();
+  const { flush, hasFailedSave, retry, saveField, saveToolBindings } = useAgentAutoSave(agentId);
   const modelPickerData = useModelPickerData({ modelType: 'text' });
   const openProviderSetup = useOpenProviderSetup();
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
@@ -150,7 +149,8 @@ function AgentEditForm({
   // user has since removed) from being seeded, which the create endpoint would
   // reject as an unregistered model.
   const defaultModelId = modelPickerData.getModelItem(defaultModelPreference)?.modelId ?? null;
-  const isSaving = isCreating || isReplacing || isSettingAvatar || isUpdating;
+  const isSaving = isCreating || isSettingAvatar;
+  const isNameInvalid = isEditing && !form.name.trim();
 
   // New agents start on the global default model. Both the preference and the
   // model catalog load asynchronously, so keep following them until the user
@@ -166,8 +166,9 @@ function AgentEditForm({
   const updateForm = useCallback(
     <TKey extends keyof AgentFormState>(key: TKey, value: AgentFormState[TKey]) => {
       setForm((current) => ({ ...current, [key]: value }));
+      saveField(key, value);
     },
-    [],
+    [saveField],
   );
   const openModelSelect = useCallback(() => {
     Keyboard.dismiss();
@@ -178,16 +179,25 @@ function AgentEditForm({
     setIsModelPickerOpen(false);
     openProviderSetup();
   }, [openProviderSetup]);
-  const handleModelSelect = useCallback((item: ModelPickerModelItem) => {
-    setHasPickedModel(true);
-    setForm((current) => ({ ...current, modelId: item.modelId }));
-    setIsModelPickerOpen(false);
-  }, []);
-  // Draft only. The file write needs an agent row to point at, which on create
-  // does not exist until Save returns an id.
-  const handleAvatarSelect = useCallback((sourceUri: string) => {
-    setForm((current) => ({ ...current, avatarUri: sourceUri }));
-  }, []);
+  const handleModelSelect = useCallback(
+    (item: ModelPickerModelItem) => {
+      setHasPickedModel(true);
+      updateForm('modelId', item.modelId);
+      setIsModelPickerOpen(false);
+    },
+    [updateForm],
+  );
+  const handleAvatarSelect = useCallback(
+    (sourceUri: string) => updateForm('avatarUri', sourceUri),
+    [updateForm],
+  );
+  const handleToolBindingsChange = useCallback(
+    (bindings: WriteAgentToolBinding[]) => {
+      setToolBindings(bindings);
+      saveToolBindings(bindings);
+    },
+    [saveToolBindings],
+  );
   const openToolApprovalModePicker = useCallback(() => {
     Keyboard.dismiss();
     setIsToolApprovalModePickerOpen(true);
@@ -221,8 +231,10 @@ function AgentEditForm({
     [t, toast],
   );
   const handleSave = useCallback(async () => {
+    if (isEditing) return;
+
     const dto = buildAgentDto(form, {
-      inheritDefaultModel: !agentId && !hasPickedModel,
+      inheritDefaultModel: !hasPickedModel,
     });
 
     if (!dto.ok) {
@@ -230,15 +242,10 @@ function AgentEditForm({
       return;
     }
 
-    let savedAgentId = agentId;
+    let savedAgentId: string;
 
     try {
-      if (agentId) {
-        await updateAgent(agentId, dto.value);
-        await replaceAgentToolBindings(agentId, toolBindings);
-      } else {
-        savedAgentId = (await createAgent(dto.value)).id;
-      }
+      savedAgentId = (await createAgent(dto.value)).id;
     } catch {
       toast.show({ label: t('agent.toast.saveFailed'), variant: 'danger' });
       return;
@@ -261,18 +268,15 @@ function AgentEditForm({
     router.back();
   }, [
     agent?.avatarUri,
-    agentId,
     alert,
     createAgent,
     form,
     hasPickedModel,
-    replaceAgentToolBindings,
+    isEditing,
     router,
     setAgentAvatar,
     t,
     toast,
-    toolBindings,
-    updateAgent,
   ]);
   // The header is opaque here, so the only inset left to clear is the home
   // indicator — and that one is owned rather than left to
@@ -304,7 +308,7 @@ function AgentEditForm({
 
   return (
     <>
-      <RouteHeader rightActions={saveActions} title={title} />
+      <RouteHeader rightActions={isEditing ? undefined : saveActions} title={title} />
       <KeyboardAwareScrollView
         alwaysBounceVertical={false}
         bottomOffset={keyboardBottomOffset}
@@ -333,18 +337,28 @@ function AgentEditForm({
             is the one the `Input` already draws. The model row borrows that same
             outline so the three read as one set. */}
         <View className="gap-3">
-          <Input
-            accessibilityLabel={t('agent.form.name')}
-            autoCorrect={false}
-            onChangeText={(value) => updateForm('name', value)}
-            placeholder={t('agent.form.namePlaceholder')}
-            returnKeyType="next"
-            value={form.name}
-          />
+          <View className="gap-1">
+            <Input
+              accessibilityLabel={t('agent.form.name')}
+              autoCorrect={false}
+              invalid={isNameInvalid}
+              onBlur={flush}
+              onChangeText={(value) => updateForm('name', value)}
+              placeholder={t('agent.form.namePlaceholder')}
+              returnKeyType="next"
+              value={form.name}
+            />
+            {isNameInvalid ? (
+              <Text accessibilityLiveRegion="polite" className="px-1 text-error text-sm">
+                {t('agent.form.nameRequired')}
+              </Text>
+            ) : null}
+          </View>
           <Input
             accessibilityLabel={t('agent.form.instructions')}
             autoCorrect
             multiline
+            onBlur={flush}
             onChangeText={(value) => updateForm('instructions', value)}
             placeholder={t('agent.form.instructionsPlaceholder')}
             value={form.instructions}
@@ -396,10 +410,15 @@ function AgentEditForm({
         {isEditing && (servers.length > 0 || toolBindings.length > 0) ? (
           <AgentToolsSection
             bindings={toolBindings}
-            onChange={setToolBindings}
+            onChange={handleToolBindingsChange}
             originalBindings={originalToolBindings}
             servers={servers}
           />
+        ) : null}
+        {hasFailedSave ? (
+          <Button onPress={retry} size="sm" variant="secondary">
+            {t('agent.actions.retry')}
+          </Button>
         ) : null}
       </KeyboardAwareScrollView>
       {isModelPickerOpen ? (

--- a/src/frontend/features/agents/edit/useAgentAutoSave.ts
+++ b/src/frontend/features/agents/edit/useAgentAutoSave.ts
@@ -1,0 +1,151 @@
+import { useToast } from '@cherrystudio/ui/components';
+import { loggerService } from '@logger';
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AppState } from 'react-native';
+
+import { useAgentMutations, useAgentToolBindingMutations } from '@/frontend/hooks/agent';
+import type { WriteAgentToolBinding } from '@/shared/data/api/schemas/agentToolBindings';
+
+import type { AgentFormState } from './agentForm';
+
+const TEXT_SAVE_DELAY_MS = 600;
+const logger = loggerService.withContext('useAgentAutoSave');
+
+type SaveKey = keyof AgentFormState | 'toolBindings';
+type SaveTask = () => Promise<unknown>;
+
+/** Keeps writes ordered and coalesces changes to the same field while a write is in flight. */
+export function useAgentAutoSave(agentId: string | undefined) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const { setAgentAvatar, updateAgent } = useAgentMutations();
+  const { replaceAgentToolBindings } = useAgentToolBindingMutations();
+  const pending = useRef(new Map<SaveKey, SaveTask>());
+  const deferred = useRef(new Map<SaveKey, SaveTask>());
+  const failed = useRef(new Map<SaveKey, SaveTask>());
+  const latest = useRef(new Map<SaveKey, SaveTask | null>());
+  const isSaving = useRef(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [hasFailedSave, setHasFailedSave] = useState(false);
+
+  const drain = useCallback(async () => {
+    if (isSaving.current) return;
+    isSaving.current = true;
+
+    try {
+      while (pending.current.size > 0) {
+        const next = pending.current.entries().next().value;
+        if (!next) break;
+        const [key, save] = next;
+        pending.current.delete(key);
+
+        try {
+          await save();
+        } catch (error) {
+          logger.error('Failed to auto-save agent field', error as Error, { agentId, key });
+          // A newer draft supersedes this failed write and will get its own attempt.
+          if (latest.current.get(key) === save) {
+            failed.current.set(key, save);
+            toast.show({
+              label: t(
+                key === 'avatarUri' ? 'agent.toast.avatarSaveFailed' : 'agent.toast.saveFailed',
+              ),
+              variant: 'danger',
+            });
+          }
+        }
+      }
+    } finally {
+      isSaving.current = false;
+      setHasFailedSave(failed.current.size > 0);
+    }
+  }, [agentId, t, toast]);
+
+  const flush = useCallback(() => {
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    for (const [key, save] of deferred.current) {
+      pending.current.set(key, save);
+    }
+    deferred.current.clear();
+    void drain();
+  }, [drain]);
+
+  const schedule = useCallback(
+    (key: SaveKey, save: SaveTask | null, shouldDebounce = false) => {
+      // Remove superseded queued work, including an invalidated name draft.
+      pending.current.delete(key);
+      deferred.current.delete(key);
+      failed.current.delete(key);
+      latest.current.set(key, save);
+      setHasFailedSave(failed.current.size > 0);
+
+      if (save) {
+        if (shouldDebounce) {
+          deferred.current.set(key, save);
+        } else {
+          pending.current.set(key, save);
+        }
+      }
+
+      if (shouldDebounce) {
+        if (timer.current !== null) clearTimeout(timer.current);
+        timer.current = deferred.current.size > 0 ? setTimeout(flush, TEXT_SAVE_DELAY_MS) : null;
+      }
+      void drain();
+    },
+    [drain, flush],
+  );
+
+  const saveField = useCallback(
+    <TKey extends keyof AgentFormState>(key: TKey, value: AgentFormState[TKey]) => {
+      if (!agentId) return;
+
+      if (key === 'avatarUri') {
+        if (typeof value === 'string' && value) {
+          schedule(key, () => setAgentAvatar(agentId, value));
+        }
+      } else if (key === 'name' && typeof value === 'string') {
+        const name = value.trim();
+        schedule(key, name ? () => updateAgent(agentId, { name }) : null, true);
+      } else {
+        schedule(key, () => updateAgent(agentId, { [key]: value }), key === 'instructions');
+      }
+    },
+    [agentId, schedule, setAgentAvatar, updateAgent],
+  );
+
+  const saveToolBindings = useCallback(
+    (bindings: WriteAgentToolBinding[]) => {
+      if (agentId) {
+        schedule('toolBindings', () => replaceAgentToolBindings(agentId, bindings));
+      }
+    },
+    [agentId, replaceAgentToolBindings, schedule],
+  );
+
+  const retry = useCallback(() => {
+    for (const [key, save] of failed.current) {
+      pending.current.set(key, save);
+    }
+    failed.current.clear();
+    setHasFailedSave(false);
+    flush();
+  }, [flush]);
+
+  // Leaving the page must submit the last keystrokes. Already-started work
+  // deliberately continues after unmount, including the remainder of the queue.
+  useFocusEffect(useCallback(() => flush, [flush]));
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state !== 'active') flush();
+    });
+    return () => subscription.remove();
+  }, [flush]);
+
+  return { flush, hasFailedSave, retry, saveField, saveToolBindings };
+}


### PR DESCRIPTION
### What this PR does

Before this PR: editing an existing agent required tapping Save to persist changes.

After this PR: existing agents save automatically without a Save button. Name and instructions save after 600 ms of idle input, with pending text submitted on input blur, navigation away, or app backgrounding. Avatar, model, capability, approval, and tool-binding changes save immediately. New agents still use an explicit Save action.

### Screenshots or videos

Not captured. Device and manual UI verification were not authorized for this task; visual acceptance remains pending.

### Why we need it and why it was done in this way

Debouncing text avoids writing on every keystroke. Writes run sequentially and coalesce queued changes to the same field so older requests cannot overwrite newer edits within the editor. Empty names do not replace the stored name. Failed writes retain the current draft while the editor remains open and expose a Retry action.

### Breaking changes

None. Persistence contracts and new-agent creation are unchanged.

### Special notes for your reviewer

- Passed: focused Oxlint and ESLint checks for both changed TypeScript files, `pnpm format:check`, and `git diff --check`.
- `pnpm lint` failed on 7 existing `@cherrystudio/ai-core` module-resolution errors in untouched files; unrelated warnings were also reported.
- Tests, type checking, builds, and device/UI verification were not run, following the user's verification and build restrictions.
- Review should include rapid typing, leaving before the debounce expires, backgrounding, blank-name validation, queued edits, and save-failure recovery.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the behavior and validation limits
- [ ] Preview: Screenshots or video are available
- [x] Code: Changes stay within the agent editor and its documentation
- [x] Upgrade: No schema or migration changes are required
- [x] Documentation: Agent screen behavior is documented in the module README
- [x] Self-review: The complete local diff has been reviewed

### Release note

```release-note
Agent edits now save automatically. Name and instructions save after a short typing pause, while other settings save immediately.
```
