### PR TITLE
Fix Android system location and long selected model labels

### DIFF
--- a/modules/device-location/README.md
+++ b/modules/device-location/README.md
@@ -1,0 +1,23 @@
+# Device Location
+
+Android foreground location through the platform `LocationManager`, without a Google Play services
+dependency. Expo discovers this local module under `modules/`. A new native app build is required;
+an OTA update cannot add the native module to an existing binary.
+
+The caller must obtain foreground location permission first. The module rechecks it, requests the
+enabled network and GPS providers together, and returns the first fix no older than ten seconds.
+Results retain the provider, original timestamp, and reported accuracy. It does not substitute an
+old last-known location. Approximate permission remains valid; the OS controls coordinate precision.
+
+Each request has a native 30-second deadline. Success, failure, cancellation, and module destruction
+remove its listeners and deadline. `createRequest()` reserves a cancellation handle synchronously,
+so `cancelRequest(id)` also prevents a queued `getCurrentPosition(id)` from starting. Every created
+handle must be released with `cancelRequest(id)` in the caller's `finally` block.
+
+The app service retains Expo location on iOS and uses Expo's platform geocoder for optional addresses.
+An unavailable address does not discard coordinates. Cancelling address lookup stops waiting;
+Expo's geocoder does not expose native cancellation.
+
+Device acceptance should cover a phone without Google Play services, GPS-only operation,
+approximate permission, services disabled mid-request, timeout, immediate cancellation, and
+repeated calls after cancellation.

--- a/modules/device-location/android/build.gradle
+++ b/modules/device-location/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.devicelocation'
+version = '1.0.0'
+
+android {
+  namespace 'expo.modules.devicelocation'
+  defaultConfig {
+    versionCode 1
+    versionName '1.0.0'
+  }
+}

--- a/modules/device-location/android/src/main/AndroidManifest.xml
+++ b/modules/device-location/android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+</manifest>

