### PR TITLE
chore(app-version): set application version to 0.0.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0_bug_report.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: 应用版本
       description: 您正在运行的 Cherry Studio 版本是什么？
-      placeholder: 例如：v0.1.0
+      placeholder: 例如：v0.0.1
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/1_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/1_feature_request.yml
@@ -55,7 +55,7 @@ body:
     attributes:
       label: 应用版本
       description: 您正在运行的 Cherry Studio 版本是什么？
-      placeholder: 例如：v0.1.0
+      placeholder: 例如：v0.0.1
     validations:
       required: true
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g. v1.0.0)'
+        description: 'Release tag (e.g. v0.0.1)'
         required: true
-        default: 'v1.0.0'
+        default: 'v0.0.1'
   push:
     tags:
       - 'v*.*.*'
@@ -55,11 +55,11 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
 
-      # Step 7: Update package.json version (DISABLED - using manual version from package.json)
+      # Step 7: Update package.json version (DISABLED - app version is configured in app.json)
       # - name: Update package.json version
       #   run: |
       #     VERSION="${{ steps.version.outputs.tag }}"
-      #     # Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
+      #     # Remove 'v' prefix if present (e.g., v0.0.1 -> 0.0.1)
       #     VERSION_NUMBER="${VERSION#v}"
       #     echo "Updating package.json version to $VERSION_NUMBER"
       #
@@ -74,7 +74,7 @@ jobs:
       #     echo "✅ package.json updated to version $VERSION_NUMBER"
       #     cat package.json | grep '"version"'
 
-      # Step 8: Set APP_VERSION environment variable (DISABLED - using manual version from package.json)
+      # Step 8: Set APP_VERSION environment variable (DISABLED - app version is configured in app.json)
       # - name: Export APP_VERSION for EAS Build
       #   run: |
       #     VERSION="${{ steps.version.outputs.tag }}"
@@ -86,7 +86,7 @@ jobs:
       - name: Build Android on EAS
         id: build_android
         run: |
-          echo "Building Android APK on EAS (version from package.json)..."
+          echo "Building Android APK on EAS (version from app.json)..."
           eas build --platform android --profile production --non-interactive --no-wait --json > android_build.json
           BUILD_ID=$(cat android_build.json | jq -r '.[0].id')
           echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g. v1.0.0)'
+        description: 'Release tag (e.g. v0.0.1)'
         required: true
-        default: 'v1.0.0'
+        default: 'v0.0.1'
   push:
     tags:
       - 'v*.*.*'
@@ -55,11 +55,11 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
 
-      # Step 7: Update package.json version (DISABLED - using manual version from package.json)
+      # Step 7: Update package.json version (DISABLED - app version is configured in app.json)
       # - name: Update package.json version
       #   run: |
       #     VERSION="${{ steps.version.outputs.tag }}"
-      #     # Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
+      #     # Remove 'v' prefix if present (e.g., v0.0.1 -> 0.0.1)
       #     VERSION_NUMBER="${VERSION#v}"
       #     echo "Updating package.json version to $VERSION_NUMBER"
       #
@@ -74,7 +74,7 @@ jobs:
       #     echo "✅ package.json updated to version $VERSION_NUMBER"
       #     cat package.json | grep '"version"'
 
-      # Step 8: Set APP_VERSION environment variable (DISABLED - using manual version from package.json)
+      # Step 8: Set APP_VERSION environment variable (DISABLED - app version is configured in app.json)
       # - name: Export APP_VERSION for EAS Build
       #   run: |
       #     VERSION="${{ steps.version.outputs.tag }}"
@@ -86,7 +86,7 @@ jobs:
       - name: Build and Submit iOS on EAS
         id: build_ios
         run: |
-          echo "Building and submitting iOS (version from package.json)..."
+          echo "Building and submitting iOS (version from app.json)..."
           eas build --platform ios --profile production --auto-submit --non-interactive --no-wait --json > ios_build.json
           BUILD_ID=$(cat ios_build.json | jq -r '.[0].id')
           echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Cherry Studio",
     "slug": "cherry-studio",
-    "version": "1.0.0",
+    "version": "0.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "cherrystudio",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cherry-studio-app",
   "main": "index.ts",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
### What this PR does

Before: the application version and release workflow defaults were `1.0.0`, while issue templates showed `v0.1.0`.

After: the Expo application config and root package version are `0.0.1`; iOS/Android release defaults and issue template examples use `v0.0.1`. The About screen and generated native app/widget versions inherit the Expo configuration. Release workflow messages now identify `app.json` as the app version source.

### Screenshots or videos

Not captured: device/UI verification was not requested. This change updates version metadata only.

### Why we need it and why it was done in this way

Align all current application version references with the requested `0.0.1` release. Keep the existing EAS remote build-number auto-increment configuration so subsequent uploads retain distinct build identifiers.

### Special notes for your reviewer

- TestFlight will reflect `0.0.1` after a new build is uploaded; existing uploaded builds are unchanged. No build or submission was performed.
- `pnpm format:check` and `git diff --check` passed. The formatting commit hook passed.
- `pnpm lint` failed with 7 import-resolution errors for `@cherrystudio/ai-core` and its provider export. The package exports point to `packages/ai-core/dist`, which is absent in this workspace. The errors occur in unchanged files; lint also reported warnings.
- Builds, typecheck (which invokes package builds), tests, and device verification were not run under the user's verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the final change and validation limits
- [x] Self-review: Reviewed the complete local diff
- [ ] Preview: No screenshot or video captured

### Release note

```release-note
Set the application version to 0.0.1 across iOS and Android.
```
