### PR TITLE
fix(tool-approval): keep sheet actions in the footer

### DIFF
--- a/src/frontend/features/chat/components/ToolApprovalSheet/ToolApprovalSheet.tsx
+++ b/src/frontend/features/chat/components/ToolApprovalSheet/ToolApprovalSheet.tsx
@@ -48,32 +48,52 @@ export function ToolApprovalSheet({
   return (
     <BottomSheet
       dismissible={false}
+      footer={
+        <ToolApprovalSheetActions
+          key={approval.approvalId}
+          approval={approval}
+          onCancel={onCancel}
+          onRespond={onRespond}
+        />
+      }
       onClose={ignoreClose}
       open={isOpen}
-      sizes={['compact', 'large']}
+      size="medium"
       title={t('chat.tool.approval.title')}
     >
-      <ToolApprovalSheetBody
+      <ScrollView
         key={approval.approvalId}
-        approval={approval}
-        onCancel={onCancel}
-        onRespond={onRespond}
-        pendingCount={approvals.length}
-      />
+        className="min-h-0 flex-1"
+        contentContainerClassName="gap-4 px-6 pt-2 pb-4"
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="gap-1">
+          <Text className="text-foreground-tertiary text-sm">
+            {t('chat.tool.approval.description')}
+          </Text>
+          <Text className="font-semibold text-base text-foreground" selectable>
+            {approval.displayName}
+          </Text>
+          {approvals.length > 1 ? (
+            <Text className="text-foreground-tertiary text-xs">
+              {t('chat.tool.approval.pendingCount', { count: approvals.length })}
+            </Text>
+          ) : null}
+        </View>
+        <ApprovalArgumentsPreview input={approval.input} />
+      </ScrollView>
     </BottomSheet>
   );
 }
 
-function ToolApprovalSheetBody({
+function ToolApprovalSheetActions({
   approval,
   onCancel,
   onRespond,
-  pendingCount,
 }: {
   approval: PendingToolApproval;
   onCancel: () => Promise<void>;
   onRespond: (input: ToolApprovalRespondInput) => Promise<void>;
-  pendingCount: number;
 }) {
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -100,21 +120,7 @@ function ToolApprovalSheetBody({
   };
 
   return (
-    <View className="gap-4 px-6 pt-2">
-      <View className="gap-1">
-        <Text className="text-foreground-tertiary text-sm">
-          {t('chat.tool.approval.description')}
-        </Text>
-        <Text className="font-semibold text-base text-foreground" selectable>
-          {approval.displayName}
-        </Text>
-        {pendingCount > 1 ? (
-          <Text className="text-foreground-tertiary text-xs">
-            {t('chat.tool.approval.pendingCount', { count: pendingCount })}
-          </Text>
-        ) : null}
-      </View>
-      <ApprovalArgumentsPreview input={approval.input} />
+    <View className="gap-4">
       <Button disabled={isSubmitting} onPress={() => void submit('stop')} variant="secondary">
         <Button.Label>{t('chat.input.action.stopGenerating')}</Button.Label>
       </Button>
@@ -145,15 +151,11 @@ function ApprovalArgumentsPreview({ input }: { input: unknown }) {
   return (
     <View className="gap-1">
       <Text className="text-foreground-tertiary text-xs">{t('chat.tool.arguments')}</Text>
-      <ScrollView
-        className="max-h-48 rounded-md bg-secondary"
-        nestedScrollEnabled
-        showsVerticalScrollIndicator={false}
-      >
+      <View className="rounded-md bg-secondary">
         <Text className="p-2 font-mono text-foreground text-xs" selectable>
           {preview}
         </Text>
-      </ScrollView>
+      </View>
     </View>
   );
 }

--- a/src/frontend/features/chat/components/ToolApprovalSheet/__tests__/ToolApprovalSheet.test.tsx
+++ b/src/frontend/features/chat/components/ToolApprovalSheet/__tests__/ToolApprovalSheet.test.tsx
@@ -22,8 +22,20 @@ jest.mock('@cherrystudio/ui/components', () => {
   }
   MockButton.Label = MockText;
 
-  function MockBottomSheet({ children, ...props }: { children?: ReactNode }) {
-    return <MockView {...props}>{children}</MockView>;
+  function MockBottomSheet({
+    children,
+    footer,
+    ...props
+  }: {
+    children?: ReactNode;
+    footer?: ReactNode;
+  }) {
+    return (
+      <MockView {...props}>
+        {children}
+        {footer}
+      </MockView>
+    );
   }
 
   return {
@@ -139,7 +151,7 @@ describe('ToolApprovalSheet', () => {
     expect(renderer.root.findAllByType(BottomSheet)).toHaveLength(0);
   });
 
-  test('hides the arguments preview scroll indicator', () => {
+  test('hides the approval details scroll indicator', () => {
     render();
 
     expect(renderer.root.findByType(ScrollView).props.showsVerticalScrollIndicator).toBe(false);


### PR DESCRIPTION
### What this PR does

Before this PR: tool approval actions followed the arguments preview inside the sheet body, so long content could push the buttons out of view.

After this PR: Stop, Deny, and Allow use the existing `BottomSheet.footer` slot while approval details scroll separately. The sheet uses the `medium` height (60% of available height), keeping the footer within the visible card. Submission guards, request switching, and closing content retention are preserved.

### Screenshots or videos

Pending device review. Device verification and screenshot capture were not authorized for this task.

### Why we need it and why it was done in this way

Approval actions need to remain accessible while inspecting tool arguments. CherryUI already owns fixed footer placement and safe-area spacing, so this change reuses that contract. A single height avoids the current multi-height shell laying out the footer at its largest card height while opening at a smaller height.

### Breaking changes

None.

### Special notes for your reviewer

- Updated the existing test mock to render the footer, preserving the approval interaction tests' button access.
- `pnpm format:check` passed.
- Focused formatting and lint checks passed for both changed files.
- `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its `/provider` entry point in unchanged backend files. This checkout has no `packages/ai-core/dist` directory, which those exports require. It also reported unrelated warnings.
- Tests, typecheck, builds, and device verification were not run under the task's verification constraints. Light/dark visual review remains pending.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the resulting behavior
- [ ] Preview: Screenshots or video uploaded
- [x] Code: The change reuses the existing shared footer contract
- [x] Refactor: The change stays limited to the approval sheet and its test mock
- [x] Upgrade: No migration or upgrade action is required
- [x] Documentation: No user-guide update is needed for this layout fix
- [x] Self-review: Reviewed the complete diff

### Release note

```release-note
Keep tool approval actions fixed at the bottom of the sheet while approval details scroll.
```
