### PR TITLE
fix(chat-streaming): settle native rendering when message parts finish

### DIFF
--- a/docs/references/chat/streaming-and-rendering.md
+++ b/docs/references/chat/streaming-and-rendering.md
@@ -93,6 +93,10 @@ approvals. Stop calls `cancelTurn` only when the selected Session has a non-term
 ## Rendering
 
 - Text and reasoning remain Markdown-capable shared message parts.
+- Each text or reasoning part leaves native streaming mode when its own state reaches `done`,
+  even if the turn continues with tools or another part. Turn completion, cancellation, and failure
+  also end streaming mode. This releases pending Markdown tail blocks and finalizes layout without
+  remounting a renderer that has streamed.
 - Tool and approval state remains structured and uses the shared tool renderer and approval sheet.
 - File-tool input appears inline in the message list while it is generated. `write_file` previews
   `content`; `edit_file` previews `new_string`. The tool's complete input remains authoritative for

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -94,8 +94,9 @@ where the current native Lucide version has renamed or redrawn them. They need n
 `MarkdownText` is the shared GitHub-flavored Markdown renderer. Static content uses the enriched
 native renderer. A part that has streamed keeps the streaming renderer for its full mounted
 lifetime, including terminal state, so completion does not remount its native subtree. Both receive
-the same theme tokens, syntax palette, LaTeX flags, and typography scale. Product code supplies the
-active font size step and decides how links open:
+the same theme tokens, syntax palette, LaTeX flags, and typography scale. Native streaming mode ends
+with each part, releasing pending tail blocks and requesting a final layout even when the text
+itself is unchanged. Product code supplies the active font size step and decides how links open:
 
 ```tsx
 <MarkdownText

--- a/packages/ui/src/components/markdown-text/__tests__/markdown-text.test.tsx
+++ b/packages/ui/src/components/markdown-text/__tests__/markdown-text.test.tsx
@@ -54,6 +54,7 @@ describe('MarkdownText', () => {
           markdown: 'Hello',
           md4cFlags: { latexMath: true, superscript: true, underline: false },
           selectable: true,
+          streamingAnimation: isStreaming,
         }),
       );
       expect(props.markdownStyle).toEqual(
@@ -131,25 +132,38 @@ describe('MarkdownText', () => {
     );
   });
 
-  test('keeps the streaming renderer mounted when the part reaches terminal state', () => {
+  test.each([
+    ['with the last text update', 'Partial', 'Complete'],
+    [
+      'without another text update',
+      '| Item |\n| --- |\n| Final row',
+      '| Item |\n| --- |\n| Final row',
+    ],
+  ])('settles the native tail %s without remounting the renderer', (_label, partial, complete) => {
     const onLinkPress = jest.fn();
     const renderer = render(
-      <MarkdownText fontSizeStep={0} isStreaming markdown="Partial" onLinkPress={onLinkPress} />,
+      <MarkdownText fontSizeStep={0} isStreaming markdown={partial} onLinkPress={onLinkPress} />,
     );
+    const block = renderer.root.findByType('StreamdownText');
+    expect(block.props.streamingAnimation).toBe(true);
 
     act(() => {
       renderer.update(
         <MarkdownText
           fontSizeStep={0}
           isStreaming={false}
-          markdown="Complete"
+          markdown={complete}
           onLinkPress={onLinkPress}
         />,
       );
     });
 
-    expect(renderer.root.findByType('StreamdownText').props.markdown).toBe('Complete');
+    expect(renderer.root.findByType('StreamdownText')).toBe(block);
+    expect(block.props.markdown).toBe(complete);
+    expect(block.props.streamingAnimation).toBe(false);
     expect(renderer.root.findAllByType('EnrichedMarkdownText')).toHaveLength(0);
+
+    act(() => renderer.unmount());
   });
 });
 

--- a/packages/ui/src/components/markdown-text/components/markdown-text.tsx
+++ b/packages/ui/src/components/markdown-text/components/markdown-text.tsx
@@ -144,6 +144,8 @@ export function MarkdownText({
   // A streamed part keeps one native renderer for its full lifetime. Switching
   // component types at terminal status remounts the whole Markdown subtree and
   // invalidates the list's measured height and native selection state.
+  // Its native streaming mode still ends with the part, releasing pending tail
+  // blocks and forcing a final layout even when the Markdown hasn't changed.
   const MarkdownRenderer = isStreaming || hasStreamed ? StreamdownText : EnrichedMarkdownText;
   const handleLinkPress = ({ url }: LinkPressEvent) => onLinkPress(url);
   const markdownStyle = useMemo<MarkdownStyle>(() => {
@@ -244,6 +246,7 @@ export function MarkdownText({
       md4cFlags={{ latexMath: true, superscript: true, underline: false }}
       onLinkPress={handleLinkPress}
       selectable={selectable}
+      streamingAnimation={isStreaming}
     />
   );
 }

--- a/src/frontend/components/Message/parts/MessagePartRenderer.tsx
+++ b/src/frontend/components/Message/parts/MessagePartRenderer.tsx
@@ -43,7 +43,7 @@ export const MessagePartRenderer = memo(function MessagePartRenderer({
     case 'text':
       return (
         <TextPart
-          isStreaming={isStreaming}
+          isStreaming={isStreaming && part.state !== 'done'}
           isTextSelectionEnabled={isTextSelectionEnabled}
           part={part}
           renderMode={renderMode}
@@ -51,7 +51,7 @@ export const MessagePartRenderer = memo(function MessagePartRenderer({
         />
       );
     case 'reasoning':
-      return <ReasoningPart isStreaming={isStreaming} part={part} />;
+      return <ReasoningPart isStreaming={isStreaming && part.state !== 'done'} part={part} />;
     case 'data-code':
       return (
         <CodePart

--- a/src/frontend/components/Message/parts/__tests__/MessagePartRenderer.test.tsx
+++ b/src/frontend/components/Message/parts/__tests__/MessagePartRenderer.test.tsx
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import type { CherryMessagePart } from '@/shared/data/types/message';
 
 import { MessagePartRenderer } from '../MessagePartRenderer';
+import { ReasoningPart } from '../ReasoningPart';
 import { TextPart } from '../TextPart';
 
 jest.mock('../CodePart', () => ({ CodePart: () => null }));
@@ -78,4 +79,40 @@ describe('MessagePartRenderer', () => {
 
     expect(mockTextPart).not.toHaveBeenCalled();
   });
+
+  test.each(['text', 'reasoning'] as const)(
+    'settles a %s block while the next block is still streaming',
+    (type) => {
+      const part = { state: 'streaming', text: '我来帮', type } as const;
+      const completePart = { ...part, state: 'done', text: '我来帮你查看日历。' } as const;
+      const component = type === 'text' ? TextPart : ReasoningPart;
+      let renderer: ReactTestRenderer | undefined;
+
+      act(() => {
+        renderer = create(<MessagePartRenderer isStreaming isTextSelectionEnabled part={part} />);
+      });
+      const block = renderer!.root.findByType(component);
+      expect(block.props.isStreaming).toBe(true);
+
+      act(() => {
+        renderer!.update(
+          <MessagePartRenderer
+            isStreaming
+            isTextSelectionEnabled
+            messageParts={[
+              completePart,
+              { state: 'streaming', text: '正在查询', type: 'reasoning' },
+            ]}
+            part={completePart}
+          />,
+        );
+      });
+
+      expect(renderer!.root.findByType(component)).toBe(block);
+      expect(block.props.isStreaming).toBe(false);
+      expect(block.props.part.text).toBe('我来帮你查看日历。');
+
+      act(() => renderer!.unmount());
+    },
+  );
 });


### PR DESCRIPTION
### What this PR does

Before this PR, completed text and reasoning parts retained the whole turn's streaming state, and the Markdown renderer never explicitly disabled native streaming mode. Pending Markdown tail blocks could therefore remain subject to streaming filters after the part ended.

After this PR, each part exits streaming mode when it reaches `done`, even while the turn continues. Native streaming mode also ends when the turn settles, including when no final text update arrives. The existing renderer stays mounted.

### Screenshots or videos

Not captured; device verification was not requested. The originally reported plain-text truncation has not been reproduced, so its connection to this rendering lifecycle defect remains unverified.

### Why we need it and why it was done in this way

Ending native streaming mode releases pending tail blocks and requests a final layout. Retaining the renderer preserves its native subtree, list measurements, and text-selection state instead of remounting it on completion.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm format`, `pnpm format:check`, `pnpm lint`, and `git diff --check`. Lint reports existing warnings in unchanged files.
- Regression cases cover a part finishing while another part is streaming, completion with and without a text update, and renderer identity across completion.
- Tests, type checks, builds, and device verification were intentionally not run per the user's instructions. The full `pnpm typecheck` command also invokes package builds.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the behavior and validation limits.
- [x] Documentation: Updated the chat rendering contract and CherryUI README.
- [x] Self-review: Reviewed the complete local diff.
- [ ] Preview: Device evidence is pending.
- [ ] Validation: Regression tests and type checks are pending.

### Release note

```release-note
Fix completed response blocks remaining in streaming rendering mode.
```