--- a/modules/device-location/android/src/main/java/expo/modules/devicelocation/DeviceLocationModule.kt
+++ b/modules/device-location/android/src/main/java/expo/modules/devicelocation/DeviceLocationModule.kt
@@ -1,0 +1,200 @@
+package expo.modules.devicelocation
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Build
+import android.os.Bundle
+import android.os.CancellationSignal
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.functions.Queues
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+private const val REQUEST_TIMEOUT_MS = 30_000L
+private const val MAX_FIX_AGE_NS = 10_000_000_000L
+
+class DeviceLocationModule : Module() {
+  private val handler = Handler(Looper.getMainLooper())
+  private val requests = ConcurrentHashMap<String, CancellationSignal>()
+
+  override fun definition() = ModuleDefinition {
+    Name("DeviceLocation")
+
+    // Reserve synchronously so cancellation cannot overtake the queued async start.
+    Function("createRequest") {
+      val id = UUID.randomUUID().toString()
+      requests[id] = CancellationSignal()
+      id
+    }
+
+    AsyncFunction("getCurrentPosition") { id: String, promise: Promise ->
+      val cancellation = requests[id]
+      val context = appContext.reactContext
+      when {
+        cancellation == null -> promise.reject("E_LOCATION_CANCELLED", "Location request cancelled", null)
+        context == null -> {
+          requests.remove(id)
+          promise.reject("E_LOCATION_UNAVAILABLE", "Android location context is unavailable", null)
+        }
+        else -> LocationRequest(id, context, cancellation, promise).start()
+      }
+    }.runOnQueue(Queues.MAIN)
+
+    Function("cancelRequest") { id: String ->
+      requests.remove(id)?.cancel()
+    }
+
+    OnDestroy {
+      requests.values.forEach { it.cancel() }
+      requests.clear()
+    }
+  }
+
+  // All provider callbacks, deadlines, and cleanup run on the main looper.
+  private inner class LocationRequest(
+    private val id: String,
+    private val context: Context,
+    private val cancellation: CancellationSignal,
+    private val promise: Promise,
+  ) {
+    private val manager = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+    private val listeners = mutableMapOf<String, LocationListener>()
+    private var settled = false
+    private val timeout = Runnable {
+      if (!hasPermission()) {
+        fail("E_LOCATION_PERMISSION_DENIED", "Location permission was revoked during the request")
+      } else {
+        fail(
+          "E_LOCATION_TIMEOUT",
+          "Android system location returned no fresh fix within 30 seconds (providers: ${listeners.keys.joinToString()}). " +
+            "This does not establish a permission failure. Check system location settings or move somewhere with a clearer sky view before trying again."
+        )
+      }
+    }
+
+    fun start() {
+      cancellation.setOnCancelListener {
+        handler.post { fail("E_LOCATION_CANCELLED", "Location request cancelled") }
+      }
+      if (cancellation.isCanceled) {
+        fail("E_LOCATION_CANCELLED", "Location request cancelled")
+        return
+      }
+      if (!hasPermission()) {
+        fail("E_LOCATION_PERMISSION_DENIED", "Foreground location permission is denied")
+        return
+      }
+      val locationManager = manager
+      if (locationManager == null) {
+        fail("E_LOCATION_UNAVAILABLE", "Android system location is unavailable")
+        return
+      }
+
+      try {
+        val providers = listOf(LocationManager.NETWORK_PROVIDER, LocationManager.GPS_PROVIDER)
+          .filter { locationManager.allProviders.contains(it) && locationManager.isProviderEnabled(it) }
+        if (providers.isEmpty()) {
+          fail("E_LOCATION_SERVICES_DISABLED", "No GPS or network location provider is enabled. Enable system location before trying again.")
+          return
+        }
+        handler.postDelayed(timeout, REQUEST_TIMEOUT_MS)
+        var registrationError: Exception? = null
+        for (provider in providers) {
+          val listener = object : LocationListener {
+            override fun onLocationChanged(location: Location) {
+              if (settled || cancellation.isCanceled) return
+              val age = SystemClock.elapsedRealtimeNanos() - location.elapsedRealtimeNanos
+              // Never pass a stale last-known position off as the current location.
+              if (age !in 0..MAX_FIX_AGE_NS) return
+              cleanup()
+              promise.resolve(location.toResult())
+            }
+
+            override fun onProviderDisabled(provider: String) {
+              if (settled) return
+              listeners.remove(provider)?.let { removeListener(it) }
+              if (listeners.isEmpty()) {
+                fail("E_LOCATION_SERVICES_DISABLED", "The active system location providers were disabled during the request")
+              }
+            }
+
+            override fun onProviderEnabled(provider: String) = Unit
+
+            @Deprecated("Only used before Android Q")
+            override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) = Unit
+          }
+          listeners[provider] = listener
+          try {
+            locationManager.requestLocationUpdates(provider, 1_000L, 0f, listener, Looper.getMainLooper())
+          } catch (error: Exception) {
+            listeners.remove(provider)
+            removeListener(listener)
+            registrationError = error
+          }
+        }
+        if (listeners.isEmpty()) {
+          val denied = registrationError is SecurityException
+          fail(
+            if (denied) "E_LOCATION_PERMISSION_DENIED" else "E_LOCATION_UNAVAILABLE",
+            if (denied) "System location providers rejected the current location permission"
+            else "Could not start Android system location providers"
+          )
+        }
+      } catch (error: SecurityException) {
+        fail("E_LOCATION_PERMISSION_DENIED", "System location access was denied")
+      } catch (error: Exception) {
+        fail("E_LOCATION_UNAVAILABLE", "Could not access Android system location providers")
+      }
+    }
+
+    private fun hasPermission() =
+      context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+        context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+
+    private fun fail(code: String, message: String) {
+      if (settled) return
+      cleanup()
+      promise.reject(code, message, null)
+    }
+
+    private fun cleanup() {
+      settled = true
+      handler.removeCallbacks(timeout)
+      cancellation.setOnCancelListener(null)
+      listeners.values.forEach { removeListener(it) }
+      listeners.clear()
+      requests.remove(id)
+    }
+
+    private fun removeListener(listener: LocationListener) {
+      try {
+        manager?.removeUpdates(listener)
+      } catch (_: SecurityException) {
+        // Revoking permission also removes the OS registration.
+      }
+    }
+  }
+}
+
+private fun Location.toResult(): Map<String, Any?> = mapOf(
+  "coords" to mapOf(
+    "latitude" to latitude,
+    "longitude" to longitude,
+    "accuracy" to if (hasAccuracy()) accuracy.toDouble() else null,
+    "altitude" to if (hasAltitude()) altitude else null,
+    "altitudeAccuracy" to if (Build.VERSION.SDK_INT >= 26 && hasVerticalAccuracy()) verticalAccuracyMeters.toDouble() else null,
+    "heading" to if (hasBearing()) bearing.toDouble() else null,
+    "speed" to if (hasSpeed()) speed.toDouble() else null,
+  ),
+  "provider" to provider,
+  "timestamp" to time.toDouble(),
+)

