### PR TITLE
fix(provider-icons): unify avatar shapes and spacing

### DIFF
--- a/src/frontend/components/Avatar/README.md
+++ b/src/frontend/components/Avatar/README.md
@@ -7,8 +7,12 @@ Cherry product data and presentation rules before composing that primitive.
 ## Public Interface
 
 - `BrandAvatar`, `BrandAvatarIcon`, and `BrandAvatarPhoto` apply provider/model brand fallback and
-  icon inset rules. `shape` defaults to `rounded`, the brand default; editing forms pass `circle`,
-  where the avatar is the subject rather than one entry in a list of brands.
+  icon inset rules. Lists use the default `rounded` frame with the shared `rounded-md` radius;
+  detail, creation, and connection forms pass `circle`. The frame owns clipping. Provider artwork
+  with its own background fills the frame; transparent marks use shape-specific insets, and
+  first-character backgrounds fill the frame. `BrandAvatarIcon` accepts a resolved light/dark
+  source pair so aliases and model-to-provider fallbacks share the actual artwork's layout.
+  OpenCode and MiMo compensate for their existing canvas padding at display time.
 - `ProviderBrandAvatar` resolves a provider's built-in logo and generated-initial fallback. It does
   not read uploaded avatars, so provider-avatar persistence remains provider-owned.
 - `ModelAvatar` resolves a model icon from its model and provider records.

--- a/src/frontend/components/Avatar/__tests__/BrandAvatar.test.tsx
+++ b/src/frontend/components/Avatar/__tests__/BrandAvatar.test.tsx
@@ -3,7 +3,6 @@ import { Text } from 'react-native';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { BrandAvatar, BrandAvatarIcon, BrandAvatarPhoto, ProviderBrandAvatar } from '..';
-import { PROVIDER_BRAND_ICON_SCALE } from '../utils/brandAvatarStyles';
 
 const mockAvatar = jest.fn(({ children }: { children?: React.ReactNode }) => children);
 const mockAvatarFallback = jest.fn((_props: unknown) => null);
@@ -22,12 +21,14 @@ jest.mock('@/frontend/hooks/useAvatar', () => ({
   useAvatar: () => 'profile-avatar-source',
 }));
 
-jest.mock('@cherrystudio/ui/icons', () => ({
-  resolveProviderIcon: jest.fn(),
-}));
+jest.mock('@cherrystudio/ui/icons', () => {
+  const actual = jest.requireActual('@cherrystudio/ui/icons');
+  return { ...actual, resolveProviderIcon: jest.fn(actual.resolveProviderIcon) };
+});
 
 jest.mock('uniwind', () => ({
   useUniwind: () => ({ theme: 'light' }),
+  useResolveClassNames: () => ({ borderRadius: 6.4 }),
 }));
 
 const mockResolveProviderIcon = jest.mocked(resolveProviderIcon);
