### PR TITLE
fix(tool-discovery): reduce redundant catalog searches

### DIFF
--- a/docs/references/agent/agent-tools-and-resources.md
+++ b/docs/references/agent/agent-tools-and-resources.md
@@ -155,10 +155,20 @@ The Pi binding consumes the Host-prepared application prompt, exposes system cap
 and translates eligible MCP tools into three catalog tools for the active model loop. When that
 catalog is present, Pi also appends its binding-specific catalog workflow guidance to the prompt:
 
-- `tool_search` ranks frozen MCP names and descriptions with BM25 and returns at most 20 matches,
-  including bounded TypeScript call signatures. Its complete serialized model result is capped by
-  both a 32,000-character ceiling and the live model-context headroom; a result that drops matches
-  reports `truncated: true`.
+- `tool_search` ranks frozen MCP names and descriptions by the number of distinct query terms a
+  tool matches, then by BM25 inside that tier, and returns only the top tier, at most 20 matches
+  with bounded TypeScript call signatures. Because the MCP layer prefixes every description with its
+  service name, a service-name query browses that service and a domain word narrows it, without
+  plugin-specific search rules. Each result leads with `catalogTotal` (the frozen catalog size),
+  `matched` (the top-tier count before limits), and `returned` (the count actually included), and
+  lists whole query words that matched nothing as `unmatchedTerms`. Unmatched words describe lexical
+  coverage, not whether a capability exists. For service overviews, the prompt asks for one initial
+  service-name search rather than parallel subdomain searches. `returned === catalogTotal` means
+  the whole catalog is in hand; `returned === matched` without truncation means this query is
+  complete. A service-name search can still be truncated and require narrower queries. The model
+  should not repeat successful searches merely to confirm coverage. The complete serialized model
+  result is capped by both a 32,000-character ceiling and the live model-context headroom; a result
+  that drops matches reports `truncated: true`.
 - `tool_describe` returns one description and signature bounded by the same live headroom.
 - `tool_call` resolves an exact name only inside the frozen catalog and re-enters the target
   `RuntimeTool` approval, cancellation, call-limit, artifact, and event boundary before execution.

--- a/src/backend/ai/agent/runtime/pi/__tests__/piDeferredToolDiscovery.test.ts
+++ b/src/backend/ai/agent/runtime/pi/__tests__/piDeferredToolDiscovery.test.ts
@@ -1,8 +1,14 @@
 import type { AgentTool as PiAgentTool } from '@earendil-works/pi-agent-core';
 
+import {
+  getBuiltInPluginCatalog,
+  requirePluginDefinition,
+} from '@/backend/services/builtInMcp/pluginRegistry';
+
 import type { RuntimeJsonValue, RuntimeTool, RuntimeToolResult } from '../../types';
 import {
   createPiDeferredToolDiscoveryTools,
+  PI_DEFERRED_TOOL_DISCOVERY_SYSTEM_PROMPT,
   PI_TOOL_CALL_TOOL_NAME,
   PI_TOOL_DESCRIBE_TOOL_NAME,
   PI_TOOL_SEARCH_TOOL_NAME,
@@ -52,6 +58,11 @@ function runMetaToolWithLimit(modelOutputCharacterLimit: number) {
       modelOutput: RuntimeToolResult;
     },
   ) => operation(modelOutputCharacterLimit).modelOutput;
