### PR TITLE
fix(composer-menu): preserve keyboard focus and follow trigger motion

### DIFF
--- a/docs/references/ui-components.md
+++ b/docs/references/ui-components.md
@@ -16,7 +16,11 @@ interfaces keep their own interaction contracts.
 Cherry-rendered menus share their row, bounded panel, and lifecycle owners. Their private
 `MenuOverlay` uses a transparent system modal for background accessibility isolation and native
 Back/Escape, while CherryUI owns content, focus, motion, and action dispatch after dismissal.
-The composer's trigger morph is a placement variant, not a separate menu interaction implementation.
+The composer's trigger morph uses the private `KeyboardMenuOverlay` variant, backed by
+`OverKeyboardView`, to preserve editor focus and the current keyboard state. Both variants share
+rows, accessibility focus, and action dispatch; the keyboard variant handles Back and waits for
+overlay removal before dispatch. Its placement follows the live trigger on the UI thread through
+opening and closing, including ongoing keyboard motion.
 
 One rule governs every platform decision:
 

--- a/packages/ui/src/components/composer/components/morph-menu/__tests__/morph-menu.test.tsx
+++ b/packages/ui/src/components/composer/components/morph-menu/__tests__/morph-menu.test.tsx
@@ -279,7 +279,9 @@ describe('MorphMenu', () => {
     }
 
     moveTrigger(18, 240);
-    const panel = portal(tree).findByProps({ testID: 'menu-panel' });
+    const panel = portal(tree).find(
+      (node) => node.props.testID === 'menu-panel' && node.props.style !== undefined,
+    );
     expect(StyleSheet.flatten(panel.props.style).maxHeight).toBe(256);
     expect(
       portal(tree).findAll((node) => StyleSheet.flatten(node.props.style)?.height === 256).length,

--- a/packages/ui/src/components/composer/components/morph-menu/__tests__/morph-menu.test.tsx
+++ b/packages/ui/src/components/composer/components/morph-menu/__tests__/morph-menu.test.tsx
@@ -17,7 +17,7 @@ jest.mock('../../../../menu/menu-overlay', () => {
   const { MenuInteraction } = jest.requireActual('../../../../menu/menu-interaction');
 
   return {
-    MenuOverlay: ({
+    KeyboardMenuOverlay: ({
       children,
       isOpen,
       isVisible,
@@ -72,11 +72,18 @@ jest.mock('expo-glass-effect', () => {
   };
 });
 
-type SharedValueStub = { set: (next: number) => void; value: number };
+type SharedValueStub<TValue> = {
+  get: () => TValue;
+  set: (next: TValue) => void;
+  value: TValue;
+};
 type TimingCallback = (finished: boolean) => void;
 let mockReducedMotion = false;
 let mockFinishTimingImmediately = true;
 let mockTimingCallbacks: TimingCallback[] = [];
+let mockFrameCallback: () => void;
+let mockFrameActive = false;
+const mockMeasure = jest.fn();
 
 jest.mock('react-native-reanimated', () => {
   const React = jest.requireActual('react');
@@ -89,16 +96,32 @@ jest.mock('react-native-reanimated', () => {
     Easing: { bezier: () => 'bezier' },
     interpolate: (value: number, _input: number[], output: number[]) =>
       output[0] + (output[1] - output[0]) * value,
+    measure: (...args: unknown[]) => mockMeasure(...args),
     runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedRef: () => React.useRef(null),
     useAnimatedStyle: (factory: () => object) => factory(),
+    useDerivedValue: (factory: () => unknown) => ({ get: factory }),
+    useFrameCallback: (callback: () => void) => {
+      mockFrameCallback = callback;
+      const ref = React.useRef(null);
+      ref.current ??= {
+        setActive: (active: boolean) => {
+          mockFrameActive = active;
+        },
+      };
+      return ref.current;
+    },
     useReducedMotion: () => mockReducedMotion,
     // Backed by a ref, like the real one: a shared value that reset itself on
     // every render would make anything driven by one untestable.
-    useSharedValue: (initial: number) => {
-      const ref = React.useRef(null) as { current: SharedValueStub | null };
+    useSharedValue: <TValue,>(initial: TValue) => {
+      const ref = React.useRef(null) as { current: SharedValueStub<TValue> | null };
 
       ref.current ??= {
-        set(next: number) {
+        get() {
+          return this.value;
+        },
+        set(next: TValue) {
           this.value = next;
         },
         value: initial,
@@ -141,6 +164,8 @@ describe('MorphMenu', () => {
     mockReducedMotion = false;
     mockFinishTimingImmediately = true;
     mockTimingCallbacks = [];
+    mockMeasure.mockReset();
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -202,13 +227,11 @@ describe('MorphMenu', () => {
 
     expect(portal(tree).findAllByProps({ testID: 'menu-panel' }).length).toBeGreaterThan(0);
     // The floating copy sits where the inline footprint was measured.
-    const positioned = portal(tree).findAll((node) => {
-      const style = StyleSheet.flatten(node.props.style as StyleProp<ViewStyle>);
-
-      return style?.left === anchorRect.x && style?.top === anchorRect.y;
-    });
-
-    expect(positioned.length).toBeGreaterThan(0);
+    const floating = portal(tree).findByProps({ role: 'menu' });
+    expect(StyleSheet.flatten(floating.props.style).transform).toEqual([
+      { translateX: anchorRect.x },
+      { translateY: anchorRect.y },
+    ]);
   });
 
   it('renders the dismiss catcher behind the menu', () => {
@@ -224,6 +247,76 @@ describe('MorphMenu', () => {
 
     expect(backdropIndex).toBeGreaterThanOrEqual(0);
     expect(menuIndex).toBeGreaterThan(backdropIndex);
+  });
+
+  it('follows a moving trigger and bounds the panel until the closing animation finishes', () => {
+    mockFinishTimingImmediately = false;
+    const menu = () => (
+      <MorphMenu accessibilityLabel="Add" testID="menu">
+        <MorphMenu.Item label="Camera" onPress={jest.fn()} testID="menu-camera" />
+      </MorphMenu>
+    );
+    act(() => {
+      renderer = create(menu());
+    });
+    const tree = renderer!;
+    expect(mockFrameActive).toBe(false);
+    layout(tree, { height: 420, width: 340 });
+    press(tree, 'menu-trigger');
+    expect(mockFrameActive).toBe(true);
+
+    function moveTrigger(pageX: number, pageY: number) {
+      mockMeasure.mockReturnValue({ pageX, pageY, width: 32, height: 32 });
+      act(() => {
+        mockFrameCallback();
+        tree.update(menu());
+      });
+      const floating = portal(tree).findByProps({ role: 'menu' });
+      expect(StyleSheet.flatten(floating.props.style).transform).toEqual([
+        { translateX: pageX },
+        { translateY: pageY },
+      ]);
+    }
+
+    moveTrigger(18, 240);
+    const panel = portal(tree).findByProps({ testID: 'menu-panel' });
+    expect(StyleSheet.flatten(panel.props.style).maxHeight).toBe(256);
+    expect(
+      portal(tree).findAll((node) => StyleSheet.flatten(node.props.style)?.height === 256).length,
+    ).toBeGreaterThan(0);
+
+    // An unavailable measurement must retain the last usable position.
+    mockMeasure.mockReturnValue(null);
+    act(() => {
+      mockFrameCallback();
+      tree.update(menu());
+    });
+    expect(
+      StyleSheet.flatten(portal(tree).findByProps({ role: 'menu' }).props.style).transform,
+    ).toEqual([{ translateX: 18 }, { translateY: 240 }]);
+
+    press(tree, 'menu-backdrop');
+    expect(mockFrameActive).toBe(true);
+    moveTrigger(18, 480);
+    act(() => mockTimingCallbacks.splice(0).forEach((callback) => callback(true)));
+    expect(mockFrameActive).toBe(false);
+    expect(tree.root.findAllByProps({ mockComponent: 'menu-overlay' })).toHaveLength(0);
+  });
+
+  it('ignores an older opening measurement delivered after the latest press', () => {
+    const pending: ((x: number, y: number, width: number, height: number) => void)[] = [];
+    jest.spyOn(View.prototype, 'measureInWindow').mockImplementation((callback) => {
+      pending.push(callback);
+    });
+    const tree = render();
+    press(tree, 'menu-trigger');
+    press(tree, 'menu-trigger');
+    act(() => pending[1](18, 300, 32, 32));
+    act(() => pending[0](12, 700, 32, 32));
+
+    expect(
+      StyleSheet.flatten(portal(tree).findByProps({ role: 'menu' }).props.style).transform,
+    ).toEqual([{ translateX: 18 }, { translateY: 300 }]);
   });
 
   it('closes on the backdrop without choosing anything', () => {

--- a/packages/ui/src/components/composer/components/morph-menu/morph-menu.tsx
+++ b/packages/ui/src/components/composer/components/morph-menu/morph-menu.tsx
@@ -1,7 +1,15 @@
 import PlusIcon from '@cherrystudio/app-icons/icons/plus';
-import { useMemo, useRef } from 'react';
-import { type LayoutChangeEvent, Pressable, useWindowDimensions, View } from 'react-native';
-import Animated, { interpolate, useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
+import { useEffect, useMemo, useRef } from 'react';
+import { type LayoutChangeEvent, Pressable, useWindowDimensions, type View } from 'react-native';
+import Animated, {
+  interpolate,
+  measure,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useDerivedValue,
+  useFrameCallback,
+  useSharedValue,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { MenuInteraction, useMenuInteraction } from '../../../menu/menu-interaction';
@@ -12,9 +20,10 @@ import {
   menuRestingScale,
   menuSlideDistance,
 } from '../../../menu/menu-motion';
-import { MenuOverlay } from '../../../menu/menu-overlay';
+import { KeyboardMenuOverlay } from '../../../menu/menu-overlay';
 import { MenuPanel, useMenuPanelRadius } from '../../../menu/menu-panel';
 import { MenuRow } from '../../../menu/menu-row';
+import type { MenuAnchor } from '../../../menu/menu.types';
 import { useMenuMotion } from '../../../menu/use-menu-motion';
 import { useMenuState } from '../../../menu/use-menu-state';
 import { SwitchIndicator } from '../../../switch/switch-indicator';
@@ -75,14 +84,39 @@ function MorphMenuRoot({
   const { anchor, close, finishClose, isOpen, open } = useMenuState(triggerRef);
   const { progress, isVisible } = useMenuMotion(isOpen);
   const cornerRadius = useMenuPanelRadius();
-  const maxPanelHeight = Math.max(
-    0,
-    (anchor ? anchor.pageY + triggerSize : windowHeight - insets.bottom - 16) - insets.top - 16,
-  );
   const panelHeight = useSharedValue(fallbackPanelHeight);
   const panelWidth = useSharedValue(minPanelWidth);
-  const footprintRef = useRef<View>(null);
-  // Keep the popover surface until both its animation and native dismissal finish.
+  const footprintRef = useAnimatedRef<View>();
+  const liveAnchor = useSharedValue<MenuAnchor | null>(null);
+  const openRequest = useRef(0);
+  const isPresented = Boolean(anchor);
+  // Measure the real footprint on the UI thread, including its ancestors'
+  // keyboard and composer transforms. A one-time JS measurement becomes stale
+  // when the keyboard is still moving at the moment the menu opens.
+  const trackingFrame = useFrameCallback(() => {
+    const next = measure(footprintRef);
+    const current = liveAnchor.get();
+    if (next && (next.pageX !== current?.pageX || next.pageY !== current?.pageY)) {
+      liveAnchor.set({
+        pageX: next.pageX,
+        pageY: next.pageY,
+        width: next.width,
+        height: next.height,
+      });
+    }
+  }, false);
+
+  useEffect(() => {
+    trackingFrame.setActive(isPresented);
+    return () => trackingFrame.setActive(false);
+  }, [isPresented, trackingFrame]);
+  useEffect(
+    () => () => {
+      openRequest.current += 1;
+    },
+    [],
+  );
+  // Keep the popover surface until its animation and overlay removal finish.
   const surfaceClassName = anchor ? 'bg-popover' : 'bg-secondary';
   const triggerFootprint = useMemo(
     () => ({ height: triggerSize, width: triggerSize }),
@@ -95,24 +129,46 @@ function MorphMenuRoot({
       return;
     }
 
-    // Measured before the state flip so the floating copy mounts exactly where
-    // the inline trigger was — otherwise the morph starts from a jump.
-    //
-    // Nothing may move the composer between this measurement and the open: the
-    // anchor is a snapshot and never re-measures, so a layout change here leaves
-    // the panel floating away from its trigger. The ＋ menu used to take the
-    // keyboard down right after this callback and did exactly that.
+    const request = ++openRequest.current;
+    // Seed the first floating frame, then keep following the mounted footprint.
     footprintRef.current?.measureInWindow((pageX, pageY, width, height) => {
-      open({ pageX, pageY, width, height });
+      if (request !== openRequest.current) return;
+      const next = { pageX, pageY, width, height };
+      liveAnchor.set(next);
+      open(next);
     });
   };
   // Every item subscribes to this, so a fresh object each render would re-render
   // the whole panel on any parent update.
   const contextValue = useMemo(() => ({ close, isOpen }), [close, isOpen]);
 
+  const floatingStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: liveAnchor.get()?.pageX ?? 0 },
+      { translateY: liveAnchor.get()?.pageY ?? 0 },
+    ],
+  }));
+  const maxPanelHeight = useDerivedValue(() =>
+    Math.max(
+      0,
+      (isPresented
+        ? (liveAnchor.get()?.pageY ?? 0) + triggerSize
+        : windowHeight - insets.bottom - 16) -
+        insets.top -
+        16,
+    ),
+  );
+  const panelBoundsStyle = useAnimatedStyle(() => ({ maxHeight: maxPanelHeight.get() }));
   const containerStyle = useAnimatedStyle(() => ({
     borderRadius: interpolate(progress.value, [0, 1], [triggerSize / 2, cornerRadius]),
-    height: interpolate(progress.value, [0, 1], [triggerSize, panelHeight.value]),
+    height: Math.min(
+      maxPanelHeight.get(),
+      interpolate(
+        progress.value,
+        [0, 1],
+        [triggerSize, Math.min(panelHeight.get(), maxPanelHeight.get())],
+      ),
+    ),
     width: interpolate(progress.value, [0, 1], [triggerSize, panelWidth.value]),
   }));
   // Fade out over the first 200/350 of the open so the plus is gone before the
@@ -146,15 +202,17 @@ function MorphMenuRoot({
     }
   };
 
-  // Only the trigger and its morph belong to the composer. The overlay, rows,
-  // bounded scrolling, selection dispatch, and dismissal are shared menus.
+  // Rows and dismissal remain shared; this overlay preserves the input context.
   const menu = (
     <>
       <Animated.View style={[panelAnchorStyle, containerStyle]}>
         <MenuPanel
-          contentStyle={[panelContentStyle, { minWidth: minPanelWidth, maxWidth: maxPanelWidth }]}
+          contentStyle={[
+            panelContentStyle,
+            { minWidth: minPanelWidth, maxWidth: maxPanelWidth },
+            panelBoundsStyle,
+          ]}
           isOpen={isOpen}
-          maxHeight={maxPanelHeight}
           onLayout={handlePanelLayout}
           progress={progress}
           surfaceClassName={surfaceClassName}
@@ -188,27 +246,32 @@ function MorphMenuRoot({
     <>
       {/* Reserves the closed footprint in the parent's flow, and is what gets
           measured — the floating copy is positioned from it. */}
-      <View className="relative" ref={footprintRef} style={[triggerFootprint, style]}>
+      <Animated.View
+        className="relative"
+        collapsable={false}
+        ref={footprintRef}
+        style={[triggerFootprint, style]}
+      >
         {anchor ? null : <MenuInteraction value={contextValue}>{menu}</MenuInteraction>}
-      </View>
+      </Animated.View>
 
       {anchor ? (
-        <MenuOverlay
+        <KeyboardMenuOverlay
           isOpen={isOpen}
           isVisible={isVisible}
           onClose={close}
           onClosed={finishClose}
           testID={testID}
         >
-          <View
+          <Animated.View
             accessibilityLabel={accessibilityLabel}
-            className="absolute"
+            className="absolute top-0 left-0"
             role="menu"
-            style={[triggerFootprint, { left: anchor.pageX, top: anchor.pageY }]}
+            style={[triggerFootprint, floatingStyle]}
           >
             {menu}
-          </View>
-        </MenuOverlay>
+          </Animated.View>
+        </KeyboardMenuOverlay>
       ) : null}
     </>
   );

--- a/packages/ui/src/components/composer/components/morph-menu/morph-menu.types.ts
+++ b/packages/ui/src/components/composer/components/morph-menu/morph-menu.types.ts
@@ -22,7 +22,7 @@ export type MorphMenuItemProps = {
   /** Rendered before the label; size it via className on the icon itself. */
   icon?: ReactNode;
   label: string;
-  /** Runs once after the menu's native dismissal, so it can open another surface safely. */
+  /** Runs once after the menu overlay is removed, so it can open another surface safely. */
   onPress: () => void;
   /** Announced to assistive tech. What it looks like selected is the caller's, via `icon` and `trailing`. */
   selected?: boolean;

--- a/packages/ui/src/components/menu/__tests__/menu-overlay.test.tsx
+++ b/packages/ui/src/components/menu/__tests__/menu-overlay.test.tsx
@@ -1,10 +1,11 @@
 import { type ReactNode } from 'react';
-import { Modal, Platform, View } from 'react-native';
+import { BackHandler, Keyboard, Modal, Platform, View } from 'react-native';
+import { KeyboardController, OverKeyboardView } from 'react-native-keyboard-controller';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { focusMenuTarget } from '../menu-focus';
 import { useMenuInteraction } from '../menu-interaction';
-import { MenuOverlay } from '../menu-overlay';
+import { KeyboardMenuOverlay, MenuOverlay } from '../menu-overlay';
 
 jest.mock('../menu-focus', () => ({ focusMenuTarget: jest.fn() }));
 jest.mock('react-native-gesture-handler', () => {
@@ -108,6 +109,102 @@ describe('menu overlay native boundary', () => {
     expect(focusMenuTarget).not.toHaveBeenCalledWith(null);
     act(() => renderer.root.findByType(Modal).props.onShow());
     act(() => renderer.update(render(false)));
+    expect(frames.size).toBe(0);
+  });
+});
+
+describe('keyboard-preserving menu overlay', () => {
+  let renderer: ReactTestRenderer;
+  let frames: Map<number, FrameRequestCallback>;
+  let nextFrame: number;
+  let back: () => boolean | null | undefined;
+  const removeBack = jest.fn();
+  const close = jest.fn();
+  const closed = jest.fn();
+  const render = (isOpen = true, isVisible = true) => (
+    <KeyboardMenuOverlay
+      isOpen={isOpen}
+      isVisible={isVisible}
+      onClose={close}
+      onClosed={closed}
+      testID="menu"
+    >
+      <Item />
+    </KeyboardMenuOverlay>
+  );
+
+  function flushFrame() {
+    act(() => {
+      const callbacks = [...frames.values()];
+      frames.clear();
+      callbacks.forEach((callback) => callback(0));
+    });
+  }
+
+  beforeEach(() => {
+    frames = new Map();
+    nextFrame = 0;
+    jest.spyOn(global, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.set(++nextFrame, callback);
+      return nextFrame;
+    });
+    jest.spyOn(global, 'cancelAnimationFrame').mockImplementation((id) => {
+      if (id != null) frames.delete(id);
+    });
+    jest.spyOn(BackHandler, 'addEventListener').mockImplementation((_event, callback) => {
+      back = callback;
+      return { remove: removeBack };
+    });
+    jest.spyOn(Keyboard, 'dismiss');
+    act(() => {
+      renderer = create(render());
+    });
+  });
+
+  afterEach(() => {
+    act(() => renderer.unmount());
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('opens and cancels without a focus-taking Modal or keyboard dismissal', () => {
+    expect(renderer.root.findAllByType(Modal)).toHaveLength(0);
+    expect(renderer.root.findByType(OverKeyboardView).props.visible).toBe(true);
+    flushFrame();
+    flushFrame();
+    expect(focusMenuTarget).toHaveBeenCalledTimes(1);
+    act(() => renderer.root.findByProps({ testID: 'menu-backdrop' }).props.onPress());
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(Keyboard.dismiss).not.toHaveBeenCalled();
+    expect(KeyboardController.dismiss).not.toHaveBeenCalled();
+    expect(KeyboardController.setFocusTo).not.toHaveBeenCalled();
+  });
+
+  it('consumes Back while visible and dispatches completion only after overlay removal', () => {
+    act(() => expect(back()).toBe(true));
+    expect(close).toHaveBeenCalledTimes(1);
+    act(() => renderer.update(render(false, true)));
+    act(() => expect(back()).toBe(true));
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(closed).not.toHaveBeenCalled();
+
+    act(() => renderer.update(render(false, false)));
+    expect(renderer.root.findByType(OverKeyboardView).props.visible).toBe(false);
+    expect(removeBack).toHaveBeenCalledTimes(1);
+    expect(closed).not.toHaveBeenCalled();
+    flushFrame();
+    expect(closed).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a queued dismissal when the menu reopens or unmounts', () => {
+    act(() => renderer.update(render(false, false)));
+    act(() => renderer.update(render()));
+    flushFrame();
+    expect(closed).not.toHaveBeenCalled();
+    act(() => renderer.update(render(false, false)));
+    act(() => renderer.update(<View />));
+    flushFrame();
+    expect(closed).not.toHaveBeenCalled();
     expect(frames.size).toBe(0);
   });
 });

--- a/packages/ui/src/components/menu/__tests__/menu-overlay.test.tsx
+++ b/packages/ui/src/components/menu/__tests__/menu-overlay.test.tsx
@@ -117,7 +117,7 @@ describe('keyboard-preserving menu overlay', () => {
   let renderer: ReactTestRenderer;
   let frames: Map<number, FrameRequestCallback>;
   let nextFrame: number;
-  let back: () => boolean | null | undefined;
+  let back: Parameters<typeof BackHandler.addEventListener>[1];
   const removeBack = jest.fn();
   const close = jest.fn();
   const closed = jest.fn();
@@ -181,10 +181,10 @@ describe('keyboard-preserving menu overlay', () => {
   });
 
   it('consumes Back while visible and dispatches completion only after overlay removal', () => {
-    act(() => expect(back()).toBe(true));
+    act(() => expect(back({ type: 'hardwareBackPress', timeStamp: 0 })).toBe(true));
     expect(close).toHaveBeenCalledTimes(1);
     act(() => renderer.update(render(false, true)));
-    act(() => expect(back()).toBe(true));
+    act(() => expect(back({ type: 'hardwareBackPress', timeStamp: 0 })).toBe(true));
     expect(close).toHaveBeenCalledTimes(1);
     expect(closed).not.toHaveBeenCalled();
 

--- a/packages/ui/src/components/menu/menu-overlay.tsx
+++ b/packages/ui/src/components/menu/menu-overlay.tsx
@@ -1,30 +1,47 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
-import { Modal, Platform, Pressable, StyleSheet, View } from 'react-native';
+import { type ComponentType, type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import { BackHandler, Modal, Platform, Pressable, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { OverKeyboardView } from 'react-native-keyboard-controller';
 
 import { focusMenuTarget } from './menu-focus';
 import { MenuInteraction, type MenuInteractionValue } from './menu-interaction';
 
-/**
- * The system modal isolates background accessibility and owns Back/Escape.
- * Unlike a portal store, it also preserves the caller's theme and React context.
- * Keep it mounted until native dismissal before launching a picker or navigating.
- */
-export function MenuOverlay({
-  children,
-  isOpen,
-  isVisible,
-  onClose,
-  onClosed,
-  testID,
-}: {
+type MenuOverlayProps = {
   children: ReactNode;
   isOpen: boolean;
   isVisible: boolean;
   onClose: MenuInteractionValue['close'];
   onClosed: () => void;
   testID?: string;
-}) {
+};
+
+type MenuOverlayHostProps = {
+  children: ReactNode;
+  onDismiss: () => void;
+  onRequestClose: () => void;
+  onShow: () => void;
+  visible: boolean;
+};
+
+/** System-presented menus retain their native dismissal and Back/Escape boundary. */
+export function MenuOverlay(props: MenuOverlayProps) {
+  return <MenuOverlayRoot {...props} host={NativeMenuOverlayHost} />;
+}
+
+/** Composer overlays keep the editor's native focus and current keyboard state. */
+export function KeyboardMenuOverlay(props: MenuOverlayProps) {
+  return <MenuOverlayRoot {...props} host={KeyboardMenuOverlayHost} />;
+}
+
+function MenuOverlayRoot({
+  children,
+  host: Host,
+  isOpen,
+  isVisible,
+  onClose,
+  onClosed,
+  testID,
+}: MenuOverlayProps & { host: ComponentType<MenuOverlayHostProps> }) {
   const items = useRef(new Set<View>());
   const isActive = useRef(isOpen);
   const focusFrame = useRef<number | undefined>(undefined);
@@ -39,14 +56,14 @@ export function MenuOverlay({
     [isOpen, onClose, registerItem],
   );
 
-  useEffect(() => {
-    // RN's Android Modal has no onDismiss event. Its native dialog is removed
-    // when visible becomes false; wait for that commit before completing close.
-    if (!isVisible && Platform.OS === 'android') {
-      const frame = requestAnimationFrame(onClosed);
-      return () => cancelAnimationFrame(frame);
-    }
-  }, [isVisible, onClosed]);
+  const requestClose = useCallback(() => {
+    if (isActive.current) onClose();
+  }, [onClose]);
+  const handleShow = useCallback(() => {
+    focusFrame.current = requestAnimationFrame(() => {
+      if (isActive.current) focusMenuTarget(items.current.values().next().value ?? null);
+    });
+  }, []);
 
   useEffect(
     () => () => {
@@ -65,25 +82,13 @@ export function MenuOverlay({
   }, [isOpen]);
 
   return (
-    <Modal
-      animationType="none"
-      hardwareAccelerated
-      navigationBarTranslucent
+    <Host
       onDismiss={onClosed}
-      onRequestClose={() => {
-        if (isOpen) onClose();
-      }}
-      onShow={() => {
-        focusFrame.current = requestAnimationFrame(() => {
-          if (isActive.current) focusMenuTarget(items.current.values().next().value ?? null);
-        });
-      }}
-      presentationStyle="overFullScreen"
-      statusBarTranslucent
-      transparent
+      onRequestClose={requestClose}
+      onShow={handleShow}
       visible={isVisible}
     >
-      <GestureHandlerRootView style={styles.root}>
+      <GestureHandlerRootView accessibilityViewIsModal style={styles.root}>
         <MenuInteraction value={interaction}>
           <Pressable
             accessibilityElementsHidden
@@ -109,8 +114,59 @@ export function MenuOverlay({
           </View>
         </MenuInteraction>
       </GestureHandlerRootView>
-    </Modal>
+    </Host>
   );
+}
+
+function NativeMenuOverlayHost({ onDismiss, visible, ...props }: MenuOverlayHostProps) {
+  useEffect(() => {
+    // RN's Android Modal has no onDismiss event. Its dialog is removed when
+    // visible becomes false; wait for that commit before completing close.
+    if (!visible && Platform.OS === 'android') {
+      const frame = requestAnimationFrame(onDismiss);
+      return () => cancelAnimationFrame(frame);
+    }
+  }, [onDismiss, visible]);
+
+  return (
+    <Modal
+      {...props}
+      animationType="none"
+      hardwareAccelerated
+      navigationBarTranslucent
+      onDismiss={onDismiss}
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
+      transparent
+      visible={visible}
+    />
+  );
+}
+
+function KeyboardMenuOverlayHost({
+  children,
+  onDismiss,
+  onRequestClose,
+  onShow,
+  visible,
+}: MenuOverlayHostProps) {
+  useEffect(() => {
+    // This host has no native presentation animation or dismissal event. Its
+    // visible commit attaches/removes the overlay without moving editor focus.
+    const frame = requestAnimationFrame(visible ? onShow : onDismiss);
+    return () => cancelAnimationFrame(frame);
+  }, [onDismiss, onShow, visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      onRequestClose();
+      return true;
+    });
+    return () => subscription.remove();
+  }, [onRequestClose, visible]);
+
+  return <OverKeyboardView visible={visible}>{children}</OverKeyboardView>;
 }
 
 const styles = StyleSheet.create({ root: { flex: 1 } });

--- a/packages/ui/src/components/menu/menu-panel.tsx
+++ b/packages/ui/src/components/menu/menu-panel.tsx
@@ -57,7 +57,7 @@ export function MenuPanel({
         importantForAccessibility={isOpen ? 'auto' : 'no-hide-descendants'}
         onLayout={onLayout}
         pointerEvents={isOpen ? 'auto' : 'none'}
-        style={[contentStyle, { maxHeight }, panelStyle]}
+        style={[contentStyle, maxHeight === undefined ? undefined : { maxHeight }, panelStyle]}
         testID={testID}
       >
         <ScrollView

--- a/packages/ui/src/components/menu/menu-panel.tsx
+++ b/packages/ui/src/components/menu/menu-panel.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import type { LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
+import type { ComponentProps, ReactNode } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
 import { ScrollView } from 'react-native';
 import Animated, { type SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 import { useResolveClassNames } from 'uniwind';
@@ -24,7 +24,7 @@ export function MenuPanel({
   testID,
 }: {
   children: ReactNode;
-  contentStyle?: StyleProp<ViewStyle>;
+  contentStyle?: ComponentProps<typeof Animated.View>['style'];
   isOpen: boolean;
   maxHeight?: number;
   onLayout: (event: LayoutChangeEvent) => void;

--- a/src/frontend/components/Composer/README.md
+++ b/src/frontend/components/Composer/README.md
@@ -116,6 +116,13 @@ walk to verify it.
   stays at its resting bottom position after the replacement closes; the next
   real field focus reconnects keyboard tracking. Success and cancellation use
   the same path.
+- The ＋ menu opens in a keyboard-preserving overlay, without changing the field's
+  expanded/resting state or starting a keyboard transition. Cancelling only closes
+  the menu. Its measured trigger remains mounted and its screen position is followed
+  on the UI thread until dismissal completes, so opening during keyboard motion
+  does not leave a detached menu. Available height follows that position; long
+  menus scroll above the trigger. Viewport changes dismiss the menu, and media
+  actions wait for overlay removal before starting the replacement protocol.
 - Transient attachments render their own progress tile while they are imported
   into managed storage. Any importing attachment disables send; text editing,
   removal, and tools remain available. The send boundary rechecks readiness and

--- a/src/frontend/components/Composer/components/ComposerMenu.tsx
+++ b/src/frontend/components/Composer/components/ComposerMenu.tsx
@@ -33,13 +33,9 @@ const logger = loggerService.withContext('ComposerMenu');
  * closes the menu, dismisses and blurs the field, then opens its picker;
  * caller-owned tool rows only close the menu and keep the input context live.
  *
- * The menu used to take the keyboard down when it opened so
- * the panel could grow into that space, but the panel is portalled and anchored
- * to where the trigger was measured *before* the dismissal — so the composer
- * dropped ~290pt while the panel stayed put, and the menu ended up floating in
- * the middle of the screen with nothing under it. The panel grows upward out of
- * the ＋ button and clears the keyboard on its own, so it never needed that
- * space.
+ * The keyboard-preserving overlay follows the live ＋ position through input
+ * layout and keyboard motion. It grows upward within the available space,
+ * scrolling its contents when needed instead of dismissing the keyboard.
  */
 type ComposerMenuProps = PropsWithChildren<{
   media?: 'all' | 'images';


### PR DESCRIPTION
### What this PR does

Before this PR, the composer add menu used a focus-taking native Modal and kept the trigger coordinates measured at opening. Keyboard movement could detach the panel from the composer, and a keyboard dismissal could also collapse an empty input.

The add menu now uses a keyboard-preserving overlay and follows the mounted trigger on the UI thread through opening and closing. Its panel and scroll bounds follow the available space. Cancelling preserves the editing context; selecting camera, photos, or files still removes the menu before the existing input-replacement flow dismisses the keyboard and opens the picker. Stale opening measurements are ignored.

### Screenshots or videos

Not captured: device/UI verification was explicitly excluded by the task instructions. This remains a draft pending iOS/Android acceptance, including empty and filled inputs, keyboard transitions, cancellation, picker handoffs, accessibility, and light/dark themes.

### Why we need it and why it was done in this way

The composer should preserve the current keyboard state while presenting attachment choices. The keyboard overlay shares menu rows, accessibility focus, and deferred action dispatch with the existing native menu host. Other menus retain their native presentation. Position tracking reads the actual trigger instead of adding another keyboard animation or delaying the user's press.

### Breaking changes

None. No new dependencies or public component API changes.

### Special notes for your reviewer

- Passed: `pnpm format:check`, changed-file `oxlint`, changed-file `expo lint`, and `git diff --check`.
- Full `pnpm lint` failed on 7 module-resolution errors in untouched backend files: `@cherrystudio/ai-core` and its provider entry point resolve to the absent `packages/ai-core/dist` build output. Existing warnings were also reported. No build was run to work around this.
- Added regression cases for moving anchors, height bounds, stale measurements, keyboard-preserving presentation, Back handling, and deferred/cancelled overlay completion. Tests, typechecking, builds, and device/UI verification were not run, per the task instructions.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the resulting behavior and validation limits.
- [ ] Preview: Screenshots or a video are pending device acceptance.
- [x] Code: The change stays within composer/menu presentation ownership.
- [x] Documentation: Updated the component and composer behavior notes.
- [x] Self-review: Reviewed the final source diff before publication.

### Release note

```release-note
Keep the keyboard open when opening or cancelling the composer add menu, and keep the menu aligned with the input while the keyboard moves.
```