@@ -35,7 +36,12 @@ const mockResolveProviderIcon = jest.mocked(resolveProviderIcon);
 describe('BrandAvatar', () => {
   let renderer: ReactTestRenderer | undefined;
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveProviderIcon.mockImplementation(
+      jest.requireActual('@cherrystudio/ui/icons').resolveProviderIcon,
+    );
+  });
 
   afterEach(() => {
     if (renderer) {
@@ -47,11 +53,10 @@ describe('BrandAvatar', () => {
   it('falls back to the generated initial when given no content', () => {
     render(<BrandAvatar label="codex" />);
 
-    // At the default size the ratios resolve to the plain constants they replaced.
     expect(mockAvatar).toHaveBeenCalledWith(
       expect.objectContaining({
         accessibilityLabel: 'codex',
-        radius: 6,
+        radius: 6.4,
         shape: 'rounded',
         size: 26,
       }),
@@ -59,8 +64,7 @@ describe('BrandAvatar', () => {
     expect(mockAvatarFallback).toHaveBeenCalledWith(
       expect.objectContaining({
         children: 'c',
-        scale: 0.8125,
-        style: { backgroundColor: '#46429b', borderRadius: 5 },
+        style: { backgroundColor: '#46429b' },
         textProps: { style: { color: '#FFFFFF', fontSize: 14 } },
       }),
     );
@@ -80,29 +84,20 @@ describe('BrandAvatar', () => {
     expect(renderer?.root.findByType(Text).props.children).toBe('…');
   });
 
-  it('scales an inset logo against the frame size it is nested in', () => {
+  it('lets the shared frame clip a logo that already has a brand background', () => {
+    const source = resolveProviderIcon('anthropic')!;
     render(
       <BrandAvatar label="Anthropic" size={32}>
-        <BrandAvatarIcon
-          displayContext="provider-list"
-          iconId="anthropic"
-          source="anthropic-light"
-        />
+        <BrandAvatarIcon displayContext="provider" source={source} />
       </BrandAvatar>,
     );
 
-    // The frame's own radius is a ratio of the default size, not a constant:
-    // the same avatar is rendered at 26 in lists and near 100 in the provider
-    // form, where a fixed 6 would read as a square.
-    expect(mockAvatar).toHaveBeenCalledWith(
-      expect.objectContaining({ radius: 32 * (6 / 26), size: 32 }),
-    );
+    expect(mockAvatar).toHaveBeenCalledWith(expect.objectContaining({ radius: 6.4, size: 32 }));
     expect(mockAvatarImage).toHaveBeenCalledWith(
       expect.objectContaining({
         contentFit: 'contain',
-        scale: PROVIDER_BRAND_ICON_SCALE,
-        source: 'anthropic-light',
-        style: { borderRadius: 5 },
+        scale: 1,
+        source: source.light,
       }),
     );
   });
@@ -110,14 +105,13 @@ describe('BrandAvatar', () => {
   it('uses the untrimmed default scale for logos without their own tile', () => {
     render(
       <BrandAvatar label="OpenAI">
-        <BrandAvatarIcon iconId="openai" source="openai-light" />
+        <BrandAvatarIcon source={{ dark: 2, light: 1 }} />
       </BrandAvatar>,
     );
 
     expect(mockAvatarImage).toHaveBeenCalledWith(
       expect.objectContaining({
         scale: 1,
-        style: { borderRadius: undefined },
       }),
     );
   });
@@ -164,7 +158,7 @@ describe('BrandAvatar', () => {
     expect(mockAvatarImage).toHaveBeenCalledWith(
       expect.objectContaining({
         recyclingKey: 'custom-openai',
-        scale: PROVIDER_BRAND_ICON_SCALE,
+        scale: 0.8125,
         source: 'openai-light',
       }),
     );

--- a/src/frontend/components/Avatar/components/BrandAvatar.tsx
+++ b/src/frontend/components/Avatar/components/BrandAvatar.tsx
@@ -1,5 +1,7 @@
-import { Avatar, Image } from '@cherrystudio/ui/components';
-import { type ComponentProps, type ReactNode } from 'react';
+import { Avatar } from '@cherrystudio/ui/components';
+import type { IconSource } from '@cherrystudio/ui/icons';
+import { createContext, type ReactNode, use } from 'react';
+import { useResolveClassNames, useUniwind } from 'uniwind';
 
 import {
   DEFAULT_BRAND_ICON_SCALE,
@@ -7,12 +9,9 @@ import {
   getBrandAvatarIconDisplayConfig,
 } from '../utils/brandAvatarStyles';
 
-type ImageSource = ComponentProps<typeof Image>['source'];
-
 const BRAND_AVATAR_SIZE = 26;
-const BRAND_AVATAR_FRAME_RADIUS = 6;
 const BRAND_AVATAR_INITIAL_FONT_SIZE = 14;
-const BRAND_AVATAR_FALLBACK_SCALE = 0.8125;
+const BrandAvatarShapeContext = createContext<'circle' | 'rounded'>('rounded');
 
 type BrandAvatarProps = {
   /**
@@ -43,63 +42,55 @@ export function BrandAvatar({
   size = BRAND_AVATAR_SIZE,
   testID,
 }: BrandAvatarProps) {
+  const { borderRadius } = useResolveClassNames('rounded-md');
   const fallback = children === undefined ? getBrandAvatarFallback(label) : undefined;
-  // Corner radius and the initial's type size are ratios of the default size,
-  // not constants: the same avatar is rendered at 26 in lists and at form-hero
-  // sizes in the provider form, and a fixed 6pt radius reads as a square there.
-  // At the default size these resolve to the plain 6/5/14 they replaced.
   const frameRadius =
-    shape === 'circle' ? size / 2 : (size * BRAND_AVATAR_FRAME_RADIUS) / BRAND_AVATAR_SIZE;
+    shape === 'circle' ? size / 2 : typeof borderRadius === 'number' ? borderRadius : 0;
 
   return (
-    <Avatar
-      accessibilityLabel={label}
-      radius={frameRadius}
-      shape={shape}
-      size={size}
-      testID={testID}
-    >
-      {fallback ? (
-        <Avatar.Fallback
-          scale={BRAND_AVATAR_FALLBACK_SCALE}
-          style={{ backgroundColor: fallback.backgroundColor, borderRadius: frameRadius - 1 }}
-          textProps={{
-            style: {
-              color: fallback.color,
-              fontSize: (size * BRAND_AVATAR_INITIAL_FONT_SIZE) / BRAND_AVATAR_SIZE,
-            },
-          }}
-        >
-          {fallback.initial}
-        </Avatar.Fallback>
-      ) : (
-        children
-      )}
-    </Avatar>
+    <BrandAvatarShapeContext value={shape}>
+      <Avatar
+        accessibilityLabel={label}
+        radius={frameRadius}
+        shape={shape}
+        size={size}
+        testID={testID}
+      >
+        {fallback ? (
+          <Avatar.Fallback
+            style={{ backgroundColor: fallback.backgroundColor }}
+            textProps={{
+              style: {
+                color: fallback.color,
+                fontSize: (size * BRAND_AVATAR_INITIAL_FONT_SIZE) / BRAND_AVATAR_SIZE,
+              },
+            }}
+          >
+            {fallback.initial}
+          </Avatar.Fallback>
+        ) : (
+          children
+        )}
+      </Avatar>
+    </BrandAvatarShapeContext>
   );
 }
 
 type BrandAvatarIconProps = {
   /**
-   * Provider or model id used to pick the inset — logos that already ship their
-   * own colored tile are inset further so they do not read as a frame in a frame.
+   * Provider artwork uses a full-frame tile or an inset mark. Model artwork
+   * keeps its original canvas when this context is omitted.
    */
-  displayContext?: 'provider' | 'provider-list';
-  iconId?: string;
+  displayContext?: 'provider';
   recyclingKey?: string;
-  source: ImageSource;
+  source: IconSource;
 };
 
-/** Built-in brand logo, inset within the frame. */
-export function BrandAvatarIcon({
-  displayContext,
-  iconId,
-  recyclingKey,
-  source,
-}: BrandAvatarIconProps) {
-  const displayConfig = displayContext
-    ? getBrandAvatarIconDisplayConfig(iconId, displayContext)
-    : undefined;
+/** Built-in brand artwork sized for its source canvas and enclosing shape. */
+export function BrandAvatarIcon({ displayContext, recyclingKey, source }: BrandAvatarIconProps) {
+  const shape = use(BrandAvatarShapeContext);
+  const { theme } = useUniwind();
+  const displayConfig = displayContext ? getBrandAvatarIconDisplayConfig(source, shape) : undefined;
 
   return (
     <Avatar.Image
@@ -107,8 +98,7 @@ export function BrandAvatarIcon({
       contentFit="contain"
       recyclingKey={recyclingKey}
       scale={displayConfig?.scale ?? DEFAULT_BRAND_ICON_SCALE}
-      source={source}
-      style={{ borderRadius: displayConfig?.borderRadius }}
+      source={source[theme === 'dark' ? 'dark' : 'light']}
     />
   );
 }

--- a/src/frontend/components/Avatar/components/ModelAvatar.tsx
+++ b/src/frontend/components/Avatar/components/ModelAvatar.tsx
@@ -1,5 +1,3 @@
-import { useUniwind } from 'uniwind';
-
 import { resolveModelIconSources } from '@/frontend/utils/modelIcons';
 import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
@@ -22,8 +20,6 @@ type ModelAvatarProps = {
  * than becoming one component with a shape switch.
  */
 export function ModelAvatar({ model, provider, size }: ModelAvatarProps) {
-  const { theme } = useUniwind();
-  const iconTheme = theme === 'dark' ? 'dark' : 'light';
   const providerIconId = provider?.presetProviderId ?? provider?.id ?? model.providerId;
   const { iconSource, modelIconSource } = resolveModelIconSources(model.modelId, providerIconId);
   const frameProps = { label: model.name, ...(size !== undefined && { size }) };
@@ -36,9 +32,8 @@ export function ModelAvatar({ model, provider, size }: ModelAvatarProps) {
     <BrandAvatar {...frameProps}>
       <BrandAvatarIcon
         displayContext={modelIconSource ? undefined : 'provider'}
-        iconId={providerIconId}
         recyclingKey={model.id}
-        source={iconSource[iconTheme]}
+        source={iconSource}
       />
     </BrandAvatar>
   );

--- a/src/frontend/components/Avatar/components/ProviderBrandAvatar.tsx
+++ b/src/frontend/components/Avatar/components/ProviderBrandAvatar.tsx
@@ -1,10 +1,8 @@
 import { resolveProviderIcon } from '@cherrystudio/ui/icons';
-import { useUniwind } from 'uniwind';
 
 import { BrandAvatar, BrandAvatarIcon } from './BrandAvatar';
 
 type ProviderBrandAvatarProps = {
-  displayContext?: 'provider-list';
   presetProviderId?: string;
   providerId: string;
   providerName: string;
@@ -19,7 +17,6 @@ type ProviderBrandAvatarProps = {
  * settings data, while this presentation is shared by any provider surface.
  */
 export function ProviderBrandAvatar({
-  displayContext,
   presetProviderId,
   providerId,
   providerName,
@@ -27,8 +24,6 @@ export function ProviderBrandAvatar({
   size,
   testID,
 }: ProviderBrandAvatarProps) {
-  const { theme } = useUniwind();
-  const iconTheme = theme === 'dark' ? 'dark' : 'light';
   const displayIconId = presetProviderId ?? providerId;
   const iconSource = resolveProviderIcon(displayIconId);
   const frameProps = {
@@ -41,12 +36,7 @@ export function ProviderBrandAvatar({
   if (iconSource) {
     return (
       <BrandAvatar {...frameProps}>
-        <BrandAvatarIcon
-          displayContext={displayContext ?? 'provider'}
-          iconId={displayIconId}
-          recyclingKey={providerId}
-          source={iconSource[iconTheme]}
-        />
+        <BrandAvatarIcon displayContext="provider" recyclingKey={providerId} source={iconSource} />
       </BrandAvatar>
     );
   }

--- a/src/frontend/components/Avatar/index.ts
+++ b/src/frontend/components/Avatar/index.ts
@@ -4,7 +4,7 @@ export { AvatarPickerField } from './components/AvatarPickerField';
 export { BrandAvatar, BrandAvatarIcon, BrandAvatarPhoto } from './components/BrandAvatar';
 export { ModelAvatar } from './components/ModelAvatar';
 export { ProviderBrandAvatar } from './components/ProviderBrandAvatar';
-export { PROVIDER_BRAND_ICON_SCALE } from './utils/brandAvatarStyles';
+export { getBrandAvatarIconDisplayConfig } from './utils/brandAvatarStyles';
 export {
   ProfileAvatarImage,
   ProfileEditableAvatar,

--- a/src/frontend/components/Avatar/utils/__tests__/brandAvatarStyles.test.ts
+++ b/src/frontend/components/Avatar/utils/__tests__/brandAvatarStyles.test.ts
@@ -1,28 +1,50 @@
+import { resolveProviderIcon } from '@cherrystudio/ui/icons';
+
 import {
   DEFAULT_BRAND_ICON_SCALE,
-  PROVIDER_BRAND_ICON_SCALE,
   getBrandAvatarFallback,
   getBrandAvatarIconDisplayConfig,
 } from '../brandAvatarStyles';
 
 describe('brand avatar styles', () => {
   it.each(['cherryin', 'aihubmix', 'lmstudio', 'anthropic', 'yi', 'groq', 'aws-bedrock'])(
-    'contains the %s logo in the shared avatar frame',
+    'fills both frame shapes with the %s brand background',
     (providerId) => {
-      expect(getBrandAvatarIconDisplayConfig(providerId)).toEqual({
-        borderRadius: 5,
-        scale: PROVIDER_BRAND_ICON_SCALE,
-      });
+      const icon = resolveProviderIcon(providerId)!;
+      expect(getBrandAvatarIconDisplayConfig(icon)).toEqual({ scale: 1 });
+      expect(getBrandAvatarIconDisplayConfig(icon, 'circle')).toEqual({ scale: 1 });
     },
   );
 
-  it('uses one normalized provider scale after transparent padding is trimmed', () => {
-    expect(getBrandAvatarIconDisplayConfig('openai')).toEqual({
-      scale: PROVIDER_BRAND_ICON_SCALE,
-    });
-    expect(getBrandAvatarIconDisplayConfig('anthropic', 'provider')).toEqual({
-      scale: PROVIDER_BRAND_ICON_SCALE,
-    });
+  it('preserves inset marks and keeps their corners inside a circular frame', () => {
+    const icon = resolveProviderIcon('openai')!;
+    const rounded = getBrandAvatarIconDisplayConfig(icon);
+    const circle = getBrandAvatarIconDisplayConfig(icon, 'circle');
+    expect(rounded.scale).toBe(0.8125);
+    expect(circle.scale).toBeLessThanOrEqual(Math.SQRT1_2);
+    expect(circle.scale).toBeGreaterThan(0.65);
+  });
+
+  it.each([
+    ['yi', 'zero-one'],
+    ['cherryai', 'cherryin'],
+  ])('uses the same layout for %s and its resolved %s artwork', (alias, providerId) => {
+    for (const shape of ['circle', 'rounded'] as const) {
+      expect(getBrandAvatarIconDisplayConfig(resolveProviderIcon(alias)!, shape)).toEqual(
+        getBrandAvatarIconDisplayConfig(resolveProviderIcon(providerId)!, shape),
+      );
+    }
+  });
+
+  it.each([
+    ['opencode', 46],
+    ['mimo', 48],
+  ] as const)('removes the extra canvas inset from %s without cropping its mark', (id, bounds) => {
+    const icon = resolveProviderIcon(id)!;
+    const rounded = getBrandAvatarIconDisplayConfig(icon);
+    const circle = getBrandAvatarIconDisplayConfig(icon, 'circle');
+    expect((rounded.scale * bounds) / 72).toBeCloseTo(0.8125);
+    expect((circle.scale * bounds) / 72).toBeLessThanOrEqual(Math.SQRT1_2);
   });
 
   it('keeps the desktop SVG canvas at its native scale outside provider lists', () => {

--- a/src/frontend/components/Avatar/utils/brandAvatarStyles.ts
+++ b/src/frontend/components/Avatar/utils/brandAvatarStyles.ts
@@ -1,41 +1,69 @@
+import { type IconSource, resolveProviderIcon } from '@cherrystudio/ui/icons';
+
 export interface BrandAvatarDisplayConfig {
-  borderRadius?: number;
   scale: number;
 }
 
 export const DEFAULT_BRAND_ICON_SCALE = 1;
 // Provider WebPs are cropped to their visible bounds during generation. This
 // shared inset restores breathing room after that asset-level normalization.
-export const PROVIDER_BRAND_ICON_SCALE = 0.8125;
+const PROVIDER_BRAND_ICON_SCALE = 0.8125;
+// Keep a square mark inside the circle, including its corner details.
+const CIRCULAR_PROVIDER_BRAND_ICON_SCALE = 0.7;
 
-const CONTAINED_BRAND_ICON: Readonly<BrandAvatarDisplayConfig> = {
-  borderRadius: 5,
-  scale: PROVIDER_BRAND_ICON_SCALE,
-};
-const PROVIDER_BRAND_ICON: Readonly<BrandAvatarDisplayConfig> = {
-  scale: PROVIDER_BRAND_ICON_SCALE,
-};
-const CONTAINED_BRAND_ICON_IDS = new Set([
-  'aihubmix',
-  'anthropic',
-  'aws-bedrock',
-  'cherryin',
-  'groq',
-  'lmstudio',
-  'yi',
-]);
+// Key by the resolved asset pair: aliases and model-to-provider fallbacks must
+// use the layout of the image actually displayed, not the configured provider.
+const FULL_FRAME_PROVIDER_ICONS = new Set(
+  [
+    '3min-top',
+    'abacus',
+    'aihubmix',
+    'aionlabs',
+    'anthropic',
+    'aws-bedrock',
+    'cherryin',
+    'coze',
+    'felo',
+    'groq',
+    'higress',
+    'lmstudio',
+    'mcpso',
+    'minimax-agent',
+    'netease-youdao',
+    'paddleocr',
+    'radeon-cloud',
+    'tesseract-js',
+    'zero-one',
+  ].flatMap((id) => {
+    const icon = resolveProviderIcon(id);
+    return icon ? [icon] : [];
+  }),
+);
+
+// These provider fallbacks use untrimmed general/model canvases. Compensate
+// their existing 72px canvas at display time without changing the image files.
+const PROVIDER_CANVAS_SCALES = new Map<IconSource, number>(
+  (
+    [
+      ['opencode', 72 / 46],
+      ['mimo', 72 / 48],
+    ] as const
+  ).flatMap(([id, scale]) => {
+    const icon = resolveProviderIcon(id);
+    return icon ? [[icon, scale] as const] : [];
+  }),
+);
 
 export function getBrandAvatarIconDisplayConfig(
-  iconId: string | undefined,
-  displayContext: 'provider' | 'provider-list' = 'provider-list',
-): BrandAvatarDisplayConfig | undefined {
-  if (!iconId) {
-    return undefined;
+  icon: IconSource,
+  shape: 'circle' | 'rounded' = 'rounded',
+): BrandAvatarDisplayConfig {
+  if (FULL_FRAME_PROVIDER_ICONS.has(icon)) {
+    return { scale: 1 };
   }
 
-  return displayContext === 'provider-list' && CONTAINED_BRAND_ICON_IDS.has(iconId.toLowerCase())
-    ? CONTAINED_BRAND_ICON
-    : PROVIDER_BRAND_ICON;
+  const inset = shape === 'circle' ? CIRCULAR_PROVIDER_BRAND_ICON_SCALE : PROVIDER_BRAND_ICON_SCALE;
+  return { scale: inset * (PROVIDER_CANVAS_SCALES.get(icon) ?? 1) };
 }
 
 export function getBrandAvatarFallback(label: string) {

--- a/src/frontend/components/ModelPicker/components/ModelPickerFastScroller.tsx
+++ b/src/frontend/components/ModelPicker/components/ModelPickerFastScroller.tsx
@@ -1,14 +1,11 @@
-import { Image } from '@cherrystudio/ui/components';
-import { resolveProviderIcon } from '@cherrystudio/ui/icons';
 import * as Haptics from 'expo-haptics';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type AccessibilityActionEvent, type LayoutChangeEvent, Text, View } from 'react-native';
+import { type AccessibilityActionEvent, type LayoutChangeEvent, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { runOnJS, useSharedValue } from 'react-native-reanimated';
-import { useUniwind } from 'uniwind';
 
-import type { Provider } from '@/shared/data/types/provider';
+import { ProviderBrandAvatar } from '@/frontend/components/Avatar';
 
 import {
   type ModelPickerFastScrollAnchor,
@@ -163,37 +160,12 @@ function ModelPickerFastScrollAnchorIcon({
 }) {
   return (
     <View className={isActive ? 'scale-110 opacity-100' : 'opacity-40'}>
-      <ProviderRailIcon provider={anchor.provider} size={providerIconSize} />
+      <ProviderBrandAvatar
+        presetProviderId={anchor.provider.presetProviderId}
+        providerId={anchor.provider.id}
+        providerName={anchor.provider.name}
+        size={providerIconSize}
+      />
     </View>
-  );
-}
-
-function ProviderRailIcon({ provider, size }: { provider: Provider; size: number }) {
-  const { theme } = useUniwind();
-  const iconTheme = theme === 'dark' ? 'dark' : 'light';
-  const iconId = provider.presetProviderId ?? provider.id;
-  const iconSource = resolveProviderIcon(iconId);
-
-  if (!iconSource) {
-    const initial = Array.from(provider.name.trim())[0] ?? 'P';
-    return (
-      <Text
-        className="text-center font-semibold text-muted-foreground"
-        style={{ fontSize: size * 0.72, lineHeight: size }}
-      >
-        {initial}
-      </Text>
-    );
-  }
-
-  return (
-    <Image
-      cachePolicy="memory-disk"
-      className="rounded"
-      contentFit="contain"
-      recyclingKey={provider.id}
-      source={iconSource[iconTheme]}
-      style={{ height: size, width: size }}
-    />
   );
 }

--- a/src/frontend/components/ModelPicker/components/ModelPickerIcon.tsx
+++ b/src/frontend/components/ModelPicker/components/ModelPickerIcon.tsx
@@ -2,7 +2,7 @@ import { Image } from '@cherrystudio/ui/components';
 import { Text, View } from 'react-native';
 import { useUniwind } from 'uniwind';
 
-import { PROVIDER_BRAND_ICON_SCALE } from '@/frontend/components/Avatar';
+import { getBrandAvatarIconDisplayConfig } from '@/frontend/components/Avatar';
 import { resolveModelIconSources } from '@/frontend/utils/modelIcons';
 import type { Model } from '@/shared/data/types/model';
 import type { Provider } from '@/shared/data/types/provider';
@@ -21,10 +21,12 @@ export function ModelPickerIcon({ model, provider, size = 32 }: ModelPickerIconP
     model.modelId,
     provider?.presetProviderId ?? provider?.id,
   );
-  const imageSize = modelIconSource ? size : size * PROVIDER_BRAND_ICON_SCALE;
+  const imageSize =
+    !modelIconSource && iconSource
+      ? size * getBrandAvatarIconDisplayConfig(iconSource, 'circle').scale
+      : size;
   const avatarInitial = model.name.trim().charAt(0).toUpperCase() || 'M';
   const frameStyle = {
-    borderRadius: size / 2,
     height: size,
     width: size,
   };
@@ -32,7 +34,7 @@ export function ModelPickerIcon({ model, provider, size = 32 }: ModelPickerIconP
   if (iconSource) {
     return (
       <View
-        className="items-center justify-center overflow-hidden border-continuous"
+        className="items-center justify-center overflow-hidden rounded-full border-continuous"
         style={frameStyle}
       >
         <Image

--- a/src/frontend/features/home/aiUsage/components/AiUsageRankingList.tsx
+++ b/src/frontend/features/home/aiUsage/components/AiUsageRankingList.tsx
@@ -5,7 +5,6 @@ import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/reac
 import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet, Text, View } from 'react-native';
-import { useUniwind } from 'uniwind';
 
 import { BrandAvatar, BrandAvatarIcon, ProviderBrandAvatar } from '@/frontend/components/Avatar';
 import { resolveModelIconSources } from '@/frontend/utils/modelIcons';
@@ -211,8 +210,6 @@ function getPrimaryLabel(item: AiUsageRankingItem, t: (key: string) => string): 
 }
 
 function AiUsageRankingIcon({ item, label }: { item: AiUsageRankingItem; label: string }) {
-  const { theme } = useUniwind();
-  const iconTheme = theme === 'dark' ? 'dark' : 'light';
   const frameProps = {
     label,
     size: AI_USAGE_RANKING_AVATAR_SIZE,
@@ -240,9 +237,8 @@ function AiUsageRankingIcon({ item, label }: { item: AiUsageRankingItem; label: 
       <BrandAvatar {...frameProps}>
         <BrandAvatarIcon
           displayContext={modelIconSource ? undefined : 'provider'}
-          iconId={item.providerId ?? undefined}
           recyclingKey={item.key}
-          source={iconSource[iconTheme]}
+          source={iconSource}
         />
       </BrandAvatar>
     );

--- a/src/frontend/features/settings/provider/components/ProviderAvatar.tsx
+++ b/src/frontend/features/settings/provider/components/ProviderAvatar.tsx
@@ -3,7 +3,6 @@ import { BrandAvatar, BrandAvatarPhoto, ProviderBrandAvatar } from '@/frontend/c
 import { useProviderAvatar } from '../hooks/useProviderAvatar';
 
 type ProviderAvatarProps = {
-  displayContext?: 'provider-list';
   presetProviderId?: string;
   providerId: string;
   providerName: string;
@@ -18,7 +17,6 @@ type ProviderAvatarProps = {
  * ③ first-character placeholder.
  */
 export function ProviderAvatar({
-  displayContext,
   presetProviderId,
   providerId,
   providerName,
@@ -37,7 +35,6 @@ export function ProviderAvatar({
 
   return (
     <ProviderBrandAvatar
-      displayContext={displayContext}
       presetProviderId={presetProviderId}
       providerId={providerId}
       providerName={providerName}

--- a/src/frontend/features/settings/provider/components/ProviderListRow.tsx
+++ b/src/frontend/features/settings/provider/components/ProviderListRow.tsx
@@ -77,7 +77,6 @@ export const ProviderListRow = memo(function ProviderListRow({
       }
       leading={
         <ProviderAvatar
-          displayContext="provider-list"
           presetProviderId={provider.presetProviderId}
           providerId={provider.id}
           providerName={provider.name}

--- a/src/frontend/features/settings/provider/new/components/ProviderSetupFormContent.tsx
+++ b/src/frontend/features/settings/provider/new/components/ProviderSetupFormContent.tsx
@@ -105,6 +105,7 @@ export function ProviderSetupPresetFields({
           presetProviderId={provider.presetProviderId}
           providerId={provider.id}
           providerName={provider.name}
+          shape="circle"
           size={40}
         />
         <Text className="flex-1 font-medium text-lg text-foreground">{provider.name}</Text>


### PR DESCRIPTION
### What this PR does

Provider logos use rounded rectangular frames in lists and circular frames on detail, creation, and connection forms. Previously, a shared 81.25% scale left colored square tiles inside circular avatars, some list surfaces applied different inner corner radii, and OpenCode/MiMo appeared too small because their source images already contain padding.

This change lets branded backgrounds fill the outer frame, applies safe insets to transparent marks, and compensates for the existing OpenCode/MiMo canvas padding. Display rules follow the resolved artwork so provider aliases and model-to-provider fallbacks receive the same treatment. Provider list, catalog, usage, and model-picker surfaces share these rules.

### Screenshots or videos

Pending device screenshots. Application UI acceptance was not authorized for this task, so this PR remains a draft.

### Why we need it and why it was done in this way

The existing Avatar composition already owns image sizing and outer clipping. Reusing it removes list-specific inner-radius patches and keeps shape and padding decisions in one place. Original icon artwork, image files, resolution, generation scripts, and provider data remain unchanged.

### Breaking changes

None for users. Internal brand-avatar callers now pass the resolved light/dark source pair, and the obsolete list-only display context has been removed.

### Special notes for your reviewer

- `pnpm format:check`: passed.
- Changed-file lint checks: passed.
- `pnpm lint`: failed with seven import-resolution errors in unchanged backend files for `@cherrystudio/ai-core` and its `/provider` entry. The package points to `dist/`, which is absent in this workspace; no package build was run. Existing warnings were also reported.
- `git diff --check`: passed.
- Existing avatar regression cases were updated for frame filling, circular insets, aliases, and padded fallback artwork; tests were not run.
- Builds, type checking, and device acceptance were intentionally skipped under the user's task permissions. The root type-check command also builds workspace packages.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the resulting behavior and scope
- [ ] Preview: Device screenshots or video uploaded
- [x] Code: Changes stay within provider avatar presentation and its callers
- [x] Upgrade: No data migration or asset regeneration required
- [x] Documentation: Avatar component contract updated; no user-guide update required
- [x] Self-review: Reviewed the local diff before submission

### Release note

```release-note
Standardize model-provider icons with rounded rectangular list frames, circular detail frames, and consistent spacing around brand artwork.
```