--- a/modules/device-location/expo-module.config.json
+++ b/modules/device-location/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.devicelocation.DeviceLocationModule"]
+  }
+}

--- a/modules/device-location/index.ts
+++ b/modules/device-location/index.ts
@@ -1,0 +1,25 @@
+import { requireOptionalNativeModule } from 'expo';
+
+export type DeviceLocation = {
+  coords: {
+    accuracy: number | null;
+    altitude: number | null;
+    altitudeAccuracy: number | null;
+    heading: number | null;
+    latitude: number;
+    longitude: number;
+    speed: number | null;
+  };
+  provider: string | null;
+  timestamp: number;
+};
+
+export type DeviceLocationModule = {
+  createRequest(): string;
+  getCurrentPosition(requestId: string): Promise<DeviceLocation>;
+  cancelRequest(requestId: string): void;
+};
+
+export function getDeviceLocation(): DeviceLocationModule | null {
+  return requireOptionalNativeModule<DeviceLocationModule>('DeviceLocation');
+}

--- a/modules/device-location/package.json
+++ b/modules/device-location/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@cherrystudio/device-location",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.ts"
+}

--- a/packages/ui/src/components/section/section.tsx
+++ b/packages/ui/src/components/section/section.tsx
@@ -40,9 +40,11 @@ type InternalSectionSwitchItemProps = SectionSwitchItemProps & {
   onPressedChange?: (isPressed: boolean) => void;
 };
 
