### PR TITLE
fix(chat-reasoning): align model-driven effort and provider requests

### DIFF
--- a/docs/references/agent/agent-runtime.md
+++ b/docs/references/agent/agent-runtime.md
@@ -188,7 +188,7 @@ type RuntimeModel = {
 }
 
 type RuntimeOptions = {
-  reasoningEffort?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  reasoningEffort?: 'default' | 'none' | 'auto' | 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
   maxOutputTokens?: number
   temperature?: number
 }
@@ -238,9 +238,12 @@ tool-call diagnostics, including work before a turn is admitted. Closing the Hos
 unfinished provider records, and late callbacks cannot reopen a settled trace. See
 [AI diagnostic tracing](../../../src/backend/ai/observability/README.md).
 
-The Host resolves protocol-level turn snapshots before this boundary. `default` and the current Pi
-`auto` fallback become an absent `reasoningEffort`, while `none` becomes `off`; Runtime
-implementations therefore receive only an executable effort level.
+The Host preserves the canonical `ReasoningEffortOption` (`default`, `none`, `auto`, `minimal`,
+`low`, `medium`, `high`, `xhigh`, or `max`) in each turn snapshot. An explicit `default` overrides
+the Agent setting; an absent selection also leaves request behavior to the provider. The legacy
+`off` value remains accepted as `none`. Pi rehydrates the selected endpoint's registry reasoning
+profile and translates its emissions at the final request-payload boundary, so model defaults,
+automatic thinking, supported effort tiers, and token budgets retain their distinct meanings.
 
 File input is resolved by the Host before it reaches a Runtime: attachments enter the application's
 file storage first, `AgentInputPart` carries the resulting `fileEntryId`, and the Host validates the

--- a/docs/references/ai/desktop-package-reuse.md
+++ b/docs/references/ai/desktop-package-reuse.md
@@ -94,7 +94,7 @@ check, platform exports, and device acceptance before the registry compatibility
 | Remote manifest compatibility | Implemented with an independent registry compatibility version | Shared catalog loading; accepted line remains `2.0.8` |
 | Model and override lookup | Implemented with parameter-size-preserving normalized indexes | Shared model materialization used by Pi and AI SDK paths |
 | Reasoning support metadata | Implemented in materialized Model data | Pi consumes supported/default thinking levels |
-| Reasoning wire dialects | Implemented for the AI SDK request serializer | Does not change Pi's request serializer |
+| Reasoning wire dialects | Implemented for AI SDK and Pi request serialization | Pi translates the shared interpreter's emissions into native endpoint payloads |
 | Service tiers | Implemented for the AI SDK request path | Does not add service-tier delivery to Pi conversation requests |
 | Endpoint dialect and actual-cost reporting | Partially implemented | Cost trust is shared; stream usage and reasoning summary are AI SDK concerns |
 | Server tools and model eligibility | Intentionally unsupported by the current Mobile product path | Must be ignored explicitly; Mobile's application Web Search remains independent |

--- a/docs/references/ai/provider-integration.md
+++ b/docs/references/ai/provider-integration.md
@@ -22,6 +22,13 @@ selected Agent model through the Host-owned provider adapter. The current Pi bin
 API-key-authenticated Anthropic Messages, Google Generate Content, OpenAI Chat Completions, and
 OpenAI Responses endpoint families; other protocol or authentication families fail explicitly.
 
