### PR TITLE
fix(chat-input): add opaque effort slider and fading backdrop

### DIFF
--- a/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdrop.android.tsx
+++ b/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdrop.android.tsx
@@ -2,10 +2,12 @@ import { StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 import type { ChatInputEffortBackdropProps } from './ChatInputEffortBackdrop.types';
+import { ChatInputEffortBackdropFocus } from './ChatInputEffortBackdropFocus';
 
 const scrimOpacity = { app: 0.2, keyboard: 0.24 } as const;
 
 export function ChatInputEffortBackdrop({
+  focusFrame,
   progress,
   scrimColor,
   variant,
@@ -15,9 +17,12 @@ export function ChatInputEffortBackdrop({
   }));
 
   return (
-    <Animated.View
-      pointerEvents="none"
-      style={[StyleSheet.absoluteFill, { backgroundColor: scrimColor }, scrimStyle]}
-    />
+    <>
+      <Animated.View
+        pointerEvents="none"
+        style={[StyleSheet.absoluteFill, { backgroundColor: scrimColor }, scrimStyle]}
+      />
+      <ChatInputEffortBackdropFocus focusFrame={focusFrame} progress={progress} />
+    </>
   );
 }

--- a/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdrop.ios.tsx
+++ b/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdrop.ios.tsx
@@ -8,12 +8,16 @@ import Animated, {
 import { useUniwind } from 'uniwind';
 
 import type { ChatInputEffortBackdropProps } from './ChatInputEffortBackdrop.types';
+import { ChatInputEffortBackdropFocus } from './ChatInputEffortBackdropFocus';
 
 const AnimatedBlurView = createAnimatedComponent(BlurView);
 const blurIntensity = 30;
 const scrimOpacity = { app: 0.07, keyboard: 0.08 } as const;
+const FOCUS_BLUR_INSETS = [0, 0.07, 0.14, 0.21] as const;
+const FOCUS_BLUR_INTENSITY = 9;
 
 export function ChatInputEffortBackdrop({
+  focusFrame,
   progress,
   scrimColor,
   tint,
@@ -22,6 +26,9 @@ export function ChatInputEffortBackdrop({
   const { theme } = useUniwind();
   const blurProps = useAnimatedProps(() => ({
     intensity: blurIntensity * progress.value,
+  }));
+  const focusBlurProps = useAnimatedProps(() => ({
+    intensity: FOCUS_BLUR_INTENSITY * progress.value,
   }));
   const scrimStyle = useAnimatedStyle(() => ({
     opacity: progress.value * scrimOpacity[variant],
@@ -39,6 +46,23 @@ export function ChatInputEffortBackdrop({
         pointerEvents="none"
         style={[StyleSheet.absoluteFill, { backgroundColor: scrimColor }, scrimStyle]}
       />
+      <ChatInputEffortBackdropFocus focusFrame={focusFrame} progress={progress}>
+        {/* Unmasked, nested bands follow SidebarFade's native backdrop path. */}
+        {focusFrame
+          ? FOCUS_BLUR_INSETS.map((inset) => (
+              <AnimatedBlurView
+                key={inset}
+                animatedProps={focusBlurProps}
+                pointerEvents="none"
+                style={[
+                  StyleSheet.absoluteFill,
+                  { bottom: focusFrame.height * inset, top: focusFrame.height * inset },
+                ]}
+                tint={tint ?? (theme === 'dark' ? 'dark' : 'light')}
+              />
+            ))
+          : null}
+      </ChatInputEffortBackdropFocus>
     </>
   );
 }

--- a/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdrop.types.ts
+++ b/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdrop.types.ts
@@ -2,6 +2,8 @@ import type { BlurTint } from 'expo-blur';
 import type { SharedValue } from 'react-native-reanimated';
 
 export type ChatInputEffortBackdropProps = {
+  /** Focus bounds in this backdrop window's coordinates, including the fade edges. */
+  focusFrame: { height: number; top: number } | null;
   progress: SharedValue<number>;
   scrimColor: string;
   tint?: BlurTint;

--- a/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdropFocus.tsx
+++ b/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortBackdrop/ChatInputEffortBackdropFocus.tsx
@@ -1,0 +1,55 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import type { ReactNode } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+
+import { useThemeColor } from '@/frontend/hooks/useThemeColor';
+
+import type { ChatInputEffortBackdropProps } from './ChatInputEffortBackdrop.types';
+
+const FADE_LOCATIONS = [0, 0.32, 0.68, 1] as const;
+const SURFACE_OPACITY = 0.72;
+
+type ChatInputEffortBackdropFocusProps = Pick<
+  ChatInputEffortBackdropProps,
+  'focusFrame' | 'progress'
+> & {
+  children?: ReactNode;
+};
+
+/** A local focus field whose surface dissolves above and below the effort panel. */
+export function ChatInputEffortBackdropFocus({
+  children,
+  focusFrame,
+  progress,
+}: ChatInputEffortBackdropFocusProps) {
+  const surfaceColor = useThemeColor('popover');
+  const surfaceStyle = useAnimatedStyle(() => ({
+    opacity: SURFACE_OPACITY * progress.value,
+  }));
+
+  if (!focusFrame) {
+    return null;
+  }
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[styles.container, focusFrame]}
+      testID="chat-input-effort-focus-backdrop"
+    >
+      {children}
+      <Animated.View style={[StyleSheet.absoluteFill, surfaceStyle]}>
+        <LinearGradient
+          colors={['transparent', surfaceColor, surfaceColor, 'transparent']}
+          locations={FADE_LOCATIONS}
+          style={StyleSheet.absoluteFill}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { left: 0, position: 'absolute', right: 0 },
+});

--- a/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortOverlay.tsx
+++ b/src/frontend/features/chat/components/ChatInput/components/ChatInputEffortOverlay.tsx
@@ -21,7 +21,6 @@ import { EffortSlider } from '../effortSlider';
 import {
   type ChatInputEffortFrame,
   type ChatInputEffortOverlayLayout,
-  chatInputEffortTrackHeight,
   getChatInputEffortOverlayLayout,
 } from '../utils/chatInputEffortLayout';
 import type { ChatInputReasoningEffort } from '../utils/chatInputReasoning';
@@ -31,6 +30,7 @@ import { ChatInputEffortGauge } from './ChatInputEffortGauge';
 
 const openDurationMs = 150;
 const closeDurationMs = 120;
+const EFFORT_BACKDROP_FADE_INSET = 96;
 
 type ActiveEffortLayout = ChatInputEffortOverlayLayout & {
   keyboardHeight: number;
@@ -224,6 +224,20 @@ export function ChatInputEffortOverlay({
       />
     ) : null;
   const keyboardOverlayVisible = Boolean(layout?.keyboardVisible && layout.keyboardHeight > 0);
+  const focusFrame = layout
+    ? {
+        height:
+          layout.sliderFrame.top +
+          layout.sliderFrame.height -
+          layout.labelFrame.top +
+          EFFORT_BACKDROP_FADE_INSET * 2,
+        top: layout.labelFrame.top - EFFORT_BACKDROP_FADE_INSET,
+      }
+    : null;
+  const keyboardFocusFrame =
+    focusFrame && layout
+      ? { ...focusFrame, top: focusFrame.top - (viewportHeight - layout.keyboardHeight) }
+      : null;
   const overlayControls = layout ? (
     <>
       <Pressable
@@ -245,14 +259,20 @@ export function ChatInputEffortOverlay({
         }
       />
 
-      <Animated.View style={[sliderContainerStyle, sliderStyle]} testID="chat-input-effort-slider">
-        <EffortSlider
-          accessibilityLabel={t('chat.reasoning.title')}
-          onChange={handleChange}
-          options={options}
-          testID="chat-input-effort-slider-control"
-          value={reasoningEffort}
-        />
+      <Animated.View
+        className="rounded-full bg-popover"
+        style={[sliderContainerStyle, { shadowColor: scrimColor }, sliderStyle]}
+        testID="chat-input-effort-slider"
+      >
+        <View className="absolute inset-0 justify-center overflow-hidden rounded-full">
+          <EffortSlider
+            accessibilityLabel={t('chat.reasoning.title')}
+            onChange={handleChange}
+            options={options}
+            testID="chat-input-effort-slider-control"
+            value={reasoningEffort}
+          />
+        </View>
       </Animated.View>
 
       <Animated.View
@@ -290,7 +310,12 @@ export function ChatInputEffortOverlay({
             pointerEvents={keyboardOverlayVisible ? 'none' : 'box-none'}
             style={StyleSheet.absoluteFill}
           >
-            <ChatInputEffortBackdrop progress={progress} scrimColor={scrimColor} variant="app" />
+            <ChatInputEffortBackdrop
+              focusFrame={focusFrame}
+              progress={progress}
+              scrimColor={scrimColor}
+              variant="app"
+            />
             {keyboardOverlayVisible ? null : overlayControls}
           </View>
         </Portal>
@@ -310,6 +335,7 @@ export function ChatInputEffortOverlay({
             style={[keyboardBackdropContainerStyle, { height: layout?.keyboardHeight ?? 0 }]}
           >
             <ChatInputEffortBackdrop
+              focusFrame={keyboardFocusFrame}
               progress={progress}
               scrimColor={scrimColor}
               tint={keyboard.appearance}
@@ -324,11 +350,13 @@ export function ChatInputEffortOverlay({
 }
 
 const emptyFrame: ChatInputEffortFrame = { height: 0, left: 0, top: 0, width: 0 };
+// Keep the floating shadow outside the clip used by the gauge-to-slider morph.
 const sliderContainerStyle = {
-  borderRadius: chatInputEffortTrackHeight / 2,
-  justifyContent: 'center',
-  overflow: 'hidden',
+  elevation: 8,
   position: 'absolute',
+  shadowOffset: { height: 8, width: 0 },
+  shadowOpacity: 0.16,
+  shadowRadius: 20,
   zIndex: 2,
 } as const;
 const labelContainerStyle = {
@@ -340,6 +368,7 @@ const labelContainerStyle = {
 const keyboardBackdropContainerStyle = {
   bottom: 0,
   left: 0,
+  overflow: 'hidden',
   position: 'absolute',
   right: 0,
 } as const;

--- a/src/frontend/features/chat/components/ChatInput/effortSlider/README.md
+++ b/src/frontend/features/chat/components/ChatInput/effortSlider/README.md
@@ -23,10 +23,17 @@ model renders 5–6 detents.
   `getEffortSliderTrackGeometry`, so two-stop and six-stop models stay aligned.
   The chat overlay centers its label-and-track panel in the live viewport, so
   keyboard and composer movement do not shift its resting position.
-- **Visuals** — the neutral outer capsule and its exposed stop dots use the
-  theme's `secondary`/`secondary-foreground` pair, so the track is light in the
-  light theme and near-black in the dark theme. The progress pill and gauge
-  pointer use the shared `brand` token with translucent white dots over the pill.
+- **Visuals** — the opaque outer capsule and its exposed stop dots use the
+  theme's `popover`/`popover-foreground` pair: white in the light theme and a
+  raised dark surface in the dark theme. The overlay adds a soft shadow outside
+  its animated clip, keeping the capsule distinct from the blurred content.
+  A local focus field extends 96dp above the label and below the track, fading
+  into the surrounding content at both edges. iOS adds nested native blur bands
+  toward the panel without masking the blur; Android uses the same theme-colored
+  dissolve over its scrim fallback. App and keyboard backdrops share the field's
+  screen coordinates, with the keyboard portion clipped to its own window.
+  The progress pill and gauge pointer use the shared `brand` token with
+  translucent white dots over the pill.
 
 ## Theming & accessibility
 

--- a/src/frontend/features/chat/components/ChatInput/effortSlider/components/EffortSliderTrack.tsx
+++ b/src/frontend/features/chat/components/ChatInput/effortSlider/components/EffortSliderTrack.tsx
@@ -22,7 +22,7 @@ type EffortSliderTrackProps = {
 };
 
 /**
- * A 64dp neutral capsule surrounds a 44dp brand progress pill. The capsule and
+ * A 64dp opaque capsule surrounds a 44dp brand progress pill. The capsule and
  * exposed ticks follow the active theme. The thumb sits inside the progress end
  * cap, leaving its four-pixel brand ring visible at the endpoints.
  */
@@ -33,19 +33,12 @@ export function EffortSliderTrack({
   measuredWidth,
 }: EffortSliderTrackProps) {
   const [brandColor, trackColor, trackForegroundColor, constantBlack, constantWhite] =
-    useThemeColor([
-      'brand',
-      'secondary',
-      'secondary-foreground',
-      'constant-black',
-      'constant-white',
-    ]);
+    useThemeColor(['brand', 'popover', 'popover-foreground', 'constant-black', 'constant-white']);
   const scale = trackHeight / effortSliderTrackHeight;
   const progressHeight = effortSliderProgressHeight * scale;
   const thumbInset = effortSliderThumbInset * scale;
   const thumbSize = effortSliderThumbSize * scale;
   const tickSize = effortSliderTickSize * scale;
-  const trackRadius = trackHeight / 2;
   const { thumbCenterStart, tickCenters, travelDistance } = getEffortSliderTrackGeometry(
     measuredWidth,
     stopCount,
@@ -67,20 +60,14 @@ export function EffortSliderTrack({
 
   return (
     <View className="w-full" style={{ height: trackHeight }}>
-      <View
-        className="absolute inset-0"
-        style={{
-          backgroundColor: trackColor,
-          borderRadius: trackRadius,
-        }}
-      >
+      <View className="absolute inset-0 rounded-full" style={{ backgroundColor: trackColor }}>
         {stops.map(({ centerX, fraction }) => (
           <View
             key={fraction}
+            className="rounded-full"
             pointerEvents="none"
             style={{
               backgroundColor: trackForegroundColor,
-              borderRadius: tickSize / 2,
               height: tickSize,
               left: centerX - tickSize / 2,
               opacity: 0.2,
@@ -91,11 +78,10 @@ export function EffortSliderTrack({
           />
         ))}
         <Animated.View
-          className="absolute overflow-hidden"
+          className="absolute overflow-hidden rounded-full"
           style={[
             {
               backgroundColor: brandColor,
-              borderRadius: progressHeight / 2,
               height: progressHeight,
               left: progressInset,
               top: (trackHeight - progressHeight) / 2,
@@ -110,9 +96,9 @@ export function EffortSliderTrack({
             {stops.map(({ centerX, fraction }) => (
               <View
                 key={fraction}
+                className="rounded-full"
                 style={{
                   backgroundColor: constantWhite,
-                  borderRadius: tickSize / 2,
                   height: tickSize,
                   left: centerX - tickSize / 2,
                   opacity: 0.16,
@@ -124,27 +110,12 @@ export function EffortSliderTrack({
             ))}
           </View>
         </Animated.View>
-        <View
-          pointerEvents="none"
-          style={{
-            borderColor: trackForegroundColor,
-            borderRadius: trackRadius,
-            borderWidth: 1,
-            bottom: 0,
-            left: 0,
-            opacity: 0.04,
-            position: 'absolute',
-            right: 0,
-            top: 0,
-          }}
-        />
       </View>
       <Animated.View
-        className="absolute"
+        className="absolute rounded-full"
         style={[
           {
             backgroundColor: constantWhite,
-            borderRadius: thumbSize / 2,
             elevation: 1,
             height: thumbSize,
             left: 0,


### PR DESCRIPTION
### What this PR does

Before this PR, the reasoning-effort slider used a translucent outer capsule, allowing chat content to show through and weakening its separation from the background.

After this PR, the slider uses an opaque, theme-aware popover surface with a soft shadow. A fading backdrop extends above the label and below the track: iOS adds nested native blur bands, while Android uses a theme-colored dissolve over its existing scrim fallback. The app and keyboard portions use aligned coordinates.

### Screenshots or videos

Pending device capture in light and dark themes. Device verification was not run under the user's task instructions; this PR remains a draft.

### Why we need it and why it was done in this way

The solid capsule and fading backdrop make the effort control easier to distinguish from the conversation. The implementation reuses existing color tokens and the sidebar's unmasked blur-band approach, with no new dependencies. A separate clip preserves the opening transition while allowing the capsule shadow to remain visible. Effort selection and gesture behavior are unchanged.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm lint` (warnings only in unchanged files), `pnpm format:check`, and `git diff --check`.
- Tests, type checks, builds, and device/UI verification were intentionally not run under the user's verification rules.
- Please inspect both themes, keyboard-visible and keyboard-hidden layouts, and the Android fallback before marking this ready.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the resulting behavior and platform differences
- [ ] Preview: Screenshots or video of the implemented result are attached
- [x] Code: The change stays local to the chat input and reuses existing dependencies
- [x] Upgrade: No persisted data or upgrade-flow changes
- [x] Documentation: Updated the effort slider's local visual contract; no user-guide update is required
- [x] Self-review: Reviewed the complete diff before submission

### Release note

```release-note
Improve the reasoning-effort slider with a solid capsule and a fading backdrop that separates it from chat content.
```
