### PR TITLE
fix(message-list): synchronize keyboard motion and scroll following

### DIFF
--- a/src/frontend/components/Message/MessageList.tsx
+++ b/src/frontend/components/Message/MessageList.tsx
@@ -4,11 +4,18 @@ import { type LegendListRef, type LegendListRenderItemProps } from '@legendapp/l
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type LayoutChangeEvent, Platform, View } from 'react-native';
-import { runOnJS, useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import {
+  runOnJS,
+  useAnimatedReaction,
+  useDerivedValue,
+  useSharedValue,
+} from 'react-native-reanimated';
 
 import { MessageListDisclosureProvider } from './list/MessageListDisclosureContext';
 import {
   getMessageRowType,
+  isMessageListAtBottom,
   MAINTAIN_VISIBLE_CONTENT_POSITION,
   MESSAGE_LIST_TOP_PADDING,
   messageKeyExtractor,
@@ -64,53 +71,57 @@ export function MessageList({
     onReady,
     onReturnToLatest,
   });
-  const isAtBottom = useSharedValue(true);
-  const contentHeightRef = useRef({ dataKey, height: 0 });
-  const viewportHeightRef = useRef(0);
-  const [contentScrollability, setContentScrollability] = useState({
-    dataKey,
-    isScrollable: false,
-  });
-  const isContentScrollable =
-    contentScrollability.dataKey === dataKey && contentScrollability.isScrollable;
-  const [isNativeAtBottomForButton, setIsNativeAtBottomForButton] = useState(true);
-  const syncScrollButtonVisibility = useCallback((atBottom: boolean) => {
-    setIsNativeAtBottomForButton(atBottom);
+  const { height: keyboardHeight, progress: keyboardProgress } = useReanimatedKeyboardAnimation();
+  const keyboardLift = useDerivedValue(() =>
+    Math.max(0, -keyboardHeight.get() - keyboardProgress.get() * keyboardOffset),
+  );
+  const scrollButtonBottom = useDerivedValue(
+    () => (bottomAccessoryHeight?.get() ?? 0) + keyboardLift.get(),
+  );
+  const contentHeight = useSharedValue({ dataKey, height: 0 });
+  const viewportHeight = useSharedValue(0);
+  const scrollOffset = useSharedValue(0);
+  const [bottomState, setBottomState] = useState({ dataKey, isAtBottom: true });
+  const syncScrollButtonVisibility = useCallback((key: string | undefined, isAtBottom: boolean) => {
+    setBottomState({ dataKey: key, isAtBottom });
   }, []);
-  const syncContentScrollability = useCallback(() => {
-    const contentHeight =
-      contentHeightRef.current.dataKey === dataKey ? contentHeightRef.current.height : 0;
-    const nextIsScrollable =
-      viewportHeightRef.current > 0 && contentHeight > viewportHeightRef.current;
-    setContentScrollability((current) => {
-      if (current.dataKey === dataKey && current.isScrollable === nextIsScrollable) {
-        return current;
-      }
-      return { dataKey, isScrollable: nextIsScrollable };
-    });
-  }, [dataKey]);
   const handleListContentSizeChange = useCallback(
     (_width: number, height: number) => {
-      contentHeightRef.current = { dataKey, height };
-      syncContentScrollability();
+      contentHeight.set({ dataKey, height });
       handleContentSizeChange();
     },
-    [dataKey, handleContentSizeChange, syncContentScrollability],
+    [contentHeight, dataKey, handleContentSizeChange],
   );
   const handleListLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      viewportHeightRef.current = event.nativeEvent.layout.height;
-      syncContentScrollability();
+      viewportHeight.set(event.nativeEvent.layout.height);
       handleLayout(event);
     },
-    [handleLayout, syncContentScrollability],
+    [handleLayout, viewportHeight],
   );
 
   useAnimatedReaction(
-    () => isAtBottom.get(),
+    () => {
+      const content = contentHeight.get();
+      const viewport = viewportHeight.get();
+      // Match the keyboard adapter's capped inset, including short conversations
+      // that become scrollable only once the keyboard covers part of the list.
+      const inset = Math.min(viewport, keyboardLift.get());
+      return {
+        dataKey,
+        isAtBottom:
+          content.dataKey !== dataKey ||
+          viewport <= 0 ||
+          isMessageListAtBottom(scrollOffset.get(), content.height + inset, viewport),
+      };
+    },
     (current, previous) => {
-      if (previous === null || current !== previous) {
-        runOnJS(syncScrollButtonVisibility)(current);
+      if (
+        previous === null ||
+        current.dataKey !== previous.dataKey ||
+        current.isAtBottom !== previous.isAtBottom
+      ) {
+        runOnJS(syncScrollButtonVisibility)(current.dataKey, current.isAtBottom);
       }
     },
   );
@@ -136,7 +147,7 @@ export function MessageList({
 
     void onLoadOlder();
   }, [onLoadOlder]);
-  const sharedValues = useMemo(() => ({ isAtEnd: isAtBottom }), [isAtBottom]);
+  const sharedValues = useMemo(() => ({ scrollOffset }), [scrollOffset]);
   const handleEndReached = useCallback(() => {
     void onLoadNewer?.();
   }, [onLoadNewer]);
@@ -167,7 +178,7 @@ export function MessageList({
               getItemType={getMessageRowType}
               keyExtractor={messageKeyExtractor}
               keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
-              keyboardLiftBehavior="whenAtEnd"
+              keyboardLiftBehavior={isFollowing ? 'persistent' : 'never'}
               keyboardOffset={keyboardOffset}
               keyboardShouldPersistTaps="handled"
               ListHeaderComponent={listHeader}
@@ -196,11 +207,11 @@ export function MessageList({
         {messages.length > 0 ? (
           <ScrollToBottomButton
             accessibilityLabel={t('chat.message.scrollToBottom')}
-            bottomAccessoryHeight={bottomAccessoryHeight}
+            bottomAccessoryHeight={scrollButtonBottom}
             gap={SCROLL_BUTTON_GAP_ABOVE_ACCESSORY}
             isAtBottom={
               !hasNewerMessages &&
-              (!isContentScrollable || isNativeAtBottomForButton || isFollowing)
+              (isFollowing || bottomState.dataKey !== dataKey || bottomState.isAtBottom)
             }
             // The press only enters following mode, which already hides the
             // button. Mirroring an optimistic at-end state here would stick at

--- a/src/frontend/components/Message/README.md
+++ b/src/frontend/components/Message/README.md
@@ -212,8 +212,8 @@ geometry contract when list layout depends on it.
 
 ## List Behavior
 
-`MessageList` owns its `LegendList` ref, role-based recycling types, keyboard lift, at-bottom shared
-value, row frames, and the business wiring for the optional CherryUI scroll-to-bottom button.
+`MessageList` owns its `LegendList` ref, role-based recycling types, keyboard lift, visible-bottom
+geometry, row frames, and the business wiring for the optional CherryUI scroll-to-bottom button.
 Callers provide stable message item references and only the layout insets and callbacks they own.
 
 One list-owned scroll controller owns product-level scroll state. It starts detached while restoring either a saved
@@ -224,8 +224,9 @@ scroll button, or sending a local message re-enters following mode. The scroll b
 means “return to the live edge,” not merely one untracked imperative scroll.
 
 The controller keeps imperative mode reads in a ref for native scroll callbacks and exposes only a
-reactive following boolean to button rendering. Dataset generations own drag and momentum events;
-callbacks from an outgoing Session cannot transition or save state for the incoming Session.
+reactive following boolean to keyboard lift and button rendering. Dataset generations own drag and
+momentum events; callbacks from an outgoing Session cannot transition or save state for the incoming
+Session.
 
 Chat Sessions store `{ message key, offset inside the row }` in the frontend memory cache. Restore
 uses `scrollToIndex`, so prepends and changing row measurements do not invalidate a raw pixel
@@ -245,9 +246,12 @@ with `hasNewerMessages` remains in reading mode even at its loaded end, requests
 `onLoadNewer`, and keeps the return-to-latest control available. `onReturnToLatest` lets the data
 owner replace that window before the controller resumes following; local sends use the same path.
 
-Keyboard lift remains `whenAtEnd`: focusing the composer must not move a viewport that is reading
-history. The keyboard controller is a platform geometry adapter; it never transitions the product
-following/reading state. A local send immediately positions the message at the live edge, keeps
+Keyboard lift uses `persistent` while following and `never` while reading history. Composer
+expansion must not disable following just because the viewport has already resized when keyboard
+motion starts. Native keyboard motion owns scrolling during the transition; application corrections
+for content and composer-size changes resume once it ends, only if still following. The return button
+moves with the keyboard and any floating composer, and checks the visible bottom including the
+keyboard inset. A local send immediately positions the message at the live edge, keeps
 keyboard geometry updates active during dismissal, and corrects the final inset without replaying
 scroll motion. A dataset switch or committed drag during dismissal cancels that final correction.
 

--- a/src/frontend/components/Message/list/__tests__/MessageList.test.tsx
+++ b/src/frontend/components/Message/list/__tests__/MessageList.test.tsx
@@ -1,7 +1,11 @@
 import type { LegendListRef } from '@legendapp/list/react-native';
 import type { ReactNode, Ref } from 'react';
 import { Platform, Pressable, type LayoutChangeEvent } from 'react-native';
-import { KeyboardController } from 'react-native-keyboard-controller';
+import {
+  KeyboardController,
+  useGenericKeyboardHandler,
+  useReanimatedKeyboardAnimation,
+} from 'react-native-keyboard-controller';
 import type { SharedValue } from 'react-native-reanimated';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
@@ -44,7 +48,7 @@ type MockLegendListProps = {
   recycleItems?: boolean;
   ref?: Ref<LegendListRef>;
   renderItem?: (info: { extraData?: unknown; index: number; item: MessageListItem }) => ReactNode;
-  sharedValues?: { isAtEnd: SharedValue<boolean> };
+  sharedValues?: { scrollOffset: SharedValue<number> };
   showsVerticalScrollIndicator?: boolean;
 };
 
@@ -52,6 +56,11 @@ let mockLatestListProps: MockLegendListProps | undefined;
 const mockKeyboardDismiss = KeyboardController.dismiss as jest.MockedFunction<
   typeof KeyboardController.dismiss
 >;
+const mockUseKeyboardHandler = jest.mocked(useGenericKeyboardHandler);
+const mockUseKeyboardAnimation = jest.mocked(useReanimatedKeyboardAnimation);
+let mockKeyboardHandlers: Parameters<typeof useGenericKeyboardHandler>[0];
+let mockKeyboardHeight: SharedValue<number>;
+let mockKeyboardProgress: SharedValue<number>;
 const mockListScrollToEnd = jest.fn(async () => undefined);
 const mockListScrollToIndex = jest.fn(async () => undefined);
 let mockListState = {
@@ -88,9 +97,18 @@ let mockScrollButtonProps:
   | undefined;
 type MockAnimatedReaction = {
   prepare: () => unknown;
+  previous?: unknown;
   react: (current: unknown, previous: unknown) => void;
 };
 let mockAnimatedReactions: MockAnimatedReaction[] = [];
+
+function flushAnimatedReactions() {
+  for (const reaction of mockAnimatedReactions) {
+    const current = reaction.prepare();
+    reaction.react(current, reaction.previous ?? null);
+    reaction.previous = current;
+  }
+}
 
 jest.mock('@legendapp/list/keyboard', () => {
   const { Fragment } = jest.requireActual('react');
@@ -174,6 +192,17 @@ jest.mock('react-native-reanimated', () => {
         mockAnimatedReactions.push(reactionRef.current);
       }
     },
+    useDerivedValue: <T,>(factory: () => T) => {
+      const factoryRef = React.useRef(factory);
+      factoryRef.current = factory;
+      const derivedRef = React.useRef({
+        get: () => factoryRef.current(),
+        get value() {
+          return factoryRef.current();
+        },
+      });
+      return derivedRef.current;
+    },
     useSharedValue: <T,>(initial: T) => {
       const ref = React.useRef<SharedValue<T> | null>(null);
       ref.current ??= mockCreateSharedValue(initial);
@@ -248,6 +277,15 @@ describe('MessageList scroll-controller ownership', () => {
     mockAnimatedReactions = [];
     mockLatestListProps = undefined;
     mockScrollButtonProps = undefined;
+    mockKeyboardHeight = mockCreateSharedValue(0);
+    mockKeyboardProgress = mockCreateSharedValue(0);
+    mockUseKeyboardAnimation.mockReturnValue({
+      height: mockKeyboardHeight,
+      progress: mockKeyboardProgress,
+    });
+    mockUseKeyboardHandler.mockImplementation((handlers) => {
+      mockKeyboardHandlers = handlers;
+    });
     mockListState = {
       contentLength: 900,
       isAtEnd: true,
@@ -291,7 +329,7 @@ describe('MessageList scroll-controller ownership', () => {
 
     expect(mockLatestListProps).toMatchObject({
       dataKey: 'session-1',
-      keyboardLiftBehavior: 'whenAtEnd',
+      keyboardLiftBehavior: 'never',
       maintainVisibleContentPosition: { data: true },
       recycleItems: false,
     });
@@ -303,6 +341,7 @@ describe('MessageList scroll-controller ownership', () => {
 
     expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
     expect(mockListScrollToEnd).toHaveBeenCalledWith({ animated: false });
+    expect(mockLatestListProps?.keyboardLiftBehavior).toBe('persistent');
     expect(onReady).toHaveBeenCalledTimes(1);
   });
 
@@ -475,6 +514,8 @@ describe('MessageList scroll-controller ownership', () => {
     mockListScrollToEnd.mockClear();
     mockListState.isAtEnd = false;
 
+    expect(mockLatestListProps?.keyboardLiftBehavior).toBe('persistent');
+
     act(() => mockLatestListProps?.onContentSizeChange?.(390, 1_000));
     act(flushAnimationFrames);
     expect(mockListScrollToEnd).toHaveBeenCalledWith({ animated: false });
@@ -486,6 +527,104 @@ describe('MessageList scroll-controller ownership', () => {
     });
     act(flushAnimationFrames);
     expect(mockListScrollToEnd).not.toHaveBeenCalled();
+    expect(mockLatestListProps?.keyboardLiftBehavior).toBe('never');
+  });
+
+  test('defers queued and ongoing layout corrections until the keyboard animation finishes', async () => {
+    act(() => {
+      renderer = create(<MessageList {...listProps([createMessage('user-1', 'user')])} />);
+    });
+    await loadList();
+    mockListScrollToEnd.mockClear();
+
+    act(() => {
+      mockLatestListProps?.onLayout?.(layoutEvent(500));
+      mockKeyboardHandlers.onStart?.({} as never);
+      flushAnimationFrames();
+      mockLatestListProps?.onLayout?.(layoutEvent(460));
+      mockLatestListProps?.onContentSizeChange?.(390, 1_100);
+      flushAnimationFrames();
+    });
+    expect(mockListScrollToEnd).not.toHaveBeenCalled();
+
+    act(() => {
+      mockKeyboardHandlers.onEnd?.({} as never);
+      mockLatestListProps?.onLayout?.(layoutEvent(440));
+      flushAnimationFrames();
+    });
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
+    expect(mockListScrollToEnd).toHaveBeenCalledWith({ animated: false });
+
+    // Multiline text and attachments also resize the composer while the keyboard is still.
+    mockListScrollToEnd.mockClear();
+    act(() => mockLatestListProps?.onLayout?.(layoutEvent(400)));
+    act(flushAnimationFrames);
+    act(() => mockLatestListProps?.onLayout?.(layoutEvent(440)));
+    act(flushAnimationFrames);
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(2);
+  });
+
+  test('corrects the live edge after keyboard dismissal even without a viewport resize', async () => {
+    act(() => {
+      renderer = create(<MessageList {...listProps([createMessage('user-1', 'user')])} />);
+    });
+    await loadList();
+    mockListScrollToEnd.mockClear();
+
+    act(() => {
+      mockKeyboardHandlers.onInteractive?.({} as never);
+      mockLatestListProps?.onContentSizeChange?.(390, 1_100);
+      flushAnimationFrames();
+    });
+    expect(mockListScrollToEnd).not.toHaveBeenCalled();
+    act(() => mockKeyboardHandlers.onEnd?.({} as never));
+    act(flushAnimationFrames);
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not resume following when the user drags during a keyboard transition', async () => {
+    act(() => {
+      renderer = create(<MessageList {...listProps([createMessage('user-1', 'user')])} />);
+    });
+    await loadList();
+    mockListScrollToEnd.mockClear();
+    act(() => {
+      mockKeyboardHandlers.onStart?.({} as never);
+      mockLatestListProps?.onLayout?.(layoutEvent(440));
+      mockLatestListProps?.onScrollBeginDrag?.();
+      mockKeyboardHandlers.onEnd?.({} as never);
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.keyboardLiftBehavior).toBe('never');
+    expect(mockListScrollToEnd).not.toHaveBeenCalled();
+  });
+
+  test('resumes following only at the visible bottom including the keyboard inset', async () => {
+    act(() => {
+      renderer = create(<MessageList {...listProps([createMessage('user-1', 'user')])} />);
+    });
+    await loadList();
+    mockListScrollToEnd.mockClear();
+    // The library reports isAtEnd at the old bottom even with 200px of keyboard inset.
+    mockListState.contentLength = 1_100;
+    act(() => {
+      mockLatestListProps?.onScrollBeginDrag?.();
+      mockLatestListProps?.onScrollEndDrag?.();
+      mockLatestListProps?.onContentSizeChange?.(390, 1_200);
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.keyboardLiftBehavior).toBe('never');
+    expect(mockListScrollToEnd).not.toHaveBeenCalled();
+
+    mockListState.scroll = 700;
+    act(() => {
+      mockLatestListProps?.onScrollBeginDrag?.();
+      mockLatestListProps?.onScrollEndDrag?.();
+      mockLatestListProps?.onLayout?.(layoutEvent(440));
+      flushAnimationFrames();
+    });
+    expect(mockLatestListProps?.keyboardLiftBehavior).toBe('persistent');
+    expect(mockListScrollToEnd).toHaveBeenCalledTimes(1);
   });
 
   test('keeps a tapped disclosure anchored instead of sticking its growth to the end', async () => {
@@ -518,9 +657,7 @@ describe('MessageList scroll-controller ownership', () => {
       mockLatestListProps?.onContentSizeChange?.(390, 500);
     });
 
-    const reaction = mockAnimatedReactions[0];
-    mockLatestListProps?.sharedValues?.isAtEnd.set(false);
-    act(() => reaction.react(reaction.prepare(), true));
+    act(flushAnimatedReactions);
     expect(mockScrollButtonProps?.isAtBottom).toBe(true);
 
     act(() => mockLatestListProps?.onScrollBeginDrag?.());
@@ -540,15 +677,63 @@ describe('MessageList scroll-controller ownership', () => {
       mockLatestListProps?.onContentSizeChange?.(390, 300);
       mockLatestListProps?.onScrollBeginDrag?.();
     });
-    const reaction = mockAnimatedReactions[0];
-    mockLatestListProps?.sharedValues?.isAtEnd.set(false);
-    act(() => reaction.react(reaction.prepare(), true));
+    act(flushAnimatedReactions);
 
     expect(mockScrollButtonProps?.isAtBottom).toBe(true);
 
     act(() => mockLatestListProps?.onContentSizeChange?.(390, 500));
+    act(flushAnimatedReactions);
 
     expect(mockScrollButtonProps?.isAtBottom).toBe(false);
+  });
+
+  test('keeps the return button above the keyboard when short content becomes obscured', async () => {
+    act(() => {
+      renderer = create(<MessageList {...listProps([createMessage('user-1', 'user')])} />);
+    });
+    await loadList();
+    act(() => {
+      mockLatestListProps?.onLayout?.(layoutEvent(400));
+      mockLatestListProps?.onContentSizeChange?.(390, 300);
+      mockLatestListProps?.onScrollBeginDrag?.();
+      flushAnimatedReactions();
+    });
+    expect(mockScrollButtonProps?.isAtBottom).toBe(true);
+
+    mockKeyboardHeight.set(-200);
+    mockKeyboardProgress.set(1);
+    act(flushAnimatedReactions);
+    expect(mockScrollButtonProps?.isAtBottom).toBe(false);
+    expect(mockScrollButtonProps?.bottomAccessoryHeight?.get()).toBe(174);
+
+    mockLatestListProps?.sharedValues?.scrollOffset.set(74);
+    act(flushAnimatedReactions);
+    expect(mockScrollButtonProps?.isAtBottom).toBe(true);
+
+    mockLatestListProps?.sharedValues?.scrollOffset.set(0);
+    mockKeyboardHeight.set(0);
+    mockKeyboardProgress.set(0);
+    act(flushAnimatedReactions);
+    expect(mockScrollButtonProps?.isAtBottom).toBe(true);
+    expect(mockScrollButtonProps?.bottomAccessoryHeight?.get()).toBe(0);
+  });
+
+  test('adds floating composer growth to the keyboard position of the return button', () => {
+    const accessoryHeight = mockCreateSharedValue(80);
+    act(() => {
+      renderer = create(
+        <MessageList
+          {...listProps([createMessage('user-1', 'user')], {
+            bottomAccessoryHeight: accessoryHeight,
+          })}
+        />,
+      );
+    });
+    mockKeyboardHeight.set(-100);
+    mockKeyboardProgress.set(0.5);
+    expect(mockScrollButtonProps?.bottomAccessoryHeight?.get()).toBe(167);
+    accessoryHeight.set(120);
+    expect(mockScrollButtonProps?.bottomAccessoryHeight?.get()).toBe(207);
   });
 
   test('rerenders only the changed row during a streaming update', () => {
@@ -783,9 +968,7 @@ describe('MessageList scroll-controller ownership', () => {
       mockLatestListProps?.onContentSizeChange?.(390, 500);
       mockLatestListProps?.onScrollBeginDrag?.();
     });
-    const reaction = mockAnimatedReactions[0];
-    mockLatestListProps?.sharedValues?.isAtEnd.set(false);
-    act(() => reaction.react(reaction.prepare(), true));
+    act(flushAnimatedReactions);
     expect(mockScrollButtonProps?.isAtBottom).toBe(false);
 
     act(() => mockScrollButtonProps?.onPress());

--- a/src/frontend/components/Message/list/messageListLayout.ts
+++ b/src/frontend/components/Message/list/messageListLayout.ts
@@ -8,6 +8,16 @@ export const MESSAGE_ROW_VERTICAL_PADDING = {
   user: 8,
 } as const satisfies Record<MessageListItem['role'], number>;
 
+/** Content height includes the current keyboard inset. */
+export function isMessageListAtBottom(
+  scrollOffset: number,
+  contentHeight: number,
+  viewportHeight: number,
+): boolean {
+  'worklet';
+  return Math.max(0, contentHeight - viewportHeight) - scrollOffset <= 1;
+}
+
 // 流式助手消息高度持续变化，不能成为 MVCP 的数据恢复锚点。
 function shouldRestoreMessagePosition(item: MessageListItem): boolean {
   return !(item.role === 'assistant' && item.status === 'pending');

--- a/src/frontend/components/Message/list/useMessageListScrollController.ts
+++ b/src/frontend/components/Message/list/useMessageListScrollController.ts
@@ -2,13 +2,15 @@ import type { LegendListRef } from '@legendapp/list/react-native';
 import type { RefObject } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { KeyboardController } from 'react-native-keyboard-controller';
+import { KeyboardController, useGenericKeyboardHandler } from 'react-native-keyboard-controller';
+import { runOnJS, useSharedValue } from 'react-native-reanimated';
 
 import { cacheService } from '@/frontend/data/CacheService';
 import { loggerService } from '@/shared/core/logger/LoggerService';
 import type { ChatScrollAnchor } from '@/shared/data/cache/cacheSchemas';
 
 import type { MessageListItem, MessageListProps } from '../types';
+import { isMessageListAtBottom } from './messageListLayout';
 import { computeScrollAnchor, resolveRestoreTarget } from './messageListScrollMemory';
 import {
   type FollowingReason,
@@ -44,6 +46,7 @@ function cacheKeyFor(dataKey: string): `chat.scroll_anchor.${string}` {
 export function useMessageListScrollController(inputs: MessageListScrollControllerInputs) {
   const inputsRef = useRef(inputs);
   const { controller: follow, isFollowingForRender } = useViewportFollowState();
+  const isKeyboardTransitioning = useSharedValue(false);
   const activeDataKeyRef = useRef<string | undefined>(inputs.dataKey);
   const didListLoadRef = useRef(false);
   const didRestoreRef = useRef(false);
@@ -96,7 +99,11 @@ export function useMessageListScrollController(inputs: MessageListScrollControll
     const generation = restoreGenerationRef.current;
     stickFrameRef.current = requestAnimationFrame(() => {
       stickFrameRef.current = null;
-      if (generation !== restoreGenerationRef.current || !follow.isFollowing()) {
+      if (
+        generation !== restoreGenerationRef.current ||
+        !follow.isFollowing() ||
+        isKeyboardTransitioning.get()
+      ) {
         return;
       }
 
@@ -105,7 +112,7 @@ export function useMessageListScrollController(inputs: MessageListScrollControll
         void list.scrollToEnd({ animated: false });
       }
     });
-  }, [follow]);
+  }, [follow, isKeyboardTransitioning]);
 
   const scrollToLiveEdge = useCallback(
     async (reason: FollowingReason, options: { animated: boolean; closeKeyboard: boolean }) => {
@@ -155,6 +162,27 @@ export function useMessageListScrollController(inputs: MessageListScrollControll
       scheduleStickToBottom();
     }
   }, [follow, scheduleStickToBottom]);
+
+  // The native keyboard adapter owns scrolling during its animation. Layout
+  // changes from the composer settle through one correction after it finishes.
+  useGenericKeyboardHandler(
+    {
+      onStart: () => {
+        'worklet';
+        isKeyboardTransitioning.set(true);
+      },
+      onInteractive: () => {
+        'worklet';
+        isKeyboardTransitioning.set(true);
+      },
+      onEnd: () => {
+        'worklet';
+        isKeyboardTransitioning.set(false);
+        runOnJS(stickToBottomIfFollowing)();
+      },
+    },
+    [isKeyboardTransitioning, stickToBottomIfFollowing],
+  );
 
   const saveScrollAnchor = useCallback(
     (immediate = false) => {
@@ -396,7 +424,10 @@ export function useMessageListScrollController(inputs: MessageListScrollControll
   }, [enterReadingForUser]);
 
   const finishUserScroll = useCallback(() => {
-    const isAtEnd = inputsRef.current.listRef.current?.getState().isAtEnd ?? false;
+    const state = inputsRef.current.listRef.current?.getState();
+    // LegendList's isAtEnd excludes the keyboard inset from its edge check.
+    const isAtEnd =
+      state && isMessageListAtBottom(state.scroll, state.contentLength, state.scrollLength);
     if (isAtEnd && !inputsRef.current.hasNewerMessages) {
       follow.enterFollowing('user-reached-bottom');
       clearStoredAnchor();


### PR DESCRIPTION
### What this PR does

Before this PR, focusing or resizing the composer could make keyboard lifting disagree with the list's following state. Layout-driven scrolling could also compete with native keyboard motion, and the return-to-bottom button did not account for keyboard obstruction.

After this PR:

- Keyboard lifting follows the existing following/reading state.
- Automatic layout and content corrections pause during keyboard transitions and coalesce after completion, provided the user is still following.
- Returning to following mode checks the actual bottom including the keyboard inset. The return button uses the same bottom calculation and moves with the keyboard and any floating composer.

Includes regression cases for transition timing, user drag ownership, composer resizing, short conversations, and button positioning, plus updated list behavior documentation.

### Screenshots or videos

Pending device validation. No screenshots or video were captured; manual UI verification was not authorized for this task.

### Why we need it and why it was done in this way

The existing list controller remains the owner of user scroll intent. The native keyboard adapter handles movement during transitions, followed by the controller's existing coalesced correction. This avoids deciding whether to lift from a temporary scroll position while the composer is expanding.

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- Passed: `pnpm format:check`, focused Oxlint and ESLint checks, and `git diff --check`.
- Full `pnpm lint` was attempted. It reports seven import resolution errors for `@cherrystudio/ai-core` and its provider export in unchanged backend files. The package exports point to `packages/ai-core/dist`, which is absent in this workspace. It also reports warnings in unchanged files.
- Tests, type checking, package builds, and device acceptance were not run under the task's verification restrictions. The added regressions are unexecuted, and native animation behavior remains unverified.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The PR description explains the change and validation limits
- [ ] Preview: Screenshots or video demonstrating the user-facing change
- [x] Code: Changes reuse the existing scroll controller and keyboard integration
- [x] Upgrade: No schema, dependency, or public API changes
- [x] Documentation: List behavior documentation updated; no user-guide changes needed
- [x] Self-review: Reviewed the full diff against `v0.2`

### Release note

```release-note
Improve chat scrolling during keyboard and composer height changes, and keep the return-to-bottom button above the keyboard.
```
