### PR TITLE
fix(model-icons): normalize model IDs before resolving brand icons

### DIFF
--- a/src/frontend/components/Avatar/components/ModelAvatar.tsx
+++ b/src/frontend/components/Avatar/components/ModelAvatar.tsx
@@ -1,6 +1,6 @@
-import { resolveModelIcon, resolveModelProviderIcon } from '@cherrystudio/ui/icons';
 import { useUniwind } from 'uniwind';
 
+import { resolveModelIconSources } from '@/frontend/utils/modelIcons';
 import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 
@@ -25,8 +25,7 @@ export function ModelAvatar({ model, provider, size }: ModelAvatarProps) {
   const { theme } = useUniwind();
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
   const providerIconId = provider?.presetProviderId ?? provider?.id ?? model.providerId;
-  const modelIconSource = resolveModelIcon(model.modelId);
-  const iconSource = modelIconSource ?? resolveModelProviderIcon(model.modelId, providerIconId);
+  const { iconSource, modelIconSource } = resolveModelIconSources(model.modelId, providerIconId);
   const frameProps = { label: model.name, ...(size !== undefined && { size }) };
 
   if (!iconSource) {

--- a/src/frontend/components/ModelPicker/components/ModelPickerIcon.tsx
+++ b/src/frontend/components/ModelPicker/components/ModelPickerIcon.tsx
@@ -1,9 +1,9 @@
 import { Image } from '@cherrystudio/ui/components';
-import { resolveModelIcon, resolveModelProviderIcon } from '@cherrystudio/ui/icons';
 import { Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
 import { PROVIDER_BRAND_ICON_SCALE } from '@/frontend/components/Avatar';
+import { resolveModelIconSources } from '@/frontend/utils/modelIcons';
 import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
 
@@ -17,11 +17,10 @@ type ModelPickerIconProps = {
 export function ModelPickerIcon({ model, provider, size = 32 }: ModelPickerIconProps) {
   const { theme } = useUniwind();
   const iconTheme = theme === 'dark' ? 'dark' : 'light';
-  const modelIconSource = resolveModelIcon(model.modelId);
-  const iconSource = provider
-    ? (modelIconSource ??
-      resolveModelProviderIcon(model.modelId, provider.presetProviderId ?? provider.id))
-    : modelIconSource;
+  const { iconSource, modelIconSource } = resolveModelIconSources(
+    model.modelId,
+    provider?.presetProviderId ?? provider?.id,
+  );
   const imageSize = modelIconSource ? size : size * PROVIDER_BRAND_ICON_SCALE;
   const avatarInitial = model.name.trim().charAt(0).toUpperCase() || 'M';
   const frameStyle = {

--- a/src/frontend/features/home/aiUsage/components/AiUsageRankingList.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageRankingList.tsx
@@ -1,7 +1,6 @@
 import ChevronDownIcon from '@cherrystudio/app-icons/icons/chevron-down';
 import EllipsisIcon from '@cherrystudio/app-icons/icons/ellipsis';
 import { Button } from '@cherrystudio/ui/components';
-import { resolveModelIcon, resolveModelProviderIcon } from '@cherrystudio/ui/icons';
 import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +8,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
 import { BrandAvatar, BrandAvatarIcon, ProviderBrandAvatar } from '@/frontend/components/Avatar';
+import { resolveModelIconSources } from '@/frontend/utils/modelIcons';
 
 import type { AiUsageRankingItem } from '../types';
 import { displayAiUsageModelId } from '../utils/aiUsageDetail';
@@ -230,10 +230,10 @@ function AiUsageRankingIcon({ item, label }: { item: AiUsageRankingItem; label: 
     );
   }
 
-  const modelIconSource = item.isOther ? undefined : resolveModelIcon(item.modelId ?? '');
-  const iconSource = item.isOther
-    ? undefined
-    : (modelIconSource ?? resolveModelProviderIcon(item.modelId ?? '', item.providerId ?? ''));
+  const { iconSource, modelIconSource } = resolveModelIconSources(
+    item.isOther ? '' : (item.modelId ?? ''),
+    item.isOther ? undefined : (item.providerId ?? ''),
+  );
 
   if (iconSource) {
     return (

--- a/src/frontend/utils/__tests__/modelIcons.test.ts
+++ b/src/frontend/utils/__tests__/modelIcons.test.ts
@@ -1,0 +1,42 @@
+import { resolveModelAssetIcon } from '@cherrystudio/ui/icons/models';
+import { resolveProviderAssetIcon } from '@cherrystudio/ui/icons/providers';
+
+import { resolveModelIconSources } from '../modelIcons';
+
+describe('model icon identity', () => {
+  test.each([
+    ['deepseek-chat', 'deepseek'],
+    ['deepseek-reasoner', 'deepseek'],
+    ['gemini-router/DeepSeek-V4-Flash:free', 'deepseek'],
+    ['gpt-gateway/deepseek-ai/DeepSeek-V4-Pro:cloud', 'deepseek'],
+    ['deepseek-proxy/kimi-k2', 'kimi'],
+    ['bytedance-seed/hy-2.0', 'hunyuan'],
+    ['accounts/fireworks/models/gpt-5p4-mini', 'gpt-5-4-mini'],
+    ['vendor/sora:cloud', 'sora'],
+    ['doubao-seed-2.0-pro', 'doubao'],
+  ])('uses the model brand for %s', (modelId, iconKey) => {
+    const expected = resolveModelAssetIcon(iconKey);
+    const { iconSource, modelIconSource } = resolveModelIconSources(modelId, 'openrouter');
+
+    expect(expected).toBeDefined();
+    expect(iconSource).toBe(expected);
+    expect(modelIconSource).toBe(expected);
+  });
+
+  test('infers the provider from the base model before falling back to its host', () => {
+    const inferred = resolveModelIconSources('deepseek-proxy/o3-mini', 'openrouter');
+    const fallback = resolveModelIconSources('deepseek-proxy/custom-model', 'azure-openai');
+
+    expect(inferred.iconSource).toBe(resolveProviderAssetIcon('openai'));
+    expect(inferred.modelIconSource).toBeUndefined();
+    expect(fallback.iconSource).toBe(resolveProviderAssetIcon('azureai'));
+    expect(fallback.modelIconSource).toBeUndefined();
+  });
+
+  test('keeps unknown models without a provider on the initial fallback', () => {
+    expect(resolveModelIconSources('deepseek-proxy/custom-model')).toEqual({
+      iconSource: undefined,
+      modelIconSource: undefined,
+    });
+  });
+});

--- a/src/frontend/utils/modelIcons.ts
+++ b/src/frontend/utils/modelIcons.ts
@@ -1,0 +1,13 @@
+import { resolveModelIcon, resolveModelProviderIcon } from '@cherrystudio/ui/icons';
+import { getLowerBaseModelName } from '@cherrystudio/universal/utils/model';
+
+export function resolveModelIconSources(modelId: string, providerId?: string) {
+  // Match the model itself, not a gateway namespace or a transport-specific suffix.
+  const baseModelId = getLowerBaseModelName(modelId);
+  const modelIconSource = resolveModelIcon(baseModelId);
+  const iconSource =
+    modelIconSource ??
+    (providerId === undefined ? undefined : resolveModelProviderIcon(baseModelId, providerId));
+
+  return { iconSource, modelIconSource };
+}


### PR DESCRIPTION
### What this PR does

Before this PR, model icons were matched against the entire API model ID. A gateway namespace
could select another brand: `gemini-router/deepseek-v4-flash` matched Gemini, and
`bytedance-seed/hy-2.0` matched Doubao.

After this PR, a shared frontend adapter normalizes the model ID before matching, following
Desktop's `getModelLogoRef` behavior. Those examples select DeepSeek and Hunyuan respectively.
Model avatars, the model picker, and AI usage rankings use the same adapter while retaining their
existing model/provider/initial fallback behavior.

### Why we need it and why it was done in this way

Reuse the existing `getLowerBaseModelName` helper for namespaces, model suffixes, and Fireworks
version spelling. Keep application-specific normalization outside the shared icon registry.
Regression cases cover misleading prefixes, DeepSeek, Kimi, Hunyuan, actual Doubao models, and
provider fallbacks. Assertions compare catalog object identity so asset mocks cannot hide a wrong
brand match.

Desktop comparison source: `CherryHQ/cherry-studio@e131f495a9af593ec873bea34b935e97d644f586`,
`src/renderer/utils/model/logo.ts`.

### Screenshots or videos

Not captured. Device/UI acceptance was not run under the task's verification policy.

### Validation

- Passed: `pnpm format:check`, `git diff --check`, and targeted Oxlint/Expo lint on all five changed files.
- Full `pnpm lint` failed with seven existing `import/no-unresolved` errors for
  `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider`. This checkout has no
  `packages/ai-core/dist`, which the package exports require. Unrelated warnings were also reported.
- Regression tests were added but not run. Tests, type checks, builds, exports, and device
  acceptance remain unrun per the user's verification policy; root `pnpm typecheck` also triggers
  package builds.
- The read-only `design-catalog` audit reports existing Desktop source drift and a missing
  `jalapeno-cloud` mobile icon adaptation. No synchronization baseline was advanced.

### Breaking changes

None. No persisted data, provider configuration, icon assets, or dependencies change.

### Special notes for your reviewer

The original report that DeepSeek displayed a Doubao icon has not been reproduced, and its root
cause remains unconfirmed. This PR fixes the confirmed normalization difference; it does not claim
that the reported incident is resolved or that the entire latest Desktop icon catalog is aligned.

### Checklist

- [x] This PR targets `v0.2`.
- [x] Changes have been reviewed locally.
- [x] Validation results and limitations are documented.
- [ ] Regression tests and device acceptance have passed.
- [ ] Screenshots or video are attached.

### Release note

```release-note
Correct model brand icons when API model IDs include gateway namespaces or model suffixes.
```
