### PR TITLE
fix(provider-catalog): separate setup and runtime exclusions

### DIFF
--- a/packages/provider-registry/src/__tests__/mobile-loader.test.ts
+++ b/packages/provider-registry/src/__tests__/mobile-loader.test.ts
@@ -108,6 +108,7 @@ describe('MobileRegistryLoader', () => {
 
     for (const providerId of ['copilot', 'grok-cli', 'openai-codex']) {
       expect(loader.isProviderExcluded(providerId)).toBe(true);
+      expect(loader.isProviderExcludedFromCatalog(providerId)).toBe(true);
       expect(loader.findProvider(providerId)).toMatchObject({ authMethods: ['oauth'] });
       expect(overrides.some((override) => override.providerId === providerId)).toBe(true);
       expect(loader.getOverridesForProvider(providerId).length).toBeGreaterThan(0);
@@ -119,9 +120,28 @@ describe('MobileRegistryLoader', () => {
 
     for (const providerId of ['302ai', 'aihubmix', 'aionly', 'cherryin', 'ppio', 'silicon']) {
       expect(loader.isProviderExcluded(providerId)).toBe(false);
+      expect(loader.isProviderExcludedFromCatalog(providerId)).toBe(false);
       expect(loader.findProvider(providerId)?.authMethods).toEqual(
         expect.arrayContaining(['api-key', 'oauth']),
       );
+    }
+  });
+
+  it('hides unsupported setup presets without excluding saved providers or catalog metadata', () => {
+    const loader = new MobileRegistryLoader();
+
+    for (const providerId of [
+      'claude-code',
+      'azure-openai',
+      'vertexai',
+      'aws-bedrock',
+      'jina',
+      'voyageai',
+    ]) {
+      expect(loader.isProviderExcludedFromCatalog(providerId)).toBe(true);
+      expect(loader.isProviderExcluded(providerId)).toBe(false);
+      expect(loader.getExcludedProviderIds()).not.toContain(providerId);
+      expect(loader.findProvider(providerId)).toMatchObject({ id: providerId });
     }
   });
 

--- a/packages/provider-registry/src/mobile-loader.ts
+++ b/packages/provider-registry/src/mobile-loader.ts
@@ -94,16 +94,28 @@ export type MobileRemoteRegistrySnapshot = {
 };
 
 /**
- * Preset providers whose only authentication path is a provider OAuth login.
- * The app has no OAuth sign-in, so these rows can never be configured and are
- * projected out of every provider read. The bundled catalog stays intact — this
- * is the app-side answer to "can a mobile user actually use this", not a claim
- * about what the desktop catalog contains.
+ * OAuth-only presets excluded from runtime reads, including saved providers.
+ * Mobile has no OAuth sign-in. Keep temporary setup or product limitations
+ * in the catalog-only exclusions below so existing
+ * records remain readable. The bundled catalog stays intact in both cases.
  */
-const MOBILE_UNSUPPORTED_PRESET_PROVIDER_IDS: ReadonlySet<string> = new Set([
+const MOBILE_RUNTIME_EXCLUDED_PRESET_PROVIDER_IDS: ReadonlySet<string> = new Set([
   'copilot',
   'grok-cli',
   'openai-codex',
+]);
+
+/** Presets hidden from new-provider setup while Mobile lacks the required support. */
+const MOBILE_CATALOG_EXCLUDED_PRESET_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  // Requires the external Claude Code CLI runtime.
+  'claude-code',
+  // Require credential fields and adapters that Mobile does not support yet.
+  'azure-openai',
+  'vertexai',
+  'aws-bedrock',
+  // Embedding/rerank catalogs have no consuming Mobile feature yet.
+  'jina',
+  'voyageai',
 ]);
 
 /**
@@ -171,11 +183,19 @@ export class MobileRegistryLoader {
   }
 
   isProviderExcluded(providerId: string): boolean {
-    return MOBILE_UNSUPPORTED_PRESET_PROVIDER_IDS.has(providerId);
+    return MOBILE_RUNTIME_EXCLUDED_PRESET_PROVIDER_IDS.has(providerId);
   }
 
   getExcludedProviderIds(): readonly string[] {
-    return [...MOBILE_UNSUPPORTED_PRESET_PROVIDER_IDS];
+    return [...MOBILE_RUNTIME_EXCLUDED_PRESET_PROVIDER_IDS];
+  }
+
+  /** Controls catalog listing and preset import, not reads of saved providers. */
+  isProviderExcludedFromCatalog(providerId: string): boolean {
+    return (
+      this.isProviderExcluded(providerId) ||
+      MOBILE_CATALOG_EXCLUDED_PRESET_PROVIDER_IDS.has(providerId)
+    );
   }
 
   getModelsVersion(): string {

--- a/src/backend/data/services/ProviderRegistryService.ts
+++ b/src/backend/data/services/ProviderRegistryService.ts
@@ -422,6 +422,10 @@ export class ProviderRegistryService {
     return this.loader.getExcludedProviderIds();
   }
 
+  isProviderExcludedFromCatalog(providerId: string): boolean {
+    return this.loader.isProviderExcludedFromCatalog(providerId);
+  }
+
   getProviderDisplayMetadata(
     providerId: string,
     presetProviderId?: string,

--- a/src/backend/services/providers/__tests__/createProvidersModule.test.ts
+++ b/src/backend/services/providers/__tests__/createProvidersModule.test.ts
@@ -1,3 +1,5 @@
+import { MobileRegistryLoader } from '@cherrystudio/provider-registry/mobile';
+
 import { ProviderSetupError } from '@/shared/contracts';
 import type { ApiKeyEntry, Provider } from '@/shared/data/types/provider';
 
@@ -36,6 +38,37 @@ function subject() {
 }
 
 describe('explicit provider activation', () => {
+  it('filters unavailable presets from setup and rejects direct imports before creating records', async () => {
+    const { dependencies } = subject();
+    const loader = new MobileRegistryLoader();
+    dependencies.catalog = {
+      isExcluded: (providerId) => loader.isProviderExcludedFromCatalog(providerId),
+      list: () => loader.loadProviders(),
+    };
+    jest.mocked(dependencies.providers.list).mockResolvedValue([]);
+    const backend = createProvidersModule(dependencies);
+    const catalogIds = (await backend.listCatalog()).map(({ id }) => id);
+
+    for (const providerId of [
+      'copilot',
+      'grok-cli',
+      'openai-codex',
+      'claude-code',
+      'azure-openai',
+      'vertexai',
+      'aws-bedrock',
+      'jina',
+      'voyageai',
+    ]) {
+      expect(catalogIds).not.toContain(providerId);
+      await expect(backend.importPreset(providerId)).rejects.toThrow(
+        `Provider preset '${providerId}' is unavailable`,
+      );
+    }
+    expect(dependencies.providers.create).not.toHaveBeenCalled();
+    expect(catalogIds).toEqual(expect.arrayContaining(['ollama', 'lmstudio', 'ovms', 'new-api']));
+  });
+
   it('prepares without enabling, then enables a configured provider with local models', async () => {
     const { backend, dependencies } = subject();
     expect(await backend.getSetupStatus('custom')).toMatchObject({

--- a/src/bootstrap/composition/createBackend.ts
+++ b/src/bootstrap/composition/createBackend.ts
@@ -135,7 +135,7 @@ export function createBackend(
       resolve: getProviderAvatarUri,
     },
     catalog: {
-      isExcluded: (providerId) => providerRegistryService.isProviderExcluded(providerId),
+      isExcluded: (providerId) => providerRegistryService.isProviderExcludedFromCatalog(providerId),
       list: () => providerRegistryService.loadProviders(),
     },
     providers: {


### PR DESCRIPTION
### What this PR does

Before this PR, Add Provider offered presets that Mobile could not configure or use. Its exclusion rule was also shared with saved-provider reads, so extending that rule would hide existing user records.

After this PR, catalog listing and preset import additionally exclude `claude-code`, `azure-openai`, `vertexai`, `aws-bedrock`, `jina`, and `voyageai`. A separate runtime exclusion list retains only `copilot`, `grok-cli`, and `openai-codex`, preserving read access to saved records for the six newly hidden presets.

### Screenshots or videos

Not captured: device and UI verification were not authorized for this task.

### Why we need it and why it was done in this way

The new catalog policy combines existing runtime exclusions with temporary setup/product limitations. Both catalog listing and direct preset import use that policy. Bundled registry data and model-level capability filtering remain intact.

### Breaking changes

No data migration. Existing saved records for the six newly hidden presets remain readable. Their presets are temporarily unavailable for new setup.

### Special notes for your reviewer

- Added regression coverage for catalog-only versus runtime exclusions, direct import rejection, and continued visibility of `ollama`, `lmstudio`, `ovms`, and `new-api`.
- Passed: changed-file Oxlint/Expo lint, `pnpm format:check`, and `git diff --check`.
- Full `pnpm lint` failed with seven unresolved `@cherrystudio/ai-core` / `@cherrystudio/ai-core/provider` imports in unchanged files because the package's exported `dist` artifacts are absent, plus existing warnings. No build was run.
- Not run under the user's task instructions: tests, type checks, builds, or device/UI verification.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the problem and resulting behavior
- [ ] Preview: Screenshots or video captured
- [x] Code: The change reuses existing catalog and persistence boundaries
- [x] Upgrade: Existing saved-provider read access is preserved
- [x] Documentation: A user-guide update is not required for temporary catalog filtering
- [x] Self-review: Reviewed the complete change before submission

### Release note

```release-note
Temporarily hide six unsupported presets from Add Provider while preserving existing saved provider records.
```
