### PR TITLE
fix(ios-permissions): add motion usage description for TestFlight

### DIFF
--- a/app.json
+++ b/app.json
@@ -103,7 +103,7 @@
           "isIosBackgroundLocationEnabled": false,
           "locationAlwaysAndWhenInUsePermission": false,
           "locationAlwaysPermission": false,
-          "motionUsagePermission": false,
+          "motionUsagePermission": "Cherry Studio does not read or track your motion and fitness activity. This permission description is required by the location service included in the app.",
           "locationWhenInUsePermission": "Allow Cherry Studio to use your location when you ask the assistant."
         }
       ],


### PR DESCRIPTION
### What this PR does

Before this PR: Apple rejected iOS build 1.0.0 (11) with ITMS-90683 because `CherryStudio.app` lacked `NSMotionUsageDescription`. The bundled `expo-location` native module references motion APIs, while `motionUsagePermission: false` omitted the required description.

After this PR: `expo-location` writes an explicit motion permission description into `Info.plist`. The text accurately states that Cherry Studio does not read or track motion and fitness activity.

### Screenshots or videos

N/A — this changes native permission metadata and has no visible application UI effect.

### Why we need it and why it was done in this way

Disabling the description does not remove motion APIs from the bundled native module. Setting the existing plugin option supplies the metadata required by Apple without adding motion requests or tracking behavior.

### Breaking changes

None.

### Special notes for your reviewer

- Built iOS production 1.0.0 (13) from the same source contents and confirmed the final IPA contains `NSMotionUsageDescription`.
- Apple accepted the build: processing state `VALID`, internal state `IN_BETA_TESTING`. The existing internal TestFlight group shows the build as testing.
- `pnpm format:check` and formatting of `app.json` passed.
- `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` in unmodified files.
- Automated tests and device/UI acceptance were not run. `pnpm typecheck` was not run because it invokes workspace builds; these checks require separate authorization under the user's workflow rules.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the failure and resulting behavior
- [x] Preview: The absence of a visible UI change is explained above
- [x] Code: The change uses the existing configuration option and is limited to one line
- [x] Self-review: Reviewed the complete diff against `origin/v0.2`

### Release note

```release-note
NONE
```