+Pi rehydrates the selected model's reasoning profile from `ProviderRegistryService` on each turn.
+Its final payload adapter uses the shared reasoning interpreter, preserves `default` and `auto`,
+and translates effort and budget fields into the selected native protocol. The same adapter gates
+temperature using model metadata and thinking-mode constraints. OpenAI-compatible chat endpoints
+use `max_tokens` and omit OpenAI-only storage/strict-tool options; stream-usage parameters follow
+the endpoint's dialect declaration rather than URL detection.
+
 Model-backed application tools use this capability path:
 
 ```text

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -1483,9 +1483,8 @@ describe('MobileAgentHost', () => {
     await waitFor(() => completedTurnCount() === 2, 'the default-effort turn');
     expect(requests[1]).toMatchObject({
       model: { modelId: 'mock-model', providerId: 'mock-provider' },
-      options: { maxOutputTokens: 512, temperature: 0.2 },
+      options: { maxOutputTokens: 512, reasoningEffort: 'default', temperature: 0.2 },
     });
-    expect(requests[1]?.options).not.toHaveProperty('reasoningEffort');
 
     await host.submitMessage({
       parts: [{ type: 'text', text: 'Use the Agent configuration again.' }],
@@ -1514,6 +1513,7 @@ describe('MobileAgentHost', () => {
         status: 'supported',
         snapshot: {
           model: { uniqueModelId: 'mock-provider::mock-model' },
+          reasoningEffort: 'default',
           parameters: { maxOutputTokens: 512, temperature: 0.2 },
           tools: [],
         },

--- a/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
@@ -186,6 +186,24 @@ describe('turn preparation', () => {
     expect(harness.loadRuntimeTurnContext).not.toHaveBeenCalled();
   });
 
+  test.each(['default', 'none', 'auto', 'xhigh', 'max'] as const)(
+    'preserves the explicit %s reasoning selection over the agent default',
+    async (reasoningEffort) => {
+      const harness = createHarness();
+      const plan = await prepareTurn(
+        harness.dependencies,
+        {
+          sessionId: SESSION_ID,
+          parts: [{ type: 'text', text: 'Hello.' }],
+          reasoningEffort,
+        },
+        new AbortController().signal,
+      );
+      expect(plan.agent.options.reasoningEffort).toBe(reasoningEffort);
+      expect(AGENT.options.reasoningEffort).toBe('low');
+    },
+  );
+
   test('builds a canonical turn plan from frozen model, tool, and attachment facts', async () => {
     const harness = createHarness();
     const input: AgentSubmitMessageInput = {
@@ -242,7 +260,7 @@ describe('turn preparation', () => {
     expect(plan.agent).toEqual({
       ...AGENT,
       model: OVERRIDE_MODEL,
-      options: { maxOutputTokens: 512, temperature: 0.2 },
+      options: { maxOutputTokens: 512, reasoningEffort: 'default', temperature: 0.2 },
     });
     expect(plan.inputParts).toEqual([
       { type: 'text', text: 'Review this file.' },

--- a/src/backend/ai/agent/host/turnPreparation.ts
+++ b/src/backend/ai/agent/host/turnPreparation.ts
@@ -379,13 +379,7 @@ function applyTurnOverrides(
 
   const options = { ...agent.options };
   if (input.reasoningEffort !== undefined) {
-    if (input.reasoningEffort === 'default' || input.reasoningEffort === 'auto') {
-      // Pi resolves an absent effort to the selected model's default. Removing
-      // the Agent setting here makes an explicit composer "default" win.
-      delete options.reasoningEffort;
-    } else {
-      options.reasoningEffort = input.reasoningEffort === 'none' ? 'off' : input.reasoningEffort;
-    }
+    options.reasoningEffort = input.reasoningEffort;
   }
 
   return {

--- a/src/backend/ai/agent/modelCheck/__tests__/checkChatModel.test.ts
+++ b/src/backend/ai/agent/modelCheck/__tests__/checkChatModel.test.ts
@@ -58,6 +58,32 @@ describe('chat model connection probe', () => {
     });
   });
 
+  test('reserves output for mandatory reasoning and only disables it when the model allows it', async () => {
+    for (const selectableEfforts of [
+      ['low', 'high'],
+      ['none', 'high'],
+    ] as const) {
+      const probe = createProbe([
+        { type: 'text.delta', partId: 'answer', text: 'OK' },
+        { type: 'completed' },
+      ]);
+      await checkChatModel(
+        probe.runtime,
+        {
+          ...model,
+          maxOutputTokens: 2048,
+          reasoning: { selectableEfforts: [...selectableEfforts] },
+        },
+        probe,
+      );
+      expect(probe.requests[0].options).toEqual(
+        selectableEfforts[0] === 'none'
+          ? { maxOutputTokens: 64, reasoningEffort: 'none' }
+          : { maxOutputTokens: 2048, reasoningEffort: 'default' },
+      );
+    }
+  });
+
   test('returns a closed failure reason instead of provider diagnostics', async () => {
     const probe = createProbe([
       {

--- a/src/backend/ai/agent/modelCheck/checkChatModel.ts
+++ b/src/backend/ai/agent/modelCheck/checkChatModel.ts
@@ -25,6 +25,8 @@ export async function checkChatModel(
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let abort: (() => void) | undefined;
   let timedOut = false;
+  const canDisableReasoning = model.reasoning?.selectableEfforts.includes('none') ?? false;
+  const requiresReasoning = model.reasoning !== undefined && !canDisableReasoning;
 
   try {
     options.signal?.throwIfAborted();
@@ -34,7 +36,10 @@ export async function checkChatModel(
       input: [{ type: 'text', text: 'Reply with OK.' }],
       instructions: '',
       model: { modelId: model.modelId, providerId: model.providerId },
-      options: { maxOutputTokens: 64, reasoningEffort: 'off' },
+      options: {
+        maxOutputTokens: Math.min(model.maxOutputTokens ?? 4096, requiresReasoning ? 4096 : 64),
+        reasoningEffort: canDisableReasoning ? 'none' : 'default',
+      },
       tools: [],
       turnId,
     });

--- a/src/backend/ai/agent/runtime/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntime.ts
@@ -638,7 +638,12 @@ function resolveThinkingLevel(
   resolution: PiModelResolution,
 ): ModelThinkingLevel {
   if (!resolution.model.reasoning) return 'off';
-  return request.options.reasoningEffort ?? resolution.defaultThinkingLevel;
+  const effort = request.options.reasoningEffort;
+  if (effort === 'none') return 'off';
+  if (effort === undefined || effort === 'default' || effort === 'auto') {
+    return resolution.defaultThinkingLevel;
+  }
+  return effort;
 }
 
 function toRuntimeJson(value: unknown, fallback: RuntimeJsonValue = null): RuntimeJsonValue {

--- a/src/backend/ai/agent/runtime/pi/__tests__/piApiAdapters.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piApiAdapters.test.ts
@@ -1,6 +1,12 @@
-import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
+import {
+  ENDPOINT_TYPE,
+  REASONING_FORMAT_PROFILES,
+  selectFormatWire,
+} from '@cherrystudio/provider-registry';
 import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type { Context, FetchFunction, Model as PiModel } from '@earendil-works/pi-ai';
+
+import type { Model } from '@/shared/data/types/model';
 
 import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from '../piApiAdapters';
 import type { PiLanguageEndpointType } from '../piLanguageBinding';
@@ -108,5 +114,41 @@ describe('Pi API adapters', () => {
         timeoutMs: 60_000,
       }),
     );
+  });
+
+  test('composes existing payload hooks and recomputes thinking budgets for each request cap', async () => {
+    const adapter = resolvePiApiAdapter(ENDPOINT_TYPE.ANTHROPIC_MESSAGES);
+    jest.spyOn(adapter, 'loadStreamSimple').mockResolvedValue(mockAnthropicStreamSimple);
+    const streamFn = await bindPiStream(adapter, {
+      apiKey: 'key',
+      fetch: mockFetch,
+      headers: {},
+      maxRetries: 0,
+      maxTokens: 8192,
+      timeoutMs: 60_000,
+      requestParameters: {
+        model: {
+          reasoning: { selectableEfforts: ['high'], thinkingTokenLimits: { min: 1024, max: 8192 } },
+        } as Model,
+        profile: selectFormatWire(REASONING_FORMAT_PROFILES.anthropic, 'budget'),
+        selection: 'high',
+      },
+    });
+    const piModel = { api: 'anthropic-messages' } as PiModel<SupportedPiApi>;
+    await streamFn(piModel, context, {
+      maxTokens: 2048,
+      onPayload: async () => ({
+        model: 'rewritten-model',
+        max_tokens: 8192,
+        tool_choice: { type: 'none' },
+      }),
+    });
+    const options = mockAnthropicStreamSimple.mock.calls.at(-1)![2];
+    expect(await options.onPayload({}, piModel)).toEqual({
+      model: 'rewritten-model',
+      max_tokens: 2048,
+      tool_choice: { type: 'none' },
+      thinking: { type: 'enabled', budget_tokens: 2047 },
+    });
   });
 });

--- a/src/backend/ai/agent/runtime/pi/__tests__/piModelResolver.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piModelResolver.test.ts
@@ -108,9 +108,17 @@ describe('Pi model resolver', () => {
       reasoning: true,
     });
     expect(resolution.model.compat).toEqual(
-      testCase.api === 'openai-completions' || testCase.api === 'openai-responses'
-        ? { supportsDeveloperRole: false }
-        : undefined,
+      testCase.api === 'openai-completions'
+        ? {
+            maxTokensField: 'max_tokens',
+            supportsDeveloperRole: false,
+            supportsStore: false,
+            supportsStrictMode: false,
+            supportsUsageInStreaming: provider.apiFeatures.streamOptions,
+          }
+        : testCase.api === 'openai-responses'
+          ? { supportsDeveloperRole: false }
+          : undefined,
     );
     expect(resolution.streamFn).toBe(mockBoundStreamFn);
     expect(resolution.supportsTools).toBe(true);
@@ -136,6 +144,33 @@ describe('Pi model resolver', () => {
         timeoutMs: 600_000,
       }),
     );
+  });
+
+  test('uses endpoint usage declarations and preserves the materialized effort vocabulary', async () => {
+    const provider = makeProvider(
+      ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      'https://proxy.test/v1',
+      'openai-compatible',
+    );
+    provider.apiFeatures.streamOptions = true;
+    provider.endpointConfigs![ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]!.dialect = {
+      streamOptions: false,
+    };
+    mockGetProviderById.mockResolvedValue(provider);
+    mockGetModelById.mockResolvedValue(makeModel(ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS));
+
+    const resolution = await resolve(resolver, { reasoningEffort: 'auto' });
+    expect(resolution.model.compat).toMatchObject({
+      supportsUsageInStreaming: false,
+      maxTokensField: 'max_tokens',
+    });
+    const parameters = mockBindPiStream.mock.calls[0][1].requestParameters;
+    expect(parameters?.selection).toBe('auto');
+    expect(parameters?.model.reasoning?.selectableEfforts).toEqual(['high']);
+    expect(parameters?.profile.effort?.operations).toContainEqual({
+      target: 'reasoningEffort',
+      value: { source: 'effort' },
+    });
   });
 
   test('preflights image input from the model registry without selecting credentials', async () => {

--- a/src/backend/ai/agent/runtime/pi/__tests__/piRequestParameters.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piRequestParameters.test.ts
@@ -1,0 +1,220 @@
+import {
+  REASONING_FORMAT_PROFILES,
+  selectFormatWire,
+  type ReasoningWireProfile,
+} from '@cherrystudio/provider-registry';
+
+import type { Model } from '@/shared/data/types/model';
+
+import type { SupportedPiApi } from '../piApiAdapters';
+import { applyPiRequestParameters, type PiRequestParameters } from '../piRequestParameters';
+
+const model: Model = {
+  id: 'provider::model',
+  providerId: 'provider',
+  modelId: 'model',
+  name: 'Model',
+  capabilities: [],
+  isEnabled: true,
+  isHidden: false,
+  supportsStreaming: true,
+  reasoning: {
+    selectableEfforts: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'auto'],
+    thinkingTokenLimits: { min: 1024, max: 8192 },
+  },
+};
+
+function apply(
+  api: SupportedPiApi,
+  profile: ReasoningWireProfile,
+  selection: PiRequestParameters['selection'],
+  payload: Record<string, unknown> = {},
+  overrides: Partial<PiRequestParameters> = {},
+  maxTokens = 4096,
+) {
+  return applyPiRequestParameters(
+    payload,
+    api,
+    { model, profile, selection, ...overrides },
+    maxTokens,
+    0.5,
+  );
+}
+
+describe('Pi registry request parameters', () => {
+  test.each(['default', undefined] as const)(
+    'leaves provider reasoning defaults intact for %s',
+    (selection) => {
+      const payload = {
+        model: 'model',
+        reasoning_effort: 'medium',
+        reasoning: { effort: 'medium', summary: 'auto' },
+        thinking: { type: 'enabled', budget_tokens: 2048 },
+        enable_thinking: true,
+        chat_template_kwargs: { enable_thinking: true, custom: 'keep' },
+        tool_choice: 'none',
+      };
+      expect(
+        apply(
+          'openai-completions',
+          REASONING_FORMAT_PROFILES['openai-chat'].wire,
+          selection,
+          payload,
+        ),
+      ).toEqual({
+        model: 'model',
+        chat_template_kwargs: { custom: 'keep' },
+        tool_choice: 'none',
+        temperature: 0.5,
+      });
+      expect(payload.chat_template_kwargs.enable_thinking).toBe(true);
+      expect(payload.reasoning.effort).toBe('medium');
+    },
+  );
+
+  test.each(['xhigh', 'max'] as const)(
+    'preserves the declared %s effort on OpenAI Responses',
+    (selection) => {
+      const result = apply(
+        'openai-responses',
+        REASONING_FORMAT_PROFILES['openai-responses'].wire,
+        selection,
+        {
+          reasoning: { effort: 'medium', summary: 'auto' },
+        },
+      );
+      expect(result.reasoning).toEqual({ effort: selection });
+      expect(result).not.toHaveProperty('reasoningEffort');
+      expect(result).not.toHaveProperty('reasoning_effort');
+    },
+  );
+
+  test('remaps unsupported effort without forcing a fixed reasoning model off', () => {
+    const fixedModel = { ...model, reasoning: { selectableEfforts: ['high' as const] } };
+    const profile = REASONING_FORMAT_PROFILES['openai-chat'].wire;
+    expect(
+      apply('openai-completions', profile, 'max', {}, { model: fixedModel }).reasoning_effort,
+    ).toBe('high');
+    expect(
+      apply(
+        'openai-completions',
+        profile,
+        'off',
+        { reasoning_effort: 'none' },
+        { model: fixedModel },
+      ),
+    ).not.toHaveProperty('reasoning_effort');
+  });
+
+  test('uses a provider-declared switch instead of Pi URL heuristics', () => {
+    const profile: ReasoningWireProfile = {
+      off: {
+        operations: [{ target: 'enable_thinking', value: { source: 'literal', value: false } }],
+      },
+      auto: {
+        operations: [{ target: 'enable_thinking', value: { source: 'literal', value: true } }],
+      },
+    };
+    expect(apply('openai-completions', profile, 'auto', { reasoning_effort: 'high' })).toEqual({
+      enable_thinking: true,
+      temperature: 0.5,
+    });
+    expect(apply('openai-completions', profile, 'off')).toEqual({
+      enable_thinking: false,
+      temperature: 0.5,
+    });
+    expect(apply('openai-completions', profile, 'default')).not.toHaveProperty('enable_thinking');
+  });
+
+  test('uses adaptive Claude effort without retaining a legacy budget or sampling parameter', () => {
+    const result = apply('anthropic-messages', REASONING_FORMAT_PROFILES.anthropic.wire, 'xhigh', {
+      thinking: { type: 'enabled', budget_tokens: 2048 },
+      max_tokens: 8192,
+      temperature: 0.5,
+      output_config: { format: { type: 'json_schema' } },
+    });
+    expect(result).toEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { effort: 'xhigh', format: { type: 'json_schema' } },
+      max_tokens: 4096,
+    });
+    expect(
+      apply('anthropic-messages', REASONING_FORMAT_PROFILES.anthropic.wire, 'auto').thinking,
+    ).toEqual({ type: 'adaptive', display: 'summarized' });
+  });
+
+  test('bounds Claude budget thinking by the total output limit and omits impossible budgets', () => {
+    const profile = selectFormatWire(REASONING_FORMAT_PROFILES.anthropic, 'budget');
+    expect(apply('anthropic-messages', profile, 'high', { max_tokens: 8192 })).toEqual({
+      thinking: { type: 'enabled', budget_tokens: 4095 },
+      max_tokens: 4096,
+    });
+    const tooSmall = apply('anthropic-messages', profile, 'high', { max_tokens: 8192 }, {}, 64);
+    expect(tooSmall).not.toHaveProperty('thinking');
+    expect(tooSmall.max_tokens).toBe(64);
+  });
+
+  test('keeps Gemini budget and level dialects separate, preserving native request controls', () => {
+    const signal = new AbortController().signal;
+    const payload = {
+      config: {
+        abortSignal: signal,
+        thinkingConfig: { thinkingBudget: 1024 },
+        toolConfig: { functionCallingConfig: { mode: 'NONE' } },
+      },
+    };
+    const budget = apply(
+      'google-generative-ai',
+      selectFormatWire(REASONING_FORMAT_PROFILES.gemini, 'budget'),
+      'auto',
+      payload,
+    );
+    expect(budget.config).toEqual({
+      abortSignal: signal,
+      thinkingConfig: { includeThoughts: true, thinkingBudget: -1 },
+      toolConfig: { functionCallingConfig: { mode: 'NONE' } },
+      temperature: 0.5,
+    });
+    const level = apply(
+      'google-generative-ai',
+      REASONING_FORMAT_PROFILES.gemini.wire,
+      'high',
+      payload,
+    );
+    expect(level.config).toMatchObject({
+      thinkingConfig: { includeThoughts: true, thinkingLevel: 'HIGH' },
+    });
+    expect(level).not.toHaveProperty('config.thinkingConfig.thinkingBudget');
+    expect(
+      apply('google-generative-ai', REASONING_FORMAT_PROFILES.gemini.wire, 'default', payload),
+    ).not.toHaveProperty('config.thinkingConfig');
+    expect(payload.config.thinkingConfig).toEqual({ thinkingBudget: 1024 });
+  });
+
+  test('honors unsupported reasoning and sampling metadata', () => {
+    const result = apply(
+      'openai-completions',
+      { disabled: true },
+      'high',
+      { reasoning_effort: 'high', temperature: 0.5 },
+      {
+        model: { ...model, parameters: { temperature: { supported: false } } },
+      },
+    );
+    expect(result).toEqual({});
+    expect(
+      apply(
+        'openai-completions',
+        { disabled: true },
+        'default',
+        {},
+        {
+          model: {
+            ...model,
+            parameters: { temperature: { supported: true, range: { min: 0, max: 0.3 } } },
+          },
+        },
+      ).temperature,
+    ).toBe(0.3);
+  });
+});

--- a/src/backend/ai/agent/runtime/pi/piApiAdapters.ts
+++ b/src/backend/ai/agent/runtime/pi/piApiAdapters.ts
@@ -4,6 +4,7 @@ import type { AgentOptions } from '@earendil-works/pi-agent-core/agent';
 import type { FetchFunction } from '@earendil-works/pi-ai';
 
 import type { PiLanguageEndpointType } from './piLanguageBinding';
+import { applyPiRequestParameters, type PiRequestParameters } from './piRequestParameters';
 
 export type SupportedPiApi =
   | 'anthropic-messages'
@@ -65,6 +66,7 @@ type PiStreamBinding = {
   headers: Record<string, string>;
   maxRetries: number;
   maxTokens: number;
+  requestParameters?: PiRequestParameters;
   temperature?: number;
   timeoutMs: number;
 };
@@ -75,16 +77,32 @@ export async function bindPiStream(
 ): Promise<PiStreamFn> {
   const streamSimple = await adapter.loadStreamSimple();
 
-  return (model, context, options) =>
-    streamSimple(model, context, {
+  return (model, context, options) => {
+    const maxTokens = options?.maxTokens ?? binding.maxTokens;
+    const temperature = options?.temperature ?? binding.temperature;
+    return streamSimple(model, context, {
       ...options,
       apiKey: binding.apiKey,
       fetch: adapter.supportsCustomFetch ? binding.fetch : undefined,
       headers: { ...options?.headers, ...binding.headers },
       maxRetries: binding.maxRetries,
-      maxTokens: options?.maxTokens ?? binding.maxTokens,
+      maxTokens,
+      onPayload: async (payload, requestModel) => {
+        const previous = await options?.onPayload?.(payload, requestModel);
+        const resolvedPayload = previous === undefined ? payload : previous;
+        return binding.requestParameters
+          ? applyPiRequestParameters(
+              resolvedPayload,
+              adapter.api,
+              binding.requestParameters,
+              maxTokens,
+              temperature,
+            )
+          : resolvedPayload;
+      },
       signal: options?.signal,
-      temperature: options?.temperature ?? binding.temperature,
+      temperature,
       timeoutMs: binding.timeoutMs,
     });
+  };
 }

--- a/src/backend/ai/agent/runtime/pi/piModelResolver.ts
+++ b/src/backend/ai/agent/runtime/pi/piModelResolver.ts
@@ -5,8 +5,13 @@ import { fetch as expoFetch } from 'expo/fetch';
 
 import { resolveProviderConnection } from '@/backend/ai/provider/providerConnection';
 import { modelService } from '@/backend/data/services/ModelService';
+import {
+  projectRuntimeReasoning,
+  providerRegistryService,
+} from '@/backend/data/services/ProviderRegistryService';
 import { providerService } from '@/backend/data/services/ProviderService';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
+import { resolveEndpointDialect } from '@/shared/data/types/provider';
 import {
   DEFAULT_MODEL_CONTEXT_WINDOW,
   DEFAULT_MODEL_MAX_OUTPUT_TOKENS,
@@ -50,11 +55,40 @@ export function createPiModelResolver(): PiRuntimeDependencies {
 
       const modelId = connection.wireModelId;
       const headers = connection.headers;
+      const reasoningProfile = providerRegistryService.resolveReasoningProfile(
+        provider,
+        model,
+        connection.endpointType,
+      );
+      const invocationModel = reasoningProfile.support
+        ? {
+            ...model,
+            reasoning: projectRuntimeReasoning(reasoningProfile.support, reasoningProfile.wire),
+          }
+        : model;
       const piModel: PiModel<SupportedPiApi> = {
         api: adapter.api,
         baseUrl: adapter.formatBaseUrl(connection.baseUrl.trim()),
         ...(adapter.api === 'openai-completions' || adapter.api === 'openai-responses'
-          ? { compat: { supportsDeveloperRole: false } }
+          ? {
+              compat: {
+                supportsDeveloperRole: false,
+                ...(adapter.api === 'openai-completions'
+                  ? {
+                      maxTokensField:
+                        connection.adapterFamily === 'openai'
+                          ? 'max_completion_tokens'
+                          : 'max_tokens',
+                      supportsStore: connection.adapterFamily === 'openai',
+                      supportsStrictMode: connection.adapterFamily === 'openai',
+                      supportsUsageInStreaming: resolveEndpointDialect(
+                        provider,
+                        connection.endpointType,
+                      ).streamOptions,
+                    }
+                  : {}),
+              },
+            }
           : {}),
         contextWindow: preflight.contextWindow,
         cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
@@ -64,7 +98,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
         maxTokens: preflight.maxOutputTokens,
         name: model.name,
         provider: provider.id,
-        reasoning: model.reasoning !== undefined,
+        reasoning: invocationModel.reasoning !== undefined,
       };
       const streamFn = await bindPiStream(adapter, {
         apiKey: selectedApiKey.value,
@@ -72,6 +106,15 @@ export function createPiModelResolver(): PiRuntimeDependencies {
         headers,
         maxRetries: 0,
         maxTokens: runtimeOptions.maxOutputTokens ?? piModel.maxTokens,
+        requestParameters: {
+          model: invocationModel,
+          profile: reasoningProfile.wire,
+          selection: runtimeOptions.reasoningEffort,
+          summary:
+            typeof provider.settings.summaryText === 'string'
+              ? provider.settings.summaryText
+              : undefined,
+        },
         temperature: runtimeOptions.temperature,
         timeoutMs: DEFAULT_PI_TIMEOUT_MS,
       });
@@ -99,7 +142,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
       };
 
       return {
-        defaultThinkingLevel: resolveDefaultThinkingLevel(model),
+        defaultThinkingLevel: resolveDefaultThinkingLevel(invocationModel),
         model: piModel,
         redactionValues: collectRedactionValues(selectedApiKey.value, headers),
         streamFn,

--- a/src/backend/ai/agent/runtime/pi/piRequestParameters.ts
+++ b/src/backend/ai/agent/runtime/pi/piRequestParameters.ts
@@ -1,0 +1,131 @@
+import { resolveReasoningInvocation } from '@cherrystudio/ai-runtime/utils';
+import { REASONING_WIRE_TARGETS, type ReasoningWireProfile } from '@cherrystudio/provider-registry';
+import {
+  isClaude47SeriesModel,
+  isGemini3Model,
+  isMaxTemperatureOneModel,
+} from '@cherrystudio/universal/utils/model';
+
+import type { Model } from '@/shared/data/types/model';
+
+import type { RuntimeOptions } from '../types';
+import type { SupportedPiApi } from './piApiAdapters';
+
+export type PiRequestParameters = {
+  model: Model;
+  profile: ReasoningWireProfile;
+  selection: RuntimeOptions['reasoningEffort'];
+  summary?: string;
+};
+
+/** Translate the registry's reasoning vocabulary at Pi's final provider-payload boundary. */
+export function applyPiRequestParameters(
+  payload: unknown,
+  api: SupportedPiApi,
+  parameters: PiRequestParameters,
+  maxTokens: number,
+  temperature: number | undefined,
+): Record<string, unknown> {
+  if (!isRecord(payload)) throw new Error('Pi produced an invalid provider request.');
+  const result = { ...payload };
+
+  // Pi infers these from model names and URLs. The selected registry profile owns them here.
+  for (const key of ['reasoning', 'thinking', 'thinking_token_budget']) delete result[key];
+  for (const target of REASONING_WIRE_TARGETS) {
+    const path = toPiReasoningPath(api, target);
+    if (path) removePath(result, path.split('.'));
+  }
+  removePath(result, ['config', 'thinkingConfig']);
+
+  // Pi may add a thinking budget to Anthropic's output cap; Cherry's cap already includes it.
+  if (api === 'anthropic-messages' && typeof result.max_tokens === 'number') {
+    maxTokens = Math.min(maxTokens, result.max_tokens);
+    result.max_tokens = maxTokens;
+  }
+  const reasoning = resolveReasoningInvocation({
+    selection: parameters.selection === 'off' ? 'none' : parameters.selection,
+    model: parameters.model,
+    profile: parameters.profile,
+    maxTokens,
+    assistantSummary: parameters.summary,
+  });
+  for (const { target, value } of reasoning.emissions) {
+    const path = toPiReasoningPath(api, target);
+    if (!path) continue;
+    setPath(
+      result,
+      path.split('.'),
+      target === 'thinkingConfig.thinkingLevel' && typeof value === 'string'
+        ? value.toUpperCase()
+        : value,
+    );
+  }
+
+  const resolvedTemperature = resolveTemperature(parameters.model, temperature);
+  const temperaturePath =
+    api === 'google-generative-ai' ? ['config', 'temperature'] : ['temperature'];
+  const thinkingType = isRecord(result.thinking) ? result.thinking.type : undefined;
+  if (
+    resolvedTemperature === undefined ||
+    (api === 'anthropic-messages' && (thinkingType === 'enabled' || thinkingType === 'adaptive'))
+  ) {
+    removePath(result, temperaturePath);
+  } else {
+    setPath(result, temperaturePath, resolvedTemperature);
+  }
+  return result;
+}
+
+function toPiReasoningPath(api: SupportedPiApi, target: string): string | undefined {
+  if (target === 'sendReasoning') return undefined;
+  if (target === 'reasoningEffort') {
+    return api === 'openai-responses' ? 'reasoning.effort' : 'reasoning_effort';
+  }
+  if (target === 'reasoningSummary') return 'reasoning.summary';
+  if (api === 'anthropic-messages') {
+    if (target === 'effort') return 'output_config.effort';
+    if (target === 'thinking.budgetTokens') return 'thinking.budget_tokens';
+  }
+  if (api === 'google-generative-ai' && target.startsWith('thinkingConfig.')) {
+    return `config.${target}`;
+  }
+  return target;
+}
+
+function resolveTemperature(model: Model, temperature: number | undefined): number | undefined {
+  if (temperature === undefined || isGemini3Model(model) || isClaude47SeriesModel(model)) {
+    return undefined;
+  }
+  const support = model.parameters?.temperature ?? model.parameterSupport?.temperature;
+  if (support?.supported === false) return undefined;
+  const range = model.parameters?.temperature?.range ?? model.parameterSupport?.temperature;
+  const minimum = range?.min ?? 0;
+  const maximum = range?.max ?? (isMaxTemperatureOneModel(model) ? 1 : 2);
+  return Math.max(minimum, Math.min(temperature, maximum));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function setPath(record: Record<string, unknown>, [key, ...rest]: string[], value: unknown): void {
+  if (rest.length === 0) {
+    record[key] = value;
+    return;
+  }
+  const child = isRecord(record[key]) ? { ...record[key] } : {};
+  setPath(child, rest, value);
+  record[key] = child;
+}
+
+function removePath(record: Record<string, unknown>, [key, ...rest]: string[]): void {
+  if (rest.length === 0) {
+    delete record[key];
+    return;
+  }
+  if (!isRecord(record[key])) return;
+  const child = { ...record[key] };
+  removePath(child, rest);
+  if (Object.keys(child).length === 0) delete record[key];
+  else record[key] = child;
+}

--- a/src/backend/ai/agent/runtime/types.ts
+++ b/src/backend/ai/agent/runtime/types.ts
@@ -85,7 +85,17 @@ export type RuntimeModelPreflight = {
 };
 
 export type RuntimeOptions = {
-  reasoningEffort?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  reasoningEffort?:
+    | 'default'
+    | 'none'
+    | 'auto'
+    | 'off'
+    | 'minimal'
+    | 'low'
+    | 'medium'
+    | 'high'
+    | 'xhigh'
+    | 'max';
   maxOutputTokens?: number;
   temperature?: number;
 };

--- a/src/backend/data/services/ProviderRegistryService.ts
+++ b/src/backend/data/services/ProviderRegistryService.ts
@@ -578,7 +578,16 @@ export class ProviderRegistryService {
     const presetReasoning = this.loader.findModel(
       matchedOverride?.modelId ?? model.presetModelId ?? '',
     )?.reasoning;
-    const support = mergeReasoningSupport(presetReasoning ?? model.reasoning, contract?.support);
+    const materializedReasoning = model.reasoning
+      ? {
+          ...model.reasoning,
+          supportedEfforts: model.reasoning.supportedEfforts ?? model.reasoning.selectableEfforts,
+        }
+      : undefined;
+    const support = mergeReasoningSupport(
+      presetReasoning ?? materializedReasoning,
+      contract?.support,
+    );
     const wireDialect =
       support?.wireDialect ?? this.loader.findModel(model.apiModelId ?? '')?.reasoning?.wireDialect;
     const resolved = resolveReasoningProfileFromRegistry({

--- a/src/frontend/features/chat/components/ChatInput/README.md
+++ b/src/frontend/features/chat/components/ChatInput/README.md
@@ -28,10 +28,11 @@ exported through `index.ts` and receives the current `agentId` and optional `ses
 - Picking a model updates the current Agent's `modelId`. Submission also snapshots the visible
   model so an immediate send cannot race the Agent mutation or query refresh. Rapid picks are
   persisted serially and coalesced to the latest visible selection.