+}
+
+function searchNames(result: RuntimeToolResult): string[] {
+  const value = result.value as { matchedNamespaces?: { tools: { name: string }[] }[] };
+  return (value.matchedNamespaces ?? []).flatMap((group) => group.tools.map((tool) => tool.name));
 }
 
 function execute(tool: PiAgentTool, input: RuntimeJsonValue, toolCallId = 'call-1') {
@@ -345,6 +356,152 @@ describe('createPiDeferredToolDiscoveryTools', () => {
     };
 
     expect(value.matchedNamespaces[0]?.tools).toHaveLength(20);
+    expect(result.value).toMatchObject({
+      catalogTotal: 25,
+      matched: 25,
+      returned: 20,
+      truncated: true,
+    });
+  });
+
+  test('keeps only the tier that matches the most query terms', async () => {
+    const search = createPiDeferredToolDiscoveryTools(
+      [
+        mcpTool('mcp_calendar_list_1', '云桥 (cloudbridge): 云桥日历、日程。List calendars.'),
+        mcpTool('mcp_task_list_1', '云桥 (cloudbridge): 云桥任务、待办。List tasks.'),
+        mcpTool('mcp_fetch_doc_1', '云桥 (cloudbridge): 查看云文档。Read a document by link.'),
+        mcpTool('mcp_list_issues_1', 'Forge (forge): List repository issues.'),
+      ],
+      async () => ({ value: null, artifacts: [] }),
+      runMetaTool,
+    ).find((tool) => tool.name === PI_TOOL_SEARCH_TOOL_NAME)!;
+
+    const narrowed = (await execute(search, { query: '云桥 日历' })).details as RuntimeToolResult;
+    expect(searchNames(narrowed)).toEqual(['mcp_calendar_list_1']);
+
+    const service = (await execute(search, { query: '云桥' })).details as RuntimeToolResult;
+    expect(searchNames(service).sort()).toEqual([
+      'mcp_calendar_list_1',
+      'mcp_fetch_doc_1',
+      'mcp_task_list_1',
+    ]);
+    expect(service.value).toMatchObject({ catalogTotal: 4, matched: 3, returned: 3 });
+  });
+
+  test('reports catalog coverage and query words that matched nothing', async () => {
+    const search = createPiDeferredToolDiscoveryTools(
+      [
+        mcpTool('mcp_calendar_list_1', '云桥 (cloudbridge): 云桥日历、日程。List calendars.'),
+        mcpTool('mcp_task_list_1', '云桥 (cloudbridge): 云桥任务、待办。List tasks.'),
+      ],
+      async () => ({ value: null, artifacts: [] }),
+      runMetaTool,
+    ).find((tool) => tool.name === PI_TOOL_SEARCH_TOOL_NAME)!;
+
+    const browse = (await execute(search, {})).details as RuntimeToolResult;
+    expect(browse.value).toMatchObject({ catalogTotal: 2, matched: 2, returned: 2 });
+    expect(browse.value).not.toHaveProperty('unmatchedTerms');
+    expect(browse.value).not.toHaveProperty('truncated');
+    expect(Object.keys(browse.value as object).slice(0, 3)).toEqual([
+      'catalogTotal',
+      'matched',
+      'returned',
+    ]);
+
+    const missing = (await execute(search, { query: '云桥 消息' })).details as RuntimeToolResult;
+    expect(searchNames(missing)).toHaveLength(2);
+    expect(missing.value).toMatchObject({ matched: 2, returned: 2, unmatchedTerms: ['消息'] });
+  });
+
+  test('every registered plugin service name is a discriminative search key', async () => {
+    const plugins = getBuiltInPluginCatalog().map((entry) => requirePluginDefinition(entry.id));
+    // Hosted descriptions are discovered remotely. This fixture protects the
+    // common service prefix using registered names, without inventing their text.
+    const toolsByPlugin = new Map(
+      plugins.map((plugin, pluginIndex) => [
+        plugin,
+        Object.keys(plugin.tools).map((toolName, toolIndex) =>
+          mcpTool(
+            `mcp_${pluginIndex}_${toolIndex}`,
+            `${plugin.serverName} (${plugin.catalog.id}): ${toolName}`,
+          ),
+        ),
+      ]),
+    );
+    const search = createPiDeferredToolDiscoveryTools(
+      [...toolsByPlugin.values()].flat(),
+      async () => ({ value: null, artifacts: [] }),
+      runMetaToolWithLimit(Number.MAX_SAFE_INTEGER),
+    ).find((tool) => tool.name === PI_TOOL_SEARCH_TOOL_NAME)!;
+
+    expect(plugins.length).toBeGreaterThan(1);
+    for (const [plugin, tools] of toolsByPlugin) {
+      const expected = tools.map((tool) => tool.providerName).sort();
+      for (const query of [plugin.serverName, plugin.catalog.id]) {
+        const result = (await execute(search, { query })).details as RuntimeToolResult;
+        const names = searchNames(result);
+        expect(result.value).toMatchObject({
+          catalogTotal: [...toolsByPlugin.values()].flat().length,
+          matched: expected.length,
+          returned: names.length,
+        });
+        expect(names.length).toBeGreaterThan(0);
+        expect(names.length).toBeLessThanOrEqual(20);
+        expect(expected).toEqual(expect.arrayContaining(names));
+        if (names.length < expected.length) {
+          expect(result.value).toHaveProperty('truncated', true);
+        } else {
+          expect(names.sort()).toEqual(expected);
+          expect(result.value).not.toHaveProperty('truncated');
+        }
+      }
+    }
+  });
+
+  test('repeated query words cannot outweigh a more specific match', async () => {
+    const search = createPiDeferredToolDiscoveryTools(
+      [mcpTool('mcp_1', 'Cloudbridge: calendars tasks'), mcpTool('mcp_2', 'Cloudbridge: messages')],
+      async () => ({ value: null, artifacts: [] }),
+      runMetaTool,
+    ).find((tool) => tool.name === PI_TOOL_SEARCH_TOOL_NAME)!;
+
+    const result = (await execute(search, { query: 'messages messages messages calendars tasks' }))
+      .details as RuntimeToolResult;
+
+    expect(searchNames(result)).toEqual(['mcp_1']);
+    expect(result.value).toMatchObject({ catalogTotal: 2, matched: 1, returned: 1 });
+  });
+
+  test.each([{ catalog: [] }, { catalog: [mcpTool('mcp_1', 'Cloudbridge: calendars')] }])(
+    'distinguishes no keyword matches from catalog size: %j',
+    async ({ catalog }) => {
+      const search = createPiDeferredToolDiscoveryTools(
+        catalog,
+        async () => ({ value: null, artifacts: [] }),
+        runMetaTool,
+      ).find((tool) => tool.name === PI_TOOL_SEARCH_TOOL_NAME)!;
+
+      const result = (await execute(search, { query: 'unknown' })).details as RuntimeToolResult;
+
+      expect(result.value).toMatchObject({
+        catalogTotal: catalog.length,
+        matched: 0,
+        returned: 0,
+        unmatchedTerms: ['unknown'],
+        matchedNamespaces: [],
+      });
+      expect(result.value).not.toHaveProperty('truncated');
+    },
+  );
+
+  test('tells the model when a search already covers the whole catalog', () => {
+    expect(PI_DEFERRED_TOOL_DISCOVERY_SYSTEM_PROMPT).toContain(
+      'When `returned` equals `catalogTotal`, the result is the entire catalog',
+    );
+    expect(PI_DEFERRED_TOOL_DISCOVERY_SYSTEM_PROMPT).toContain(
+      'Do not repeat or rephrase a successful search within the same turn.',
+    );
+    expect(PI_DEFERRED_TOOL_DISCOVERY_SYSTEM_PROMPT).toContain('`unmatchedTerms`');
   });
 
   test('bounds oversized declarations with a valid generic signature', async () => {
@@ -390,6 +547,13 @@ describe('createPiDeferredToolDiscoveryTools', () => {
     const result = (await execute(search, {})).details as RuntimeToolResult;
 
     expect(JSON.stringify(result).length).toBeLessThanOrEqual(modelOutputCharacterLimit);
-    expect(result.value).toMatchObject({ truncated: true });
+    expect(result.value).toMatchObject({
+      catalogTotal: 20,
+      matched: 20,
+      returned: searchNames(result).length,
+      truncated: true,
+    });
+    expect(searchNames(result).length).toBeGreaterThan(0);
+    expect(searchNames(result).length).toBeLessThan(20);
   });
 });

