### PR TITLE
fix(sidebar): align footer controls with chat send action

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -565,6 +565,10 @@ const dock = useComposerDockLayout();
 </Composer.Dock>;
 ```
 
+`getComposerActionCenterOffset(bottomInset)` exposes the toolbar action center's distance from the
+screen bottom with the keyboard closed, so adjacent controls can align without duplicating composer
+padding.
+
 `Composer.Pill` is its wide sibling, for a tool that has to say what it is *set to* rather than only
 what it does — the model in use, a mode. Same height and material, but sized to its label, and it is
 the one thing in the row that can be arbitrarily wide, so it is also the one thing that gives: it

--- a/packages/ui/src/components/composer/index.ts
+++ b/packages/ui/src/components/composer/index.ts
@@ -18,4 +18,8 @@ export type {
   ComposerToolbarProps,
 } from './composer.types';
 export { useComposerDockLayout } from './hooks/use-composer-dock-layout';
-export { composerContentGap, getComposerKeyboardStickyOffset } from './utils/composer-dock-layout';
+export {
+  composerContentGap,
+  getComposerActionCenterOffset,
+  getComposerKeyboardStickyOffset,
+} from './utils/composer-dock-layout';

--- a/packages/ui/src/components/composer/utils/composer-dock-layout.ts
+++ b/packages/ui/src/components/composer/utils/composer-dock-layout.ts
@@ -1,3 +1,5 @@
+import { composerActionSize, surfaceStyle } from './composer-layout';
+
 const composerTextRowHeight = 44;
 const composerToolbarRowHeight = 44;
 const composerMinHeight = composerTextRowHeight + composerToolbarRowHeight;
@@ -9,6 +11,13 @@ export const composerContentGap = 8;
 
 export function getComposerBottomPadding(bottomInset: number) {
   return Math.max(bottomInset, composerMinBottomPadding) + composerBottomLift;
+}
+
+/** Distance from the screen bottom to the toolbar action centers with the keyboard closed. */
+export function getComposerActionCenterOffset(bottomInset: number) {
+  return (
+    getComposerBottomPadding(bottomInset) + surfaceStyle.paddingBottom + composerActionSize / 2
+  );
 }
 
 export function getComposerMinimumHeight(bottomInset: number) {

--- a/src/frontend/appShell/sidebar/components/SidebarBody.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarBody.tsx
@@ -55,8 +55,7 @@ export function SidebarBody({ children }: PropsWithChildren) {
             <ScrollView
               {...scrollHandlers}
               contentContainerStyle={{
-                // Clears the whole floating dock, whose own bottom padding is
-                // concentric with the display's corners rather than a fixed inset.
+                // Clears the floating dock at its shared composer-aligned position.
                 paddingBottom: dockBottomPadding + appSidebar.dockHeight + appSidebar.headerGapY,
                 paddingTop: headerInset,
               }}

--- a/src/frontend/appShell/sidebar/components/SidebarDock.tsx
+++ b/src/frontend/appShell/sidebar/components/SidebarDock.tsx
@@ -55,7 +55,7 @@ export function SidebarDock({ onNewChatPress, onSettingsPress }: SidebarDockProp
         </Pressable>
       </Surface>
 
-      <View className="overflow-hidden rounded-full bg-card">
+      <Surface interactive shape="pill">
         <Pressable
           accessibilityLabel={t('navigation.settings')}
           accessibilityRole="button"
@@ -83,7 +83,7 @@ export function SidebarDock({ onNewChatPress, onSettingsPress }: SidebarDockProp
             </Text>
           ) : null}
         </Pressable>
-      </View>
+      </Surface>
     </View>
   );
 }

--- a/src/frontend/appShell/sidebar/hooks/useDockMetrics.ts
+++ b/src/frontend/appShell/sidebar/hooks/useDockMetrics.ts
@@ -1,3 +1,4 @@
+import { getComposerActionCenterOffset } from '@cherrystudio/ui/components';
 import { getCornerRadiusSync } from 'expo-screen-corner-radius';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -7,11 +8,9 @@ import { appSidebar } from '@/frontend/utils/constants';
  * Geometry of the floating dock, shared by the dock itself and by the body that
  * has to scroll clear of it.
  *
- * `inset` makes the dock's corners concentric with the display's: a rounded
- * rect nested in another only looks right when the two share a center, which
- * means the gap has to equal the difference of their radii. Anything less and
- * the pill's corner visibly tightens against the screen's. The drawer's right
- * edge is straight, so there the same inset is plain symmetry.
+ * Horizontal spacing follows the display's corner radius, mirrored at the
+ * drawer's straight right edge. Vertical placement aligns both button centers
+ * with the chat composer's send action through its public layout contract.
  */
 export function useDockMetrics() {
   const insets = useSafeAreaInsets();
@@ -23,7 +22,7 @@ export function useDockMetrics() {
   return {
     /** Horizontal inset from the sidebar's edges. */
     inset,
-    /** Bottom padding: the concentric inset, never less than the home indicator. */
-    bottomPadding: Math.max(inset, insets.bottom),
+    /** Aligns the dock's button centers with the composer's bottom action row. */
+    bottomPadding: getComposerActionCenterOffset(insets.bottom) - buttonRadius,
   };
 }


### PR DESCRIPTION
### What this PR does

Before this PR: the sidebar positioned its footer independently of the chat composer, and New Chat and Settings used different surface implementations despite sharing a 48-point button height.

After this PR: New Chat and Settings use the same pill surface component. Their centers align with the chat send action when the keyboard is closed, and the sidebar list reserves space for the adjusted footer position.

### Screenshots or videos

Pending device acceptance. Screenshots and manual UI verification were not authorized for this task.

### Why we need it and why it was done in this way

Expose `getComposerActionCenterOffset(bottomInset)` from CherryUI and derive sidebar placement from that contract. This keeps composer padding and action dimensions with their owner instead of duplicating them in the sidebar. The existing button height and horizontal insets are preserved.

### Special notes for your reviewer

- Passed: `pnpm format:check`, formatting of changed files, and `git diff --check`.
- `pnpm lint` failed with seven unresolved imports of `@cherrystudio/ai-core` or its provider entry point in unchanged backend files; it also reported existing warnings. No diagnostics referenced the changed files.
- Builds, typecheck, tests, and device acceptance were not run under the task's verification constraints. This PR remains a draft pending validation, including light and dark appearance.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the change and validation limitations
- [ ] Preview: Screenshots or video uploaded
- [x] Code: Changes are limited to the sidebar alignment and its shared layout contract
- [x] Documentation: The new layout helper is documented in the UI package README
- [x] Self-review: Reviewed the complete local diff

### Release note

```release-note
Align the sidebar's New Chat and profile/settings controls with the chat send button and give both sidebar controls consistent pill surfaces.
```
