### PR TITLE
Fix input budgets, background refresh, and atomic provider saves

### DIFF
--- a/src/backend/ai/agent/runtime/pi/PiRuntime.ts
+++ b/src/backend/ai/agent/runtime/pi/PiRuntime.ts
@@ -68,6 +68,8 @@ import { tracePiStream } from './tracePiStream';
 
 export type PiModelResolution = {
   defaultThinkingLevel: ModelThinkingLevel;
+  /** Independent provider input cap, before reserving this request's output. */
+  maxInputTokens?: number;
   model: PiModel<PiApi>;
   redactionValues: readonly string[];
   streamFn: AgentOptions['streamFn'];
@@ -858,6 +860,24 @@ class PiRuntimeSession implements AgentRuntimeSession {
       const streamFn = tracePiStream(providerStream, request.trace);
       const models: Pick<Models, 'completeSimple'> = {
         completeSimple: async (model, context, options) => {
+          if (
+            estimatePiLoopContextHeadroomTokens({
+              contextWindow: model.contextWindow,
+              maxInputTokens: resolution.maxInputTokens,
+              messages: context.messages,
+              outputReserveTokens: options?.maxTokens ?? model.maxTokens,
+              systemPrompt: context.systemPrompt ?? '',
+              tools: context.tools ?? [],
+            }) < 0
+          ) {
+            throw Object.assign(
+              new Error('The compaction request exceeds the model input budget.'),
+              {
+                code: 'context_window_exceeded',
+                retryable: false,
+              },
+            );
+          }
           const response = this.contextOptions.completeSimple
             ? await this.contextOptions.completeSimple(model, context, options)
             : await (await streamFn(model, context, options)).result();
@@ -871,6 +891,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
         planPiContext({
           checkpoint: request.contextCheckpoint,
           conversation,
+          maxInputTokens: resolution.maxInputTokens,
           model: resolution.model,
           models,
           options: this.contextOptions,
@@ -906,6 +927,7 @@ class PiRuntimeSession implements AgentRuntimeSession {
       const updateModelContextHeadroom = (messages: PiAgentMessage[]) => {
         turn.modelContextHeadroomTokens = estimatePiLoopContextHeadroomTokens({
           contextWindow: resolution.model.contextWindow,
+          maxInputTokens: resolution.maxInputTokens,
           messages,
           outputReserveTokens,
           systemPrompt: modelContext.systemPrompt,

--- a/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
@@ -33,6 +33,7 @@ import type {
 } from '../../types';
 import {
   estimatePiContextFixedCosts,
+  estimatePiLoopContextHeadroomTokens,
   PI_CONTEXT_SAFETY_MARGIN_TOKENS,
   PI_IMAGE_CONTEXT_TOKEN_RESERVE,
 } from '../contextCompaction';
@@ -1235,6 +1236,156 @@ describe('PiRuntime mapping', () => {
     await session.close();
   });
 
+  test('reserves output once while respecting independent input and total context limits', () => {
+    const context = { messages: [], systemPrompt: 'x'.repeat(400), tools: [] };
+    const inputCosts = 100 + PI_CONTEXT_SAFETY_MARGIN_TOKENS;
+    for (const outputReserveTokens of [512, 32_768]) {
+      expect(
+        estimatePiLoopContextHeadroomTokens({
+          ...context,
+          contextWindow: 128_000,
+          maxInputTokens: 8_000,
+          outputReserveTokens,
+        }),
+      ).toBe(8_000 - inputCosts);
+      expect(
+        estimatePiLoopContextHeadroomTokens({
+          ...context,
+          contextWindow: 128_000,
+          outputReserveTokens,
+        }),
+      ).toBe(128_000 - outputReserveTokens - inputCosts);
+    }
+    expect(
+      estimatePiLoopContextHeadroomTokens({
+        ...context,
+        contextWindow: 6_000,
+        maxInputTokens: 8_000,
+        outputReserveTokens: 2_048,
+      }),
+    ).toBe(6_000 - 2_048 - inputCosts);
+  });
+
+  test.each(['text', 'text-attachment'] as const)(
+    'rejects %s input above the independent cap before executing the model',
+    async (type) => {
+      const runtime = createTestRuntime();
+      const holder = arrange(runtime, (context) => emitText(context, 'Must not run.'));
+      holder.resolution = { ...holder.resolution, maxInputTokens: 8_000 };
+      const session = await runtime.open();
+      const text = 'x'.repeat(40_000);
+      const input: RuntimeExecutionRequest['input'] =
+        type === 'text'
+          ? [{ type, text }]
+          : [
+              {
+                type,
+                text,
+                fileEntryId: '00000000-0000-7000-8000-000000000001',
+                mediaType: 'text/plain',
+                name: 'large.txt',
+                truncated: false,
+                trust: 'untrusted-user-content',
+              },
+            ];
+
+      const events = await collect(session.execute(baseRequest('turn-input-cap', { input })));
+
+      expect(holder.lastOptions).toBeUndefined();
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'failed',
+          error: expect.objectContaining({ code: 'context_window_exceeded' }),
+        }),
+      ]);
+      await session.close();
+    },
+  );
+
+  test('compacts at the independent input cap and discards usage for the old prefix', async () => {
+    let summaryCalls = 0;
+    const runtime = createCompactionRuntime(
+      compactionOptions(
+        summaryCompletion('Retained fact.', () => {
+          summaryCalls += 1;
+        }),
+        { estimateHistoryTokens: () => 11_000 },
+      ),
+    );
+    const holder = arrange(runtime, (context) => emitText(context, 'Continued.'));
+    holder.resolution = { ...holder.resolution, maxInputTokens: 12_000 };
+    const history = compactableHistory();
+    history[1].messages[1] = {
+      ...history[1].messages[1],
+      usage: { inputTokens: 120_000, outputTokens: 8, totalTokens: 120_008 },
+    };
+    const session = await runtime.open();
+
+    const events = await collect(
+      session.execute(baseRequest('turn-input-compaction', { history })),
+    );
+
+    expect(summaryCalls).toBe(1);
+    expect(events.some((event) => event.type === 'context.checkpoint')).toBe(true);
+    expect(events.some((event) => event.type === 'failed')).toBe(false);
+    expect(holder.lastOptions?.initialState?.model?.contextWindow).toBe(128_000);
+    expect(holder.lastOptions?.initialState?.messages?.[0].role).toBe('compactionSummary');
+    await session.close();
+  });
+
+  test('rejects an oversized summary request before sending it to the provider', async () => {
+    let summaryCalls = 0;
+    const runtime = createCompactionRuntime(
+      compactionOptions(
+        summaryCompletion('Must not run.', () => {
+          summaryCalls += 1;
+        }),
+      ),
+    );
+    const holder = arrange(runtime, (context) => emitText(context, 'Must not run.'));
+    holder.resolution = { ...holder.resolution, maxInputTokens: 8_000 };
+    const history = compactableHistory();
+    history[0].messages[0].parts = [{ type: 'text', text: 'x'.repeat(40_000) }];
+    const session = await runtime.open();
+
+    const events = await collect(
+      session.execute(baseRequest('turn-summary-input-cap', { history })),
+    );
+
+    expect(summaryCalls).toBe(0);
+    expect(holder.lastOptions).toBeUndefined();
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'failed',
+        error: expect.objectContaining({ code: 'context_window_exceeded' }),
+      }),
+    ]);
+    await session.close();
+  });
+
+  test('does not start the agent when compaction still exceeds the input cap', async () => {
+    const runtime = createCompactionRuntime(
+      compactionOptions(summaryCompletion('x'.repeat(40_000))),
+    );
+    const holder = arrange(runtime, (context) => emitText(context, 'Must not run.'));
+    holder.resolution = { ...holder.resolution, maxInputTokens: 8_000 };
+    const session = await runtime.open();
+
+    const events = await collect(
+      session.execute(baseRequest('turn-compacted-input-cap', { history: compactableHistory() })),
+    );
+
+    expect(holder.lastOptions).toBeUndefined();
+    expect(events.some((event) => event.type === 'context.checkpoint')).toBe(false);
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        type: 'failed',
+        error: expect.objectContaining({ code: 'context_window_exceeded' }),
+      }),
+    );
+    await session.close();
+  });
+
   test('rejects oversized fixed costs before summary or agent model calls', async () => {
     let summaryCalls = 0;
     const runtime = createCompactionRuntime(
@@ -1271,15 +1422,21 @@ describe('PiRuntime mapping', () => {
     await session.close();
   });
 
-  test.each([20, 1])(
-    'stops on exhausted context even at the tool budget (%i steps)',
-    async (maxToolSteps) => {
+  test.each([
+    { maxToolSteps: 20, contextWindow: 8_000, maxInputTokens: undefined },
+    { maxToolSteps: 1, contextWindow: 8_000, maxInputTokens: undefined },
+    { maxToolSteps: 20, contextWindow: 128_000, maxInputTokens: 8_000 },
+    { maxToolSteps: 1, contextWindow: 128_000, maxInputTokens: 8_000 },
+  ])(
+    'stops on exhausted context at $maxToolSteps steps (window $contextWindow, input $maxInputTokens)',
+    async ({ maxToolSteps, contextWindow, maxInputTokens }) => {
       const runtime = createTestRuntime({ ...DEFAULT_PI_RUNTIME_LIMITS, maxToolSteps });
       const holder = holders.get(runtime);
       if (!holder) throw new Error('missing Runtime holder');
       holder.resolution = {
         ...holder.resolution,
-        model: { ...holder.resolution.model, contextWindow: 8_000, maxTokens: 512 },
+        maxInputTokens,
+        model: { ...holder.resolution.model, contextWindow, maxTokens: 512 },
       };
       arrange(runtime, async (context) => {
         const toolMessage = assistantMessage({

--- a/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/PiRuntime.test.ts
@@ -1314,7 +1314,7 @@ describe('PiRuntime mapping', () => {
     );
     const holder = arrange(runtime, (context) => emitText(context, 'Continued.'));
     holder.resolution = { ...holder.resolution, maxInputTokens: 12_000 };
-    const history = compactableHistory();
+    const history: RuntimeExecutionRequest['history'] = compactableHistory();
     history[1].messages[1] = {
       ...history[1].messages[1],
       usage: { inputTokens: 120_000, outputTokens: 8, totalTokens: 120_008 },

--- a/src/backend/ai/agent/runtime/pi/__tests__/piModelResolver.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piModelResolver.test.ts
@@ -146,6 +146,26 @@ describe('Pi model resolver', () => {
     );
   });
 
+  test('keeps the independent input cap separate from the default output reservation', async () => {
+    const endpoint = ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS;
+    const model = makeModel(endpoint, {
+      contextWindow: 128_000,
+      maxInputTokens: 120_000,
+      maxOutputTokens: 32_000,
+    });
+    mockGetProviderById.mockResolvedValue(
+      makeProvider(endpoint, 'https://chat.test/v1', 'openai-compatible'),
+    );
+    mockGetModelById.mockResolvedValue(model);
+
+    const resolution = await resolve(resolver, { maxOutputTokens: 1024 });
+
+    expect(toPiModelPreflight(model).maxInputTokens).toBe(96_000);
+    expect(resolution.maxInputTokens).toBe(120_000);
+    expect(resolution.model.contextWindow).toBe(128_000);
+    expect(resolution.model.maxTokens).toBe(32_000);
+  });
+
   test('uses endpoint usage declarations and preserves the materialized effort vocabulary', async () => {
     const provider = makeProvider(
       ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,

--- a/src/backend/ai/agent/runtime/pi/contextCompaction.ts
+++ b/src/backend/ai/agent/runtime/pi/contextCompaction.ts
@@ -132,6 +132,7 @@ export function estimatePiMessagesTokens(messages: AgentMessage[]): number {
 /** Remaining room for model-loop messages before another provider request. */
 export function estimatePiLoopContextHeadroomTokens(input: {
   contextWindow: number;
+  maxInputTokens?: number;
   messages: AgentMessage[];
   outputReserveTokens: number;
   systemPrompt: string;
@@ -145,7 +146,21 @@ export function estimatePiLoopContextHeadroomTokens(input: {
     tools: input.tools,
   });
 
-  return input.contextWindow - messageTokens - fixedCosts.totalTokens;
+  return resolveContextBudget(input) - messageTokens - fixedCosts.totalTokens;
+}
+
+/** Fixed costs include output once; an independent input cap does not reserve it again. */
+function resolveContextBudget(input: {
+  contextWindow: number;
+  maxInputTokens?: number;
+  outputReserveTokens: number;
+}): number {
+  return Math.min(
+    input.contextWindow,
+    input.maxInputTokens === undefined
+      ? input.contextWindow
+      : Math.max(0, input.maxInputTokens) + Math.max(0, input.outputReserveTokens),
+  );
 }
 
 export function estimatePiContextFixedCosts(input: {
@@ -170,6 +185,7 @@ export function estimatePiContextFixedCosts(input: {
 export async function planPiContext(input: {
   checkpoint: RuntimeContextCheckpoint | null;
   conversation: PiConversation;
+  maxInputTokens?: number;
   model: PiModel<PiApi>;
   models: Pick<Models, 'completeSimple'>;
   options?: PiContextCompactionOptions;
@@ -180,7 +196,16 @@ export async function planPiContext(input: {
   tools: readonly PiToolSchema[];
 }): Promise<PiContextPlan> {
   const projected = projectContext(input.checkpoint, input.conversation.historyTurns);
-  const settings = input.options?.settings ?? resolveCompactionSettings(input.model.contextWindow);
+  const contextBudget = resolveContextBudget({
+    contextWindow: input.model.contextWindow,
+    maxInputTokens: input.maxInputTokens,
+    outputReserveTokens: input.outputReserveTokens,
+  });
+  const settings =
+    input.options?.settings ??
+    resolveCompactionSettings(
+      Math.min(input.model.contextWindow, input.maxInputTokens ?? input.model.contextWindow),
+    );
   const estimateHistory =
     input.options?.estimateHistoryTokens ??
     ((messages: AgentMessage[]) => estimateContextTokens(messages).tokens);
@@ -190,7 +215,7 @@ export async function planPiContext(input: {
     outputReserveTokens: input.outputReserveTokens,
     tools: input.tools,
   });
-  const compactionThreshold = Math.max(0, input.model.contextWindow - settings.reserveTokens);
+  const compactionThreshold = Math.max(0, contextBudget - settings.reserveTokens);
 
   if (fixedCosts.totalTokens > compactionThreshold) {
     return {
@@ -202,7 +227,7 @@ export async function planPiContext(input: {
   }
 
   const totalTokens = historyTokens + fixedCosts.totalTokens;
-  if (!shouldCompact(totalTokens, input.model.contextWindow, settings)) {
+  if (!shouldCompact(totalTokens, contextBudget, settings)) {
     return { ok: true, messages: projected.messages, checkpoint: null, usage: null };
   }
 
@@ -220,7 +245,7 @@ export async function planPiContext(input: {
     (preparation.value.messagesToSummarize.length === 0 &&
       preparation.value.turnPrefixMessages.length === 0)
   ) {
-    return totalTokens > input.model.contextWindow
+    return totalTokens > contextBudget
       ? {
           ok: false,
           code: 'context_window_exceeded',
@@ -255,6 +280,43 @@ export async function planPiContext(input: {
   }
 
   const summary = input.redactSummary(result.value.summary);
+  const messages = [
+    createCompactionSummary(summary, result.value.tokensBefore),
+    ...result.value.retainedTail.map((message) =>
+      // Provider usage includes the discarded prefix. Estimate the compacted
+      // content until the next live response reports usage for the new context.
+      message.role === 'assistant'
+        ? {
+            ...message,
+            usage: {
+              ...message.usage,
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+            },
+          }
+        : message,
+    ),
+  ];
+  if (
+    estimatePiLoopContextHeadroomTokens({
+      contextWindow: input.model.contextWindow,
+      maxInputTokens: input.maxInputTokens,
+      messages: [...messages, input.conversation.prompt],
+      outputReserveTokens: input.outputReserveTokens,
+      systemPrompt: input.conversation.systemPrompt,
+      tools: input.tools,
+    }) < 0
+  ) {
+    return {
+      ok: false,
+      code: 'context_window_exceeded',
+      message: 'The compacted conversation exceeds the model input budget.',
+      retryable: false,
+    };
+  }
   const checkpoint = createCheckpoint(
     projected.checkpoint,
     input.conversation.historyTurns,
@@ -265,10 +327,7 @@ export async function planPiContext(input: {
   );
   return {
     ok: true,
-    messages: [
-      createCompactionSummary(summary, result.value.tokensBefore),
-      ...result.value.retainedTail,
-    ],
+    messages,
     checkpoint,
     usage: result.value.usage ?? null,
   };

--- a/src/backend/ai/agent/runtime/pi/piModelResolver.ts
+++ b/src/backend/ai/agent/runtime/pi/piModelResolver.ts
@@ -143,6 +143,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
 
       return {
         defaultThinkingLevel: resolveDefaultThinkingLevel(invocationModel),
+        maxInputTokens: model.maxInputTokens,
         model: piModel,
         redactionValues: collectRedactionValues(selectedApiKey.value, headers),
         streamFn,

--- a/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
+++ b/src/backend/ai/agent/sessionStore/SqliteAgentSessionStore.ts
@@ -8,6 +8,7 @@ import {
   Phase,
   ServicePhase,
 } from '@/backend/core/lifecycle';
+import { publishDataApiChanges } from '@/backend/data/dataApiChanges';
 import type { Database, DbService } from '@/backend/data/db/DbService';
 import { agentSessionMessageTable, agentSessionTable } from '@/backend/data/db/schemas';
 import { createOrderedUuid } from '@/backend/data/db/schemas/_columnHelpers';
@@ -99,7 +100,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
     expectedTitle: string,
     title: string,
   ): Promise<AgentSessionView | null> {
-    return this.dbService.withWriteTx(async (tx) => {
+    const session = await this.dbService.withWriteTx(async (tx) => {
       const [row] = await tx
         .update(agentSessionTable)
         .set({ title, titleIsManual: false })
@@ -113,6 +114,10 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
         .returning();
       return row ? toAgentSessionView(row) : null;
     });
+    if (session) {
+      publishDataApiChanges(['/agent-sessions', `/agent-sessions/${sessionId}`]);
+    }
+    return session;
   }
 
   async deleteSession(sessionId: string): Promise<boolean> {
@@ -440,7 +445,7 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
   }
 
   async finalizeAssistantMessage(input: FinalizeAssistantMessageInput): Promise<AgentMessageView> {
-    return this.dbService.withWriteTx(async (tx) => {
+    const message = await this.dbService.withWriteTx(async (tx) => {
       const [existing] = await tx
         .select({
           sessionId: agentSessionMessageTable.sessionId,
@@ -479,6 +484,8 @@ export class SqliteAgentSessionStore extends BaseService implements AgentSession
         .where(eq(agentSessionTable.id, existing.sessionId));
       return toAgentMessageView(row);
     });
+    publishDataApiChanges(['/agent-sessions', `/agent-sessions/${message.sessionId}`]);
+    return message;
   }
 
   async reconcileInterrupted(error: AgentErrorView): Promise<AgentMessageView[]> {

--- a/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
@@ -986,7 +986,7 @@ describe('SqliteAgentSessionStore database guarantees', () => {
       notices.push({
         paths,
         inTransaction: raw.isTransaction,
-        row: raw.prepare('SELECT title FROM agent_session WHERE id = ?').get(session.id),
+        row: raw.prepare('SELECT name AS title FROM agent_session WHERE id = ?').get(session.id),
       });
     });
     try {

--- a/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
+++ b/src/backend/ai/agent/sessionStore/__tests__/AgentSessionStore.test.ts
@@ -14,6 +14,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { drizzle } from 'drizzle-orm/sqlite-proxy';
 import { v7 as uuidv7 } from 'uuid';
 
+import { subscribeDataApiChanges } from '@/backend/data/dataApiChanges';
 import { customSqlStatements } from '@/backend/data/db/customSql';
 import type { Database, DbService } from '@/backend/data/db/DbService';
 import { schema } from '@/backend/data/db/schemas';
@@ -973,6 +974,89 @@ describe('SqliteAgentSessionStore database guarantees', () => {
 
   afterEach(() => {
     harness.cleanup();
+  });
+
+  test('publishes a committed automatic title without an active session observer', async () => {
+    const { store, raw } = harness;
+    if (!raw) throw new Error('sqlite harness provides raw access');
+    const agentId = await harness.makeAgentId();
+    const session = await harness.createEmptySession({ agentId });
+    const notices: unknown[] = [];
+    const unsubscribe = subscribeDataApiChanges((paths) => {
+      notices.push({
+        paths,
+        inTransaction: raw.isTransaction,
+        row: raw.prepare('SELECT title FROM agent_session WHERE id = ?').get(session.id),
+      });
+    });
+    try {
+      await store.autoRenameSession(session.id, '', 'Background title');
+      expect(notices).toEqual([
+        {
+          paths: ['/agent-sessions', `/agent-sessions/${session.id}`],
+          inTransaction: false,
+          row: { title: 'Background title' },
+        },
+      ]);
+      await store.autoRenameSession(session.id, '', 'Stale title');
+      expect(notices).toHaveLength(1);
+      await store.renameSession(session.id, 'Manual title');
+      notices.length = 0;
+      await store.autoRenameSession(session.id, 'Manual title', 'Unwanted title');
+      expect(notices).toEqual([]);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  test('publishes background completion activity after commit and skips failed writes', async () => {
+    const { store, raw } = harness;
+    if (!raw) throw new Error('sqlite harness provides raw access');
+    const agentId = await harness.makeAgentId();
+    const session = await harness.createEmptySession({ agentId });
+    const reserved = await store.reserveSubmission({
+      ...messageIds(),
+      ...RESERVATION_FACTS,
+      sessionId: session.id,
+      userParts: [{ id: 'input-0', type: 'text', text: 'Hello.', state: 'done' }],
+    });
+    const completedAt = Date.now() + 1_000;
+    const notices: unknown[] = [];
+    const unsubscribe = subscribeDataApiChanges((paths) => {
+      notices.push({
+        paths,
+        inTransaction: raw.isTransaction,
+        row: raw.prepare('SELECT last_activity_at FROM agent_session WHERE id = ?').get(session.id),
+      });
+    });
+    const finalization = {
+      assistantMessageId: reserved.assistantMessage.id,
+      status: 'success' as const,
+      parts: [],
+      usage: null,
+      error: null,
+      contextCheckpoint: null,
+      runtimeStats: { runtimeTiming: terminalTiming(completedAt) },
+    };
+    try {
+      await store.finalizeAssistantMessage(finalization);
+      expect(notices).toEqual([
+        {
+          paths: ['/agent-sessions', `/agent-sessions/${session.id}`],
+          inTransaction: false,
+          row: { last_activity_at: completedAt },
+        },
+      ]);
+      await expect(
+        store.finalizeAssistantMessage({
+          ...finalization,
+          assistantMessageId: uuidv7(),
+        }),
+      ).rejects.toThrow();
+      expect(notices).toHaveLength(1);
+    } finally {
+      unsubscribe();
+    }
   });
 
   test('rolls back the Session when its initial message reservation fails', async () => {

--- a/src/backend/data/services/ProviderService.ts
+++ b/src/backend/data/services/ProviderService.ts
@@ -61,6 +61,7 @@ export type CreateProviderInput = {
 type ProviderInputWithoutOrderKey = Omit<InsertUserProviderRow, 'orderKey'>;
 export type UpdateProviderInput = {
   apiFeatures?: Partial<RuntimeApiFeatures> | null;
+  apiKeys?: ApiKeyEntry[];
   authConfig?: AuthConfig | null;
   defaultChatEndpoint?: InsertUserProviderRow['defaultChatEndpoint'] | null;
   endpointConfigs?: EndpointConfigs | null;
@@ -545,6 +546,9 @@ export class ProviderService {
   async update(providerId: string, input: UpdateProviderInput): Promise<Provider> {
     const updates: Partial<InsertUserProviderRow> = {};
 
+    if (input.apiKeys !== undefined) {
+      updates.apiKeys = normalizeApiKeys(input.apiKeys);
+    }
     if (input.apiFeatures !== undefined) {
       updates.apiFeatures = input.apiFeatures;
     }

--- a/src/backend/data/services/__tests__/providerModelEndpointIntegrity.integration.test.ts
+++ b/src/backend/data/services/__tests__/providerModelEndpointIntegrity.integration.test.ts
@@ -66,6 +66,44 @@ describe('custom provider model endpoint integrity', () => {
     ).resolves.toMatchObject({ defaultChatEndpoint: 'anthropic-messages' });
   });
 
+  it('commits configuration and keys together and preserves both on validation failure', async () => {
+    const providerId = 'atomic-config';
+    await createProvider(providerId);
+    const apiKeys = [{ id: 'key-1', key: 'sk-new', isEnabled: true }];
+    await providers.update(providerId, {
+      name: 'Saved configuration',
+      apiKeys,
+      endpointConfigs: {
+        'openai-chat-completions': { baseUrl: 'https://new.example.com/v1' },
+      },
+    });
+    await expect(providers.listApiKeys(providerId)).resolves.toMatchObject({ keys: apiKeys });
+    await expect(providers.getByProviderId(providerId)).resolves.toMatchObject({
+      name: 'Saved configuration',
+      endpointConfigs: {
+        'openai-chat-completions': { baseUrl: 'https://new.example.com/v1' },
+      },
+    });
+
+    await expect(
+      providers.update(providerId, {
+        name: 'Invalid keys',
+        apiKeys: [{ ...apiKeys[0], key: ' ' }],
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    await expect(
+      providers.update(providerId, {
+        name: 'Invalid endpoint',
+        apiKeys: [{ ...apiKeys[0], key: 'sk-should-not-save' }],
+        defaultChatEndpoint: 'anthropic-messages',
+      }),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    await expect(providers.getByProviderId(providerId)).resolves.toMatchObject({
+      name: 'Saved configuration',
+    });
+    await expect(providers.listApiKeys(providerId)).resolves.toMatchObject({ keys: apiKeys });
+  });
+
   it('rejects a model endpoint write after the provider endpoint was removed', async () => {
     await createProvider('provider-c');
     await models.create({

--- a/src/backend/services/file/__tests__/fileStorage.test.ts
+++ b/src/backend/services/file/__tests__/fileStorage.test.ts
@@ -541,6 +541,7 @@ describe('fileStorage', () => {
     expect(entries.updateSizeTx).toHaveBeenCalledWith(tx, entry.id, 14);
     expect(rewritten.size).toBe(14);
     expect(onFileChange).toHaveBeenCalledTimes(1);
+    expect(onFileChange).toHaveBeenCalledWith(entry.id);
   });
 
   test('refuses to rewrite a draft whose bytes are missing', async () => {

--- a/src/backend/services/file/fileStorage.ts
+++ b/src/backend/services/file/fileStorage.ts
@@ -26,10 +26,10 @@ import { resolveTextImportMediaType } from '@/shared/utils/textFileTypes';
 const DATA_DIRECTORY_NAME = 'Data';
 const FILE_DIRECTORY_NAME = 'Files';
 const logger = loggerService.withContext('fileStorage');
-const fileChanges = new Emitter<void>();
+const fileChanges = new Emitter<FileEntryId>();
 
 /** All managed-file writers notify here, after their entry changes commit. */
-export function subscribeFileChanges(listener: () => void): () => void {
+export function subscribeFileChanges(listener: (entryId: FileEntryId) => void): () => void {
   const subscription = fileChanges.event(listener);
   return () => subscription.dispose();
 }
@@ -190,7 +190,7 @@ export async function createInternalEntry(
   const written = await writeInternalFile(input);
   try {
     const entry = await entries.create(written);
-    fileChanges.fire();
+    fileChanges.fire(entry.id);
     return entry;
   } catch (error) {
     try {
@@ -259,7 +259,7 @@ export async function discardInternalEntries(
     } catch (error) {
       logger.warn('Failed to delete a discarded internal file', error as Error, { id: entry.id });
     }
-    fileChanges.fire();
+    fileChanges.fire(entry.id);
   }
 }
 
@@ -289,7 +289,7 @@ export async function rewriteInternalTextEntry(
     throw new Error(`Rewritten internal file has an invalid size: ${file.uri}`);
   }
   const updatedEntry = await entries.withWriteTx((tx) => entries.updateSizeTx(tx, entry.id, size));
-  fileChanges.fire();
+  fileChanges.fire(entry.id);
   return updatedEntry;
 }
 
@@ -320,7 +320,7 @@ export async function deleteInternalEntry(
   } catch (error) {
     logger.warn('Failed to unlink a deleted internal file', error as Error, { id });
   }
-  fileChanges.fire();
+  fileChanges.fire(id);
   return true;
 }
 

--- a/src/frontend/data/FileQueryBridge.tsx
+++ b/src/frontend/data/FileQueryBridge.tsx
@@ -4,15 +4,26 @@ import { useEffect } from 'react';
 import { useBackendModule } from './BackendProvider';
 import { queryKeys } from './queryKeys';
 
-/** Keep every file list current, including writes made without a mounted composer or library. */
+/** Refresh lists and the changed file's detail/content, including background draft edits. */
 export function FileQueryBridge() {
   const file = useBackendModule('file');
   const queryClient = useQueryClient();
 
   useEffect(
     () =>
-      file.subscribeChanges(() => {
-        void queryClient.invalidateQueries({ queryKey: queryKeys.files.entries() });
+      file.subscribeChanges((entryId) => {
+        const listPath = queryKeys.files.entries()[0];
+        const detailPath = `${listPath}/${entryId}`;
+        void queryClient.invalidateQueries({
+          predicate: ({ queryKey: [resource, idOrKind, entries] }) =>
+            resource === listPath ||
+            resource === detailPath ||
+            (resource === 'files' &&
+              (idOrKind === entryId ||
+                (idOrKind === 'preview-uri-page' &&
+                  Array.isArray(entries) &&
+                  entries.some((entry) => entry.id === entryId)))),
+        });
       }),
     [file, queryClient],
   );

--- a/src/frontend/data/README.md
+++ b/src/frontend/data/README.md
@@ -9,7 +9,7 @@ src/frontend/data/
 ├── PreferenceProvider.tsx  # internal PreferenceClient injection for preference hooks
 ├── CacheService.ts         # frontend memory and persisted UI cache
 ├── QueryProvider.tsx       # React Query client and AppState focus bridge
-├── FileQueryBridge.tsx     # invalidates shared file lists after managed-file writes
+├── FileQueryBridge.tsx     # invalidates file lists and affected details/content after writes
 ├── ProviderRegistryQueryBridge.tsx # invalidates model projections after a registry hot-swap
 ├── queryKeys/              # one file per endpoint family plus the public registry
 ├── hooks/                  # typed Data API, preference, and cache React bindings
@@ -23,9 +23,11 @@ directory does not duplicate those endpoints as service or gateway wrappers.
 
 `FileQueryBridge` subscribes to the file workflow's committed changes for the app lifetime.
 Managed-file creation, draft rewrites, deletion, and rollback discards all notify through
-`fileStorage`; the bridge invalidates every file-list page size while retaining versioned URI and
-preview caches. Composer, painting, and Agent callers only perform their file operation. Library
-and picker readers reuse fresh pages and receive updates without owning focus or write refreshes.
+`fileStorage` with the affected entry id. The bridge invalidates every file-list page size and that
+entry's detail, URI, text, and preview caches, including pages containing it. Unchanged files retain
+their caches; content refresh does not rely on a draft's timestamp changing. Composer, painting, and
+Agent callers only perform their file operation. Library and picker readers reuse fresh pages and
+receive updates without owning focus or write refreshes.
 
 Preferences remain a separate client and hook family, matching Cherry Desktop. `BackendProvider`
 is reserved for multi-step workflows and long-lived sessions defined in `shared/contracts`; it is

--- a/src/frontend/features/library/components/FileLibraryList.tsx
+++ b/src/frontend/features/library/components/FileLibraryList.tsx
@@ -79,7 +79,7 @@ export function FileLibraryList({
   const { enterEditing, toggleId } = useSelectionActions();
   const { isDeletionPending, isEditing, selectedIds } = useSelectionState();
   const { width: windowWidth } = useWindowDimensions();
-  const { entries, isLoading, isLoadingMore, loadMore } = useFileEntries(filter, {
+  const { entries, error, isLoading, isLoadingMore, loadMore, refresh } = useFileEntries(filter, {
     enabled: isDataLoadEnabled,
   });
   const visibleEntries = useMemo(
@@ -179,7 +179,14 @@ export function FileLibraryList({
   const listEmpty = useMemo(
     () => (
       <View style={styles.empty}>
-        {isLoading || isLoadingMore ? (
+        {error ? (
+          <View className="min-h-48 flex-1 justify-center px-6 pb-24">
+            <ContentState.Error
+              primaryAction={{ children: t('common.retry'), onPress: () => void refresh() }}
+              title={t('library.loadFailed')}
+            />
+          </View>
+        ) : isLoading || isLoadingMore ? (
           <FileLibrarySkeleton
             count={fileLibraryGrid.skeletonTiles}
             tileSize={tileSize}
@@ -192,18 +199,25 @@ export function FileLibraryList({
         )}
       </View>
     ),
-    [isLoading, isLoadingMore, t, tileSize, viewMode],
+    [error, isLoading, isLoadingMore, refresh, t, tileSize, viewMode],
   );
   const listFooter = useMemo(
     () =>
-      isLoadingMore && visibleEntries.length > 0 ? (
+      visibleEntries.length === 0 ? null : error ? (
+        <View className="px-6 py-4">
+          <ContentState.Error
+            primaryAction={{ children: t('common.retry'), onPress: () => void refresh() }}
+            title={t('library.loadFailed')}
+          />
+        </View>
+      ) : isLoadingMore ? (
         <FileLibrarySkeleton
           count={fileLibraryGrid.columns}
           tileSize={tileSize}
           viewMode={viewMode}
         />
       ) : null,
-    [isLoadingMore, tileSize, viewMode, visibleEntries.length],
+    [error, isLoadingMore, refresh, t, tileSize, viewMode, visibleEntries.length],
   );
 
   return (

--- a/src/frontend/features/library/hooks/__tests__/useFileEntries.test.tsx
+++ b/src/frontend/features/library/hooks/__tests__/useFileEntries.test.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { type ReactNode, useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
@@ -8,7 +8,7 @@ import { FileQueryBridge } from '@/frontend/data/FileQueryBridge';
 import { queryKeys } from '@/frontend/data/queryKeys';
 import type { Backend } from '@/shared/contracts';
 import type { ApiClient } from '@/shared/data/api/types';
-import { FileEntrySchema } from '@/shared/data/types/file';
+import { FileEntrySchema, type FileEntryId } from '@/shared/data/types/file';
 
 import { useFileEntries } from '../useFileEntries';
 
@@ -64,12 +64,12 @@ const generatePreviewUri = jest.fn(
       completePreview = resolve;
     }),
 );
-const fileChangeListeners = new Set<() => void>();
+const fileChangeListeners = new Set<(entryId: FileEntryId) => void>();
 const backend = {
   file: {
     generatePreviewUri,
     resolveUris,
-    subscribeChanges: (listener: () => void) => {
+    subscribeChanges: (listener: (entryId: FileEntryId) => void) => {
       fileChangeListeners.add(listener);
       return () => fileChangeListeners.delete(listener);
     },
@@ -237,7 +237,7 @@ describe('useFileEntries', () => {
     // Background generation finishes with only the app-wide bridge mounted.
     await act(async () => renderer?.update(<Providers>{null}</Providers>));
     dataApi.get.mockResolvedValueOnce({ items: [generatedEntry, entry, documentEntry] });
-    await act(async () => notifyFileChange());
+    await act(async () => notifyFileChange(generatedEntry.id));
     expect(dataApi.get).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -288,7 +288,7 @@ describe('useFileEntries', () => {
     const previews = previewKeys.map((key) => queryClient.getQueryData(key));
 
     dataApi.get.mockResolvedValueOnce({ items: [generatedEntry, entry, documentEntry] });
-    await act(async () => notifyFileChange());
+    await act(async () => notifyFileChange(generatedEntry.id));
     await flushQueryNotifications();
     await flushQueryNotifications();
 
@@ -304,16 +304,16 @@ describe('useFileEntries', () => {
     }
     expect(generatePreviewUri).toHaveBeenCalledTimes(1);
 
-    const rewrittenEntry = FileEntrySchema.parse({ ...generatedEntry, size: 1024, updatedAt: 4 });
+    const rewrittenEntry = FileEntrySchema.parse({ ...generatedEntry, size: 1024 });
     dataApi.get.mockResolvedValueOnce({ items: [rewrittenEntry, entry, documentEntry] });
-    await act(async () => notifyFileChange());
+    await act(async () => notifyFileChange(generatedEntry.id));
     await flushQueryNotifications();
     await flushQueryNotifications();
     expect(latestResult?.entries[0].entry).toEqual(rewrittenEntry);
 
     // Deletion uses the same notification, regardless of which workflow owns it.
     dataApi.get.mockResolvedValueOnce({ items: [documentEntry] });
-    await act(async () => notifyFileChange());
+    await act(async () => notifyFileChange(entry.id));
     await flushQueryNotifications();
     await flushQueryNotifications();
     expect(latestResult?.entries.map((item) => item.entry.id)).toEqual([documentEntry.id]);
@@ -328,13 +328,111 @@ describe('useFileEntries', () => {
     await act(async () => renderer?.unmount());
     renderer = undefined;
 
-    notifyFileChange();
+    notifyFileChange(generatedEntry.id);
     expect(queryClient.getQueryState(pagesKey)?.isInvalidated).toBe(false);
+  });
+
+  test('refreshes an open draft and its detail even when the timestamp has not changed', async () => {
+    let currentEntry = generatedEntry;
+    let content = 'old content';
+    let displayedText: string | undefined;
+    const detailKey = [`/files/entries/${generatedEntry.id}`];
+    const textKey = queryKeys.files.viewerText(generatedEntry, 'file:///draft.txt');
+    const affectedPage = queryKeys.files.previewUriPage([generatedEntry, documentEntry]);
+    const otherTextKey = queryKeys.files.viewerText(documentEntry, 'file:///notes.pdf');
+    const readText = jest.fn(async () => content);
+    function DraftProbe() {
+      const detail = useQuery({ queryKey: detailKey, queryFn: async () => currentEntry });
+      const text = useQuery({ queryKey: textKey, queryFn: readText, staleTime: Infinity });
+      useEffect(() => {
+        displayedText = text.data;
+      }, [detail.data, text.data]);
+      return null;
+    }
+    queryClient.setQueryData(affectedPage, []);
+    queryClient.setQueryData(otherTextKey, 'unchanged');
+    await act(async () => {
+      renderer = create(
+        <Providers>
+          <DraftProbe />
+        </Providers>,
+      );
+    });
+    await flushQueryNotifications();
+    expect(displayedText).toBe('old content');
+
+    content = 'rewritten content';
+    currentEntry = FileEntrySchema.parse({ ...generatedEntry, size: 1024 });
+    await act(async () => notifyFileChange(generatedEntry.id));
+    await flushQueryNotifications();
+
+    expect(displayedText).toBe('rewritten content');
+    expect(readText).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData(detailKey)).toEqual(currentEntry);
+    expect(queryClient.getQueryState(affectedPage)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(otherTextKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryData(otherTextKey)).toBe('unchanged');
+  });
+
+  test.each(['entries', 'uris'] as const)(
+    'exposes a failed %s load and recovers on retry',
+    async (source) => {
+      const error = new Error('File load failed');
+      if (source === 'entries') dataApi.get.mockRejectedValueOnce(error);
+      else resolveUris.mockRejectedValueOnce(error);
+      await act(async () => {
+        renderer = create(
+          <Providers>
+            <Probe enabled />
+          </Providers>,
+        );
+      });
+      await flushQueryNotifications();
+      await flushQueryNotifications();
+
+      expect(latestResult?.error).toBe(error);
+      expect(latestResult?.entries).toEqual([]);
+      expect(latestResult?.isLoading).toBe(false);
+      const callsBeforeLoadMore = dataApi.get.mock.calls.length;
+      await act(async () => latestResult?.loadMore());
+      expect(dataApi.get).toHaveBeenCalledTimes(callsBeforeLoadMore);
+
+      await act(async () => {
+        await latestResult?.refresh();
+      });
+      await flushQueryNotifications();
+      await flushQueryNotifications();
+      expect(latestResult?.error).toBeUndefined();
+      expect(latestResult?.entries.map((item) => item.entry.id)).toEqual([
+        entry.id,
+        documentEntry.id,
+      ]);
+    },
+  );
+
+  test('keeps loaded entries and stops automatic pagination after a later page fails', async () => {
+    const error = new Error('Next page failed');
+    dataApi.get.mockResolvedValueOnce({ items: [documentEntry], nextCursor: 'next' });
+    dataApi.get.mockRejectedValueOnce(error);
+    await act(async () => {
+      renderer = create(
+        <Providers>
+          <Probe enabled />
+        </Providers>,
+      );
+    });
+    await flushQueryNotifications();
+    await flushQueryNotifications();
+    expect(latestResult?.error).toBe(error);
+    expect(latestResult?.entries.map((item) => item.entry.id)).toEqual([documentEntry.id]);
+    await act(async () => latestResult?.loadMore());
+    await flushQueryNotifications();
+    expect(dataApi.get).toHaveBeenCalledTimes(2);
   });
 });
 
-function notifyFileChange() {
-  for (const listener of fileChangeListeners) listener();
+function notifyFileChange(entryId: FileEntryId) {
+  for (const listener of fileChangeListeners) listener(entryId);
 }
 
 async function flushQueryNotifications() {

--- a/src/frontend/features/library/hooks/useFileEntries.ts
+++ b/src/frontend/features/library/hooks/useFileEntries.ts
@@ -30,23 +30,25 @@ export function useFileEntries(filter: FileLibraryFilter, { enabled }: { enabled
   );
 
   useFillViewport({
-    enabled,
+    enabled: enabled && !query.error,
     hasNext: query.hasNext,
     isLoadingMore: query.isLoadingMore,
     loadNext,
     visibleCount: entries.length,
   });
   const loadMore = useCallback(() => {
-    if (enabled) {
+    if (enabled && !query.error) {
       void loadNext();
     }
-  }, [enabled, loadNext]);
+  }, [enabled, loadNext, query.error]);
 
   return {
     entries,
+    error: query.error,
     isLoading: query.isLoading,
     isLoadingMore: query.isLoadingMore,
     loadMore,
+    refresh: query.refresh,
   };
 }
 

--- a/src/frontend/features/settings/provider/apiService/README.md
+++ b/src/frontend/features/settings/provider/apiService/README.md
@@ -12,7 +12,8 @@ This module owns provider API key, auth, endpoint validation, query, and save he
   and success feedback. Setup additionally requires usable credentials before continuing.
 - The same save path protects referenced endpoints and confirms default-endpoint changes that
   affect existing models. Provider enabled state belongs to the explicit setup workflow.
-- Save is explicit. After provider and API-key mutations finish, the mounted form resets its
+- Save is explicit. Provider configuration and changed API keys commit together through one
+  provider update transaction. After that save finishes, the mounted form resets its
   baseline to the saved values; leaving with a dirty draft asks for confirmation.
 
 ## Public Interface

--- a/src/frontend/features/settings/provider/apiService/hooks/__tests__/useProviderConfigurationForm.test.tsx
+++ b/src/frontend/features/settings/provider/apiService/hooks/__tests__/useProviderConfigurationForm.test.tsx
@@ -30,6 +30,7 @@ const followingModel: Model = {
 };
 let mockModels: Model[] = [];
 const mockSave = jest.fn();
+const mockReplaceApiKeys = jest.fn();
 const mockConfirm = jest.fn();
 const mockAlert = jest.fn();
 const mockToast = jest.fn();
@@ -57,7 +58,7 @@ jest.mock('../useProviderApiServiceQueries', () => ({
     authConfigQuery: { isPending: false, isError: false },
     isSaving: false,
     saveProviderMutation: { mutateAsync: mockSave },
-    replaceApiKeysMutation: { mutateAsync: jest.fn() },
+    replaceApiKeysMutation: { mutateAsync: mockReplaceApiKeys },
   }),
 }));
 jest.mock('../../../components/ProviderForm', () => ({
@@ -135,14 +136,45 @@ describe('shared provider configuration saves', () => {
   it('retains the draft and prevents continuation when persistence fails', async () => {
     const onSaved = jest.fn();
     mockSave.mockRejectedValue(new Error('write failed'));
-    act(() => configuration.form.actions.setName('Unsaved'));
+    act(() => {
+      configuration.form.actions.setName('Unsaved');
+      configuration.form.actions.setApiKey('sk-new');
+    });
     await act(async () => {
       configuration.requestSave(onSaved);
     });
     expect(configuration.form.state.name).toBe('Unsaved');
+    expect(configuration.form.state.apiKey).toBe('sk-new');
+    expect(mockReplaceApiKeys).not.toHaveBeenCalled();
     expect(configuration.form.meta.isDirty).toBe(true);
     expect(configuration.isSaving).toBe(false);
     expect(onSaved).not.toHaveBeenCalled();
     expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'danger' }));
+  });
+
+  it('submits changed endpoints and keys together before clearing the draft', async () => {
+    act(() => {
+      configuration.form.actions.setEndpointUrl(
+        ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        'https://new.example.com/v1',
+      );
+      configuration.form.actions.setApiKey('sk-new');
+    });
+
+    await act(async () => configuration.requestSave());
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeys: [expect.objectContaining({ key: 'sk-new', isEnabled: true })],
+        endpointConfigs: expect.objectContaining({
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: expect.objectContaining({
+            baseUrl: 'https://new.example.com/v1',
+          }),
+        }),
+      }),
+    );
+    expect(mockReplaceApiKeys).not.toHaveBeenCalled();
+    expect(configuration.form.meta.isDirty).toBe(false);
   });
 });

--- a/src/frontend/features/settings/provider/apiService/hooks/useProviderApiServiceQueries.ts
+++ b/src/frontend/features/settings/provider/apiService/hooks/useProviderApiServiceQueries.ts
@@ -31,7 +31,13 @@ export function useProviderApiServiceQueries(providerId: string) {
       '/models',
       '/providers',
       '/providers/page',
-      ...(args ? [`/providers/${args.params.id}`, `/providers/${args.params.id}/auth`] : []),
+      ...(args
+        ? [
+            `/providers/${args.params.id}`,
+            `/providers/${args.params.id}/auth`,
+            ...(args.body?.apiKeys !== undefined ? [`/providers/${args.params.id}/api-keys`] : []),
+          ]
+        : []),
     ],
   });
   const replaceMutation = useMutation('PUT', '/providers/:id/api-keys', {

--- a/src/frontend/features/settings/provider/apiService/hooks/useProviderConfigurationForm.ts
+++ b/src/frontend/features/settings/provider/apiService/hooks/useProviderConfigurationForm.ts
@@ -180,12 +180,8 @@ export function useProviderConfigurationForm(providerId: string) {
       savePending.current = true;
       setIsPersisting(true);
       Keyboard.dismiss();
-      void Promise.all([
-        queries.saveProviderMutation.mutateAsync(updates),
-        shouldSaveApiKeys
-          ? queries.replaceApiKeysMutation.mutateAsync(nextApiKeys)
-          : Promise.resolve(),
-      ])
+      void queries.saveProviderMutation
+        .mutateAsync({ ...updates, ...(shouldSaveApiKeys ? { apiKeys: nextApiKeys } : {}) })
         .then(async () => {
           if (state.avatarUri !== (storedAvatarUri ?? null)) {
             if (state.avatarUri) await providerAvatars.persist(providerId, state.avatarUri);

--- a/src/frontend/hooks/file/useFileEntryPages.ts
+++ b/src/frontend/hooks/file/useFileEntryPages.ts
@@ -80,7 +80,10 @@ export function useFileEntryPages({ enabled }: { enabled: boolean }) {
   );
   const combinePreviews = useCallback(
     (results: readonly FilePreviewResult[]) =>
-      results.map((result, index) => result.data ?? uriPages.entries[index]),
+      results.map((result, index) => {
+        const item = uriPages.entries[index];
+        return fileEntryPreviewKind(item.entry) === 'image' ? (result.data ?? item) : item;
+      }),
     [uriPages.entries],
   );
   const entries = useQueries({ combine: combinePreviews, queries: previewQueries });

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -397,6 +397,7 @@
   "navigation.library": "Files",
   "library.title": "Files",
   "library.empty": "No files yet",
+  "library.loadFailed": "Could not load files",
   "library.filter.label": "File type",
   "library.filter.all": "All",
   "library.filter.images": "Images",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -394,6 +394,7 @@
   "navigation.library": "文件",
   "library.title": "文件",
   "library.empty": "暂无文件",
+  "library.loadFailed": "无法加载文件",
   "library.filter.label": "文件类型",
   "library.filter.all": "全部",
   "library.filter.images": "图片",

--- a/src/shared/contracts/file.ts
+++ b/src/shared/contracts/file.ts
@@ -40,7 +40,7 @@ export type PreparedFile = ResolvedFile & {
 
 export interface FileModule {
   /** Subscribe to committed managed-file creates, rewrites, deletions, and discards. */
-  subscribeChanges(listener: () => void): () => void;
+  subscribeChanges(listener: (entryId: FileEntryId) => void): () => void;
   /** Copies the transient source URI into managed storage and creates the entry. */
   createInternalEntry(input: CreateInternalEntryInput): Promise<ResolvedFile>;
   /** Validates managed references and parses supported content only when the caller submits. */

--- a/src/shared/data/api/schemas/providers.ts
+++ b/src/shared/data/api/schemas/providers.ts
@@ -24,6 +24,7 @@ export type CreateProviderInput = {
 
 export type UpdateProviderInput = {
   apiFeatures?: Partial<RuntimeApiFeatures> | null;
+  apiKeys?: ApiKeyEntry[];
   authConfig?: AuthConfig | null;
   defaultChatEndpoint?: EndpointType | null;
   endpointConfigs?: EndpointConfigs | null;


### PR DESCRIPTION
### What this PR does

Fixes five issues in normal conversation, file, and provider-settings workflows:

| Before | After |
| --- | --- |
| Pi context planning and tool loops only used the total context window, dropping the model's independent input limit. | Input limits apply to context planning, summary requests, and tool loops, with output reserved once. Compacted context is checked before execution. |
| Rewriting a draft file could leave its open preview and details stale, especially when its timestamp did not change. | File changes identify the affected entry and refresh its content, details, and relevant page caches. |
| A background conversation could finish or receive an automatic title without updating the session list. | Committed title and completion changes notify the existing Data API cache bridge. |
| Saving provider connection settings and API keys used separate writes that could partially succeed. | Changed settings and keys commit through one provider update transaction. |
| File-library load failures could appear as an empty library or repeatedly trigger pagination. | The library shows an error and retry action, retains loaded entries, and stops automatic pagination after failure. |

### Why we need it and why it was done in this way

The fixes reuse the existing Pi budget calculations, file change notifications, Data API change bus, provider transaction, and shared error UI. No new persistence or synchronization framework is introduced. Historical provider usage is excluded from the newly compacted context estimate because it still includes the discarded prefix.

### Screenshots or videos

Not captured: device/UI verification was not authorized for this task. The visible UI change is the file-library error and retry state; visual acceptance remains pending.

### Breaking changes

No database migration or user action is required. Internally, file-change callbacks now receive the affected entry ID, and provider PATCH requests accept optional API keys for an atomic configuration save.

### Special notes for your reviewer

- Regression coverage includes independent input limits, compaction, tool-loop limits, committed session notifications, draft-file refresh, provider saves, and file-library recovery.
- [CI passed on `c5b3b0977`](https://github.com/CherryHQ/cherry-studio-app/actions/runs/34372237499): tests, type checking, and lint all succeeded. The workflow also ran package builds, formatting, UI boundary, documentation-link, and skill checks.
- Local changed-file formatting and lint passed, with one pre-existing warning. Local builds, tests, and type checking were not run; device/UI acceptance remains pending.

### Checklist

- [x] This PR targets `v0.2`.
- [x] The description explains the behavior changes and implementation choices.
- [x] The source diff was reviewed locally.
- [x] Existing module documentation was updated where its contract changed.
- [ ] Screenshots or video for the file-library error/retry state.
- [x] Repository CI checks passed on `c5b3b0977`.
- [ ] Device/UI acceptance.

### Release note

```release-note
Fix conversation input budgeting, refresh background session titles and edited draft files, save provider connection settings and API keys together, and provide retry actions for file-library loading errors.
```

