### PR TITLE
fix(chat-workspace): group timestamps and show time in usage details

### DIFF
--- a/src/frontend/features/chat/components/ChatWorkspace/ChatWorkspace.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/ChatWorkspace.tsx
@@ -32,6 +32,7 @@ import {
 } from './hooks/useMessageListInitialRenderGate';
 
 const logger = loggerService.withContext('AgentChatWorkspace');
+const MESSAGE_TIME_INTERVAL_MS = 5 * 60 * 1000;
 
 type ChatWorkspaceProps = {
   enteringUserMessageId?: string;
@@ -108,6 +109,10 @@ export function ChatWorkspace({
     else result.push(user, assistant);
     return result;
   }, [mergedMessages, pendingSend, projectionCache]);
+  const timestampMessageIds = useMemo(
+    () => getTimestampMessageIds(projectedMessages),
+    [projectedMessages],
+  );
   const listMessages = useMemo(() => {
     if (!forkBoundaryMessageId || !forkedFromSessionId) {
       return projectedMessages;
@@ -159,14 +164,15 @@ export function ChatWorkspace({
           assistantPresentation={assistantPresentation}
           isMessageActionsEnabled={isAssistantToolbarEnabled}
           message={message}
+          shouldShowTimestamp={timestampMessageIds.has(message.id)}
         />
       );
     },
-    [assistantPresentation, isAssistantToolbarEnabled],
+    [assistantPresentation, isAssistantToolbarEnabled, timestampMessageIds],
   );
   const messageListExtraData = useMemo(
-    () => ({ assistantPresentation, isAssistantToolbarEnabled }),
-    [assistantPresentation, isAssistantToolbarEnabled],
+    () => ({ assistantPresentation, isAssistantToolbarEnabled, timestampMessageIds }),
+    [assistantPresentation, isAssistantToolbarEnabled, timestampMessageIds],
   );
   const pendingApprovals = useMemo<readonly PendingToolApproval[]>(
     () =>
@@ -279,4 +285,26 @@ export function ChatWorkspace({
       />
     </View>
   );
+}
+
+function getTimestampMessageIds(messages: readonly MessageListItem[]): ReadonlySet<string> {
+  const ids = new Set<string>();
+  let previousTimestamp: number | undefined;
+
+  for (const message of messages) {
+    if (message.role === 'system' || !message.createdAt) continue;
+
+    const timestamp = new Date(message.createdAt).getTime();
+    if (Number.isNaN(timestamp)) continue;
+
+    if (
+      previousTimestamp === undefined ||
+      timestamp - previousTimestamp >= MESSAGE_TIME_INTERVAL_MS
+    ) {
+      ids.add(message.id);
+    }
+    previousTimestamp = timestamp;
+  }
+
+  return ids;
 }

--- a/src/frontend/features/chat/components/ChatWorkspace/components/ChatMessage.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/ChatMessage.tsx
@@ -17,6 +17,7 @@ type ChatMessageProps = {
   assistantPresentation: AssistantMessagePresentation;
   isMessageActionsEnabled: boolean;
   message: MessageListItem;
+  shouldShowTimestamp: boolean;
 };
 
 function renderChatAssistantMessage(
@@ -24,8 +25,6 @@ function renderChatAssistantMessage(
   message: MessageListItem,
   presentation: AssistantMessagePresentation,
 ) {
-  const createdAt = formatMessageCreatedAt(message.createdAt);
-
   return (
     <View className="w-full gap-2.5">
       <View className="w-full flex-row items-center gap-2">
@@ -47,15 +46,6 @@ function renderChatAssistantMessage(
                 {message.model.name}
               </Text>
             </View>
-          ) : null}
-          {createdAt ? (
-            <Text
-              className="shrink-0 text-foreground-tertiary text-xs tabular-nums"
-              numberOfLines={1}
-              testID="assistant-message-time"
-            >
-              {createdAt}
-            </Text>
           ) : null}
         </View>
       </View>
@@ -95,11 +85,21 @@ export const ChatMessage = memo(function ChatMessage({
   assistantPresentation,
   isMessageActionsEnabled,
   message,
+  shouldShowTimestamp,
 }: ChatMessageProps) {
   const isTextSelectionEnabled = !isMessageActionsEnabled;
+  const createdAt = shouldShowTimestamp ? formatMessageCreatedAt(message.createdAt) : undefined;
 
   return (
-    <View className="w-full" testID={`chat-message-${message.id}`}>
+    <View className="w-full gap-3" testID={`chat-message-${message.id}`}>
+      {createdAt ? (
+        <Text
+          className="text-center font-mono text-muted-foreground text-xs"
+          testID="chat-message-time"
+        >
+          {createdAt}
+        </Text>
+      ) : null}
       {message.role === 'user' ? (
         <UserMessage message={message} />
       ) : (

--- a/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/MessageUsageDetail.tsx
@@ -21,6 +21,14 @@ export function MessageUsageDetail({
   const { error, isLoading, records, refresh } = useMessageUsageRecords(message.id);
   const detail = getMessageUsageDetails(message.stats, records, message.model);
   const locale = i18n.resolvedLanguage ?? i18n.language;
+  const createdAt = message.createdAt ? new Date(message.createdAt) : undefined;
+  const formattedCreatedAt =
+    createdAt && !Number.isNaN(createdAt.getTime())
+      ? new Intl.DateTimeFormat(locale, {
+          dateStyle: 'medium',
+          timeStyle: 'medium',
+        }).format(createdAt)
+      : undefined;
   const numbers = new Intl.NumberFormat(locale);
   const decimals = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
   const seconds = new Intl.NumberFormat(locale, {
@@ -235,6 +243,16 @@ export function MessageUsageDetail({
             <Button onPress={() => void refresh()} size="inline" variant="ghost">
               <Text className="font-medium text-foreground text-xs">{t('common.retry')}</Text>
             </Button>
+          </View>
+        ) : null}
+        {formattedCreatedAt ? (
+          <View className="gap-1">
+            <Text className="text-muted-foreground text-xs">
+              {t('chat.messageUsage.createdAt')}
+            </Text>
+            <Text className="font-mono text-foreground text-xs" selectable>
+              {formattedCreatedAt}
+            </Text>
           </View>
         ) : null}
       </View>

--- a/src/frontend/features/chat/components/ChatWorkspace/components/README.md
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/README.md
@@ -50,9 +50,10 @@ The detail sheet retains localized exact counts. It opens at medium height and e
 large to full height. The model and provider remain at the top, followed by total tokens and the
 input/cache and output/reasoning measurements in two columns. A neutral segmented bar shows the
 relative input/output counts only when both are known and their sum is positive. Performance
-measurements follow without an explanatory paragraph, and costs appear last. The message metadata
-section is omitted. The groups retain their theme tokens and scalable text. Missing counts stay
-unavailable and a measured zero remains visible.
+measurements follow without an explanatory paragraph, then costs. The message's creation date and
+time appear at the bottom, formatted for the current locale in the device's local time zone with
+seconds. Missing or invalid dates are omitted. The groups retain their theme tokens and scalable
+text. Missing counts stay unavailable and a measured zero remains visible.
 
 Message rows do not register a long-press copy menu. Copy is an explicit assistant toolbar action.
 The usage button uses CherryUI's release-time press action.

--- a/src/frontend/features/chat/components/ChatWorkspace/components/README.md
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/README.md
@@ -15,6 +15,14 @@ cover and loading indicator exit together with a short eased fade.
 Viewport following, scroll memory, keyboard spacing, manual scrolling, and the scroll-to-bottom
 control are owned and documented by `@/frontend/components/Message`.
 
+## Message Timestamps
+
+Chat shows a centered timestamp above the first dated message in the loaded history and above
+each message at least five minutes after the preceding dated message. User and assistant messages
+share this rule; missing or invalid dates and synthetic system rows do not create time markers.
+Loading older history recalculates the boundaries. The assistant header contains only the assistant
+and model identity.
+
 ## Message Usage
 
 Settled assistant messages show total tokens and elapsed time beside their actions. The usage

--- a/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/ChatMessage.test.tsx
+++ b/src/frontend/features/chat/components/ChatWorkspace/components/__tests__/ChatMessage.test.tsx
@@ -81,7 +81,7 @@ describe('ChatMessage', () => {
     expect(mockContextMenu).not.toHaveBeenCalled();
   });
 
-  test('shows the model identity and local creation time for the individual message', () => {
+  test('shows the local creation time separately from the model identity', () => {
     act(() => {
       renderer = create(
         renderMessage({
@@ -97,7 +97,7 @@ describe('ChatMessage', () => {
       );
     });
 
-    expect(renderer?.root.findByProps({ testID: 'assistant-message-time' }).props.children).toBe(
+    expect(renderer?.root.findByProps({ testID: 'chat-message-time' }).props.children).toBe(
       '08/28 15:02',
     );
     expect(
@@ -116,6 +116,7 @@ function renderMessage(message: MessageListItem, isMessageActionsEnabled = true)
       assistantPresentation={{ name: 'Assistant' }}
       isMessageActionsEnabled={isMessageActionsEnabled}
       message={message}
+      shouldShowTimestamp
     />
   );
 }


### PR DESCRIPTION
### What this PR does

Before this PR, every assistant message displayed its creation time beside the assistant and model names, crowding the header.

After this PR, timestamps appear centered above the first dated message in the loaded history and whenever consecutive dated messages are at least five minutes apart. User and assistant messages share this rule, and loading older history recalculates the boundaries.

The token usage detail sheet also shows the message's creation date and time at the bottom, including seconds, formatted for the current locale and device time zone. Missing or invalid dates are omitted.

### Screenshots or videos

Pending. Device and UI verification were not requested; visual review in both light and dark themes remains outstanding.

### Why we need it and why it was done in this way

Separate timestamps leave more room for assistant and model names and reduce repeated metadata. Grouping stays in the chat workspace, uses existing message dates, and ignores synthetic system rows and missing or invalid dates.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm format:check`, `git diff --check`, and focused `oxlint` / `expo lint` for the changed TypeScript files.
- Full `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider entry point in unchanged backend files. The package points to `dist`, which is absent in this workspace; no build was run. Unrelated lint warnings also remain.
- Tests, type checks, builds, and device verification were not run under the user's verification policy. The existing timestamp assertion was updated but has not been executed.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the resulting behavior.
- [ ] Preview: Screenshots or a video are attached.
- [x] Code: The change stays within the existing chat presentation.
- [x] Documentation: The workspace component documentation describes the timestamp rule.
- [x] Self-review: The local diff has been reviewed.

### Release note

```release-note
Chat timestamps now appear centered above messages, with a new timestamp shown when consecutive messages are at least five minutes apart. The token usage detail sheet shows the full message date and time at the bottom.
```