-- The reasoning gauge inherits the Agent setting until the user picks a value. A pick is local to
-  the current Agent composer and is snapshotted into each submission; it never updates Agent
-  configuration. An explicit `default` selection bypasses the Agent effort for that turn and uses
-  the selected model's default.
+- The reasoning gauge derives its stops from the selected model's `selectableEfforts`, retaining
+  `xhigh` and `max` as distinct values. It starts at the provider default. A pick is local to the
+  current Agent composer and is snapshotted into each submission; it never updates Agent
+  configuration. Switching models projects that pick to the closest supported stop. `default`
+  bypasses the Agent effort for that turn; `auto` remains a separate provider-controlled mode.
 - The composer menu offers media only. Web search and create-image were removed from it, so the
   composer no longer requests any turn-local capability; tool availability comes from Agent
   configuration alone.

--- a/src/frontend/features/chat/components/ChatInput/utils/__tests__/chatInputReasoning.test.ts
+++ b/src/frontend/features/chat/components/ChatInput/utils/__tests__/chatInputReasoning.test.ts
@@ -8,6 +8,7 @@ import {
   getChatInputReasoningEffortOption,
   getChatInputReasoningEffortSnapshot,
   getChatInputReasoningEffortsForModel,
+  resolveAvailableChatInputReasoningEffort,
 } from '../chatInputReasoning';
 
 describe('chat input reasoning', () => {
@@ -19,6 +20,7 @@ describe('chat input reasoning', () => {
       'low',
       'medium',
       'high',
+      'xhigh',
       'max',
       'auto',
     ]);
@@ -48,17 +50,32 @@ describe('chat input reasoning', () => {
     ]);
   });
 