-function renderTextSlot(content: ReactNode, className?: string) {
+function renderTextSlot(content: ReactNode, className?: string, numberOfLines?: number) {
   return typeof content === 'string' || typeof content === 'number' ? (
-    <Text className={className}>{content}</Text>
+    <Text className={className} numberOfLines={numberOfLines}>
+      {content}
+    </Text>
   ) : (
     content
   );
@@ -198,7 +200,7 @@ function SectionSelectItem({
           {valueLeading ? (
             <View className="shrink-0 items-center justify-center">{valueLeading}</View>
           ) : null}
-          {renderTextSlot(value, 'min-w-0 shrink text-right text-base text-foreground')}
+          {renderTextSlot(value, 'min-w-0 shrink text-right text-base text-foreground', 1)}
           <ChevronDownIcon
             className="size-5 shrink-0 text-muted-foreground"
             testID="section-select-chevron"

--- a/src/backend/ai/agent/tools/device/__tests__/locationTools.test.ts
+++ b/src/backend/ai/agent/tools/device/__tests__/locationTools.test.ts
@@ -1,0 +1,58 @@
+import { getCurrentLocation } from '@/backend/services/device';
+
+import { createLocationTools } from '../locationTools';
+
+jest.mock('@/backend/services/device', () => ({ getCurrentLocation: jest.fn() }));
+
+function execute(signal = new AbortController().signal) {
+  const [tool] = createLocationTools({
+    devicePermissions: {
+      getStatuses: jest.fn(async () => ({
+        'location.read': { state: 'granted' as const, canAskAgain: false },
+      })),
+      request: jest.fn(),
+    },
+  });
+  return tool!.execute({
+    input: { includeAddress: false },
+    signal,
+    toolCallId: 'location-1',
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+test.each(['E_LOCATION_TIMEOUT', 'E_LOCATION_SERVICES_DISABLED', 'E_LOCATION_PERMISSION_DENIED'])(
+  'reports %s as a position failure without instructing a blind retry',
+  async (code) => {
+    jest
+      .mocked(getCurrentLocation)
+      .mockRejectedValue(Object.assign(new Error('Native reason'), { code }));
+    const result = await execute();
+    expect(result.value).toMatchObject({
+      status: 'error',
+      stage: 'position',
+      code,
+      retryable: false,
+      message: expect.stringContaining('Native reason'),
+    });
+    expect(result.value).toMatchObject({ message: expect.not.stringContaining('Retry once') });
+  },
+);
+
+test('turn cancellation reaches the location operation and propagates out of the tool', async () => {
+  const controller = new AbortController();
+  jest.mocked(getCurrentLocation).mockImplementation(async (_input, signal) => {
+    expect(signal).toBe(controller.signal);
+    controller.abort();
+    throw controller.signal.reason;
+  });
+  await expect(execute(controller.signal)).rejects.toMatchObject({ name: 'AbortError' });
+});
+
+test('native cancellation propagates instead of becoming a retryable tool failure', async () => {
+  jest
+    .mocked(getCurrentLocation)
+    .mockRejectedValue(Object.assign(new Error('Cancelled'), { code: 'E_LOCATION_CANCELLED' }));
+  await expect(execute()).rejects.toMatchObject({ name: 'AbortError' });
+});

--- a/src/backend/ai/agent/tools/device/locationTools.ts
+++ b/src/backend/ai/agent/tools/device/locationTools.ts
@@ -17,7 +17,29 @@ export function createLocationTools(deps: DeviceToolDependencies) {
       displayName: 'Current location',
       inputSchema: currentLocationSchema,
       permissionScopes: ['location.read'],
-      run: (input) => getCurrentLocation({ includeAddress: input.includeAddress }),
+      run: async (input, signal) => {
+        try {
+          return await getCurrentLocation({ includeAddress: input.includeAddress }, signal);
+        } catch (error) {
+          const code =
+            error && typeof error === 'object' && 'code' in error
+              ? String(error.code)
+              : 'E_LOCATION_FAILED';
+          if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+            throw error;
+          }
+          if (code === 'E_LOCATION_CANCELLED') {
+            throw Object.assign(new Error('Location request cancelled'), { name: 'AbortError' });
+          }
+          return {
+            status: 'error',
+            stage: 'position',
+            code,
+            message: `${error instanceof Error ? error.message : String(error)} Tell the user the reported reason; do not automatically repeat this location request.`,
+            retryable: false,
+          };
+        }
+      },
     }),
   ];
 }

--- a/src/backend/services/device/__tests__/location.test.ts
+++ b/src/backend/services/device/__tests__/location.test.ts
@@ -1,0 +1,138 @@
+import * as Location from 'expo-location';
+import { Platform } from 'react-native';
+
+import { type DeviceLocation, getDeviceLocation } from '../../../../../modules/device-location';
+import { getCurrentLocation } from '../location';
+
+jest.mock('../../../../../modules/device-location', () => ({ getDeviceLocation: jest.fn() }));
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+jest.mock('expo-location', () => ({
+  Accuracy: { Balanced: 3 },
+  getCurrentPositionAsync: jest.fn(),
+  reverseGeocodeAsync: jest.fn(),
+}));
+
+const position: DeviceLocation = {
+  coords: {
+    latitude: 31.23,
+    longitude: 121.47,
+    accuracy: 1200,
+    altitude: null,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null,
+  },
+  provider: 'network',
+  timestamp: Date.parse('2026-09-09T10:00:00Z'),
+};
+
+const native = {
+  createRequest: jest.fn(() => 'location-1'),
+  getCurrentPosition: jest.fn<Promise<DeviceLocation>, [string]>(),
+  cancelRequest: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  jest.replaceProperty(Platform, 'OS', 'android');
+  native.getCurrentPosition.mockResolvedValue(position);
+  jest.mocked(getDeviceLocation).mockReturnValue(native);
+  jest.mocked(Location.reverseGeocodeAsync).mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+test('Android uses system location and preserves approximate accuracy, source, and fix time', async () => {
+  await expect(getCurrentLocation({ includeAddress: false })).resolves.toEqual({
+    address: null,
+    coords: position.coords,
+    provider: 'network',
+    timestamp: '2026-09-09T10:00:00.000Z',
+  });
+  expect(Location.getCurrentPositionAsync).not.toHaveBeenCalled();
+  expect(native.cancelRequest).toHaveBeenCalledWith('location-1');
+});
+
+test('an old binary reports the missing native module instead of falling back to Google location', async () => {
+  jest.mocked(getDeviceLocation).mockReturnValue(null);
+  await expect(getCurrentLocation()).rejects.toMatchObject({
+    code: 'E_LOCATION_MODULE_UNAVAILABLE',
+  });
+  expect(Location.getCurrentPositionAsync).not.toHaveBeenCalled();
+});
+
+test('an already cancelled call never creates a native request', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await expect(getCurrentLocation({}, controller.signal)).rejects.toMatchObject({
+    name: 'AbortError',
+  });
+  expect(native.createRequest).not.toHaveBeenCalled();
+});
+
+test('cancellation releases the native handle without waiting for a fix', async () => {
+  native.getCurrentPosition.mockReturnValue(new Promise(() => {}));
+  const controller = new AbortController();
+  const request = getCurrentLocation({}, controller.signal);
+  controller.abort();
+  await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+  expect(native.cancelRequest).toHaveBeenCalledTimes(1);
+  expect(native.cancelRequest).toHaveBeenCalledWith('location-1');
+  expect(Location.reverseGeocodeAsync).not.toHaveBeenCalled();
+});
+
+test('a stalled native response is bounded and its request is cancelled', async () => {
+  native.getCurrentPosition.mockReturnValue(new Promise(() => {}));
+  const request = getCurrentLocation({ includeAddress: false });
+  const rejected = expect(request).rejects.toMatchObject({ code: 'E_LOCATION_TIMEOUT' });
+  await jest.advanceTimersByTimeAsync(35_000);
+  await rejected;
+  expect(native.cancelRequest).toHaveBeenCalledWith('location-1');
+  expect(Location.getCurrentPositionAsync).not.toHaveBeenCalled();
+});
+
+test('a native provider failure retains its code and releases the request', async () => {
+  const error = Object.assign(new Error('No providers enabled'), {
+    code: 'E_LOCATION_SERVICES_DISABLED',
+  });
+  native.getCurrentPosition.mockRejectedValue(error);
+  await expect(getCurrentLocation()).rejects.toBe(error);
+  expect(native.cancelRequest).toHaveBeenCalledWith('location-1');
+  expect(Location.reverseGeocodeAsync).not.toHaveBeenCalled();
+});
+
+test('an unavailable geocoder still returns usable coordinates', async () => {
+  jest.mocked(Location.reverseGeocodeAsync).mockRejectedValue(new Error('Geocoder unavailable'));
+  await expect(getCurrentLocation()).resolves.toMatchObject({
+    address: null,
+    coords: position.coords,
+  });
+});
+
+test('cancellation during address lookup is not swallowed as a missing address', async () => {
+  const controller = new AbortController();
+  jest.mocked(Location.reverseGeocodeAsync).mockImplementation(() => {
+    controller.abort();
+    return new Promise(() => {});
+  });
+  await expect(getCurrentLocation({}, controller.signal)).rejects.toMatchObject({
+    name: 'AbortError',
+  });
+});
+
+test('iOS retains Expo location without loading the Android module', async () => {
+  jest.replaceProperty(Platform, 'OS', 'ios');
+  jest.mocked(Location.getCurrentPositionAsync).mockResolvedValue({
+    coords: position.coords,
+    timestamp: position.timestamp,
+  });
+  await expect(getCurrentLocation({ includeAddress: false })).resolves.toMatchObject({
+    coords: position.coords,
+    provider: null,
+  });
+  expect(getDeviceLocation).not.toHaveBeenCalled();
+});

--- a/src/backend/services/device/location.ts
+++ b/src/backend/services/device/location.ts
@@ -1,23 +1,35 @@
 import * as Location from 'expo-location';
+import { Platform } from 'react-native';
 
-import { withNativeToolTimeout } from './utils';
+import { getDeviceLocation } from '../../../../modules/device-location';
+import { NATIVE_TOOL_TIMEOUT_MS } from './utils';
 
-export async function getCurrentLocation(input: { includeAddress?: boolean } = {}) {
-  const location = await withNativeToolTimeout(
-    Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
-    'Current location request',
-  );
+// The Android module owns a 30-second deadline. This guard also covers a stalled bridge.
+const ANDROID_LOCATION_TIMEOUT_MS = 35_000;
+
+export async function getCurrentLocation(
+  input: { includeAddress?: boolean } = {},
+  signal?: AbortSignal,
+) {
+  const location = await getPosition(signal);
   const address =
     (input.includeAddress ?? true)
-      ? await withNativeToolTimeout(
-          Location.reverseGeocodeAsync({
-            latitude: location.coords.latitude,
-            longitude: location.coords.longitude,
-          }),
+      ? await waitForLocationOperation(
+          () =>
+            Location.reverseGeocodeAsync({
+              latitude: location.coords.latitude,
+              longitude: location.coords.longitude,
+            }),
           'Reverse geocoding',
+          signal,
         )
           .then((results) => results[0])
-          .catch(() => undefined)
+          .catch((error: unknown) => {
+            if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+              throw error;
+            }
+            return undefined;
+          })
       : undefined;
 
   return {
@@ -44,6 +56,81 @@ export async function getCurrentLocation(input: { includeAddress?: boolean } = {
       longitude: location.coords.longitude,
       speed: location.coords.speed ?? null,
     },
+    provider: location.provider ?? null,
     timestamp: new Date(location.timestamp).toISOString(),
   };
+}
+
+async function getPosition(
+  signal?: AbortSignal,
+): Promise<Location.LocationObject & { provider?: string | null }> {
+  if (signal?.aborted) throw abortedLocationError(signal);
+  if (Platform.OS !== 'android') {
+    return waitForLocationOperation(
+      () => Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
+      'Current location request',
+      signal,
+    );
+  }
+
+  const native = getDeviceLocation();
+  if (!native) {
+    throw Object.assign(
+      new Error(
+        'This app version does not include Android system location support. Install an updated app build before trying again.',
+      ),
+      { code: 'E_LOCATION_MODULE_UNAVAILABLE' },
+    );
+  }
+  const requestId = native.createRequest();
+  try {
+    return await waitForLocationOperation(
+      () => native.getCurrentPosition(requestId),
+      'Android system location request',
+      signal,
+      ANDROID_LOCATION_TIMEOUT_MS,
+    );
+  } finally {
+    // Idempotent after success, and cancels native listeners on abort or bridge timeout.
+    native.cancelRequest(requestId);
+  }
+}
+
+function abortedLocationError(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : Object.assign(new Error('Location request cancelled'), { name: 'AbortError' });
+}
+
+function waitForLocationOperation<T>(
+  start: () => Promise<T>,
+  label: string,
+  signal?: AbortSignal,
+  timeoutMs = NATIVE_TOOL_TIMEOUT_MS,
+): Promise<T> {
+  if (signal?.aborted) return Promise.reject(abortedLocationError(signal));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => finish(() => reject(abortedLocationError(signal)));
+    const timeoutError = Object.assign(
+      new Error(
+        `${label} timed out before a result was available. This does not establish a permission failure.`,
+      ),
+      { code: 'E_LOCATION_TIMEOUT' },
+    );
+    const timeout = setTimeout(() => finish(() => reject(timeoutError)), timeoutMs);
+    function finish(settle: () => void) {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      settle();
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+    try {
+      start().then(
+        (value) => finish(() => resolve(value)),
+        (error: unknown) => finish(() => reject(error)),
+      );
+    } catch (error) {
+      finish(() => reject(error));
+    }
+  });
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

- Android location requests used Expo's Google Play services location path, which could time out on devices without working Google services. The JavaScript timeout did not cancel the native request, and the tool repeatedly suggested retrying.
- Long selected model names wrapped onto multiple lines in settings rows.

After this PR:

- An Android-only Expo module requests the enabled system network and GPS providers through `LocationManager`, without requiring Google Play services. It returns the first fix no older than ten seconds, preserving its provider, timestamp, and accuracy.
- A native 30-second deadline and turn cancellation remove location listeners. A synchronous request reservation also handles cancellation before native startup; a 35-second JavaScript guard covers a stalled bridge.
- Position failures retain their native code and failure stage, with guidance against automatic retries. Optional address lookup failures still return coordinates, while cancellation propagates.
- String and numeric values in `Section.SelectItem` stay on one line, fixing long default model labels.

### Screenshots or videos

Pending for this draft. No device/UI acceptance or after-change screenshots were captured. The Android preview APK was built and inspected; physical-device location behavior and the settings layout still need acceptance.

### Why we need it and why it was done in this way

System providers cover Android devices that do not have working Google services, including domestic ROMs. Network and GPS requests run together so a missing or unresponsive network provider does not prevent a GPS fix. The first fresh result favors response time; callers still receive its reported accuracy, and indoor GPS may time out.

iOS keeps Expo location. The optional native loader reports an actionable update requirement for older Android binaries. Expo's geocoder has no native cancellation API, so cancellation stops waiting for address lookup rather than cancelling the platform geocoder.

### Breaking changes

Android system location requires a new native app build. An existing binary cannot acquire this module through a JavaScript-only update.

### Special notes for your reviewer

- Passed: changed-file `oxfmt`, `oxlint`, and `expo lint`; repository-wide `pnpm format:check`; commit formatting hooks.
- Passed: local EAS Android `preview` build (`arm64-v8a`, version `1.0.0`). APK signature verification passed, and the APK contains the new native location class and embedded application bundle.
- `pnpm lint` was run and failed with seven existing `import/no-unresolved` errors for `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` in unchanged files. Their generated package entry points are unavailable in this checkout. Changed-file lint passes.
- Regression tests were added for Android routing, cancellation, deadlines, failure codes, old binaries, address lookup, and the retained iOS path. These tests and the repository type check were not run under the task's verification constraints.
- EAS's bundled Expo Doctor reported existing setup/dependency warnings, including a Hermes memory-regression advisory; the native build completed successfully without dependency upgrades.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description explains the resulting behavior and validation limits
- [ ] Preview: Screenshots or video demonstrate the user-facing changes
- [x] Code: The implementation is scoped to the existing owners
- [x] Upgrade: The native-module installation requirement is documented
- [x] Documentation: Module behavior and device acceptance cases are documented; no separate user-guide change is needed for these fixes
- [x] Self-review: The complete local diff was reviewed before submission

### Release note

```release-note
Fix Android location requests on devices without working Google Play services and stop location requests when cancelled or timed out. Keep long selected model names on one line in settings. action required: install an updated Android app build to receive system location support.
```