--- a/src/backend/ai/agent/runtime/pi/piDeferredToolDiscovery.ts
+++ b/src/backend/ai/agent/runtime/pi/piDeferredToolDiscovery.ts
@@ -10,7 +10,7 @@ export const PI_TOOL_CALL_TOOL_NAME = 'tool_call';
 
 export const PI_DEFERRED_TOOL_DISCOVERY_SYSTEM_PROMPT = `## MCP Tool Discovery
 
-MCP tools are available through a searchable catalog. Use \`${PI_TOOL_SEARCH_TOOL_NAME}\` only for tool discovery, not for web search or general research. For requests about a named cloud service, search this catalog for service-specific tools. Device capabilities do not establish cloud-service access. Before claiming a connected service is unavailable, search this catalog. An empty keyword result does not mean the catalog is empty: search by service name or omit the query to browse. Use it to discover relevant tools and their TypeScript signatures, and narrow the query when a result reports \`truncated: true\`. Use \`${PI_TOOL_DESCRIBE_TOOL_NAME}\` when you need the bounded signature for one exact tool name. Inspect each tool with search or describe in the current turn before calling it, even if its name or signature appears in conversation history. Use \`${PI_TOOL_CALL_TOOL_NAME}\` with an exact discovered name and params matching that signature. If \`${PI_TOOL_CALL_TOOL_NAME}\` returns a signature, read it and retry with corrected params. Never guess tool names or parameters.`;
+MCP tools are available through a searchable catalog. Use \`${PI_TOOL_SEARCH_TOOL_NAME}\` only for tool discovery, not for web search or general research. For requests about a named cloud service, search this catalog for service-specific tools. Device capabilities do not establish cloud-service access. Before claiming a connected service is unavailable, search this catalog. An empty keyword result does not mean the catalog is empty: search by service name or omit the query to browse. Use it to discover relevant tools and their TypeScript signatures, and narrow the query when a result reports \`truncated: true\`. For a service overview, start with one service-name search instead of parallel searches for subdomains. A service-name search browses its matching tools, subject to result limits. When \`returned\` equals \`matched\` and the result is not truncated, all matches for that query have been returned; use those results instead of searching the same service by subdomain just to confirm coverage. When \`returned\` equals \`catalogTotal\`, the result is the entire catalog and no further search can discover more tools in this turn. Do not repeat or rephrase a successful search within the same turn. Words listed in \`unmatchedTerms\` have no lexical matches in tool names or descriptions; they do not prove that a capability is unavailable. Do not retry them with synonyms just to reconfirm an already covered catalog. Use \`${PI_TOOL_DESCRIBE_TOOL_NAME}\` when you need the bounded signature for one exact tool name. Inspect each tool with search or describe in the current turn before calling it, even if its name or signature appears in conversation history. Use \`${PI_TOOL_CALL_TOOL_NAME}\` with an exact discovered name and params matching that signature. If \`${PI_TOOL_CALL_TOOL_NAME}\` returns a signature, read it and retry with corrected params. Never guess tool names or parameters.`;
 
 const SEARCH_RESULT_LIMIT = 20;
 const SEARCH_RESULT_CHARACTER_LIMIT = 32_000;
