### PR TITLE
fix(agent-picker): open chat after creating an agent

### DIFF
--- a/src/frontend/appShell/header/MainHeader/MainHeaderAgentPickerSheet.tsx
+++ b/src/frontend/appShell/header/MainHeader/MainHeaderAgentPickerSheet.tsx
@@ -36,7 +36,7 @@ export function MainHeaderAgentPickerSheet({
   };
   const createAgent = () => {
     onClose();
-    router.push('/agents/new');
+    router.push({ params: { startChat: 'true' }, pathname: '/agents/new' });
   };
 
   return (

--- a/src/frontend/features/agents/README.md
+++ b/src/frontend/features/agents/README.md
@@ -9,6 +9,8 @@ surfaces.
 - `AgentListScreen` is the root page. `edit/AgentEditScreen` is shared by the edit and create route
   adapters.
 - The list header's plus action opens the create-Agent route.
+- Creating from the chat header's Agent picker opens a draft conversation with the saved Agent.
+  Creating from the management list returns to that list.
 - Tapping a list row opens that Agent's editor.
 - Long-pressing a row enters multi-selection and selects that Agent. Rows keep one press target
   across the mode change, so releasing the long press cannot open the editor or toggle it again.

--- a/src/frontend/features/agents/edit/AgentEditScreen.tsx
+++ b/src/frontend/features/agents/edit/AgentEditScreen.tsx
@@ -17,6 +17,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { RouteHeader, type HeaderToolbarAction } from '@/frontend/appShell/header';
 import { useOpenProviderSetup } from '@/frontend/appShell/navigation';
+import { chatHref } from '@/frontend/appShell/navigation/chat';
 import { AgentAvatar, AvatarPickerField } from '@/frontend/components/Avatar';
 import {
   ModelPickerDrawer,
@@ -51,7 +52,10 @@ const logger = loggerService.withContext('AgentEditScreen');
 
 export default function AgentEditScreen() {
   const { t } = useTranslation();
-  const params = useLocalSearchParams<{ agentId?: string | string[] }>();
+  const params = useLocalSearchParams<{
+    agentId?: string | string[];
+    startChat?: string | string[];
+  }>();
   const agentId = getSingleRouteParam(params.agentId);
   const { agent, isLoading, refetch } = useAgentApiById(agentId);
   const {
@@ -110,6 +114,7 @@ export default function AgentEditScreen() {
       agentId={agentId}
       originalToolBindings={bindings}
       servers={servers}
+      shouldStartChat={!agentId && getSingleRouteParam(params.startChat) === 'true'}
     />
   );
 }
@@ -119,11 +124,13 @@ function AgentEditForm({
   agentId,
   originalToolBindings,
   servers,
+  shouldStartChat,
 }: {
   agent: Agent | undefined;
   agentId?: string;
   originalToolBindings: readonly AgentToolBinding[];
   servers: readonly McpServer[];
+  shouldStartChat: boolean;
 }) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -133,7 +140,9 @@ function AgentEditForm({
   const { createAgent, isCreating, isSettingAvatar, setAgentAvatar } = useAgentMutations();
   const { flush, hasFailedSave, retry, saveField, saveToolBindings } = useAgentAutoSave(agentId);
   const modelPickerData = useModelPickerData({ modelType: 'text' });
-  const openProviderSetup = useOpenProviderSetup();
+  const openProviderSetup = useOpenProviderSetup(
+    shouldStartChat ? '/agents/new?startChat=true' : undefined,
+  );
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
   const [isToolApprovalModePickerOpen, setIsToolApprovalModePickerOpen] = useState(false);
   const [defaultModelPreference] = usePreference('agent.default_model_id');
@@ -265,7 +274,11 @@ function AgentEditForm({
       }
     }
 
-    router.back();
+    if (shouldStartChat) {
+      router.dismissTo(chatHref({ agentId: savedAgentId, kind: 'draft' }));
+    } else {
+      router.back();
+    }
   }, [
     agent?.avatarUri,
     alert,
@@ -275,6 +288,7 @@ function AgentEditForm({
     isEditing,
     router,
     setAgentAvatar,
+    shouldStartChat,
     t,
     toast,
   ]);


### PR DESCRIPTION
### What this PR does

Before this PR: saving an Agent created from the chat header's Agent picker returned to the previous Agent's conversation.

After this PR: saving opens a blank conversation with the newly created Agent. The creation intent survives provider setup, and creation from the Agent management list still returns to that list.

### Screenshots or videos

Not captured: device verification was not requested for this task. The expected flow is chat → Agent picker → create Agent → Save → the new Agent's blank conversation.

### Why we need it and why it was done in this way

Carry the chat creation intent through the existing create route and use the shared chat destination helper after saving. This keeps navigation at the save boundary and avoids introducing shared selection state.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm format`, `pnpm format:check`, and `git diff --check`.
- Passed: targeted Oxlint and Expo lint checks for both changed TypeScript files.
- Full `pnpm lint` failed with 7 unresolved imports of `@cherrystudio/ai-core` and its provider entry in unchanged files. The local package exports point to `packages/ai-core/dist`, which is absent. Existing warnings were also reported in unchanged files.
- Type checking, tests, builds, and device verification were not run, per the task's verification restrictions. The root typecheck command also builds workspace packages.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the behavior change.
- [ ] Preview: Screenshots or video are available.
- [x] Documentation: Updated the Agent screens' behavior documentation; no user-guide update is needed for this fix.
- [x] Self-review: Reviewed the complete code diff.

### Release note

```release-note
Creating an Agent from the chat page now opens a conversation with that Agent immediately after saving.
```
