### PR TITLE
fix(agent-runtime): recover DeepSeek DSML tool calls

### DIFF
--- a/packages/ai-runtime/README.md
+++ b/packages/ai-runtime/README.md
@@ -8,6 +8,11 @@ Despite the package name, this is not Cherry Mobile's Agent Runtime. Pi is the s
 conversation engine and lives in `src/backend/ai/agent/runtime/pi/`. What is here serves the AI SDK
 path behind `AiService`, plus the connection facts Pi and the AI SDK share.
 
+The platform-neutral DeepSeek DSML decoder is also shared through `provider`. It recognizes wire
+markup and returns text or tool-call data; Pi and the AI SDK separately own event projection,
+terminal errors, and tool execution. Malformed or incomplete markup produces an explicit error
+instead of being published as ordinary model output.
+
 ## Why this is a package
 
 The code originated as a port from Cherry Studio desktop, and an earlier plan was to dissolve it

--- a/packages/ai-runtime/src/provider/__tests__/deepseek-dsml.test.ts
+++ b/packages/ai-runtime/src/provider/__tests__/deepseek-dsml.test.ts
@@ -1,0 +1,117 @@
+import {
+  createDeepseekDsmlParser,
+  DeepseekDsmlError,
+  type DeepseekDsmlPart,
+} from '../deepseek-dsml';
+
+// Full single-bar response shape observed in Desktop #19312/#19921.
+const CALL =
+  '<｜DSML｜tool_calls><｜DSML｜invoke name="mcp__notes__save"><｜DSML｜parameter name="text" string="true">第一行\nsecond line</｜DSML｜parameter><｜DSML｜parameter name="options" string="false">{"overwrite":false,"count":2,"tags":["a"],"parent":null}</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>';
+
+function parse(chunks: string[], tools: { name: string }[] = []) {
+  const parser = createDeepseekDsmlParser(tools);
+  return [...chunks.flatMap((chunk) => parser.push(chunk)), ...parser.finish()];
+}
+
+function text(parts: DeepseekDsmlPart[]) {
+  return parts.flatMap((part) => (part.type === 'text' ? [part.text] : [])).join('');
+}
+
+describe('DeepSeek DSML protocol', () => {
+  test.each([
+    ['single bar', CALL],
+    ['double bar', CALL.replaceAll('｜', '｜｜')],
+    ['tool invoke', CALL.replaceAll('DSML｜invoke', 'DSML｜tool_invoke')],
+    ['tool', CALL.replaceAll('DSML｜invoke', 'DSML｜tool')],
+  ])('recovers %s calls across every character boundary', (_variant, source) => {
+    const parts = parse([...`before ${source} after`]);
+    expect(text(parts)).toBe('before  after');
+    expect(parts.filter((part) => part.type === 'tool-call')).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: expect.stringMatching(/^dsml_/),
+        toolName: 'mcp__notes__save',
+        input: {
+          text: '第一行\nsecond line',
+          options: { overwrite: false, count: 2, tags: ['a'], parent: null },
+        },
+      },
+    ]);
+  });
+
+  test('recovers repeated blocks with distinct identities and preserves ordinary punctuation', () => {
+    const parts = parse([`a ${CALL} b ${CALL} c <`]);
+    const calls = parts.filter((part) => part.type === 'tool-call');
+    expect(text(parts)).toBe('a  b  c <');
+    expect(calls).toHaveLength(2);
+    expect(calls[0].toolCallId).not.toBe(calls[1].toolCallId);
+    expect(parse(['Compare < 5; DSML is a protocol.'])).toEqual([
+      { type: 'text', text: 'Compare < 5; DSML is a protocol.' },
+    ]);
+  });
+
+  test.each(['ToolSearch', 'tool_search'])(
+    'maps the search-loop variant to the available %s',
+    (name) => {
+      const parts = parse(
+        [...'<｜DSML｜Tool loop><search>notes save</search></｜DSML｜Tool>'],
+        [{ name }],
+      );
+      expect(parts).toEqual([
+        expect.objectContaining({ toolName: name, input: { query: 'notes save' } }),
+      ]);
+      expect(() => parse(['<｜DSML｜Tool loop><search>notes</search></｜DSML｜Tool>'])).toThrow(
+        DeepseekDsmlError,
+      );
+    },
+  );
+
+  test('resolves only unambiguous request-scoped tool names', () => {
+    const source = CALL.replace('mcp__notes__save', 'MCP__NOTES__SAVE');
+    expect(parse([source], [{ name: 'mcp__notes__save' }])).toEqual([
+      expect.objectContaining({ toolName: 'mcp__notes__save' }),
+    ]);
+    expect(parse([source], [{ name: 'OtherTool' }])).toEqual([
+      expect.objectContaining({ toolName: 'MCP__NOTES__SAVE' }),
+    ]);
+    expect(parse([source], [{ name: 'mcp__notes__save' }, { name: 'Mcp__Notes__Save' }])).toEqual([
+      expect.objectContaining({ toolName: 'MCP__NOTES__SAVE' }),
+    ]);
+  });
+
+  test.each([
+    '</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>',
+    '<｜DSML｜tool_calls>not an invoke</｜DSML｜tool_calls>',
+    '<｜DSML｜tool_calls><｜DSML｜invoke name="save">',
+    '<｜DSML｜tool_calls',
+    '<|dsml|>',
+    CALL.replace(
+      '</｜DSML｜tool_calls>',
+      '<｜DSML｜invoke name="lost">missing</｜DSML｜tool_calls>',
+    ),
+    CALL.replace('{"overwrite":false,"count":2,"tags":["a"],"parent":null}', '{"broken":'),
+    CALL.replace(
+      '</｜DSML｜invoke>',
+      '<｜DSML｜parameter name="lost" string="true">missing</｜DSML｜invoke>',
+    ),
+  ])('rejects unrecoverable markup without inventing arguments: %s', (source) => {
+    expect(() => parse([...source])).toThrow(DeepseekDsmlError);
+  });
+
+  test('bounds an unterminated block and rejects duplicate parameter names', () => {
+    expect(() => parse(['<｜DSML｜tool_calls>', 'x'.repeat(64 * 1024 + 1)])).toThrow(
+      DeepseekDsmlError,
+    );
+    expect(() => parse([CALL.replace('name="options"', 'name="text"')])).toThrow(DeepseekDsmlError);
+  });
+
+  test('preserves special JSON keys as own properties without changing the object prototype', () => {
+    const parts = parse([
+      '<｜DSML｜tool_calls><｜DSML｜invoke name="save"><｜DSML｜parameter name="__proto__" string="false">{"value":1}</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>',
+    ]);
+    const call = parts.find((part) => part.type === 'tool-call')!;
+    expect(Object.hasOwn(call.input, '__proto__')).toBe(true);
+    expect(Object.getPrototypeOf(call.input)).toBe(Object.prototype);
+    expect(JSON.stringify(call.input)).toBe('{"__proto__":{"value":1}}');
+  });
+});

