### PR TITLE
feat(observability): add Sentry error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ configuration, not in repository rules.
   [Testing And CI](docs/guides/testing-and-ci.md).
 - Before creating commits, splitting work, or opening a pull request, read
   [Git Workflow](docs/guides/git-workflow.md).
+- Before creating installation packages or changing build configuration, read
+  [Local EAS Builds](docs/guides/local-builds.md). Use `pnpm build:local` for local EAS packaging;
+  it defaults to development. Sentry reporting and build-time uploads are production-only.
 - When building or changing product UI, read
   [UI Development](docs/guides/ui-development.md) and [Design Spec](DESIGN.md). The project motion
   contract determines whether and how an interaction moves; generic skill guidance does not make

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ pnpm dev
 Rebuild the development client after native dependency or native configuration changes. Use
 `pnpm dev:clear` when the Metro cache must be reset.
 
+To create installation packages with EAS on your machine, use `pnpm build:local --platform android`
+or `pnpm build:local --platform ios`. Both default to the development client and load `.env` and
+`.env.local` into the build process. See [Local EAS Builds](docs/guides/local-builds.md) for native
+tool requirements, Sentry credentials, build profiles, and artifact output options.
+Development and preview packages do not report to Sentry or upload build-time debug artifacts;
+Sentry credentials are only needed for production monitoring.
+
 ### App variants
 
 `app.json` holds the production defaults. `app.config.ts` selects the app identity using `PROFILE`,

--- a/app.config.ts
+++ b/app.config.ts
@@ -31,18 +31,23 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       },
     },
     android: { ...config.android, package: `${config.android!.package}${suffix}` },
