### PR TITLE
fix(model-settings): hide unused model selectors

### DIFF
--- a/src/frontend/features/settings/model/ModelSettingsScreen.tsx
+++ b/src/frontend/features/settings/model/ModelSettingsScreen.tsx
@@ -19,6 +19,11 @@ import {
 
 import { SettingsScrollPage } from '../components/SettingsScrollPage';
 
+// 快速模型和翻译模型暂无功能接入，暂时隐藏设置入口，待功能接通后恢复。
+const VISIBLE_MODEL_SETTING_KINDS = MODEL_SETTING_KINDS.filter(
+  (kind) => kind !== 'fast' && kind !== 'translate',
+);
+
 export default function ModelSettingsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -101,7 +106,7 @@ export default function ModelSettingsScreen() {
   );
   const items = useMemo(
     () =>
-      MODEL_SETTING_KINDS.map((kind: ModelSettingKind) => {
+      VISIBLE_MODEL_SETTING_KINDS.map((kind: ModelSettingKind) => {
         const item =
           kind === 'painting'
             ? imageModelPickerData.getModelItem(draft[kind])


### PR DESCRIPTION
### What this PR does

Before this PR, default-model settings exposed Fast model and Translation model selectors even though neither has a connected generation feature.

After this PR, the page shows only Default model and Drawing model. A screen-local filter hides the two unused selectors, with a comment explaining that they can return when their features are connected.

### Screenshots or videos

Not captured: device/UI verification was not authorized for this task.

### Why we need it and why it was done in this way

Hide settings that currently have no functional effect on generation. Keep preference keys, saved values, and existing model-deletion protection intact so this remains a small UI-only change.

### Breaking changes

None. No preference or database migration.

### Special notes for your reviewer

- Passed: formatting and Oxlint/Expo lint for the changed file; full `pnpm format:check`; `git diff --check`.
- Full `pnpm lint` failed with 7 import-resolution errors for `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` in unchanged files. The package exports point to its missing `dist` directory. Existing warnings were also reported.
- Type checking, builds, tests, and device/UI verification were not run under the task's verification constraints. `pnpm typecheck` invokes package builds.
- Previously saved Fast/Translation selections still participate in model-deletion protection, although these selectors are hidden.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the final change and validation limits
- [ ] Preview: Screenshots or video uploaded
- [x] Code: The change is limited to the settings screen
- [x] Upgrade: Existing preference values are preserved
- [x] Documentation: An inline comment records why the selectors are hidden
- [x] Self-review: Reviewed the diff

### Release note

```release-note
Temporarily hide Fast model and Translation model settings until their features are connected.
```