-  test('normalizes xhigh model options to the mobile max effort', () => {
+  test('keeps xhigh and max as distinct model-supported request values', () => {
     const model = createModel({
       reasoning: {
-        selectableEfforts: [REASONING_EFFORT.XHIGH],
+        selectableEfforts: [REASONING_EFFORT.XHIGH, REASONING_EFFORT.MAX],
       },
     });
 
     expect(getChatInputReasoningEffortsForModel(model)).toEqual([
       CHAT_INPUT_DEFAULT_REASONING_EFFORT,
+      REASONING_EFFORT.XHIGH,
       REASONING_EFFORT.MAX,
     ]);
+    expect(getChatInputReasoningEffortSnapshot('xhigh', true)).toBe('xhigh');
+    expect(getChatInputReasoningEffortOption('xhigh')?.labelKey).toBe('chat.reasoning.xhigh');
+  });
+
+  test('projects a previous model selection onto the next model without adding unsupported levels', () => {
+    expect(resolveAvailableChatInputReasoningEffort('max', ['default', 'low', 'xhigh'])).toBe(
+      'xhigh',
+    );
+    expect(resolveAvailableChatInputReasoningEffort('none', ['default', 'low', 'high'])).toBe(
+      'low',
+    );
+    expect(
+      getChatInputReasoningEffortsForModel(createModel({ reasoning: { selectableEfforts: [] } })),
+    ).toEqual([]);
   });
 
   test('snapshots the model default until the user selects a request override', () => {

--- a/src/frontend/features/chat/components/ChatInput/utils/chatInputReasoning.ts
+++ b/src/frontend/features/chat/components/ChatInput/utils/chatInputReasoning.ts
@@ -43,6 +43,10 @@ export const chatInputReasoningEffortOptions = [
     value: REASONING_EFFORT.HIGH,
   },
   {
+    labelKey: 'chat.reasoning.xhigh',
+    value: REASONING_EFFORT.XHIGH,
+  },
+  {
     labelKey: 'chat.reasoning.max',
     value: REASONING_EFFORT.MAX,
   },
@@ -59,6 +63,7 @@ const chatInputReasoningEffortCycleOrder = [
   REASONING_EFFORT.LOW,
   REASONING_EFFORT.MEDIUM,
   REASONING_EFFORT.HIGH,
+  REASONING_EFFORT.XHIGH,
   REASONING_EFFORT.MAX,
   REASONING_EFFORT.AUTO,
 ] as const satisfies readonly ChatInputReasoningEffort[];
@@ -148,10 +153,6 @@ function normalizeChatInputReasoningEfforts(values: readonly string[]): ChatInpu
 function normalizeChatInputReasoningEffort(value: string): ChatInputReasoningEffort | undefined {
   if (value === CHAT_INPUT_DEFAULT_REASONING_EFFORT) {
     return CHAT_INPUT_DEFAULT_REASONING_EFFORT;
-  }
-
-  if (value === 'xhigh') {
-    return REASONING_EFFORT.MAX;
   }
 
   return reasoningEffortValueSet.has(value) ? (value as ReasoningEffort) : undefined;

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -326,6 +326,7 @@
   "chat.reasoning.off": "Off",
   "chat.reasoning.smarter": "Smarter",
   "chat.reasoning.title": "Reasoning effort",
+  "chat.reasoning.xhigh": "Extra high",
   "chat.reasoningStatus.thinking": "Thinking",
   "chat.reasoningStatus.thought": "Thought it through",
   "chat.sources.count_one": "{{count}} source",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -324,6 +324,7 @@
   "chat.reasoning.off": "关闭",
   "chat.reasoning.smarter": "更聪明",
   "chat.reasoning.title": "思考深度",
+  "chat.reasoning.xhigh": "极高",
   "chat.reasoningStatus.thinking": "思考中",
   "chat.reasoningStatus.thought": "已深度思考",
   "chat.sources.count": "{{count}} 个来源",


### PR DESCRIPTION
### What this PR does

Before this PR:
- Reasoning selections lost meaning before reaching the request: `xhigh` became `max`, while `auto` and `default` could be dropped.
- Provider requests relied on Pi's inferred capabilities instead of the shared model registry, causing incompatible reasoning and token-limit parameters for some models.
- Model checks always disabled reasoning and used a 64-token cap, including models that require reasoning.

After this PR:
- Preserve each model's supported reasoning choices from chat input through turn preparation, and refresh registry capabilities for each request.
- Translate the shared reasoning invocation into OpenAI Chat/Responses, Claude, and Gemini request fields, including reasoning budgets/levels and sampling constraints.
- Correct generic OpenAI-compatible chat token limits, unsupported request fields, and endpoint-specific streaming usage behavior.
- Disable reasoning during model checks only when supported; otherwise retain the model default and use a 4,096-token cap.

### Screenshots or videos

Layout and interactions are unchanged. Supported models can expose the existing reasoning control's new “Extra high” label. No screenshots were captured because device/UI verification was not authorized for this task.

### Why we need it and why it was done in this way

Reuse the desktop-aligned registry and shared reasoning interpreter so mobile sends parameters supported by the selected model. Pi remains the conversation runtime; the adapter translates the resolved parameters into its outgoing payloads.

Desktop reference: `e131f495a9af593ec873bea34b935e97d644f586`. Scoped registry/shared-AI audits reported no invariant errors; broader pre-existing desktop drift remains outside this change.

### Breaking changes

None. Legacy `off` values remain accepted. No dependency updates, database migrations, or catalog baseline changes.

### Special notes for your reviewer

- Passed: `pnpm format`, `pnpm format:check`, and Git whitespace checks.
- `pnpm lint` reports seven unresolved imports of `@cherrystudio/ai-core` or its `/provider` entry in unchanged files. The package's exported `dist` artifacts are absent in this checkout.
- Regression tests were added but not executed. Builds, type checks, tests, live provider calls, and device/UI verification were not run under the user's verification restrictions.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the resulting behavior
- [ ] Preview: Screenshots or video uploaded
- [x] Code: Changes reuse existing registry and runtime boundaries
- [x] Upgrade: Compatibility with existing reasoning settings considered
- [x] Documentation: Runtime, provider integration, and chat input documentation updated
- [x] Self-review: Local diff reviewed

### Release note

```release-note
Fix model-dependent reasoning controls and provider request parameters to improve chat compatibility with reasoning models and OpenAI-compatible services.
```