--- a/packages/ai-runtime/src/provider/deepseek-dsml.ts
+++ b/packages/ai-runtime/src/provider/deepseek-dsml.ts
@@ -1,0 +1,171 @@
+// Protocol variants from Cherry Desktop #19921; execution stays with each consumer.
+const TOOL_CALLS_OPEN = ['<｜DSML｜tool_calls>', '<｜｜DSML｜｜tool_calls>'];
+const TOOL_CALLS_CLOSE = ['</｜DSML｜tool_calls>', '</｜｜DSML｜｜tool_calls>'];
+const TOOL_LOOP_OPEN = ['<｜DSML｜Tool loop>', '<｜｜DSML｜｜Tool loop>'];
+const TOOL_LOOP_CLOSE = ['</｜DSML｜Tool>', '</｜｜DSML｜｜Tool>'];
+const OPEN_TAGS = [...TOOL_CALLS_OPEN, ...TOOL_LOOP_OPEN];
+const MARKERS = [
+  '<｜DSML｜',
+  '</｜DSML｜',
+  '<｜｜DSML｜｜',
+  '</｜｜DSML｜｜',
+  '<|dsml|>',
+  '</|dsml|>',
+];
+const BUFFER_LIMIT = 64 * 1024;
+const INVOKE_PATTERN =
+  /<｜{1,2}DSML｜{1,2}(?:tool_)?(invoke|tool)\s+name="([^"]+)">([\s\S]*?)<\/｜{1,2}DSML｜{1,2}(?:tool_)?\1>/g;
+const PARAMETER_PATTERN =
+  /<｜{1,2}DSML｜{1,2}parameter\s+name="([^"]+)"(?:\s+string="(true|false)")?>([\s\S]*?)<\/｜{1,2}DSML｜{1,2}parameter>/g;
+
+export class DeepseekDsmlError extends Error {
+  readonly code = 'deepseek_dsml_parse_error';
+  readonly retryable = false;
+
+  constructor() {
+    super('DeepSeek returned an incomplete or unsupported tool call. Please retry the request.');
+    this.name = 'DeepseekDsmlError';
+  }
+}
+
+export type DeepseekDsmlCall = {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+};
+
+export type DeepseekDsmlPart = { type: 'text'; text: string } | DeepseekDsmlCall;
+
+type ToolName = { name: string };
+
+function call(
+  toolName: string,
+  input: Record<string, unknown>,
+  tools: readonly ToolName[],
+): DeepseekDsmlCall {
+  const matches = tools.filter((tool) => tool.name.toLowerCase() === toolName.toLowerCase());
+  return {
+    type: 'tool-call',
+    toolCallId: `dsml_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`,
+    toolName: matches.length === 1 ? matches[0].name : toolName,
+    input,
+  };
+}
+
+function parseCalls(
+  content: string,
+  openTag: string,
+  tools: readonly ToolName[],
+): DeepseekDsmlCall[] {
+  if (TOOL_LOOP_OPEN.includes(openTag)) {
+    const search = /^\s*<search>([\s\S]+)<\/search>\s*$/.exec(content);
+    if (search) {
+      const searchTools = tools.filter((tool) =>
+        ['toolsearch', 'tool_search'].includes(tool.name.toLowerCase()),
+      );
+      if (searchTools.length !== 1) throw new DeepseekDsmlError();
+      return [call(searchTools[0].name, { query: search[1] }, tools)];
+    }
+  }
+
+  const calls: DeepseekDsmlCall[] = [];
+  const remainder = content.replace(
+    INVOKE_PATTERN,
+    (_match, _kind: string, name: string, parameters: string) => {
+      const entries = new Map<string, unknown>();
+      const remainingParameters = parameters.replace(
+        PARAMETER_PATTERN,
+        (_parameter, key: string, string: string | undefined, value: string) => {
+          if (entries.has(key)) throw new DeepseekDsmlError();
+          try {
+            entries.set(key, string === 'false' ? JSON.parse(value) : value);
+          } catch {
+            throw new DeepseekDsmlError();
+          }
+          return '';
+        },
+      );
+      if (remainingParameters.trim()) throw new DeepseekDsmlError();
+      calls.push(call(name, Object.fromEntries(entries), tools));
+      return '';
+    },
+  );
+  // Never execute a valid prefix when a sibling call or parameter was truncated.
+  if (remainder.trim() || calls.length === 0) throw new DeepseekDsmlError();
+  return calls;
+}
+
+function firstTag(
+  text: string,
+  tags: readonly string[],
+): { index: number; tag: string } | undefined {
+  let first: { index: number; tag: string } | undefined;
+  for (const tag of tags) {
+    const index = text.indexOf(tag);
+    if (index >= 0 && (!first || index < first.index)) first = { index, tag };
+  }
+  return first;
+}
+
+function partialMarkerLength(text: string): number {
+  const limit = Math.min(text.length, Math.max(...MARKERS.map((marker) => marker.length)) - 1);
+  for (let length = limit; length > 0; length -= 1) {
+    if (MARKERS.some((marker) => marker.startsWith(text.slice(-length)))) return length;
+  }
+  return 0;
+}
+
+/** One bounded parser per text/reasoning block; never share state between requests. */
+export function createDeepseekDsmlParser(tools: readonly ToolName[] = []) {
+  let buffer = '';
+  let openTag: string | undefined;
+
+  return {
+    push(delta: string): DeepseekDsmlPart[] {
+      buffer += delta;
+      const parts: DeepseekDsmlPart[] = [];
+      while (buffer) {
+        if (openTag) {
+          const close = firstTag(
+            buffer,
+            TOOL_LOOP_OPEN.includes(openTag) ? TOOL_LOOP_CLOSE : TOOL_CALLS_CLOSE,
+          );
+          if (!close) {
+            if (buffer.length > BUFFER_LIMIT) throw new DeepseekDsmlError();
+            break;
+          }
+          if (close.index > BUFFER_LIMIT) throw new DeepseekDsmlError();
+          parts.push(...parseCalls(buffer.slice(0, close.index), openTag, tools));
+          buffer = buffer.slice(close.index + close.tag.length);
+          openTag = undefined;
+          continue;
+        }
+
+        const marker = firstTag(buffer, MARKERS);
+        if (!marker) {
+          const pendingLength = partialMarkerLength(buffer);
+          const text = buffer.slice(0, buffer.length - pendingLength);
+          if (text) parts.push({ type: 'text', text });
+          buffer = buffer.slice(buffer.length - pendingLength);
+          break;
+        }
+        if (marker.index > 0) parts.push({ type: 'text', text: buffer.slice(0, marker.index) });
+        buffer = buffer.slice(marker.index);
+        openTag = OPEN_TAGS.find((tag) => buffer.startsWith(tag));
+        if (!openTag) {
+          if (buffer.includes('>') || buffer.length > BUFFER_LIMIT) throw new DeepseekDsmlError();
+          break;
+        }
+        buffer = buffer.slice(openTag.length);
+      }
+      return parts;
+    },
+    finish(): DeepseekDsmlPart[] {
+      if (openTag || /DSML|dsml/.test(buffer)) throw new DeepseekDsmlError();
+      const parts: DeepseekDsmlPart[] = buffer ? [{ type: 'text', text: buffer }] : [];
+      buffer = '';
+      return parts;
+    },
+  };
+}

--- a/packages/ai-runtime/src/provider/index.ts
+++ b/packages/ai-runtime/src/provider/index.ts
@@ -35,6 +35,8 @@ export * from './custom/transportUtils';
 export * from './custom/wire/buildImageRequest';
 export * from './custom/wire/wireProfile';
 export * from './custom/zhipuProvider';
+export { createDeepseekDsmlParser, DeepseekDsmlError } from './deepseek-dsml';
+export type { DeepseekDsmlCall, DeepseekDsmlPart } from './deepseek-dsml';
 export * from './diagnostics';
 export * from './endpoint';
 export * from './extensions';

--- a/packages/ai-runtime/src/runtime/aiSdk/params/features/__tests__/deepseekDsmlParser.test.ts
+++ b/packages/ai-runtime/src/runtime/aiSdk/params/features/__tests__/deepseekDsmlParser.test.ts
@@ -22,23 +22,27 @@ async function getMiddleware(): Promise<LanguageModelMiddleware> {
   return context.middlewares[0];
 }
 