-    plugins: config.plugins?.map((plugin) => {
-      if (plugin === 'expo-dev-client') {
-        return [plugin, { addGeneratedScheme: profile === 'development' }];
-      }
-      if (Array.isArray(plugin) && plugin[0] === 'expo-widgets') {
-        return [
-          plugin[0],
-          { ...plugin[1], bundleIdentifier: widgetBundleIdentifier, groupIdentifier },
-        ];
-      }
-      return plugin;
-    }),
+    plugins: config.plugins
+      ?.filter((plugin) => {
+        const name = Array.isArray(plugin) ? plugin[0] : plugin;
+        return name !== '@sentry/react-native/expo' || profile === 'production';
+      })
+      .map((plugin) => {
+        if (plugin === 'expo-dev-client') {
+          return [plugin, { addGeneratedScheme: profile === 'development' }];
+        }
+        if (Array.isArray(plugin) && plugin[0] === 'expo-widgets') {
+          return [
+            plugin[0],
+            { ...plugin[1], bundleIdentifier: widgetBundleIdentifier, groupIdentifier },
+          ];
+        }
+        return plugin;
+      }),
     extra: {
       ...config.extra,
       sentryEnvironment: profile,

--- a/app.config.ts
+++ b/app.config.ts
@@ -45,6 +45,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     }),
     extra: {
       ...config.extra,
+      sentryEnvironment: profile,
       eas: {
         ...eas,
         build: {

--- a/app.json
+++ b/app.json
@@ -60,6 +60,14 @@
       "expo-router",
       "expo-dev-client",
       [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "organization": "cherryai",
+          "project": "cherry-studio-a0"
+        }
+      ],
+      [
         "expo-widgets",
         {
           "enablePushNotifications": false

--- a/app.json
+++ b/app.json
@@ -11,6 +11,49 @@
       "icon": "./assets/icon.png",
       "bundleIdentifier": "com.cherryai.cherrystudio-app",
       "appleTeamId": "87242QY66T",
+      "privacyManifests": {
+        "NSPrivacyTracking": false,
+        "NSPrivacyCollectedDataTypes": [
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeCrashData",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypePerformanceData",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeOtherDiagnosticData",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          }
+        ],
+        "NSPrivacyAccessedAPITypes": [
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
+            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
+            "NSPrivacyAccessedAPITypeReasons": ["C617.1"]
+          }
+        ]
+      },
       "entitlements": {
         "com.apple.developer.healthkit": true,
         "com.apple.security.application-groups": ["group.com.cherryai.cherrystudio-app"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Guides are task-oriented procedures for changing or extending the application.
 | --- | --- |
 | [Extending Cherry Mobile](./guides/extending.md) | Add resource endpoints, workflows, persistence, backend behavior, and UI |
 | [Git Workflow](./guides/git-workflow.md) | Commits, stacked PRs, review readiness, and case-only renames |
+| [Local EAS Builds](./guides/local-builds.md) | Local installation packages, Sentry environment variables, and build profiles |
 | [Parallel Device Testing](./guides/parallel-device-testing.md) | Agent self-test preparation design, configuration and development-client reuse, Conductor device isolation, and cleanup |
 | [Testing And CI](./guides/testing-and-ci.md) | Focused checks, test value, local PR gates, and remote CI |
 | [UI Development](./guides/ui-development.md) | CherryUI ownership and reusable React component composition |

--- a/docs/guides/local-builds.md
+++ b/docs/guides/local-builds.md
@@ -1,0 +1,100 @@
+# Local EAS Builds
+
+Use `pnpm build:local` to create an Android or iOS installation package on your machine. It runs
+`eas build --local`, defaults to the `development` profile, and forwards EAS build arguments.
+The existing `eas-build-post-install` hook builds the workspace packages during the build.
+
+| Build profile | Sentry reporting | Sentry source-map and debug-symbol uploads |
+| --- | --- | --- |
+| `development` / `development-simulator` | Disabled | Disabled |
+| `preview` | Disabled | Disabled |
+| `production` | Enabled with a DSN outside development mode | Enabled; requires an upload token |
+
+## Prerequisites
+
+- Install the repository dependencies with Node.js 24 and `pnpm@12.2.1`.
+- Install EAS CLI (`pnpm add --global eas-cli`) and authenticate with `eas login`, or provide
+  `EXPO_TOKEN` in the process environment.
+- Install the native build tools for the selected platform: Xcode, CocoaPods, and fastlane for
+  iOS; the Android SDK and NDK for Android.
+
+`pnpm-workspace.yaml` allows the `@sentry/cli` installation script so Sentry's upload executable is
+available to native builds. It uses the platform package when available and can download the
+binary as a fallback.
+
+Local EAS builds still contact Expo for project information and managed signing credentials. They
+do not use Expo's cloud build workers. See the
+[Expo local build guide](https://docs.expo.dev/build-reference/local-builds/) for platform requirements
+and limitations.
+
+## Sentry Environment Variables
+
+Development and preview builds do not need Sentry credentials. `app.config.ts` omits the Sentry
+Expo plugin for these profiles, so their generated native projects have no Sentry upload hooks.
+Runtime initialization also checks the profile; supplying a DSN does not enable their reporting.
+
+For production monitoring, add these entries to the repository-root `.env.local`, filling in the
+values for the Sentry project configured in `app.json`:
+
+```dotenv
+EXPO_PUBLIC_SENTRY_DSN=
+SENTRY_AUTH_TOKEN=
+```
+
+- `EXPO_PUBLIC_SENTRY_DSN` is the public event-ingestion address embedded in the app. Reporting is
+  enabled only for the production profile, with a DSN, and outside development mode (`__DEV__`).
+- `SENTRY_AUTH_TOKEN` is a build-only credential used to upload source maps and debug symbols.
+  Use a token with the source-map upload permissions for the configured Sentry project. Do not
+  prefix it with `EXPO_PUBLIC_` or add it to app config.
+
+The wrapper uses Node's env-file loader before starting EAS. Existing shell environment variables
+take precedence over `.env.local`, which takes precedence over `.env`. Missing files are allowed;
+values must be literal because Node's loader does not expand references such as `${OTHER_VAR}`.
+The loaded variables are inherited by the local build process. `.env` and `.env.local` remain
+excluded from Git and the EAS source archive; do not remove those ignore rules to pass credentials.
+The wrapper does not load profile-specific files such as `.env.production.local`.
+
+Choose local values for the intended build profile, or export them from your credential manager
+before running the command. EAS also resolves its selected environment; variables with **Secret**
+visibility must be supplied locally for local builds. Cloud release builds continue to use the
+EAS `production` environment described in the
+[observability module](../../src/frontend/appShell/observability/README.md).
+
+## Build Commands
+
+Build one platform at a time. Both commands default to the development client:
+
+```bash
+pnpm build:local --platform android
+pnpm build:local --platform ios
+```
+
+Pass `--output /absolute/path/to/package.apk` or `--output /absolute/path/to/package.ipa` to choose
+the artifact location. For an iOS simulator package, select `--profile development-simulator`;
+that profile produces a simulator artifact rather than an IPA for a physical device.
+
+To create a standalone preview package, select the existing preview profile:
+
+```bash
+pnpm build:local --platform android --profile preview
+pnpm build:local --platform ios --profile preview
+```
+
+Preview and development bundles do not report to Sentry, even when the native dependency and a DSN
+are present. Production builds require `--profile production`; that profile is never the wrapper's
+default.
+
+For production monitoring, provide a valid upload token and keep automatic uploads enabled.
+`SENTRY_DISABLE_AUTO_UPLOAD=true` skips uploads but does not disable runtime reporting. Without
+matching source maps and debug symbols, reported error stacks may not resolve back to source.
+Missing or invalid upload credentials can fail the build.
+
+Rebuild the native client after adding or changing native dependencies such as Sentry. Starting
+Metro again does not add a native module to an already installed client. Local and cloud EAS builds
+generate native projects from the selected profile because `.easignore` excludes `ios` and `android`.
+When using direct Expo builds with existing native folders, follow the
+[app-variant regeneration instructions](../../README.md#app-variants) after switching profiles;
+removing a plugin from app config does not clean its hooks out of an existing native project.
+
+Successful compilation alone does not verify production Sentry event delivery or source-map
+matching; those require a separate runtime check.

--- a/eas.json
+++ b/eas.json
@@ -39,6 +39,7 @@
       "ios": {}
     },
     "production": {
+      "environment": "production",
       "autoIncrement": true,
       "channel": "production",
       "node": "24.19.0",

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,10 +1,10 @@
-const { getDefaultConfig } = require('expo/metro-config');
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const path = require('path');
 const { getBundleModeMetroConfig } = require('react-native-worklets/bundleMode');
 const { withStorybook } = require('@storybook/react-native/withStorybook');
 const { withUniwindConfig } = require('uniwind/metro');
 
-let config = getDefaultConfig(__dirname);
+let config = getSentryExpoConfig(__dirname);
 
 config.resolver.sourceExts.push('sql');
 config.watchFolders.push(path.resolve(__dirname, 'packages'));

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@openrouter/ai-sdk-provider": "^2.10.0",
     "@react-native-community/slider": "5.2.0",
     "@react-native-masked-view/masked-view": "0.3.2",
+    "@sentry/react-native": "~7.11.0",
     "@shopify/flash-list": "2.3.2",
     "@shopify/react-native-skia": "2.6.2",
     "@swmansion/react-native-bottom-sheet": "0.15.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "packages:build": "pnpm --filter @cherrystudio/ai-sdk-provider build && pnpm --filter @cherrystudio/ai-core build",
     "eas-build-post-install": "pnpm packages:build",
+    "build:local": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --import tsx scripts/buildLocal.ts",
     "dev": "pnpm packages:build && PROFILE=development expo start --dev-client",
     "dev:clear": "pnpm packages:build && PROFILE=development expo start --dev-client --clear",
     "start": "pnpm packages:build && PROFILE=development expo start --dev-client",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       '@react-native-masked-view/masked-view':
         specifier: 0.3.2
         version: 0.3.2(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      '@sentry/react-native':
+        specifier: ~7.11.0
+        version: 7.11.0(encoding@0.1.13)(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
       '@shopify/flash-list':
         specifier: 2.3.2
         version: 2.3.2(@babel/runtime@7.29.7)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -4268,6 +4271,107 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sentry-internal/browser-utils@10.37.0':
+    resolution: {integrity: sha512-rqdESYaVio9Ktz55lhUhtBsBUCF3wvvJuWia5YqoHDd+egyIfwWxITTAa0TSEyZl7283A4WNHNl0hyeEMblmfA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.37.0':
+    resolution: {integrity: sha512-P0PVlfrDvfvCYg2KPIS7YUG/4i6ZPf8z1MicXx09C9Cz9W9UhSBh/nii13eBdDtLav2BFMKhvaFMcghXHX03Hw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.37.0':
+    resolution: {integrity: sha512-PyIYSbjLs+L5essYV0MyIsh4n5xfv2eV7l0nhUoPJv9Bak3kattQY3tholOj0EP3SgKgb+8HSZnmazgF++Hbog==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.37.0':
+    resolution: {integrity: sha512-snuk12ZaDerxesSnetNIwKoth/51R0y/h3eXD/bGtXp+hnSkeXN5HanI/RJl297llRjn4zJYRShW9Nx86Ay0Dw==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@4.8.0':
+    resolution: {integrity: sha512-cy/9Eipkv23MsEJ4IuB4dNlVwS9UqOzI3Eu+QPake5BVFgPYCX0uP0Tr3Z43Ime6Rb+BiDnWC51AJK9i9afHYw==}
+    engines: {node: '>= 14'}
+
+  '@sentry/browser@10.37.0':
+    resolution: {integrity: sha512-kheqJNqGZP5TSBCPv4Vienv1sfZwXKHQDYR+xrdHHYdZqwWuZMJJW/cLO9XjYAe+B9NnJ4UwJOoY4fPvU+HQ1Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/cli-darwin@2.58.4':
+    resolution: {integrity: sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.4':
+    resolution: {integrity: sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.4':
+    resolution: {integrity: sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.4':
+    resolution: {integrity: sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.4':
+    resolution: {integrity: sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.4':
+    resolution: {integrity: sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.4':
+    resolution: {integrity: sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.4':
+    resolution: {integrity: sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.4':
+    resolution: {integrity: sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/core@10.37.0':
+    resolution: {integrity: sha512-hkRz7S4gkKLgPf+p3XgVjVm7tAfvcEPZxeACCC6jmoeKhGkzN44nXwLiqqshJ25RMcSrhfFvJa/FlBg6zupz7g==}
+    engines: {node: '>=18'}
+
+  '@sentry/react-native@7.11.0':
+    resolution: {integrity: sha512-OiDaLCAGpRN18YG/o7IIwLhU0Xpb0tYKQ5QxkGHiwb+L3VHn+MqGCGfITYNdhqr06HHMvu9Lysm+UJxaNmGaJg==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@sentry/react@10.37.0':
+    resolution: {integrity: sha512-XLnXJOHgsCeVAVBbO+9AuGlZWnCxLQHLOmKxpIr8wjE3g7dHibtug6cv8JLx78O4dd7aoCqv2TTyyKY9FLJ2EQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/types@10.37.0':
+    resolution: {integrity: sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==}
+    engines: {node: '>=18'}
 
   '@shopify/flash-list@2.3.2':
     resolution: {integrity: sha512-vQnd0y0Ag11yzS30llaeCrtIU3xYTMe7KEOP3dveLImnVjQEUw6BEg1+Ztja6aODlVNz1BpvxtlQ5eZGxiLwKw==}
@@ -8297,6 +8401,9 @@ packages:
   protobufjs@7.6.5:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -13131,6 +13238,106 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@sentry-internal/browser-utils@10.37.0':
+    dependencies:
+      '@sentry/core': 10.37.0
+
+  '@sentry-internal/feedback@10.37.0':
+    dependencies:
+      '@sentry/core': 10.37.0
+
+  '@sentry-internal/replay-canvas@10.37.0':
+    dependencies:
+      '@sentry-internal/replay': 10.37.0
+      '@sentry/core': 10.37.0
+
+  '@sentry-internal/replay@10.37.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.37.0
+      '@sentry/core': 10.37.0
+
+  '@sentry/babel-plugin-component-annotate@4.8.0': {}
+
+  '@sentry/browser@10.37.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.37.0
+      '@sentry-internal/feedback': 10.37.0
+      '@sentry-internal/replay': 10.37.0
+      '@sentry-internal/replay-canvas': 10.37.0
+      '@sentry/core': 10.37.0
+
+  '@sentry/cli-darwin@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.4':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.4':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.4':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.4':
+    optional: true
+
+  '@sentry/cli@2.58.4(encoding@0.1.13)(supports-color@8.1.1)':
+    dependencies:
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.4
+      '@sentry/cli-linux-arm': 2.58.4
+      '@sentry/cli-linux-arm64': 2.58.4
+      '@sentry/cli-linux-i686': 2.58.4
+      '@sentry/cli-linux-x64': 2.58.4
+      '@sentry/cli-win32-arm64': 2.58.4
+      '@sentry/cli-win32-i686': 2.58.4
+      '@sentry/cli-win32-x64': 2.58.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.37.0': {}
+
+  '@sentry/react-native@7.11.0(encoding@0.1.13)(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 4.8.0
+      '@sentry/browser': 10.37.0
+      '@sentry/cli': 2.58.4(encoding@0.1.13)(supports-color@8.1.1)
+      '@sentry/core': 10.37.0
+      '@sentry/react': 10.37.0(react@19.2.3)
+      '@sentry/types': 10.37.0
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
+    optionalDependencies:
+      expo: 57.0.6(d5f991ac186e51872435ca0bcd5a72a5)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/react@10.37.0(react@19.2.3)':
+    dependencies:
+      '@sentry/browser': 10.37.0
+      '@sentry/core': 10.37.0
+      react: 19.2.3
+
+  '@sentry/types@10.37.0':
+    dependencies:
+      '@sentry/core': 10.37.0
+
   '@shopify/flash-list@2.3.2(@babel/runtime@7.29.7)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -17864,6 +18071,8 @@ snapshots:
       '@protobufjs/utf8': 1.1.2
       '@types/node': 25.9.5
       long: 5.3.2
+
+  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,8 @@ allowBuilds:
   core-js: true
   '@j178/prek': true
   '@shopify/react-native-skia': true
+  # Installs the Sentry CLI binary used for source-map and debug-symbol uploads.
+  '@sentry/cli': true
   # 1.0.0 起把 tree-sitter 语法和 RaTeX XCFramework 挪到 postinstall 下载，
   # 不放行就装不出代码高亮和数学公式所需的原生产物。
   react-native-enriched-markdown: true

--- a/scripts/buildLocal.ts
+++ b/scripts/buildLocal.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+const args = process.argv.slice(2);
+const { values } = parseArgs({
+  args,
+  options: { profile: { type: 'string', short: 'e' } },
+  // EAS owns validation of the remaining build arguments.
+  strict: false,
+  allowPositionals: true,
+});
+
+const result = spawnSync(
+  'eas',
+  [
+    'build',
+    '--local',
+    ...(values.profile === undefined ? ['--profile', 'development'] : []),
+    ...args,
+  ],
+  {
+    stdio: 'inherit',
+    // The package script loads local env files before EAS creates its build archive.
+    env: process.env,
+  },
+);
+
+if (result.error) {
+  console.error(
+    'Could not start EAS CLI. Ensure eas-cli is installed and eas is available on PATH.',
+  );
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+} else {
+  process.exitCode = result.status ?? 1;
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -3,6 +3,7 @@ import '@/bootstrap/preboot/abortSignal';
 import '@/bootstrap/preboot/blob';
 import '@/bootstrap/preboot/webCrypto';
 import { Alert, BottomSheetProvider, Toast } from '@cherrystudio/ui/components';
+import * as Sentry from '@sentry/react-native';
 import { ObserveRoot } from 'expo-observe';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
@@ -22,7 +23,7 @@ import {
   NavigationThemeProvider,
   paintingViewerHeaderShown,
 } from '@/frontend/appShell/navigation';
-import { configureObserve } from '@/frontend/appShell/observability';
+import { configureObserve, configureSentry } from '@/frontend/appShell/observability';
 import { APP_SEARCH_TRANSITION_DURATION_MS } from '@/frontend/appShell/search';
 import { StartupCoordinator, StartupRouteReadyReporter } from '@/frontend/appShell/startup';
 import { QueryProvider } from '@/frontend/data';
@@ -36,6 +37,7 @@ void SplashScreen.preventAutoHideAsync().catch(() => {});
 // The router integration has to be live before the first screen mounts, so this
 // runs at module scope alongside the splash screen hold rather than in an effect.
 configureObserve();
+configureSentry();
 
 const RootGestureView = withUniwind(GestureHandlerRootView);
 
@@ -74,7 +76,7 @@ function RootLayout() {
 // `wrap` mounts the metrics root above the tree, which is what times the first
 // render. It has to sit outside `RootLayout` rather than inside its JSX so the
 // measurement starts before any provider below renders.
-export default ObserveRoot.wrap(RootLayout);
+export default Sentry.wrap(ObserveRoot.wrap(RootLayout));
 
 function AppAlertProvider({ children }: PropsWithChildren) {
   const { t } = useTranslation();

--- a/src/frontend/appShell/observability/README.md
+++ b/src/frontend/appShell/observability/README.md
@@ -25,12 +25,23 @@ UserDefaults, system boot time, and file timestamp API reasons from the
 These declarations are the app's baseline; React Native aggregates additional API reasons from
 native dependencies during CocoaPods installation.
 
-Reporting and native initialization are disabled in development mode or when
-`EXPO_PUBLIC_SENTRY_DSN` is absent. `app.config.ts` supplies the build's `PROFILE` through
-`extra.sentryEnvironment` to distinguish report environments.
+Reporting and native initialization require `extra.sentryEnvironment === 'production'`, a configured
+`EXPO_PUBLIC_SENTRY_DSN`, and a bundle running outside development mode. `app.config.ts` supplies the
+build's `PROFILE` through `extra.sentryEnvironment`. Development and preview packages never enable
+reporting, even when a DSN is present.
+
+`app.config.ts` includes the Sentry Expo plugin only for `PROFILE=production`, so generated
+development and preview native projects have no Sentry source-map or debug-symbol upload hooks.
+The Sentry dependency remains installed across profiles; disabling reporting and uploads does not
+remove its native code from the app.
 
 The GitHub release workflows trigger EAS cloud builds using the `production` environment. Configure
 `EXPO_PUBLIC_SENTRY_DSN` as a plain-text variable and `SENTRY_AUTH_TOKEN` as a sensitive variable in
 that EAS environment. The DSN is embedded in the app; the token is used only by native build hooks
 to upload source maps and debug symbols to `cherryai/cherry-studio-a0`. GitHub keeps `EXPO_TOKEN`
 for EAS authentication. The Sentry Expo and Metro plugins handle uploads and source map identifiers.
+
+Sentry also works with local EAS builds; cloud workers are not required. Use `pnpm build:local` to
+load `.env` and `.env.local` into the build process before EAS creates its source archive. See
+[Local EAS Builds](../../../../docs/guides/local-builds.md) for production credentials, profile-specific
+Sentry behavior, and native regeneration when switching profiles.

--- a/src/frontend/appShell/observability/README.md
+++ b/src/frontend/appShell/observability/README.md
@@ -13,8 +13,17 @@ come from inside a screen, so entry routes mount `StartupInteractiveMarker` them
 
 `configureSentry` configures JavaScript error and native crash reporting. The root layout composes
 `Sentry.wrap` with the existing `ObserveRoot.wrap`. Performance tracing, session replay, and log
-streaming are not enabled. Default PII collection is disabled, as are JavaScript console and HTTP
-breadcrumbs, which can contain conversation data or provider credentials.
+streaming are not enabled. Default PII collection is disabled. `maxBreadcrumbs: 0` disables all
+breadcrumbs in both JavaScript and the native SDKs, including native HTTP breadcrumbs whose URLs
+can contain conversation data or provider credentials. JavaScript console and HTTP breadcrumb
+instrumentation is also disabled. Error stacks and native crash reporting remain enabled.
+
+`app.json` explicitly declares crash, performance, and other diagnostic data for observability in
+`ios.privacyManifests`, without identity linkage or tracking. It also declares Sentry's required
+UserDefaults, system boot time, and file timestamp API reasons from the
+[official privacy manifest guide](https://docs.sentry.io/platforms/react-native/data-management/apple-privacy-manifest/).
+These declarations are the app's baseline; React Native aggregates additional API reasons from
+native dependencies during CocoaPods installation.
 
 Reporting and native initialization are disabled in development mode or when
 `EXPO_PUBLIC_SENTRY_DSN` is absent. `app.config.ts` supplies the build's `PROFILE` through

--- a/src/frontend/appShell/observability/README.md
+++ b/src/frontend/appShell/observability/README.md
@@ -1,9 +1,27 @@
 # Observability
 
-This App Shell module owns the app's EAS Observe integration: the one-time SDK configuration the
-root layout runs at module scope, and the entry-screen marker that closes the Time to Interactive
-span.
+This App Shell module owns the app's EAS Observe and Sentry integrations. The root layout runs
+their configuration at module scope, before the first screen mounts.
+
+## EAS Observe
 
 Time to First Render comes from `ObserveRoot.wrap` in `src/app/_layout.tsx`; navigation timings come
 from the Expo Router integration `configureObserve` enables. Only TTI needs a caller, and it must
 come from inside a screen, so entry routes mount `StartupInteractiveMarker` themselves.
+
+## Sentry
+
+`configureSentry` configures JavaScript error and native crash reporting. The root layout composes
+`Sentry.wrap` with the existing `ObserveRoot.wrap`. Performance tracing, session replay, and log
+streaming are not enabled. Default PII collection is disabled, as are JavaScript console and HTTP
+breadcrumbs, which can contain conversation data or provider credentials.
+
+Reporting and native initialization are disabled in development mode or when
+`EXPO_PUBLIC_SENTRY_DSN` is absent. `app.config.ts` supplies the build's `PROFILE` through
+`extra.sentryEnvironment` to distinguish report environments.
+
+The GitHub release workflows trigger EAS cloud builds using the `production` environment. Configure
+`EXPO_PUBLIC_SENTRY_DSN` as a plain-text variable and `SENTRY_AUTH_TOKEN` as a sensitive variable in
+that EAS environment. The DSN is embedded in the app; the token is used only by native build hooks
+to upload source maps and debug symbols to `cherryai/cherry-studio-a0`. GitHub keeps `EXPO_TOKEN`
+for EAS authentication. The Sentry Expo and Metro plugins handle uploads and source map identifiers.

--- a/src/frontend/appShell/observability/configureSentry.ts
+++ b/src/frontend/appShell/observability/configureSentry.ts
@@ -11,7 +11,9 @@ export function configureSentry() {
     enableNative: isEnabled,
     environment: Constants.expoConfig?.extra?.sentryEnvironment,
     sendDefaultPii: false,
-    // Console arguments and request URLs can contain chat data or provider credentials.
+    // Also reaches the native SDKs, so iOS request URLs cannot become crash breadcrumbs.
+    maxBreadcrumbs: 0,
+    // Avoid instrumenting JS console and requests when breadcrumbs are disabled.
     integrations: [Sentry.breadcrumbsIntegration({ console: false, fetch: false, xhr: false })],
   });
 }

--- a/src/frontend/appShell/observability/configureSentry.ts
+++ b/src/frontend/appShell/observability/configureSentry.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
+
+export function configureSentry() {
+  const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+  const isEnabled = Boolean(dsn) && !__DEV__;
+
+  Sentry.init({
+    dsn,
+    enabled: isEnabled,
+    enableNative: isEnabled,
+    environment: Constants.expoConfig?.extra?.sentryEnvironment,
+    sendDefaultPii: false,
+    // Console arguments and request URLs can contain chat data or provider credentials.
+    integrations: [Sentry.breadcrumbsIntegration({ console: false, fetch: false, xhr: false })],
+  });
+}

--- a/src/frontend/appShell/observability/configureSentry.ts
+++ b/src/frontend/appShell/observability/configureSentry.ts
@@ -3,13 +3,14 @@ import Constants from 'expo-constants';
 
 export function configureSentry() {
   const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
-  const isEnabled = Boolean(dsn) && !__DEV__;
+  const environment = Constants.expoConfig?.extra?.sentryEnvironment;
+  const isEnabled = environment === 'production' && Boolean(dsn) && !__DEV__;
 
   Sentry.init({
     dsn,
     enabled: isEnabled,
     enableNative: isEnabled,
-    environment: Constants.expoConfig?.extra?.sentryEnvironment,
+    environment,
     sendDefaultPii: false,
     // Also reaches the native SDKs, so iOS request URLs cannot become crash breadcrumbs.
     maxBreadcrumbs: 0,

--- a/src/frontend/appShell/observability/index.ts
+++ b/src/frontend/appShell/observability/index.ts
@@ -1,2 +1,3 @@
 export { configureObserve } from './configureObserve';
+export { configureSentry } from './configureSentry';
 export { StartupInteractiveMarker } from './StartupInteractiveMarker';


### PR DESCRIPTION
### What this PR does

Before this PR, the mobile app had no Sentry error reporting or source map upload integration.

After this PR, non-development builds report JavaScript errors and native crashes when `EXPO_PUBLIC_SENTRY_DSN` is configured. Sentry initializes alongside the existing EAS Observe integration, and the Expo and Metro plugins configure source map and native debug symbol uploads during EAS builds.

### Screenshots or videos

N/A — this change adds error monitoring and build configuration without changing the visible UI.

### Why we need it and why it was done in this way

EAS performs the native builds launched by the existing GitHub release workflows, so the production build profile explicitly selects the EAS `production` environment. The public DSN comes from that environment; `SENTRY_AUTH_TOKEN` remains a build-only credential. Missing DSNs and development mode disable reporting. Default PII collection and JavaScript console/HTTP breadcrumbs are disabled; performance tracing, replay, and log streaming are not enabled.

### Breaking changes

No public API changes. The new native dependency requires rebuilding the custom development client.

### Special notes for your reviewer

- Configure `EXPO_PUBLIC_SENTRY_DSN` and a sensitive `SENTRY_AUTH_TOKEN` in the EAS environment used for builds. No credential values are committed.
- `pnpm dedupe --ignore-scripts`, `pnpm format`, `pnpm format:check`, and `git diff --check` passed. The lockfile contains only the new Sentry dependency graph.
- `pnpm lint` reports seven unresolved imports from `@cherrystudio/ai-core` and its `provider` entry because this workspace has no `packages/ai-core/dist` artifacts. These errors occur in unchanged consumers; the modified files have no lint errors.
- Typecheck, tests, native builds, device verification, and actual Sentry event delivery were not run. Typecheck invokes workspace builds, so build and runtime validation remain pending.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the change and its validation limits
- [x] Preview: No visible UI changes; screenshots are not applicable
- [x] Self-review: Reviewed the complete diff and dependency changes

### Release note

```release-note
NONE
```
