### PR TITLE
fix(design-tokens): align action colors with desktop green theme

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,7 +37,7 @@ product.css                46 Cherry product semantics
         ↓
 native.css                 Generated. Never edit by hand.
         ↓
-components                 className="bg-card text-foreground"  or  useThemeColor('brand')
+components                 className="bg-card text-foreground"  or  useThemeColor('primary')
 ```
 
 Two ways to take a colour, and only two:
@@ -47,7 +47,7 @@ Two ways to take a colour, and only two:
 
 ```tsx
 const scrimColor = useThemeColor('scrim');
-const [accent, ring] = useThemeColor(['primary', 'constant-white']);
+const [primary, primaryForeground] = useThemeColor(['primary', 'primary-foreground']);
 ```
 
 `useThemeColor` takes contract names without the `--color-` prefix. A string returns a string; an array returns a tuple of the same length.
@@ -80,20 +80,29 @@ There is no fifth. A new literal must state in its commit which case it falls un
 
 ### `--brand` vs `--primary`
 
-Both currently resolve to the same value, but they mean different things:
+Mobile follows desktop's neutral-first interface with green action emphasis. These roles are independent:
 
-- `--brand` — "this must be the Cherry logo red (`#ff5757`)."
-- `--primary` — "this is the accent, and would follow a theme-colour setting if one existed."
+- `--primary` uses `--green-900`: dark green in light mode, bright green in dark mode. The mode-aware
+  steps preserve readable text and icons; they follow desktop's green direction rather than copying
+  its fixed `#00b96b` preference value onto every surface.
+- `--primary-foreground` uses `--background-100`: white on the light-mode green, black on the dark-mode green.
+- `--brand` is the fixed Cherry logo red (`#ff5757`), reserved for brand artwork. Actions, selections,
+  links, and tool mentions must not consume it.
 
-The test: **if the user set the accent to purple, should this turn purple?**
+Use `primary` for emphasized actions and adjustable progress, `link` for links and tool mentions,
+and neutral `secondary` / `border-selected` for ordinary selection. Default buttons remain neutral.
+HeroUI's `accent` adapter follows `primary`; the underlying Shadcn `accent` remains a neutral overlay.
 
-The `--theme-primary` runtime-input layer was removed (`beccaa2e`); mobile has never shipped a screen that writes an accent preference. The preference key stays in `packages/universal` because it is persisted data shared with desktop. Building the feature means adding the screen first, then reintroducing the pair.
+Mobile currently exposes no custom action-color setting. Keep defaults in the token package;
+introduce runtime color inputs together with a real setting and its paired foreground.
 
 ### Contrast
 
 Body text (`text-sm` / `text-base`, including semibold) needs **4.5:1**. Graphics and borders need **3:1**.
 
-This is enforced, not aspirational. `--brand` moved off `#00b96b` because that measures 2.58:1 on white while `text-brand` lands on body copy. Compute before choosing.
+Check the actual foreground/background pair before choosing. Desktop's fixed `#00b96b` has only
+2.58:1 contrast on white, so Mobile uses the existing mode-aware green emphasis step for `primary`.
+Logo artwork is not a substitute for a readable text or interaction color.
 
 ### The Gray Ramp Is Not Monotonic
 

--- a/packages/design-tokens/scripts/theme-contract.ts
+++ b/packages/design-tokens/scripts/theme-contract.ts
@@ -18,12 +18,7 @@
  * - Tailwind color variables are generated only for roles used as utilities.
  */
 