@@ -21,6 +21,8 @@ const DISPATCH_ACTIVITY_NAME_CHARACTER_LIMIT = 256;
 const TOOL_SCHEMA_RENDER_CHARACTER_LIMIT = 32_000;
 const TOOL_CORRECTION_DECLARATION_CHARACTER_LIMIT = 3_000;
 const TOOL_CORRECTION_MESSAGE_CHARACTER_LIMIT = 1_000;
+const UNMATCHED_TERM_LIMIT = 8;
+const UNMATCHED_TERM_CHARACTER_LIMIT = 64;
 const BM25_K1 = 1.2;
 const BM25_B = 0.75;
 const MAX_NESTING_DEPTH = 5;
@@ -30,7 +32,8 @@ const SEARCH_INPUT_SCHEMA = {
   properties: {
     query: {
       type: 'string',
-      description: 'BM25 query matched against MCP tool names and descriptions. Omit to browse.',
+      description:
+        'Query matched against MCP tool names and descriptions. Returns tools matching the most distinct query terms, ranked by BM25. Omit to browse.',
     },
   },
   additionalProperties: false,
@@ -99,7 +102,7 @@ export function createPiDeferredToolDiscoveryTools(
     name: PI_TOOL_SEARCH_TOOL_NAME,
     label: 'Search tools',
     description:
-      'Search the available MCP tool catalog. Returns matching names, descriptions, and TypeScript signatures for use with tool_call. Narrow the query when the result is truncated.',
+      'Search the available MCP tool catalog. Returns names, descriptions, TypeScript signatures, and catalogTotal/matched/returned coverage counts for use with tool_call. For a service overview, search its name once before considering narrower queries. Narrow the query when the result is truncated.',
     parameters: SEARCH_INPUT_SCHEMA as never,
     async execute(toolCallId, params, signal) {
       const input = (isRecord(params) ? params : {}) as RuntimeJsonValue;
@@ -109,16 +112,17 @@ export function createPiDeferredToolDiscoveryTools(
         { displayName: 'Search tools', input, providerName: PI_TOOL_SEARCH_TOOL_NAME },
         (modelOutputCharacterLimit) => {
           const query = isRecord(params) && typeof params.query === 'string' ? params.query : '';
-          const searchResult = boundedSearchResult(
-            rankTools([...catalog.values()], query),
-            modelOutputCharacterLimit,
-          );
+          const ranked = rankTools([...catalog.values()], query);
+          const searchResult = boundedSearchResult(ranked, catalog.size, modelOutputCharacterLimit);
           for (const match of searchResult.matches) inspectedNames.add(match.name);
 
           return {
             modelOutput: searchResult.output,
             activityOutput: {
               value: {
+                catalogTotal: catalog.size,
+                matched: ranked.matches.length,
+                returned: searchResult.matches.length,
                 matchedNamespaces:
                   searchResult.matches.length > 0
                     ? [
@@ -353,9 +357,17 @@ function createToolInputValidator(tool: RuntimeTool): z.ZodType | null {
   }
 }
 
-function rankTools(tools: readonly RuntimeTool[], query: string): RuntimeTool[] {
-  const terms = tokenize(query);
-  if (terms.length === 0) return [...tools];
+type RankedTools = { matches: RuntimeTool[]; unmatchedTerms: string[] };
+
+/**
+ * Rank by how many distinct query terms a tool matches, then by BM25 within
+ * that tier, and keep only the top tier. A term shared by every tool, such as
+ * a service name that prefixes each description, cannot separate tiers, so a
+ * service-name query browses that service while a domain word narrows it.
+ */
+function rankTools(tools: readonly RuntimeTool[], query: string): RankedTools {
+  const terms = [...new Set(tokenize(query))];
+  if (terms.length === 0) return { matches: [...tools], unmatchedTerms: [] };
 
   const documents = tools.map((tool) => tokenize(`${tool.providerName} ${tool.description}`));
   const averageLength =
@@ -367,30 +379,45 @@ function rankTools(tools: readonly RuntimeTool[], query: string): RuntimeTool[] 
     }
   }
 
-  return tools
-    .map((tool, index) => {
-      const document = documents[index] ?? [];
-      const score = terms.reduce((total, term) => {
-        const frequency = document.filter((token) => token === term).length;
-        if (frequency === 0) return total;
-        const containingDocuments = documentFrequency.get(term) ?? 0;
-        const idf = Math.log(
-          1 + (documents.length - containingDocuments + 0.5) / (containingDocuments + 0.5),
-        );
-        return (
-          total +
-          (idf * frequency * (BM25_K1 + 1)) /
-            (frequency + BM25_K1 * (1 - BM25_B + BM25_B * (document.length / averageLength)))
-        );
-      }, 0);
-      return { tool, score };
-    })
-    .filter(({ score }) => score > 0)
-    .sort(
-      (left, right) =>
-        right.score - left.score || left.tool.providerName.localeCompare(right.tool.providerName),
-    )
-    .map(({ tool }) => tool);
+  const scored = tools.flatMap((tool, index) => {
+    const document = documents[index] ?? [];
+    let hits = 0;
+    let score = 0;
+    for (const term of terms) {
+      const frequency = document.filter((token) => token === term).length;
+      if (frequency === 0) continue;
+      const containingDocuments = documentFrequency.get(term) ?? 0;
+      const idf = Math.log(
+        1 + (documents.length - containingDocuments + 0.5) / (containingDocuments + 0.5),
+      );
+      hits += 1;
+      score +=
+        (idf * frequency * (BM25_K1 + 1)) /
+        (frequency + BM25_K1 * (1 - BM25_B + BM25_B * (document.length / averageLength)));
+    }
+    return hits > 0 ? [{ tool, hits, score }] : [];
+  });
+  const topHits = scored.reduce((best, entry) => Math.max(best, entry.hits), 0);
+
+  return {
+    matches: scored
+      .filter((entry) => entry.hits === topHits)
+      .sort(
+        (left, right) =>
+          right.score - left.score || left.tool.providerName.localeCompare(right.tool.providerName),
+      )
+      .map(({ tool }) => tool),
+    unmatchedTerms: unmatchedQueryWords(query, documentFrequency),
+  };
+}
+
+/** Whole query words whose tokens matched no tool; Chinese character pairs are never reported alone. */
+function unmatchedQueryWords(query: string, documentFrequency: ReadonlyMap<string, number>) {
+  const words = [...new Set(query.match(/[\p{L}\p{N}]+/gu) ?? [])];
+  return words
+    .filter((word) => tokenize(word).every((token) => !documentFrequency.has(token)))
+    .slice(0, UNMATCHED_TERM_LIMIT)
+    .map((word) => boundedText(word, UNMATCHED_TERM_CHARACTER_LIMIT));
 }
 
 function tokenize(value: string): string[] {
@@ -496,10 +523,23 @@ function isJsonWithinCharacterLimit(value: RuntimeJsonValue, characterLimit: num
 
 type SearchMatch = { name: string; description: string; declaration: string };
 
+type SearchCoverage = {
+  catalogTotal: number;
+  matched: number;
+  unmatchedTerms: readonly string[];
+};
+
 function boundedSearchResult(
-  tools: readonly RuntimeTool[],
+  ranked: RankedTools,
+  catalogTotal: number,
   requestedCharacterLimit: number,
 ): { matches: SearchMatch[]; output: RuntimeToolResult; truncated: boolean } {
+  const tools = ranked.matches;
+  const coverage: SearchCoverage = {
+    catalogTotal,
+    matched: tools.length,
+    unmatchedTerms: ranked.unmatchedTerms,
+  };
   const characterLimit = Math.max(
     0,
     Math.min(SEARCH_RESULT_CHARACTER_LIMIT, Math.floor(requestedCharacterLimit)),
@@ -516,7 +556,7 @@ function boundedSearchResult(
       ),
       declaration: toolToTypeScript(tool, Math.max(1, Math.floor(characterLimit / 2))),
     };
-    const candidate = createSearchOutput([...matches, match], true);
+    const candidate = createSearchOutput(coverage, [...matches, match], true);
     if (JSON.stringify(candidate).length > characterLimit) {
       truncated = true;
       continue;
@@ -524,21 +564,32 @@ function boundedSearchResult(
     matches.push(match);
   }
 
-  let output = createSearchOutput(matches, truncated);
+  let output = createSearchOutput(coverage, matches, truncated);
   while (matches.length > 0 && JSON.stringify(output).length > characterLimit) {
     matches.pop();
     truncated = true;
-    output = createSearchOutput(matches, truncated);
+    output = createSearchOutput(coverage, matches, truncated);
   }
   return { matches, output, truncated };
 }
 
+/**
+ * Coverage counts lead the payload so a budget-bounded result still tells the
+ * model whether the whole catalog is already in hand.
+ */
 function createSearchOutput(
+  coverage: SearchCoverage,
   matches: readonly SearchMatch[],
   truncated: boolean,
 ): RuntimeToolResult {
   return {
     value: {
+      catalogTotal: coverage.catalogTotal,
+      matched: coverage.matched,
+      returned: matches.length,
+      ...(coverage.unmatchedTerms.length > 0
+        ? { unmatchedTerms: [...coverage.unmatchedTerms] }
+        : {}),
       matchedNamespaces: matches.length > 0 ? [{ namespace: 'mcp', tools: [...matches] }] : [],
       ...(truncated ? { truncated: true } : {}),
     },

--- a/src/frontend/components/Message/parts/tools/metaTool/metaToolState.ts
+++ b/src/frontend/components/Message/parts/tools/metaTool/metaToolState.ts
@@ -46,8 +46,10 @@ export function getMetaToolStatusText(
     if (toolName === 'tool_search') {
       const namespaces = parseToolSearchNamespaces(part.output);
       const toolCount = namespaces.reduce((count, group) => count + group.tools.length, 0);
-      return toolCount === 0
-        ? t('chat.metaToolSearch.noResults')
+      if (toolCount === 0) return t('chat.metaToolSearch.noResults');
+      const catalogTotal = isRecord(part.output) ? part.output.catalogTotal : undefined;
+      return catalogTotal === toolCount
+        ? t('chat.metaToolSearch.completeCount', { count: toolCount })
         : t('chat.metaToolSearch.resultCount', { count: toolCount });
     }
 

--- a/src/frontend/i18n/locales/en-us.json
+++ b/src/frontend/i18n/locales/en-us.json
@@ -144,6 +144,7 @@
   "chat.metaToolInvoke.invalidInput": "The tool was not executed. Argument errors were returned to the model so it can correct the request and try again.",
   "chat.metaToolInvoke.schemaRequired": "The tool was not executed. Its argument requirements were returned to the model so it can inspect them and try again.",
   "chat.metaToolInvoke.title": "Invoke tool",
+  "chat.metaToolSearch.completeCount": "All {{count}} tools",
   "chat.metaToolSearch.noResults": "No tools matched",
   "chat.metaToolSearch.resultCount": "{{count}} tools",
   "chat.metaToolSearch.searching": "Searching tools",

--- a/src/frontend/i18n/locales/zh-cn.json
+++ b/src/frontend/i18n/locales/zh-cn.json
@@ -144,6 +144,7 @@
   "chat.metaToolInvoke.invalidInput": "本次未执行工具。已将具体参数错误返回给模型，供其修正后重试。",
   "chat.metaToolInvoke.schemaRequired": "本次未执行工具。已将参数说明返回给模型，供其查看后重试。",
   "chat.metaToolInvoke.title": "调用工具",
+  "chat.metaToolSearch.completeCount": "全部 {{count}} 个工具",
   "chat.metaToolSearch.noResults": "没有匹配的工具",
   "chat.metaToolSearch.resultCount": "{{count}} 个工具",
   "chat.metaToolSearch.searching": "搜索工具中",


### PR DESCRIPTION
### What this PR does

Before this PR, queries such as a service name plus a domain word could return the same broad tool catalog repeatedly. The model had no coverage counts to tell when discovery was complete.

After this PR:

- Search retains tools matching the most distinct query terms, with BM25 ranking within that group.
- Results include `catalogTotal`, `matched`, `returned`, and bounded `unmatchedTerms`. The prompt starts service overviews with one service-name search and discourages redundant searches while preserving narrowing for truncated results.
- The search activity shows “All N tools” when the complete catalog was returned.
- Regression cases cover synthetic service catalogs, registered plugin prefixes, duplicate query terms, empty matches, and result budgets. The discovery reference documents the contract.

### Screenshots or videos

Not captured: device and manual UI verification were not authorized for this task. The visible change is the completed search count label, localized in English and Chinese.

### Why we need it and why it was done in this way

The strategy uses tool names and descriptions, including the existing service prefix, without plugin-specific search rules. New plugins use the same ranking and coverage contract. Service catalogs may exceed the 20-tool limit; coverage distinguishes a complete query from a truncated response.

Parallel tool execution is unchanged. This does not enforce a search-call cap or deduplicate repeated signatures. The expected reduction in model search calls still requires model/device evaluation.

### Breaking changes

No public API changes. The model-facing search envelope gains coverage metadata and search results become more selective.

### Special notes for your reviewer

Validation:

- Passed: `pnpm format:check`, focused Oxlint and Expo lint for all changed TypeScript files, and `git diff --check`.
- `pnpm lint` failed with seven `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider entry in unchanged files. The package exports reference its absent `dist` directory. Existing lint warnings were also reported.
- Tests, builds, typecheck, and device/manual verification were not run, per the task's explicit execution constraints. Root typecheck invokes package builds. No claim is made that the regression cases pass or that search calls have reached the 1–2-call target.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the behavior and validation limits
- [ ] Preview: Screenshots or video uploaded
- [x] Code: Changes are scoped to tool discovery and coverage presentation
- [x] Documentation: Updated the agent tools and resources reference
- [x] Self-review: Reviewed the local diff

### Release note

```release-note
Reduce redundant tool discovery by improving search relevance and exposing catalog coverage. Show when a search has returned all available tools.
```