-async function runStream(deltas: string[]) {
-  const middleware = await getMiddleware();
+async function runStream(deltas: string[], type: 'text' | 'reasoning' = 'text') {
   const parts: LanguageModelV3StreamPart[] = [
     { type: 'stream-start', warnings: [] },
-    { type: 'text-start', id: 'text-1' },
+    { type: `${type}-start`, id: 'text-1' },
     ...deltas.map<LanguageModelV3StreamPart>((delta) => ({
-      type: 'text-delta',
+      type: `${type}-delta`,
       id: 'text-1',
       delta,
     })),
-    { type: 'text-end', id: 'text-1' },
+    { type: `${type}-end`, id: 'text-1' },
     {
       type: 'finish',
       finishReason: { unified: 'stop', raw: 'stop' },
       usage: {} as never,
     },
   ];
+  return runParts(parts);
+}
+
+async function runParts(parts: LanguageModelV3StreamPart[]) {
+  const middleware = await getMiddleware();
   const source = new ReadableStream<LanguageModelV3StreamPart>({
     start(controller) {
       for (const part of parts) controller.enqueue(part);
@@ -63,12 +67,12 @@ async function runStream(deltas: string[]) {
   return events;
 }
 
-async function runGenerate(text: string) {
+async function runGenerate(text: string, type: 'text' | 'reasoning' = 'text') {
   const middleware = await getMiddleware();
   const result = await middleware.wrapGenerate?.({
     doGenerate: async () =>
       ({
-        content: [{ type: 'text', text }],
+        content: [{ type, text }],
         finishReason: { unified: 'stop', raw: 'stop' },
         request: { body: {} },
         usage: {} as never,
@@ -123,12 +127,16 @@ describe('deepseekDsmlParser', () => {
     expect(streamText(events)).toBe('before  after');
   });
 
-  test('preserves malformed and unclosed DSML as text', async () => {
+  test('reports malformed and unclosed DSML instead of leaking it as successful text', async () => {
     const malformed = `before ${OPEN}not an invoke${CLOSE} after`;
-    expect(streamText(await runStream([malformed]))).toBe(malformed);
+    await expect(runStream([malformed])).rejects.toMatchObject({
+      code: 'deepseek_dsml_parse_error',
+    });
 
     const unclosed = `${OPEN}${invoke('web_search', parameter('query', 'query'))}`;
-    expect(streamText(await runStream([unclosed]))).toBe(unclosed);
+    await expect(runStream([unclosed])).rejects.toMatchObject({
+      code: 'deepseek_dsml_parse_error',
+    });
   });
 
   test('passes ordinary text through without changing the finish reason', async () => {
@@ -162,12 +170,73 @@ describe('deepseekDsmlParser', () => {
     expect(result.finishReason.unified).toBe('tool-calls');
   });
 
-  test('preserves malformed non-streaming blocks', async () => {
+  test('reports malformed non-streaming blocks', async () => {
     const text = `before ${OPEN}garbage${CLOSE} after`;
-    const result = await runGenerate(text);
+    await expect(runGenerate(text)).rejects.toMatchObject({ code: 'deepseek_dsml_parse_error' });
+  });
 
-    expect(result.content).toEqual([expect.objectContaining({ type: 'text', text })]);
-    expect(result.finishReason.unified).toBe('stop');
+  test('closes reasoning before emitting recovered calls and keeps both channels free of markup', async () => {
+    const source =
+      'thinking ' +
+      `${OPEN}${invoke('lookup', parameter('query', 'notes'))}${CLOSE}`.replaceAll('｜｜', '｜');
+    const events = await runStream([...source], 'reasoning');
+    expect(events.findIndex((event) => event.type === 'reasoning-end')).toBeLessThan(
+      events.findIndex((event) => event.type === 'tool-input-start'),
+    );
+    expect(
+      events
+        .filter((event) => event.type === 'reasoning-delta')
+        .map((event) => event.delta)
+        .join(''),
+    ).toBe('thinking ');
+    expect(events.filter((event) => event.type === 'tool-call')).toEqual([
+      expect.objectContaining({ toolName: 'lookup', input: '{"query":"notes"}' }),
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'tool-calls' },
+    });
+  });
+
+  test('also recovers calls in non-streaming reasoning', async () => {
+    const result = await runGenerate(
+      `think ${OPEN}${invoke('lookup', parameter('query', 'notes'))}${CLOSE}`,
+      'reasoning',
+    );
+    expect(result.content).toEqual([
+      { type: 'reasoning', text: 'think ' },
+      expect.objectContaining({
+        type: 'tool-call',
+        toolName: 'lookup',
+        input: '{"query":"notes"}',
+      }),
+    ]);
+    expect(result.finishReason.unified).toBe('tool-calls');
+  });
+
+  test('isolates interleaved content and flushes recovered calls before a terminal finish', async () => {
+    const source = `${OPEN}${invoke('lookup', parameter('query', 'notes'))}${CLOSE}`;
+    const events = await runParts([
+      { type: 'reasoning-start', id: 'shared-id' },
+      { type: 'reasoning-delta', id: 'shared-id', delta: source.slice(0, 10) },
+      { type: 'text-start', id: 'shared-id' },
+      { type: 'text-delta', id: 'shared-id', delta: 'visible' },
+      { type: 'text-end', id: 'shared-id', providerMetadata: { vendor: { tag: 'keep' } } },
+      { type: 'reasoning-delta', id: 'shared-id', delta: source.slice(10) },
+      { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: {} as never },
+    ]);
+    expect(streamText(events)).toBe('visible');
+    expect(events.find((event) => event.type === 'text-end')).toMatchObject({
+      providerMetadata: { vendor: { tag: 'keep' } },
+    });
+    expect(events.filter((event) => event.type === 'tool-call')).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'tool-calls' },
+    });
+    expect(events.findIndex((event) => event.type === 'reasoning-end')).toBeLessThan(
+      events.findIndex((event) => event.type === 'tool-call'),
+    );
   });
 });
 

--- a/packages/ai-runtime/src/runtime/aiSdk/params/features/deepseekDsmlParserPlugin.ts
+++ b/packages/ai-runtime/src/runtime/aiSdk/params/features/deepseekDsmlParserPlugin.ts
@@ -2,314 +2,163 @@ import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
 import { definePlugin } from '@cherrystudio/ai-core';
 import type { LanguageModelMiddleware } from 'ai';
 
-const TOOL_CALLS_OPEN = '<｜｜DSML｜｜tool_calls>';
-const TOOL_CALLS_CLOSE = '</｜｜DSML｜｜tool_calls>';
-const SWALLOW_BUFFER_LIMIT = 64 * 1024;
-
-const INVOKE_RE = /<｜｜DSML｜｜invoke\s+name="([^"]+)">([\s\S]*?)<\/｜｜DSML｜｜invoke>/g;
-const PARAM_RE =
-  /<｜｜DSML｜｜parameter\s+name="([^"]+)"(?:\s+string="(true|false)")?>([\s\S]*?)<\/｜｜DSML｜｜parameter>/g;
-
-interface ParsedDsmlCall {
-  toolName: string;
-  args: Record<string, unknown>;
-}
-
-function parseInvokeBlocks(dsmlContent: string): ParsedDsmlCall[] {
-  const calls: ParsedDsmlCall[] = [];
-  INVOKE_RE.lastIndex = 0;
-  let invokeMatch: RegExpExecArray | null;
-  while ((invokeMatch = INVOKE_RE.exec(dsmlContent)) !== null) {
-    const toolName = invokeMatch[1];
-    const inner = invokeMatch[2];
-    const args: Record<string, unknown> = {};
-
-    PARAM_RE.lastIndex = 0;
-    let paramMatch: RegExpExecArray | null;
-    while ((paramMatch = PARAM_RE.exec(inner)) !== null) {
-      const paramName = paramMatch[1];
-      const isString = paramMatch[2] !== 'false';
-      const rawValue = paramMatch[3];
-      if (isString) {
-        args[paramName] = rawValue;
-      } else {
-        try {
-          args[paramName] = JSON.parse(rawValue);
-        } catch {
-          args[paramName] = rawValue;
-        }
-      }
-    }
-    calls.push({ toolName, args });
-  }
-  return calls;
-}
-
-function findPartialPrefix(buffer: string, target: string): number {
-  const maxLen = Math.min(buffer.length, target.length - 1);
-  for (let len = maxLen; len > 0; len -= 1) {
-    if (target.startsWith(buffer.slice(buffer.length - len))) {
-      return buffer.length - len;
-    }
-  }
-  return -1;
-}
-
-function generateToolCallId(): string {
-  return `dsml_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
-}
+import {
+  createDeepseekDsmlParser,
+  type DeepseekDsmlCall,
+  type DeepseekDsmlPart,
+} from '../../../../provider/deepseek-dsml';
 
 function createDeepseekDsmlParserMiddleware(): LanguageModelMiddleware {
   return {
     specificationVersion: 'v3',
-
-    wrapStream: async ({ doStream }) => {
+    wrapStream: async ({ doStream, params }) => {
       const { stream, ...rest } = await doStream();
-
-      let textBuffer = '';
-      let dsmlBuffer = '';
-      let inDsml = false;
-      let activeTextId: string | null = null;
-      let extractedToolCalls = false;
-      let drainDsmlBuffer: (
-        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
-        textId: string,
-      ) => void;
-
-      const enqueueRemainderText = (
-        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
-        textId: string,
-      ) => {
-        const startIdx = textBuffer.indexOf(TOOL_CALLS_OPEN);
-        if (startIdx === -1) {
-          const partialIdx = findPartialPrefix(textBuffer, TOOL_CALLS_OPEN);
-          if (partialIdx >= 0) {
-            const safe = textBuffer.slice(0, partialIdx);
-            if (safe) controller.enqueue({ type: 'text-delta', id: textId, delta: safe });
-            textBuffer = textBuffer.slice(partialIdx);
-          } else {
-            if (textBuffer) {
-              controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer });
-            }
-            textBuffer = '';
-          }
-          return;
-        }
-        if (startIdx > 0) {
-          controller.enqueue({
-            type: 'text-delta',
-            id: textId,
-            delta: textBuffer.slice(0, startIdx),
-          });
-        }
-        dsmlBuffer = textBuffer.slice(startIdx + TOOL_CALLS_OPEN.length);
-        textBuffer = '';
-        inDsml = true;
-        drainDsmlBuffer(controller, textId);
+      type ContentState = {
+        id: string;
+        type: 'text' | 'reasoning';
+        parser: ReturnType<typeof createDeepseekDsmlParser>;
+        pendingCalls: DeepseekDsmlCall[];
       };
+      type Controller = TransformStreamDefaultController<LanguageModelV3StreamPart>;
+      const states = new Map<string, ContentState>();
+      let extracted = false;
 
-      drainDsmlBuffer = (controller, textId) => {
-        const closeIdx = dsmlBuffer.indexOf(TOOL_CALLS_CLOSE);
-        if (closeIdx === -1) {
-          if (dsmlBuffer.length > SWALLOW_BUFFER_LIMIT) {
-            controller.enqueue({
-              type: 'text-delta',
-              id: textId,
-              delta: TOOL_CALLS_OPEN + dsmlBuffer,
-            });
-            dsmlBuffer = '';
-            inDsml = false;
-          }
-          return;
+      const getState = (type: ContentState['type'], id: string): ContentState => {
+        const key = `${type}:${id}`;
+        let state = states.get(key);
+        if (!state) {
+          state = { type, id, parser: createDeepseekDsmlParser(params.tools), pendingCalls: [] };
+          states.set(key, state);
         }
-
-        const blockContent = dsmlBuffer.slice(0, closeIdx);
-        const remainder = dsmlBuffer.slice(closeIdx + TOOL_CALLS_CLOSE.length);
-        const calls = parseInvokeBlocks(blockContent);
-
-        if (calls.length === 0) {
-          controller.enqueue({
-            type: 'text-delta',
-            id: textId,
-            delta: TOOL_CALLS_OPEN + blockContent + TOOL_CALLS_CLOSE,
-          });
-        } else {
-          for (const call of calls) {
-            const id = generateToolCallId();
-            const inputJson = JSON.stringify(call.args);
-            controller.enqueue({ type: 'tool-input-start', id, toolName: call.toolName });
-            controller.enqueue({ type: 'tool-input-delta', id, delta: inputJson });
-            controller.enqueue({ type: 'tool-input-end', id });
-            controller.enqueue({
-              type: 'tool-call',
-              toolCallId: id,
-              toolName: call.toolName,
-              input: inputJson,
-            });
-          }
-          extractedToolCalls = true;
+        return state;
+      };
+      const emitCalls = (calls: DeepseekDsmlCall[], controller: Controller) => {
+        for (const call of calls) {
+          const { toolCallId: id, toolName } = call;
+          const input = JSON.stringify(call.input);
+          controller.enqueue({ type: 'tool-input-start', id, toolName });
+          controller.enqueue({ type: 'tool-input-delta', id, delta: input });
+          controller.enqueue({ type: 'tool-input-end', id });
+          controller.enqueue({ type: 'tool-call', toolCallId: id, toolName, input });
+          extracted = true;
         }
-
-        dsmlBuffer = '';
-        inDsml = false;
-        textBuffer = remainder;
-        if (textBuffer) enqueueRemainderText(controller, textId);
+      };
+      const emitParts = (
+        parts: DeepseekDsmlPart[],
+        state: ContentState,
+        controller: Controller,
+      ) => {
+        for (const part of parts) {
+          if (part.type === 'text') {
+            controller.enqueue({ type: `${state.type}-delta`, id: state.id, delta: part.text });
+          } else if (state.type === 'reasoning') {
+            state.pendingCalls.push(part);
+          } else {
+            emitCalls([part], controller);
+          }
+        }
+      };
+      const endContent = (
+        state: ContentState,
+        controller: Controller,
+        end?: LanguageModelV3StreamPart,
+      ) => {
+        emitParts(state.parser.finish(), state, controller);
+        controller.enqueue(end ?? { type: `${state.type}-end`, id: state.id });
+        // Reasoning must close before the recovered call reaches the tool loop.
+        emitCalls(state.pendingCalls, controller);
+        states.delete(`${state.type}:${state.id}`);
       };
 
       return {
+        ...rest,
         stream: stream.pipeThrough(
           new TransformStream<LanguageModelV3StreamPart, LanguageModelV3StreamPart>({
             transform(chunk, controller) {
-              if (chunk.type === 'text-start') {
-                activeTextId = chunk.id;
-                controller.enqueue(chunk);
-                return;
-              }
-
-              if (chunk.type === 'text-end') {
-                const textId = chunk.id;
-                if (inDsml) {
-                  controller.enqueue({
-                    type: 'text-delta',
-                    id: textId,
-                    delta: TOOL_CALLS_OPEN + dsmlBuffer,
-                  });
-                  dsmlBuffer = '';
-                  inDsml = false;
-                } else if (textBuffer) {
-                  controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer });
-                  textBuffer = '';
-                }
-                controller.enqueue(chunk);
-                activeTextId = null;
-                return;
-              }
-
-              if (chunk.type === 'finish') {
-                if (extractedToolCalls && chunk.finishReason.unified === 'stop') {
-                  controller.enqueue({
-                    ...chunk,
-                    finishReason: { ...chunk.finishReason, unified: 'tool-calls' },
-                  });
-                } else {
+              switch (chunk.type) {
+                case 'text-start':
+                case 'reasoning-start':
+                  getState(chunk.type === 'text-start' ? 'text' : 'reasoning', chunk.id);
                   controller.enqueue(chunk);
+                  return;
+                case 'text-delta':
+                case 'reasoning-delta': {
+                  const state = getState(
+                    chunk.type === 'text-delta' ? 'text' : 'reasoning',
+                    chunk.id,
+                  );
+                  emitParts(state.parser.push(chunk.delta), state, controller);
+                  return;
                 }
-                return;
+                case 'text-end':
+                case 'reasoning-end':
+                  endContent(
+                    getState(chunk.type === 'text-end' ? 'text' : 'reasoning', chunk.id),
+                    controller,
+                    chunk,
+                  );
+                  return;
+                case 'error':
+                  states.clear();
+                  controller.enqueue(chunk);
+                  return;
+                case 'finish':
+                  if (chunk.finishReason.unified === 'error') {
+                    states.clear();
+                  } else {
+                    for (const state of states.values()) endContent(state, controller);
+                  }
+                  controller.enqueue(
+                    extracted && chunk.finishReason.unified === 'stop'
+                      ? { ...chunk, finishReason: { ...chunk.finishReason, unified: 'tool-calls' } }
+                      : chunk,
+                  );
+                  return;
+                default:
+                  controller.enqueue(chunk);
               }
-
-              if (chunk.type !== 'text-delta') {
-                controller.enqueue(chunk);
-                return;
-              }
-
-              const textId = chunk.id;
-              if (!activeTextId) activeTextId = textId;
-
-              if (inDsml) {
-                dsmlBuffer += chunk.delta;
-                drainDsmlBuffer(controller, textId);
-                return;
-              }
-
-              textBuffer += chunk.delta;
-              enqueueRemainderText(controller, textId);
             },
             flush(controller) {
-              const textId = activeTextId ?? 'dsml-fallback';
-              if (inDsml) {
-                controller.enqueue({
-                  type: 'text-delta',
-                  id: textId,
-                  delta: TOOL_CALLS_OPEN + dsmlBuffer,
-                });
-              } else if (textBuffer) {
-                controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer });
-              }
-              textBuffer = '';
-              dsmlBuffer = '';
-              inDsml = false;
+              for (const state of states.values()) endContent(state, controller);
             },
           }),
         ),
-        ...rest,
       };
     },
-
-    wrapGenerate: async ({ doGenerate }) => {
+    wrapGenerate: async ({ doGenerate, params }) => {
       const result = await doGenerate();
-      const newContent: typeof result.content = [];
+      const content: typeof result.content = [];
       let extracted = false;
-
       for (const part of result.content) {
-        if (part.type !== 'text') {
-          newContent.push(part);
+        if (part.type !== 'text' && part.type !== 'reasoning') {
+          content.push(part);
           continue;
         }
-        const text = part.text;
-        const partsForText: typeof newContent = [];
-        let textAccum = '';
-        let cursor = 0;
-        let foundCallInPart = false;
-
-        while (cursor < text.length) {
-          const startIdx = text.indexOf(TOOL_CALLS_OPEN, cursor);
-          if (startIdx === -1) {
-            textAccum += text.slice(cursor);
-            break;
-          }
-          const closeIdx = text.indexOf(TOOL_CALLS_CLOSE, startIdx + TOOL_CALLS_OPEN.length);
-          if (closeIdx === -1) {
-            textAccum += text.slice(cursor);
-            break;
-          }
-
-          const blockEnd = closeIdx + TOOL_CALLS_CLOSE.length;
-          const blockContent = text.slice(startIdx + TOOL_CALLS_OPEN.length, closeIdx);
-          const calls = parseInvokeBlocks(blockContent);
-
-          if (calls.length === 0) {
-            textAccum += text.slice(cursor, blockEnd);
-            cursor = blockEnd;
-            continue;
-          }
-
-          textAccum += text.slice(cursor, startIdx);
-          if (textAccum) {
-            partsForText.push({ ...part, text: textAccum });
-            textAccum = '';
-          }
-          for (const call of calls) {
-            partsForText.push({
-              type: 'tool-call',
-              toolCallId: generateToolCallId(),
-              toolName: call.toolName,
-              input: JSON.stringify(call.args),
-            });
-          }
-          foundCallInPart = true;
-          cursor = blockEnd;
-        }
-
-        if (!foundCallInPart) {
-          newContent.push(part);
+        const parser = createDeepseekDsmlParser(params.tools);
+        const parts = [...parser.push(part.text), ...parser.finish()];
+        if (!parts.some((item) => item.type === 'tool-call')) {
+          content.push(part);
           continue;
         }
-
-        newContent.push(...partsForText);
-        if (textAccum) newContent.push({ ...part, text: textAccum });
         extracted = true;
+        for (const item of parts) {
+          content.push(
+            item.type === 'text'
+              ? { ...part, text: item.text }
+              : { ...item, input: JSON.stringify(item.input) },
+          );
+        }
       }
-
-      if (!extracted) return result;
-
-      return {
-        ...result,
-        content: newContent,
-        finishReason:
-          result.finishReason.unified === 'stop'
-            ? { ...result.finishReason, unified: 'tool-calls' }
-            : result.finishReason,
-      };
+      return extracted
+        ? {
+            ...result,
+            content,
+            finishReason:
+              result.finishReason.unified === 'stop'
+                ? { ...result.finishReason, unified: 'tool-calls' }
+                : result.finishReason,
+          }
+        : result;
     },
   };
 }

--- a/src/backend/ai/agent/runtime/pi/__tests__/piDeepseekDsml.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piDeepseekDsml.test.ts
@@ -1,0 +1,374 @@
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import { Agent } from '@earendil-works/pi-agent-core/agent';
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Context,
+  Model,
+} from '@earendil-works/pi-ai';
+import { AssistantMessageEventStream } from '@earendil-works/pi-ai/utils/event-stream';
+
+import type { RuntimeJsonValue, RuntimeTool } from '../../types';
+import { withPiDeepseekDsml } from '../piDeepseekDsml';
+import { createPiDeferredToolDiscoveryTools } from '../piDeferredToolDiscovery';
+
+const MODEL: Model<'openai-completions'> = {
+  api: 'openai-completions',
+  provider: 'proxy',
+  id: 'deepseek-v4.1-flash',
+  name: 'DeepSeek V4.1 Flash',
+  baseUrl: 'https://example.test',
+  reasoning: true,
+  input: ['text'],
+  contextWindow: 4096,
+  maxTokens: 256,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+const CALL =
+  '<｜DSML｜tool_calls><｜DSML｜invoke name="Lookup"><｜DSML｜parameter name="query" string="true">notes</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>';
+const CONTEXT: Context = {
+  messages: [],
+  tools: [
+    {
+      name: 'lookup',
+      description: 'Find notes',
+      parameters: { type: 'object', properties: { query: { type: 'string' } } } as never,
+    },
+  ],
+};
+
+function message(
+  content: AssistantMessage['content'],
+  stopReason: AssistantMessage['stopReason'] = 'stop',
+): AssistantMessage {
+  return {
+    role: 'assistant',
+    api: MODEL.api,
+    provider: MODEL.provider,
+    model: MODEL.id,
+    responseId: 'response-1',
+    timestamp: 123,
+    content,
+    stopReason,
+    rawStopReason: 'stop',
+    usage: {
+      input: 12,
+      output: 9,
+      cacheRead: 3,
+      cacheWrite: 0,
+      totalTokens: 24,
+      cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0, total: 0.3 },
+    },
+  };
+}
+
+function sourceOf(result: AssistantMessage) {
+  const source = new AssistantMessageEventStream();
+  source.push({ type: 'start', partial: result });
+  result.content.forEach((block, contentIndex) => {
+    if (block.type === 'toolCall') {
+      source.push({ type: 'toolcall_start', contentIndex, partial: result });
+      source.push({
+        type: 'toolcall_delta',
+        contentIndex,
+        delta: JSON.stringify(block.arguments),
+        partial: result,
+      });
+      source.push({ type: 'toolcall_end', contentIndex, toolCall: block, partial: result });
+    } else {
+      const type = block.type === 'text' ? 'text' : 'thinking';
+      const content = block.type === 'text' ? block.text : block.thinking;
+      source.push({ type: `${type}_start`, contentIndex, partial: result });
+      for (const delta of content)
+        source.push({ type: `${type}_delta`, contentIndex, delta, partial: result });
+      source.push({ type: `${type}_end`, contentIndex, content, partial: result });
+    }
+  });
+  if (result.stopReason === 'error' || result.stopReason === 'aborted')
+    source.push({ type: 'error', reason: result.stopReason, error: result });
+  else source.push({ type: 'done', reason: result.stopReason, message: result });
+  source.end();
+  return source;
+}
+
+async function collect(streamFn: StreamFn, options?: Parameters<StreamFn>[2]) {
+  const stream = await withPiDeepseekDsml(streamFn)(MODEL, CONTEXT, options);
+  const events: AssistantMessageEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return { events, result: await stream.result() };
+}
+
+describe('Pi DeepSeek DSML adaptation', () => {
+  test.each(['text', 'thinking'] as const)(
+    'recovers calls from %s in both events and the final message',
+    async (type) => {
+      const original = message([
+        type === 'text'
+          ? { type, text: `before ${CALL} after` }
+          : { type, thinking: `before ${CALL} after`, thinkingSignature: 'reasoning_content' },
+      ]);
+      const { events, result } = await collect(() => sourceOf(original));
+      expect(result.content).toEqual([
+        type === 'text'
+          ? { type, text: 'before  after' }
+          : { type, thinking: 'before  after', thinkingSignature: 'reasoning_content' },
+        {
+          type: 'toolCall',
+          id: expect.stringMatching(/^dsml_/),
+          name: 'lookup',
+          arguments: { query: 'notes' },
+        },
+      ]);
+      expect(result).toMatchObject({
+        stopReason: 'toolUse',
+        usage: original.usage,
+        responseId: 'response-1',
+        timestamp: 123,
+      });
+      expect(
+        events.filter((event) => event.type === 'toolcall_end').map((event) => event.toolCall),
+      ).toEqual([result.content[1]]);
+      expect(events.findIndex((event) => event.type === `${type}_end`)).toBeLessThan(
+        events.findIndex((event) => event.type === 'toolcall_start'),
+      );
+      expect(JSON.stringify(events)).not.toContain('DSML');
+      expect(JSON.stringify(original)).toContain('DSML');
+    },
+  );
+
+  test('remaps indices without altering native tool calls, signatures, or later text', async () => {
+    const native = {
+      type: 'toolCall' as const,
+      id: 'native-1',
+      name: 'lookup',
+      arguments: { query: 'native' },
+      thoughtSignature: 'signature',
+    };
+    const { events, result } = await collect(() =>
+      sourceOf(
+        message(
+          [
+            { type: 'text', text: CALL },
+            native,
+            { type: 'text', text: 'tail', textSignature: 'text-signature' },
+          ],
+          'toolUse',
+        ),
+      ),
+    );
+    expect(result.content[2]).toEqual(native);
+    expect(result.content[3]).toEqual({
+      type: 'text',
+      text: 'tail',
+      textSignature: 'text-signature',
+    });
+    expect(
+      events.filter((event) => event.type === 'toolcall_end').map((event) => event.contentIndex),
+    ).toEqual([1, 2]);
+    expect(
+      events.filter((event) => event.type === 'text_end').map((event) => event.contentIndex),
+    ).toEqual([0, 3]);
+  });
+
+  test('preserves metadata that arrives after the content end', async () => {
+    const source = new AssistantMessageEventStream();
+    const initial = message([{ type: 'text', text: 'answer' }]);
+    source.push({ type: 'start', partial: initial });
+    source.push({ type: 'text_start', contentIndex: 0, partial: initial });
+    source.push({ type: 'text_delta', contentIndex: 0, delta: 'answer', partial: initial });
+    source.push({ type: 'text_end', contentIndex: 0, content: 'answer', partial: initial });
+    source.push({
+      type: 'done',
+      reason: 'stop',
+      message: {
+        ...initial,
+        content: [{ type: 'text', text: 'answer', textSignature: 'late-signature' }],
+      },
+    });
+    expect((await collect(() => source)).result.content).toEqual([
+      { type: 'text', text: 'answer', textSignature: 'late-signature' },
+    ]);
+  });
+
+  test('keeps interleaved text and thinking parsers independent', async () => {
+    const result = message([
+      { type: 'thinking', thinking: CALL },
+      { type: 'text', text: 'visible' },
+    ]);
+    const source = new AssistantMessageEventStream();
+    source.push({ type: 'start', partial: result });
+    source.push({ type: 'thinking_start', contentIndex: 0, partial: result });
+    source.push({
+      type: 'thinking_delta',
+      contentIndex: 0,
+      delta: CALL.slice(0, 12),
+      partial: result,
+    });
+    source.push({ type: 'text_start', contentIndex: 1, partial: result });
+    source.push({ type: 'text_delta', contentIndex: 1, delta: 'visible', partial: result });
+    source.push({ type: 'text_end', contentIndex: 1, content: 'visible', partial: result });
+    source.push({
+      type: 'thinking_delta',
+      contentIndex: 0,
+      delta: CALL.slice(12),
+      partial: result,
+    });
+    source.push({ type: 'done', reason: 'stop', message: result });
+    const normalized = await collect(() => source);
+    expect(normalized.result.content).toEqual([
+      { type: 'thinking', thinking: '' },
+      { type: 'text', text: 'visible' },
+      expect.objectContaining({ type: 'toolCall', name: 'lookup', arguments: { query: 'notes' } }),
+    ]);
+    expect(JSON.stringify(normalized.events)).not.toContain('DSML');
+  });
+
+  test('reports malformed and closing-only fragments without exposing them or claiming success', async () => {
+    for (const text of [
+      CALL.slice(0, -12),
+      '</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>',
+    ]) {
+      const { events, result } = await collect(() =>
+        sourceOf(message([{ type: 'thinking', thinking: text }])),
+      );
+      expect(result).toMatchObject({
+        stopReason: 'error',
+        diagnostics: [
+          expect.objectContaining({
+            error: expect.objectContaining({ code: 'deepseek_dsml_parse_error' }),
+            details: { retryable: false },
+          }),
+        ],
+      });
+      expect(events.at(-1)?.type).toBe('error');
+      expect(events.some((event) => event.type === 'toolcall_end')).toBe(false);
+      expect(JSON.stringify(result.content)).not.toContain('DSML');
+    }
+  });
+
+  test('preserves provider failure diagnostics and output limits', async () => {
+    const failure = {
+      ...message([{ type: 'text', text: 'partial' }], 'error'),
+      errorMessage: 'HTTP 429',
+      diagnostics: [
+        {
+          type: 'provider_response_failure',
+          timestamp: 1,
+          error: { message: 'HTTP 429', code: 'rate_limit' },
+        },
+      ],
+    };
+    expect((await collect(() => sourceOf(failure))).result).toEqual(failure);
+    expect(
+      (await collect(() => sourceOf(message([{ type: 'text', text: CALL }], 'length')))).result
+        .stopReason,
+    ).toBe('length');
+  });
+
+  test('preserves cancellation and resolves the final result even without an event consumer', async () => {
+    const controller = new AbortController();
+    const source = new AssistantMessageEventStream();
+    let forwardedSignal: AbortSignal | undefined;
+    const stream = await withPiDeepseekDsml((_model, _context, options) => {
+      forwardedSignal = options?.signal;
+      return source;
+    })(MODEL, CONTEXT, { signal: controller.signal });
+    controller.abort();
+    source.push({ type: 'done', reason: 'stop', message: message([{ type: 'text', text: CALL }]) });
+    expect((await stream.result()).stopReason).toBe('aborted');
+    expect(forwardedSignal).toBe(controller.signal);
+  });
+
+  test('turns thrown or unterminated provider streams into terminal errors', async () => {
+    const thrown = await collect(() => {
+      throw new Error('provider failed');
+    });
+    expect(thrown.result).toMatchObject({ stopReason: 'error', errorMessage: 'provider failed' });
+    const source = new AssistantMessageEventStream();
+    source.end(message([]));
+    expect((await collect(() => source)).result.stopReason).toBe('error');
+  });
+
+  test('runs MCP discovery, dispatch, and the follow-up answer through the real Pi agent loop', async () => {
+    const executions: RuntimeJsonValue[] = [];
+    const target: RuntimeTool = {
+      ref: { source: 'mcp', serverId: 'notes', rawToolName: 'save' },
+      providerName: 'mcp__notes__save',
+      displayName: 'Save note',
+      description: 'Save a note',
+      inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+      approval: 'ask',
+      execute: async () => ({ value: 'saved', artifacts: [] }),
+    };
+    const tools = createPiDeferredToolDiscoveryTools(
+      [target],
+      async (_tool, input) => {
+        executions.push(input);
+        return { value: 'saved', artifacts: [] };
+      },
+      async (_id, _signal, _activity, operation) => operation(32_000).modelOutput,
+    );
+    const responses = [
+      '<｜DSML｜Tool loop><search>save note</search></｜DSML｜Tool>',
+      '<｜DSML｜tool_calls><｜DSML｜invoke name="tool_call"><｜DSML｜parameter name="name" string="true">mcp__notes__save</｜DSML｜parameter><｜DSML｜parameter name="params" string="false">{"text":"hello"}</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>',
+      'Saved your note.',
+    ];
+    const requests: Context[] = [];
+    const agent = new Agent({
+      initialState: { model: MODEL, tools },
+      streamFn: withPiDeepseekDsml((_model, context) => {
+        requests.push(context);
+        const response = responses.shift();
+        if (!response) throw new Error('Unexpected additional model request.');
+        return sourceOf(message([{ type: 'text', text: response }]));
+      }),
+    });
+    await agent.prompt('Save hello in notes.');
+    expect(executions).toEqual([{ text: 'hello' }]);
+    expect(requests).toHaveLength(3);
+    expect(requests[1].tools?.map((tool) => tool.name)).toEqual([
+      'tool_search',
+      'tool_describe',
+      'tool_call',
+    ]);
+    expect(agent.state.messages.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Saved your note.' }],
+    });
+    expect(agent.state.messages.filter((item) => item.role === 'toolResult')).toHaveLength(2);
+    expect(JSON.stringify(agent.state.messages)).not.toContain('DSML');
+  });
+
+  test.each(['error', 'length'] as const)(
+    'never executes recovered calls from a %s turn',
+    async (reason) => {
+      const executed: string[] = [];
+      const agent = new Agent({
+        initialState: {
+          model: MODEL,
+          tools: [
+            {
+              ...CONTEXT.tools![0],
+              label: 'Lookup',
+              execute: async () => {
+                executed.push('lookup');
+                return { content: [{ type: 'text', text: 'done' }], details: {} };
+              },
+            },
+          ],
+        },
+        shouldStopAfterTurn: async () => true,
+        streamFn: withPiDeepseekDsml(() =>
+          sourceOf(
+            message(
+              [{ type: 'text', text: reason === 'error' ? `${CALL}<｜DSML｜tool_calls>` : CALL }],
+              reason === 'error' ? 'stop' : 'length',
+            ),
+          ),
+        ),
+      });
+      await agent.prompt('Find notes.');
+      expect(executed).toEqual([]);
+    },
+  );
+});

--- a/src/backend/ai/agent/runtime/pi/__tests__/piDeepseekDsml.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piDeepseekDsml.test.ts
@@ -63,6 +63,7 @@ function message(
 }
 
 function sourceOf(result: AssistantMessage) {
+  if (result.stopReason === 'pending') throw new Error('Expected a completed assistant message.');
   const source = new AssistantMessageEventStream();
   source.push({ type: 'start', partial: result });
   result.content.forEach((block, contentIndex) => {

--- a/src/backend/ai/agent/runtime/pi/__tests__/piModelResolver.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piModelResolver.test.ts
@@ -3,6 +3,8 @@ import {
   MODEL_CAPABILITY,
   type EndpointType,
 } from '@cherrystudio/provider-registry';
+import type { AssistantMessage } from '@earendil-works/pi-ai';
+import { AssistantMessageEventStream } from '@earendil-works/pi-ai/utils/event-stream';
 
 import { installProviderRegistryTestSnapshot } from '@/backend/data/services/providerRegistryTestSnapshot';
 import type { Model } from '@/shared/data/types/model';
@@ -148,6 +150,52 @@ describe('Pi model resolver', () => {
       }),
     );
   });
+
+  test.each(CASES)(
+    'normalizes DeepSeek responses on the configured $api route',
+    async (testCase) => {
+      mockGetProviderById.mockResolvedValue(
+        makeProvider(testCase.endpointType, testCase.baseUrl, testCase.adapterFamily),
+      );
+      mockGetModelById.mockResolvedValue(
+        makeModel(testCase.endpointType, { name: 'DeepSeek V4.1 Flash' }),
+      );
+      const resolution = await resolve(resolver, {});
+      const source = new AssistantMessageEventStream();
+      const response: AssistantMessage = {
+        role: 'assistant',
+        api: testCase.api,
+        provider: 'test-provider',
+        model: resolution.model.id,
+        timestamp: 1,
+        stopReason: 'stop',
+        content: [
+          {
+            type: 'text',
+            text: '<｜DSML｜tool_calls><｜DSML｜invoke name="lookup"></｜DSML｜invoke></｜DSML｜tool_calls>',
+          },
+        ],
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      };
+      source.push({ type: 'done', reason: 'stop', message: response });
+      mockBoundStreamFn.mockReturnValueOnce(source);
+      const stream = await resolution.streamFn(resolution.model, { messages: [] });
+      expect(await stream.result()).toMatchObject({
+        stopReason: 'toolUse',
+        content: [
+          { type: 'text', text: '' },
+          expect.objectContaining({ type: 'toolCall', name: 'lookup', arguments: {} }),
+        ],
+      });
+    },
+  );
 
   test('keeps the independent input cap separate from the default output reservation', async () => {
     const endpoint = ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS;

--- a/src/backend/ai/agent/runtime/pi/piDeepseekDsml.ts
+++ b/src/backend/ai/agent/runtime/pi/piDeepseekDsml.ts
@@ -1,0 +1,267 @@
+import {
+  createDeepseekDsmlParser,
+  DeepseekDsmlError,
+  type DeepseekDsmlCall,
+  type DeepseekDsmlPart,
+} from '@cherrystudio/ai-runtime/provider';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import type {
+  AssistantMessage,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+} from '@earendil-works/pi-ai';
+import { AssistantMessageEventStream } from '@earendil-works/pi-ai/utils/event-stream';
+
+type ContentState = {
+  index: number;
+  block: TextContent | ThinkingContent;
+  parser?: ReturnType<typeof createDeepseekDsmlParser>;
+  receivedLength: number;
+  ended: boolean;
+  calls: DeepseekDsmlCall[];
+};
+
+/** Normalize before Pi commits the assistant message and decides which tools to execute. */
+export function withPiDeepseekDsml(streamFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    const stream = new AssistantMessageEventStream();
+    const content: AssistantMessage['content'] = [];
+    const states = new Map<number, ContentState>();
+    const nativeToolIndices = new Map<number, number>();
+    let parseError: DeepseekDsmlError | undefined;
+    let extracted = false;
+    let started = false;
+    let partial: AssistantMessage = {
+      role: 'assistant',
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      content,
+      stopReason: 'stop',
+      timestamp: Date.now(),
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    };
+
+    const updateMessage = (source: AssistantMessage) => {
+      partial = { ...source, content };
+      if (!started) {
+        stream.push({ type: 'start', partial });
+        started = true;
+      }
+    };
+    const getState = (sourceIndex: number, block: TextContent | ThinkingContent): ContentState => {
+      let state = states.get(sourceIndex);
+      if (!state) {
+        state = {
+          index: content.length,
+          block: block.type === 'text' ? { ...block, text: '' } : { ...block, thinking: '' },
+          parser: createDeepseekDsmlParser(context.tools),
+          receivedLength: 0,
+          ended: false,
+          calls: [],
+        };
+        states.set(sourceIndex, state);
+        content.push(state.block);
+        stream.push({
+          type: block.type === 'text' ? 'text_start' : 'thinking_start',
+          contentIndex: state.index,
+          partial,
+        });
+      }
+      return state;
+    };
+    const emitParts = (state: ContentState, parts: DeepseekDsmlPart[]) => {
+      for (const part of parts) {
+        if (part.type === 'tool-call') {
+          state.calls.push(part);
+        } else if (state.block.type === 'text') {
+          state.block.text += part.text;
+          stream.push({ type: 'text_delta', contentIndex: state.index, delta: part.text, partial });
+        } else {
+          state.block.thinking += part.text;
+          stream.push({
+            type: 'thinking_delta',
+            contentIndex: state.index,
+            delta: part.text,
+            partial,
+          });
+        }
+      }
+    };
+    const parse = (state: ContentState, delta?: string) => {
+      if (delta !== undefined) state.receivedLength += delta.length;
+      if (!state.parser) return;
+      try {
+        emitParts(state, delta === undefined ? state.parser.finish() : state.parser.push(delta));
+      } catch (error) {
+        if (!(error instanceof DeepseekDsmlError)) throw error;
+        parseError = error;
+        state.parser = undefined;
+        state.calls = [];
+      }
+    };
+    const emitToolCall = (toolCall: ToolCall) => {
+      const contentIndex = content.length;
+      content.push(toolCall);
+      stream.push({ type: 'toolcall_start', contentIndex, partial });
+      stream.push({
+        type: 'toolcall_delta',
+        contentIndex,
+        delta: JSON.stringify(toolCall.arguments),
+        partial,
+      });
+      stream.push({ type: 'toolcall_end', contentIndex, toolCall, partial });
+    };
+    const endContent = (state: ContentState, source: TextContent | ThinkingContent) => {
+      if (!state.ended) {
+        const original = source.type === 'text' ? source.text : source.thinking;
+        if (original.length > state.receivedLength)
+          parse(state, original.slice(state.receivedLength));
+        parse(state);
+      }
+      const text = state.block.type === 'text' ? state.block.text : state.block.thinking;
+      state.block = source.type === 'text' ? { ...source, text } : { ...source, thinking: text };
+      content[state.index] = state.block;
+      if (state.ended) return;
+      stream.push({
+        type: source.type === 'text' ? 'text_end' : 'thinking_end',
+        contentIndex: state.index,
+        content: text,
+        partial,
+      });
+      state.ended = true;
+      state.parser = undefined;
+      for (const call of state.calls) {
+        emitToolCall({
+          type: 'toolCall',
+          id: call.toolCallId,
+          name: call.toolName,
+          arguments: call.input,
+        });
+        extracted = true;
+      }
+      state.calls = [];
+    };
+    const fail = (error: Error, aborted = false) => {
+      updateMessage(partial);
+      partial = {
+        ...partial,
+        stopReason: aborted ? 'aborted' : 'error',
+        errorMessage: error.message,
+        diagnostics: [
+          ...(partial.diagnostics ?? []),
+          {
+            type: 'provider_response_failure',
+            timestamp: Date.now(),
+            error: {
+              name: error.name,
+              message: error.message,
+              ...(error instanceof DeepseekDsmlError ? { code: error.code } : {}),
+            },
+            ...(error instanceof DeepseekDsmlError
+              ? { details: { retryable: error.retryable } }
+              : {}),
+          },
+        ],
+      };
+      stream.push({ type: 'error', reason: aborted ? 'aborted' : 'error', error: partial });
+    };
+
+    void (async () => {
+      try {
+        const source = await streamFn(model, context, options);
+        for await (const event of source) {
+          updateMessage(
+            event.type === 'done'
+              ? event.message
+              : event.type === 'error'
+                ? event.error
+                : event.partial,
+          );
+          if (options?.signal?.aborted && !(event.type === 'error' && event.reason === 'aborted')) {
+            fail(new Error('Request aborted.'), true);
+            return;
+          }
+          if (event.type === 'error') {
+            stream.push({ ...event, error: partial });
+            return;
+          }
+          if (event.type === 'done') {
+            event.message.content.forEach((block, index) => {
+              if (block.type === 'toolCall') {
+                const mappedIndex = nativeToolIndices.get(index);
+                if (mappedIndex !== undefined) content[mappedIndex] = { ...block };
+                else emitToolCall({ ...block });
+              } else {
+                endContent(getState(index, block), block);
+              }
+            });
+            if (parseError) {
+              fail(parseError);
+            } else {
+              const reason = extracted && event.reason === 'stop' ? 'toolUse' : event.reason;
+              partial = { ...partial, stopReason: reason };
+              stream.push({ type: 'done', reason, message: partial });
+            }
+            return;
+          }
+          if (event.type === 'start') continue;
+          if (
+            event.type === 'toolcall_start' ||
+            event.type === 'toolcall_delta' ||
+            event.type === 'toolcall_end'
+          ) {
+            const block =
+              event.type === 'toolcall_end'
+                ? event.toolCall
+                : event.partial.content[event.contentIndex];
+            if (block?.type !== 'toolCall') continue;
+            let contentIndex = nativeToolIndices.get(event.contentIndex);
+            if (contentIndex === undefined) {
+              contentIndex = content.length;
+              nativeToolIndices.set(event.contentIndex, contentIndex);
+            }
+            const toolCall = { ...block, arguments: { ...block.arguments } };
+            content[contentIndex] = toolCall;
+            stream.push(
+              event.type === 'toolcall_end'
+                ? { ...event, contentIndex, toolCall, partial }
+                : { ...event, contentIndex, partial },
+            );
+            continue;
+          }
+          const block = event.partial.content[event.contentIndex];
+          if (!block || block.type === 'toolCall') continue;
+          const state = getState(event.contentIndex, block);
+          if (event.type === 'text_delta' || event.type === 'thinking_delta')
+            parse(state, event.delta);
+          else if (event.type === 'text_end' || event.type === 'thinking_end') {
+            endContent(
+              state,
+              block.type === 'text'
+                ? { ...block, text: event.content }
+                : { ...block, thinking: event.content },
+            );
+          }
+        }
+        fail(
+          new Error('The model response ended without a terminal event.'),
+          options?.signal?.aborted,
+        );
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)), options?.signal?.aborted);
+      } finally {
+        stream.end();
+      }
+    })();
+    return stream;
+  };
+}

--- a/src/backend/ai/agent/runtime/pi/piModelResolver.ts
+++ b/src/backend/ai/agent/runtime/pi/piModelResolver.ts
@@ -1,5 +1,6 @@
 import { createAiUsageCaptureContext } from '@cherrystudio/ai-runtime/utils';
 import { MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
+import { isDeepSeekModel } from '@cherrystudio/universal/utils/model';
 import type { FetchFunction, Model as PiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
 import { fetch as expoFetch } from 'expo/fetch';
 
@@ -22,6 +23,7 @@ import {
 
 import type { RuntimeModel, RuntimeModelPreflight, RuntimeUsageContext } from '..';
 import { bindPiStream, resolvePiApiAdapter, type SupportedPiApi } from './piApiAdapters';
+import { withPiDeepseekDsml } from './piDeepseekDsml';
 import { requirePiLanguageBinding, resolvePiLanguageBinding } from './piLanguageBinding';
 import type { PiModelResolution, PiRuntimeDependencies } from './PiRuntime';
 
@@ -152,7 +154,7 @@ export function createPiModelResolver(): PiRuntimeDependencies {
         maxInputTokens: model.maxInputTokens,
         model: piModel,
         redactionValues: collectRedactionValues(selectedApiKey.value, headers),
-        streamFn,
+        streamFn: isDeepSeekModel(model) ? withPiDeepseekDsml(streamFn) : streamFn,
         supportsTools: preflight.supportsTools,
         usageContext,
       };


### PR DESCRIPTION
### What this PR does

Before this PR, DeepSeek could emit DSML tool markup in text or reasoning. Pi treated it as ordinary content, so raw tags reached the conversation and MCP tools were not invoked. The separate AI SDK parser also missed protocol variants and leaked malformed blocks.

After this PR:

- A shared incremental decoder handles single/double fullwidth separators, invoke/tool variants, Tool loop search, typed parameters, and tool-name casing.
- Pi converts recovered calls into native events and final message content before its existing tool loop runs. It preserves native calls, response metadata, usage, and cancellation semantics.
- The AI SDK adapter uses the same decoder for streamed and generated text/reasoning.
- Incomplete, malformed, oversized, or unsupported blocks return an explicit parse error. Pi prevents tools in a failed response from executing.

### Why we need it and why it was done in this way

Port the protocol behavior from [Cherry Desktop #19921](https://github.com/CherryHQ/cherry-studio/pull/19921), inspected at `f4c7dcef860516512b74bbf3ed08b5e7548947af`, into Mobile's actual Pi conversation path. The existing Mobile MCP discovery, approval, and execution mechanisms continue to own tool execution. The shared decoder keeps the Pi and AI SDK paths consistent.

Literal ASCII `<|dsml|>` is detected as unsupported and fails explicitly; no call syntax is inferred without a response sample.

### Screenshots or videos

Not captured. This changes response parsing and tool execution, with no layout changes. Device and live-model validation were not run under the task's verification constraints.

### Breaking changes

None to public application APIs or persisted data. Malformed DSML now produces an error instead of appearing as ordinary output.

### Special notes for your reviewer

- Added regression cases for decoder variants, stream fragmentation, text/reasoning isolation, malformed responses, metadata preservation, all four Pi endpoint routes, and the Pi MCP tool loop.
- [Remote PR CI](https://github.com/CherryHQ/cherry-studio-app/actions/runs/34567337024) passed on `970754d3c`: tests, type checking, and the lint job (including package builds, UI boundaries, formatting, documentation links, and skills). The fixture stream rejects `pending` responses so only terminal reasons reach completion events.
- `pnpm format`: passed.
- Oxlint: passed with existing repository warnings; changed-file checks passed.
- `git diff --check`: passed.
- Local `pnpm lint`: blocked by seven unresolved `@cherrystudio/ai-core` imports in unchanged application files; the package's generated `dist` entry points are absent. Targeted ESLint also reports the existing AI SDK plugin import, reproduced against its pre-change contents. Remote lint passes with the packages built.
- Local tests, type checking, builds, and device/live-model verification were intentionally not run per the task constraints. No DSML recovery is claimed as verified against a live V4.1-Flash response.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the behavior and validation limits.
- [ ] Preview: Runtime behavior demonstrated with a recording.
- [x] Code: Changes use the existing runtime and tool execution boundaries.
- [x] Upgrade: No migration or dependency changes are required.
- [x] Documentation: Shared decoder ownership is documented in the AI runtime README.
- [x] Self-review: The code diff has been reviewed.

### Release note

```release-note
Fix DeepSeek DSML tool markup appearing in chat without invoking MCP tools. Supported text and reasoning formats now become tool calls, while incomplete or unsupported markup reports an explicit error.
```