-/* `RUNTIME_THEME_INPUT_TOKENS` stood here, naming the `--theme-primary` pair the
- * app rewrote at startup from `ui.theme_user.color_primary`. Mobile has no UI
- * that writes that preference — bootstrap read it and nothing else touched it —
- * so the indirection made one unreachable setting configurable. `--primary` now
- * reads `--brand` in shadcn.css. The preference key itself stays in
- * packages/universal: it is persisted data shared with desktop. */
+/* No runtime color inputs: shadcn.css owns the defaults until Mobile has an action-color setting. */
 
 export const SHADCN_COLOR_TOKENS = [
   'background',

--- a/packages/design-tokens/src/styles/contract.css
+++ b/packages/design-tokens/src/styles/contract.css
@@ -4,11 +4,7 @@
  * Import order is architectural and must remain one-way:
  * foundation providers -> official Shadcn semantics -> product semantics.
  *
- * There used to be a `runtime inputs` layer between the first two, holding the
- * `--theme-*` pair the app rewrote from the theme-colour preference. Mobile
- * never shipped a screen that sets that preference, so the layer existed to
- * make one unreachable setting configurable; `--primary` reads `--brand`
- * directly now.
+ * Mobile has no custom action-color setting; shadcn.css owns its mode-aware defaults.
  * This entry contains no Tailwind adapter and is suitable for consumers that
  * use CSS custom properties directly.
  */

--- a/packages/design-tokens/src/styles/native.css
+++ b/packages/design-tokens/src/styles/native.css
@@ -150,8 +150,8 @@
       --card-foreground: var(--gray-1000);
       --popover: var(--background-100);
       --popover-foreground: var(--gray-1000);
-      --primary: var(--brand);
-      --primary-foreground: var(--constant-white);
+      --primary: var(--green-900);
+      --primary-foreground: var(--background-100);
       --secondary: var(--gray-alpha-100);
       --secondary-foreground: var(--gray-1000);
       --muted: var(--gray-alpha-100);
@@ -273,8 +273,8 @@
       --card-foreground: var(--gray-1000);
       --popover: var(--gray-100);
       --popover-foreground: var(--gray-1000);
-      --primary: var(--brand);
-      --primary-foreground: var(--constant-white);
+      --primary: var(--green-900);
+      --primary-foreground: var(--background-100);
       --secondary: var(--gray-alpha-100);
       --secondary-foreground: var(--gray-1000);
       --muted: var(--gray-alpha-100);

--- a/packages/design-tokens/src/styles/product.css
+++ b/packages/design-tokens/src/styles/product.css
@@ -61,11 +61,7 @@
   --inline-code: var(--gray-alpha-100);
   --inline-code-foreground: var(--red-900);
 
-  /* 产品自己的 Logo 红。`--primary` 现在直接读它（见 shadcn.css），所以两者暂时是同一个
-   * 值 —— 但仍是两个名字：`--brand` 说「这里必须是产品的颜色」，`--primary` 说「这里
-   * 是主色，将来可能由用户决定」。真做了主题色界面时，只有后者会开始变。
-   *
-   * #ff5757 直接取自 Cherry Studio Logo SVG，在明暗主题中保持一致。 */
+  /* Fixed logo artwork color. Actions and content must use their semantic roles. */
   --brand: #ff5757;
 
   /* Stable product domain: user-message surface (UserMessageItem) */

--- a/packages/design-tokens/src/styles/shadcn.css
+++ b/packages/design-tokens/src/styles/shadcn.css
@@ -32,18 +32,9 @@
   --card-foreground: var(--gray-1000);
   --popover: var(--background-100);
   --popover-foreground: var(--gray-1000);
-  /* 直接就是 `--brand`。此前这两条读 `--theme-primary{,-foreground}`，一对由 app
-   * 在启动时按 `ui.theme_user.color_primary` 改写的运行时输入 —— 但移动端从来没有
-   * 过设置主题色的界面，那个 key 只在 bootstrap 被读一次、无人写入，所以整层间接
-   * 服务的是一个改不了的设置。偏好键本身留在 packages/universal（持久化数据、与桌
-   * 面共享），真做了主题色界面再把这层接回来。
-   *
-   * 前景恒为白。这对 token 的唯一消费者是发送/停止主按钮，白色是实心品牌填充上的
-   * 通行做法，也与紧邻的 `--destructive-foreground` 一致。#521 把品牌色从绿换成
-   * #ff5757 时一并改成过黑色，理由写的是「白字对比度不足」——那是按正文的 4.5:1 判
-   * 的，而这里画的是图标，适用的是非文本的 3:1，白对 #ff5757 为 3.1:1，达标。 */
-  --primary: var(--brand);
-  --primary-foreground: var(--constant-white);
+  /* Follow desktop's green action hierarchy; use mode-aware steps for readable icons and text. */
+  --primary: var(--green-900);
+  --primary-foreground: var(--background-100);
   --secondary: var(--gray-alpha-100);
   --secondary-foreground: var(--gray-1000);
   --muted: var(--gray-alpha-100);
@@ -57,10 +48,7 @@
   /* Controls */
   --border: var(--gray-alpha-200);
   --input: var(--gray-alpha-200);
-  /* Follows the picked accent rather than the brand default: this used to mix
-   * against the static green, so choosing a custom theme colour left the focus
-   * ring green. No component of ours consumes `--ring`; HeroUI's `--focus`
-   * does. */
+  /* HeroUI focus follows the action color, independently of logo artwork. */
   --ring: color-mix(in srgb, var(--primary) 40%, transparent);
 
   /* Charts

--- a/packages/ui/stories/foundations/tokens.ts
+++ b/packages/ui/stories/foundations/tokens.ts
@@ -38,7 +38,7 @@ export const PALETTE_SCALES: PaletteScale[] = [
     variables: scale('gray-alpha', neutralSteps),
   },
   { title: 'Blue', hint: 'info、reference', variables: scale('blue', hueSteps) },
-  { title: 'Green', hint: 'success', variables: scale('green', hueSteps) },
+  { title: 'Green', hint: 'primary、success', variables: scale('green', hueSteps) },
   { title: 'Amber', hint: 'warning、highlight', variables: scale('amber', hueSteps) },
   { title: 'Red', hint: 'error、destructive、inline-code', variables: scale('red', hueSteps) },
 ];
@@ -87,8 +87,8 @@ export const SEMANTIC_GROUPS: SemanticGroup[] = [
     variables: ['--secondary', '--secondary-active', '--muted', '--accent'],
   },
   {
-    title: '品牌',
-    hint: '--primary 是主操作颜色；--brand 是固定的 Cherry Studio Logo 红（#ff5757）。两者当前取值相同，但语义仍分开。',
+    title: '主操作与品牌',
+    hint: '--primary 采用与 PC 一致的绿色方向，明暗模式使用对应绿色阶及配套前景；--brand 仅用于固定的 Cherry Studio Logo 红（#ff5757），不用于操作和内容。',
     kind: 'surface',
     variables: ['--primary', '--primary-foreground', '--brand'],
   },

--- a/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
+++ b/src/backend/ai/agent/host/__tests__/turnPreparation.test.ts
@@ -208,8 +208,7 @@ describe('turn preparation', () => {
       const plan = await prepareTurn(
         harness.dependencies,
         {
-          sessionId: SESSION_ID,
-          parts: [{ type: 'text', text: 'Hello.' }],
+          ...textInput(),
           reasoningEffort,
         },
         new AbortController().signal,

--- a/src/frontend/components/Composer/components/ComposerField.tsx
+++ b/src/frontend/components/Composer/components/ComposerField.tsx
@@ -27,9 +27,7 @@ export function ComposerField({ onBlur, onFocus, placeholder, style, testID }: C
   const { addAttachments } = useComposerActions();
   const { inputRef } = useComposerMeta();
   const { resumeKeyboardTracking } = useComposerPresentationActions();
-  // `brand`, not `primary`: the product colour is a promise, while `primary` is
-  // a slot the user may get to repaint.
-  const brand = useThemeColor('brand');
+  const linkColor = useThemeColor('link');
 
   const handlePaste = useCallback(
     (payload: PasteEventPayload) => {
@@ -44,10 +42,10 @@ export function ComposerField({ onBlur, onFocus, placeholder, style, testID }: C
   // creates any other kind, and auto-detection is off — so the base `link`
   // style is set alongside the variant rather than left to the library's blue.
   const markdownStyle = useMemo(() => {
-    const mentionStyle = { color: brand, underline: false };
+    const mentionStyle = { color: linkColor, underline: false };
 
     return { link: mentionStyle, linkVariants: { '^tool:': mentionStyle } };
-  }, [brand]);
+  }, [linkColor]);
 
   const handleFocus = useCallback<NonNullable<ComposerInputProps['onFocus']>>(() => {
     // Focus is the only event that is allowed to reconnect the dock after a

--- a/src/frontend/components/Message/parts/TextPart.tsx
+++ b/src/frontend/components/Message/parts/TextPart.tsx
@@ -28,7 +28,7 @@ function renderMentionSegments(segments: readonly MentionSegment[]) {
     occurrenceById.set(segment.id, occurrence + 1);
 
     return (
-      <Text className="text-brand" key={`${segment.id}-${occurrence}`}>
+      <Text className="text-link" key={`${segment.id}-${occurrence}`}>
         {segment.text}
       </Text>
     );
@@ -36,7 +36,7 @@ function renderMentionSegments(segments: readonly MentionSegment[]) {
 }
 
 /**
- * Plain text with its tool mentions picked out in the brand color, showing the
+ * Plain text with its tool mentions picked out in the link color, showing the
  * name the sender saw rather than the link syntax carrying it. Nested `Text`
  * rather than a markdown renderer: the mention is the only thing to style, and
  * reaching for a renderer would start parsing everything else the user typed

--- a/src/frontend/features/chat/components/ChatInput/effortSlider/README.md
+++ b/src/frontend/features/chat/components/ChatInput/effortSlider/README.md
@@ -1,7 +1,7 @@
 # effortSlider
 
 Discrete effort-level slider used by the chat composer's gauge overlay. Its
-two-layer capsule, brand fill, stop dots, and circular thumb follow the ChatGPT
+two-layer capsule, stop dots, and circular thumb follow the ChatGPT
 iOS interaction reference.
 
 The number of stops is entirely driven by `options` — i.e. by how many
@@ -18,7 +18,7 @@ model renders 5–6 detents.
   selection tick on every crossed stop. Commit fires as soon as the active
   stop changes.
 - **Geometry** — the sampled reference is a 64dp outer capsule with a centered
-  44dp progress pill, a 36dp white thumb, and 10dp stop dots. Stop
+  44dp progress pill, a 36dp thumb, and 10dp stop dots. Stop
   dots share the thumb's endpoint centers, derived by
   `getEffortSliderTrackGeometry`, so two-stop and six-stop models stay aligned.
   The chat overlay centers its label-and-track panel in the live viewport, so
@@ -32,8 +32,8 @@ model renders 5–6 detents.
   toward the panel without masking the blur; Android uses the same theme-colored
   dissolve over its scrim fallback. App and keyboard backdrops share the field's
   screen coordinates, with the keyboard portion clipped to its own window.
-  The progress pill and gauge pointer use the shared `brand` token with
-  translucent white dots over the pill.
+  The progress pill uses `primary`; the thumb and translucent dots use its
+  paired `primary-foreground`.
 
 ## Theming & accessibility
 

--- a/src/frontend/features/chat/components/ChatInput/effortSlider/components/EffortSliderTrack.tsx
+++ b/src/frontend/features/chat/components/ChatInput/effortSlider/components/EffortSliderTrack.tsx
@@ -22,9 +22,9 @@ type EffortSliderTrackProps = {
 };
 
 /**
- * A 64dp opaque capsule surrounds a 44dp brand progress pill. The capsule and
+ * A 64dp opaque capsule surrounds a 44dp primary progress pill. The capsule and
  * exposed ticks follow the active theme. The thumb sits inside the progress end
- * cap, leaving its four-pixel brand ring visible at the endpoints.
+ * cap, leaving its four-pixel primary ring visible at the endpoints.
  */
 export function EffortSliderTrack({
   trackHeight,
@@ -32,8 +32,14 @@ export function EffortSliderTrack({
   position,
   measuredWidth,
 }: EffortSliderTrackProps) {
-  const [brandColor, trackColor, trackForegroundColor, constantBlack, constantWhite] =
-    useThemeColor(['brand', 'popover', 'popover-foreground', 'constant-black', 'constant-white']);
+  const [primaryColor, primaryForegroundColor, trackColor, trackForegroundColor, constantBlack] =
+    useThemeColor([
+      'primary',
+      'primary-foreground',
+      'popover',
+      'popover-foreground',
+      'constant-black',
+    ]);
   const scale = trackHeight / effortSliderTrackHeight;
   const progressHeight = effortSliderProgressHeight * scale;
   const thumbInset = effortSliderThumbInset * scale;
@@ -81,7 +87,7 @@ export function EffortSliderTrack({
           className="absolute overflow-hidden rounded-full"
           style={[
             {
-              backgroundColor: brandColor,
+              backgroundColor: primaryColor,
               height: progressHeight,
               left: progressInset,
               top: (trackHeight - progressHeight) / 2,
@@ -98,7 +104,7 @@ export function EffortSliderTrack({
                 key={fraction}
                 className="rounded-full"
                 style={{
-                  backgroundColor: constantWhite,
+                  backgroundColor: primaryForegroundColor,
                   height: tickSize,
                   left: centerX - tickSize / 2,
                   opacity: 0.16,
@@ -115,7 +121,7 @@ export function EffortSliderTrack({
         className="absolute rounded-full"
         style={[
           {
-            backgroundColor: constantWhite,
+            backgroundColor: primaryForegroundColor,
             elevation: 1,
             height: thumbSize,
             left: 0,

--- a/src/frontend/utils/theme.ts
+++ b/src/frontend/utils/theme.ts
@@ -3,20 +3,7 @@ import { Uniwind } from 'uniwind';
 
 import { type FontSizeStep, ThemeMode } from '@/shared/data/preference';
 
-/**
- * The primary-colour half of this module used to live here: `DEFAULT_PRIMARY_COLOR`,
- * hex normalization, a WCAG relative-luminance test picking black or white ink,
- * and `applyPrimaryColorPreference` writing the resulting pair into
- * `--theme-primary{,-foreground}` on both themes at startup.
- *
- * All of it fed `ui.theme_user.color_primary`, a preference no mobile screen
- * ever wrote — bootstrap read it once and nothing else touched it — so the
- * machinery let the user recolour the app through a control that does not
- * exist. `--primary` reads `--brand` directly now (see shadcn.css). The
- * preference key stays in packages/universal because it is persisted data
- * shared with desktop; reviving the feature means adding the screen and
- * re-introducing this pair, not resurrecting a dead default.
- */
+// Action colors are authored in shadcn.css; Mobile currently exposes only mode and font-size settings.
 
 function updateBothThemes(variables: Record<string, string | number>) {
   const activeTheme = Uniwind.currentTheme === 'dark' ? 'dark' : 'light';


### PR DESCRIPTION
### What this PR does

Before this PR, the primary action color inherited the fixed red logo color. Tool mentions and the effort slider also consumed the brand color directly, spreading red into ordinary interactions.

After this PR, primary actions use the existing mode-aware green ramp, following desktop's neutral-first interface and green action emphasis. Tool mentions use the blue link role, and the effort slider uses the primary/foreground pair. Logo artwork keeps its independent brand color.

The generated light/dark CSS, design guidelines, and foundation examples are updated together.

### Screenshots or videos

Pending light/dark device acceptance. No screenshots were captured because device/UI verification was not authorized for this task.

### Why we need it and why it was done in this way

Separating action semantics from logo artwork prevents future logo color changes from recoloring interactions. Mobile keeps its existing token pipeline and uses green palette steps suited to its light/dark surfaces; it does not copy desktop's fixed `#00b96b` preference value verbatim. Ordinary controls and selection surfaces retain their neutral treatment.

### Breaking changes

None to APIs or persisted preferences. The default action and tool-mention colors change visibly; no migration or new setting is required.

### Special notes for your reviewer

- Passed: authorized `pnpm design:build` CSS generation, `pnpm format`, final `pnpm format:check`, focused Oxlint/Expo lint for changed TypeScript files, and `git diff --check`.
- Blocked: full `pnpm lint` reports seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider export in unchanged backend files. The package exports point to `dist`, which is absent in this workspace; the run also reports warnings in unchanged files.
- Not run locally: package/application builds, type checking, tests, specialized design checks, and device acceptance, per the task's verification restrictions. Only CSS generation was authorized; GitHub Actions runs the PR checks.
- CI exposed an existing reasoning-selection test fixture missing required user and assistant message IDs. The test now reuses its typed `textInput()` helper; production behavior and assertions are unchanged.
- Remote validation passed for `55bb0212e`: [test, lint, and typecheck](https://github.com/CherryHQ/cherry-studio-app/actions/runs/34336642309).
- Rebased onto the latest `v0.2`; the effort slider's opaque surface and fading backdrop from #870 are preserved.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the behavior and tradeoffs
- [ ] Preview: Light/dark screenshots or video supplied
- [x] Code: Changes use existing semantic roles and the existing generator
- [x] Upgrade: No preference or data migration required
- [x] Documentation: Design guidelines and foundation examples updated
- [x] Self-review: Reviewed the final diff against `origin/v0.2`

### Release note

```release-note
Use green emphasis for primary actions and the effort slider, and blue for tool mentions, while keeping the interface neutral and logo colors independent.
```
