### PR TITLE
fix(paintings): align image generation routing with desktop

### DIFF
--- a/packages/ai-runtime/src/image/index.ts
+++ b/packages/ai-runtime/src/image/index.ts
@@ -7,6 +7,7 @@ export {
 } from '../provider/custom/imageGenerationModel';
 export {
   hasImageTransport,
+  isImageTransportDescriptorSupported,
   resolveImageTransport,
 } from '../provider/custom/imageTransportRegistry';
 export {

--- a/packages/ai-runtime/src/provider/custom/__tests__/imageTransportRegistry.test.ts
+++ b/packages/ai-runtime/src/provider/custom/__tests__/imageTransportRegistry.test.ts
@@ -29,6 +29,15 @@ describe('resolveImageTransport', () => {
     }
   });
 
+  it('resolves the registered TokenHub transport for catalog image routes', () => {
+    expect(hasImageTransport('tokenhub', 'hy-image-v3')).toBe(true);
+    const transport = resolveImageTransport('tokenhub', 'hy-image-v3', {
+      baseURL: 'https://tokenhub.tencentmaas.com/v1',
+    });
+    expect(typeof transport?.submit).toBe('function');
+    expect(typeof transport?.poll).toBe('function');
+  });
+
   it('returns null for dmxapi native / openai-flat models (in-SDK path)', () => {
     const settings = { baseURL: 'https://www.dmxapi.cn/v1' };
     for (const modelId of [

--- a/packages/ai-runtime/src/provider/custom/__tests__/tokenhub-transport.test.ts
+++ b/packages/ai-runtime/src/provider/custom/__tests__/tokenhub-transport.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import type { ImageGenerationSubmitInput } from '../imageGenerationModel';
+import {
+  createTokenhubTransport,
+  TokenhubApiError,
+  TokenhubTaskFailedError,
+} from '../tokenhub/tokenhub-transport';
+
+const HUNYUAN = {
+  id: 'hy-image-v3',
+  endpoint: '/v1/wand/hunyuan-image/v3-generation',
+  isSync: true,
+};
+const SEEDREAM = {
+  id: 'seedream-image-v5.0-lite',
+  endpoint: '/v1/wand/si-image/generation',
+  isSync: true,
+};
+const VIDU = { id: 'vidu-image-q2', endpoint: '/v1/wand/vidu-image/generation' };
+
+const baseInput = {
+  n: 1,
+  size: undefined,
+  aspectRatio: undefined,
+  seed: undefined,
+  files: undefined,
+  mask: undefined,
+  providerParams: {},
+} satisfies Partial<ImageGenerationSubmitInput>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function lastRequest(fetchMock: MockInstance<typeof fetch>): {
+  url: string;
+  init: RequestInit;
+  body: unknown;
+} {
+  const call = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+  return {
+    url: call[0],
+    init: call[1],
+    body: call[1].body ? JSON.parse(call[1].body as string) : undefined,
+  };
+}
+
+describe('TokenhubTransport', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts the hunyuan body (size / seed / revise / images) to the descriptor endpoint and returns data[].url', async () => {
+    const transport = createTokenhubTransport({
+      apiKey: 'token',
+      baseURL: 'https://tokenhub.tencentmaas.com',
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        jsonResponse({ data: [{ url: 'https://img/hy.png', revised_prompt: 'x' }] }),
+      );
+
+    const result = await transport.submit({
+      ...baseInput,
+      modelId: 'hy-image-v3',
+      modelDescriptor: HUNYUAN,
+      prompt: 'a fox',
+      size: '1280x768',
+      seed: 42,
+      files: [{ type: 'url', url: 'https://ref/a.jpg' }],
+      providerParams: { promptEnhancement: true },
+    });
+
+    const { url, init, body } = lastRequest(fetchMock);
+    expect(url).toBe('https://tokenhub.tencentmaas.com/v1/wand/hunyuan-image/v3-generation');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer token');
+    expect(body).toEqual({
+      model: 'hy-image-v3',
+      prompt: 'a fox',
+      images: ['https://ref/a.jpg'],
+      size: '1280x768',
+      seed: 42,
+      revise: true,
+    });
+    expect(result).toEqual({ imageUrls: ['https://img/hy.png'] });
+  });
+
+  it('maps seedream imageResolution to size and only sends max_images under sequential auto', async () => {
+    const transport = createTokenhubTransport({ apiKey: 'token' });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => jsonResponse({ data: [{ url: 'https://img/s.png' }] }));
+
+    await transport.submit({
+      ...baseInput,
+      modelId: 'seedream-image-v5.0-lite',
+      modelDescriptor: SEEDREAM,
+      prompt: 'a cat',
+      providerParams: {
+        imageResolution: '4K',
+        outputFormat: 'png',
+        addWatermark: false,
+        sequentialImageGeneration: 'disabled',
+        maxImages: 5,
+      },
+    });
+    expect(lastRequest(fetchMock).body).toEqual({
+      model: 'seedream-image-v5.0-lite',
+      prompt: 'a cat',
+      response_format: 'url',
+      size: '4K',
+      output_format: 'png',
+      watermark: false,
+      sequential_image_generation: 'disabled',
+    });
+
+    await transport.submit({
+      ...baseInput,
+      modelId: 'seedream-image-v5.0-lite',
+      modelDescriptor: SEEDREAM,
+      prompt: 'a cat',
+      providerParams: { sequentialImageGeneration: 'auto', maxImages: 5 },
+    });
+    expect(lastRequest(fetchMock).body).toMatchObject({
+      sequential_image_generation: 'auto',
+      sequential_image_generation_options: { max_images: 5 },
+    });
+  });
+
+  it('submits vidu with the native aspectRatio + resolution and returns the task id', async () => {
+    const transport = createTokenhubTransport({ apiKey: 'token' });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ task_id: 'task-1', state: 'created' }));
+
+    const result = await transport.submit({
+      ...baseInput,
+      modelId: 'vidu-image-q2',
+      modelDescriptor: VIDU,
+      prompt: 'a dog',
+      aspectRatio: '9:16',
+      seed: 7,
+      providerParams: { resolution: '2K' },
+    });
+
+    expect(lastRequest(fetchMock).url).toBe(
+      'https://tokenhub.tencentmaas.com/v1/wand/vidu-image/generation',
+    );
+    expect(lastRequest(fetchMock).body).toEqual({
+      model: 'vidu-image-q2',
+      prompt: 'a dog',
+      aspect_ratio: '9:16',
+      resolution: '2K',
+      seed: 7,
+    });
+    expect(result).toEqual({ taskId: 'task-1' });
+  });
+
+  it('routes requests through the provider fetch and merges provider headers under the bearer auth', async () => {
+    const globalFetch = vi.spyOn(globalThis, 'fetch');
+    const providerFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ data: [{ url: 'https://img/x' }] }));
+    const transport = createTokenhubTransport({
+      apiKey: 'token',
+      fetch: providerFetch,
+      headers: { 'X-App': 'cherry', Authorization: 'Bearer stale' },
+    });
+
+    await transport.submit({
+      ...baseInput,
+      modelId: 'hy-image-v3',
+      modelDescriptor: HUNYUAN,
+      prompt: 'x',
+    });
+
+    expect(globalFetch).not.toHaveBeenCalled();
+    const headers = lastRequest(providerFetch as unknown as MockInstance<typeof fetch>).init
+      .headers as Record<string, string>;
+    expect(headers['X-App']).toBe('cherry');
+    expect(headers.Authorization).toBe('Bearer token');
+  });
+
+  it('rejects a vidu submit that returns no task_id instead of completing empty', async () => {
+    const transport = createTokenhubTransport({ apiKey: 'token' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ state: 'created' }));
+
+    await expect(
+      transport.submit({
+        ...baseInput,
+        modelId: 'vidu-image-q2',
+        modelDescriptor: VIDU,
+        prompt: 'x',
+      }),
+    ).rejects.toBeInstanceOf(TokenhubApiError);
+  });
+
+  it('preserves the API message and status for terminal request failures', async () => {
+    const transport = createTokenhubTransport({ apiKey: 'token' });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ error: { message: 'content blocked' } }, 422))
+      .mockResolvedValueOnce(jsonResponse({}, 401));
+
+    const blocked = await transport
+      .submit({ ...baseInput, modelId: 'hy-image-v3', modelDescriptor: HUNYUAN, prompt: 'x' })
+      .catch((e) => e);
+    expect(blocked).toBeInstanceOf(TokenhubApiError);
+    expect(blocked).toMatchObject({
+      statusCode: 422,
+      message: 'TokenHub API error: 422 - content blocked',
+    });
+
+    const unauthorized = await transport
+      .submit({ ...baseInput, modelId: 'hy-image-v3', modelDescriptor: HUNYUAN, prompt: 'x' })
+      .catch((e) => e);
+    expect(unauthorized).toMatchObject({ statusCode: 401 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  describe('poll', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('GETs the vidu task until success and returns creations[].url', async () => {
+      const transport = createTokenhubTransport({ apiKey: 'token' });
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse({ state: 'queueing' }))
+        .mockResolvedValueOnce(jsonResponse({ state: 'processing' }))
+        .mockResolvedValueOnce(
+          jsonResponse({ state: 'success', creations: [{ url: 'https://img/v.png' }, {}] }),
+        );
+
+      const promise = transport.poll('task/1', {});
+      await vi.advanceTimersByTimeAsync(10000);
+
+      await expect(promise).resolves.toEqual(['https://img/v.png']);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(lastRequest(fetchMock).url).toBe(
+        'https://tokenhub.tencentmaas.com/v1/wand/vidu-image/tasks/task%2F1',
+      );
+      expect(lastRequest(fetchMock).init.method).toBe('GET');
+    });
+
+    it('fails fast on state=failed with the vendor reason', async () => {
+      const transport = createTokenhubTransport({ apiKey: 'token' });
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ state: 'failed', err_msg: 'moderation rejected' }));
+
+      const error = await transport.poll('task-1', {}).catch((e) => e);
+      expect(error).toBeInstanceOf(TokenhubTaskFailedError);
+      expect(error.message).toBe('moderation rejected');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops polling when the signal aborts', async () => {
+      const transport = createTokenhubTransport({ apiKey: 'token' });
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ state: 'processing' }));
+      const controller = new AbortController();
+
+      const promise = transport.poll('task-1', { signal: controller.signal });
+      await Promise.resolve();
+      controller.abort();
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a 5xx poll response as transient but ends on a 4xx', async () => {
+      const transport = createTokenhubTransport({ apiKey: 'token' });
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse({}, 503))
+        .mockResolvedValueOnce(jsonResponse({ error: { message: 'no such task' } }, 404));
+
+      const promise = transport.poll('task-1', {}).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(5000);
+      const error = await promise;
+
+      expect(error).toBeInstanceOf(TokenhubApiError);
+      expect(error.message).toBe('TokenHub API error: 404 - no such task');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/ai-runtime/src/provider/custom/dashscope/dashscopeProvider.ts
+++ b/packages/ai-runtime/src/provider/custom/dashscope/dashscopeProvider.ts
@@ -21,6 +21,22 @@ export const DASHSCOPE_PROVIDER_NAME = 'dashscope' as const;
 const DASHSCOPE_CHAT_BASE_PATH = '/compatible-mode/v1';
 const DASHSCOPE_RERANK_BASE_PATH = '/compatible-api/v1';
 
+// Only admitted models whose native request supports `parameters.n` may batch.
+const DASHSCOPE_IMAGE_BATCH_LIMITS: Readonly<Record<string, number>> = {
+  'qwen-image': 4,
+  'qwen-image-3.0': 6,
+  'qwen-image-3.0-pro': 6,
+  'wan2.5-i2i-preview': 4,
+  'wan2.6-image': 4,
+  'wan2.7-image': 4,
+  'wan2.7-image-pro': 4,
+  'wanx-v1': 4,
+  'wanx2.0-t2i-turbo': 4,
+  'wanx2.1-imageedit': 4,
+  'wanx2.1-t2i-plus': 4,
+  'wanx2.1-t2i-turbo': 4,
+};
+
 export interface DashScopeProviderSettings {
   apiKey?: string;
   /** Chat / embedding endpoint, e.g. `https://dashscope.aliyuncs.com/compatible-mode/v1/`. */
@@ -127,7 +143,11 @@ export function createDashScopeProvider(
       fetch: customFetch,
     });
   provider.imageModel = (modelId: string) =>
-    createImageGenerationModel(modelId, { provider: DASHSCOPE_PROVIDER_NAME, transport });
+    createImageGenerationModel(modelId, {
+      maxImagesPerCall: DASHSCOPE_IMAGE_BATCH_LIMITS[modelId] ?? 1,
+      provider: DASHSCOPE_PROVIDER_NAME,
+      transport,
+    });
   provider.rerankingModel = (modelId: string) =>
     new OpenAICompatibleRerankingModel(modelId, {
       provider: `${DASHSCOPE_PROVIDER_NAME}.rerank`,

--- a/packages/ai-runtime/src/provider/custom/dashscope/dashscopeTransport.ts
+++ b/packages/ai-runtime/src/provider/custom/dashscope/dashscopeTransport.ts
@@ -361,36 +361,58 @@ function buildWanxImageEditBody(
   };
 }
 
-function buildRequestBody(
-  input: ImageGenerationSubmitInput,
-  descriptor: DashScopeModelDescriptor,
-): Record<string, unknown> {
-  const bag = (input.providerParams ?? {}) as DashScopeProviderParams;
-  switch (descriptor.id) {
+function resolveBodyBuilder(modelId: string) {
+  switch (modelId) {
     case 'z-image-turbo':
+    case 'qwen-image-3.0':
+    case 'qwen-image-3.0-pro':
     case 'qwen-image-edit':
     case 'qwen-image-edit-plus':
     case 'wan2.6-image':
     case 'wan2.7-image':
     case 'wan2.7-image-pro':
-      return buildChatLikeBody(input, bag);
+      return buildChatLikeBody;
     case 'qwen-image':
     case 'qwen-image-plus':
     case 'wanx2.1-t2i-turbo':
     case 'wanx2.1-t2i-plus':
     case 'wanx2.0-t2i-turbo':
-      return buildText2ImageBody(input, bag);
+      return buildText2ImageBody;
     case 'wanx-v1':
-      return buildWanxV1Body(input, bag);
+      return buildWanxV1Body;
     case 'wan2.5-i2i-preview':
-      return buildWan25I2IBody(input, bag);
+      return buildWan25I2IBody;
     case 'qwen-mt-image':
-      return buildQwenMtImageBody(input, bag);
+      return buildQwenMtImageBody;
     case 'wanx2.1-imageedit':
-      return buildWanxImageEditBody(input, bag);
+      return buildWanxImageEditBody;
     default:
-      throw new Error(`Unsupported DashScope image model: ${descriptor.id}`);
+      return undefined;
   }
+}
+
+export function isDashScopeImageDescriptorSupported(
+  descriptor: DashScopeModelDescriptor | undefined,
+): boolean {
+  return (
+    descriptor !== undefined &&
+    resolveBodyBuilder(descriptor.id) !== undefined &&
+    [
+      '/api/v1/services/aigc/text2image/image-synthesis',
+      '/api/v1/services/aigc/multimodal-generation/generation',
+      '/api/v1/services/aigc/image-generation/generation',
+      '/api/v1/services/aigc/image2image/image-synthesis',
+    ].includes(descriptor.endpoint)
+  );
+}
+
+function buildRequestBody(
+  input: ImageGenerationSubmitInput,
+  descriptor: DashScopeModelDescriptor,
+): Record<string, unknown> {
+  const build = resolveBodyBuilder(descriptor.id);
+  if (!build) throw new Error(`Unsupported DashScope image model: ${descriptor.id}`);
+  return build(input, (input.providerParams ?? {}) as DashScopeProviderParams);
 }
 
 class DashScopeTransport implements ImageGenerationTransport {

--- a/packages/ai-runtime/src/provider/custom/dmxapi/dmxapiProvider.ts
+++ b/packages/ai-runtime/src/provider/custom/dmxapi/dmxapiProvider.ts
@@ -220,7 +220,11 @@ export function createDmxapiProvider(settings: DmxapiProviderSettings = {}): Dmx
     // body, `extra.output.results[].url` async wrapper), so they go through
     // the custom transport.
     if (resolveDmxapiFamily(modelId) !== 'openai-flat') {
-      return createImageGenerationModel(modelId, { provider: DMXAPI_PROVIDER_NAME, transport });
+      return createImageGenerationModel(modelId, {
+        maxImagesPerCall: modelId === 'qwen-image' || modelId === 'wan2.6-t2i' ? 4 : 1,
+        provider: DMXAPI_PROVIDER_NAME,
+        transport,
+      });
     }
     // Fallback for unknown models — OpenAI-compat image model is the safest
     // assumption since DMXAPI's gateway translates the rest of its catalog

--- a/packages/ai-runtime/src/provider/custom/imageGenerationModel.ts
+++ b/packages/ai-runtime/src/provider/custom/imageGenerationModel.ts
@@ -63,6 +63,7 @@ export interface ImageGenerationSubmitInput {
 }
 
 export interface CreateImageGenerationModelOptions {
+  maxImagesPerCall?: number;
   provider: string;
   transport: ImageGenerationTransport;
 }
@@ -95,13 +96,13 @@ function readModelDescriptor(value: unknown): ImageTransportDescriptor | undefin
  */
 export function createImageGenerationModel(
   modelId: string,
-  { provider, transport }: CreateImageGenerationModelOptions,
+  { maxImagesPerCall = 1, provider, transport }: CreateImageGenerationModelOptions,
 ): ImageModelV3 {
   return {
     specificationVersion: 'v3',
     provider,
     modelId,
-    maxImagesPerCall: 1,
+    maxImagesPerCall,
     async doGenerate(options: ImageModelV3CallOptions) {
       const { abortSignal } = options;
 

--- a/packages/ai-runtime/src/provider/custom/imageTransportRegistry.ts
+++ b/packages/ai-runtime/src/provider/custom/imageTransportRegistry.ts
@@ -3,13 +3,14 @@ import {
   DASHSCOPE_PROVIDER_NAME,
   type DashScopeProviderSettings,
 } from './dashscope/dashscopeProvider';
+import { isDashScopeImageDescriptorSupported } from './dashscope/dashscopeTransport';
 import {
   buildDmxapiTransport,
   DMXAPI_PROVIDER_NAME,
   type DmxapiProviderSettings,
   dmxapiUsesCustomTransport,
 } from './dmxapi/dmxapiProvider';
-import type { ImageGenerationTransport } from './imageGenerationModel';
+import type { ImageGenerationTransport, ImageTransportDescriptor } from './imageGenerationModel';
 import {
   buildModelscopeTransport,
   MODELSCOPE_PROVIDER_NAME,
@@ -20,6 +21,13 @@ import {
   PPIO_PROVIDER_NAME,
   type PpioProviderSettings,
 } from './ppio/ppioProvider';
+import { isPpioImageDescriptorSupported } from './ppio/ppioTransport';
+import {
+  buildTokenhubTransport,
+  TOKENHUB_PROVIDER_NAME,
+  type TokenhubProviderSettings,
+} from './tokenhub/tokenhub-provider';
+import { isTokenhubImageDescriptorSupported } from './tokenhub/tokenhub-transport';
 
 /**
  * Resolve a poll-capable image transport for a custom provider. The side-effect
@@ -34,21 +42,29 @@ import {
  */
 interface TransportRegistration {
   supports: (modelId: string) => boolean;
+  supportsDescriptor?: (descriptor: ImageTransportDescriptor | undefined) => boolean;
   build: (providerSettings: unknown) => ImageGenerationTransport;
 }
 
 const TRANSPORTS: Record<string, TransportRegistration> = {
   [PPIO_PROVIDER_NAME]: {
     supports: () => true,
+    supportsDescriptor: isPpioImageDescriptorSupported,
     build: (settings) => buildPpioTransport(settings as PpioProviderSettings),
   },
   [DASHSCOPE_PROVIDER_NAME]: {
     supports: () => true,
+    supportsDescriptor: isDashScopeImageDescriptorSupported,
     build: (settings) => buildDashScopeTransport(settings as DashScopeProviderSettings),
   },
   [MODELSCOPE_PROVIDER_NAME]: {
     supports: () => true,
     build: (settings) => buildModelscopeTransport(settings as ModelscopeProviderSettings),
+  },
+  [TOKENHUB_PROVIDER_NAME]: {
+    supports: () => true,
+    supportsDescriptor: isTokenhubImageDescriptorSupported,
+    build: (settings) => buildTokenhubTransport(settings as TokenhubProviderSettings),
   },
   // DMXAPI is a multi-backend gateway — only its bespoke families use the
   // custom transport (the rest go through native / openai-compat SDK image
@@ -61,6 +77,14 @@ const TRANSPORTS: Record<string, TransportRegistration> = {
 
 export function hasImageTransport(providerId: string, modelId: string): boolean {
   return TRANSPORTS[providerId]?.supports(modelId) ?? false;
+}
+
+/** Catalog-driven transports must implement the requested model and endpoint before admission. */
+export function isImageTransportDescriptorSupported(
+  providerId: string,
+  descriptor: ImageTransportDescriptor | undefined,
+): boolean {
+  return TRANSPORTS[providerId]?.supportsDescriptor?.(descriptor) ?? true;
 }
 
 export function resolveImageTransport(

--- a/packages/ai-runtime/src/provider/custom/ppio/ppioTransport.ts
+++ b/packages/ai-runtime/src/provider/custom/ppio/ppioTransport.ts
@@ -86,6 +86,30 @@ export interface PpioModelDescriptor {
   mode?: string;
 }
 
+// The endpoint is authoritative even when saved catalog IDs use hyphens instead of dots.
+const PPIO_IMAGE_MODELS_BY_ENDPOINT: Readonly<Record<string, string>> = {
+  '/v3/async/jimeng-txt2img-v3.1': 'jimeng-txt2img-v3.1',
+  '/v3/async/jimeng-txt2img-v3.0': 'jimeng-txt2img-v3.0',
+  '/v3/async/hunyuan-image-3': 'hunyuan-image-3',
+  '/v3/async/qwen-image-txt2img': 'qwen-image-txt2img',
+  '/v3/async/qwen-image-edit-2509': 'qwen-image-edit-2509',
+  '/v3/async/qwen-image-edit': 'qwen-image-edit',
+  '/v3/async/glm-image': 'glm-image',
+  '/v3/async/z-image-turbo': 'z-image-turbo',
+  '/v3/async/z-image-turbo-lora': 'z-image-turbo-lora',
+  '/v3/seedream-4.0': 'seedream-4.0',
+  '/v3/seedream-4.5': 'seedream-4.5',
+  '/v3/seedream-5.0-lite': 'seedream-5.0-lite',
+};
+
+export function isPpioImageDescriptorSupported(
+  descriptor: PpioModelDescriptor | undefined,
+): boolean {
+  return (
+    descriptor !== undefined && Object.hasOwn(PPIO_IMAGE_MODELS_BY_ENDPOINT, descriptor.endpoint)
+  );
+}
+
 /**
  * Painting fields forwarded through `providerOptions['ppio']`. Mirrors the
  * `PpioPaintingData` subset the legacy `buildRequestParams` consumed.
@@ -234,13 +258,7 @@ class PpioTransport implements ImageGenerationTransport {
     painting: PpioProviderParams,
     descriptor: PpioModelDescriptor,
   ): Record<string, unknown> {
-    const modelId = descriptor.id;
-    const params: Record<string, unknown> = {};
-
-    if (input.prompt) {
-      params.prompt = input.prompt;
-    }
-
+    const modelId = PPIO_IMAGE_MODELS_BY_ENDPOINT[descriptor.endpoint];
     switch (modelId) {
       case 'jimeng-txt2img-v3.1':
       case 'jimeng-txt2img-v3.0':
@@ -265,7 +283,7 @@ class PpioTransport implements ImageGenerationTransport {
           ? this.buildSeedreamEditParams(input, painting, modelId)
           : this.buildSeedreamDrawParams(input, painting);
       default:
-        return params;
+        throw new Error(`Unsupported PPIO image endpoint: ${descriptor.endpoint}`);
     }
   }
 

--- a/packages/ai-runtime/src/provider/custom/tokenhub/tokenhub-provider.ts
+++ b/packages/ai-runtime/src/provider/custom/tokenhub/tokenhub-provider.ts
@@ -1,0 +1,97 @@
+import {
+  OpenAICompatibleChatLanguageModel,
+  OpenAICompatibleEmbeddingModel,
+} from '@ai-sdk/openai-compatible';
+import type { EmbeddingModelV3, ImageModelV3, LanguageModelV3, ProviderV3 } from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils';
+
+import { withoutTrailingApiVersion } from '../../../utils/provider';
+import { createImageGenerationModel, type ImageGenerationTransport } from '../imageGenerationModel';
+import { createTokenhubTransport } from './tokenhub-transport';
+
+export const TOKENHUB_PROVIDER_NAME = 'tokenhub' as const;
+
+export interface TokenhubProviderSettings {
+  apiKey?: string;
+  /** OpenAI-compatible chat / embedding endpoint (`https://tokenhub.tencentmaas.com/v1`). */
+  baseURL?: string;
+  headers?: Record<string, string>;
+  fetch?: FetchFunction;
+}
+
+export interface TokenhubProvider extends ProviderV3 {
+  (modelId: string): LanguageModelV3;
+  languageModel(modelId: string): LanguageModelV3;
+  embeddingModel(modelId: string): EmbeddingModelV3;
+  imageModel(modelId: string): ImageModelV3;
+}
+
+/**
+ * Build the TokenHub image transport from provider settings. Shared by the
+ * provider factory and the image-generation job's transport registry so the
+ * job handler can rebuild the same transport from re-resolved settings.
+ */
+export function buildTokenhubTransport(
+  settings: TokenhubProviderSettings,
+): ImageGenerationTransport {
+  if (!settings.baseURL) {
+    throw new Error(
+      'TokenHub provider requires a non-empty `baseURL` to build the image transport.',
+    );
+  }
+  return createTokenhubTransport({
+    apiKey: settings.apiKey ?? '',
+    // The `/v1/wand/*` image endpoints are host-root paths; the chat baseURL carries `/v1`.
+    baseURL: withoutTrailingApiVersion(settings.baseURL),
+    headers: settings.headers,
+    fetch: settings.fetch,
+  });
+}
+
+export function createTokenhubProvider(settings: TokenhubProviderSettings = {}): TokenhubProvider {
+  const { baseURL, fetch: customFetch } = settings;
+  if (!baseURL) {
+    throw new Error('TokenHub provider requires a non-empty `baseURL`.');
+  }
+
+  const resolveApiKey = () =>
+    loadApiKey({
+      apiKey: settings.apiKey,
+      environmentVariableName: 'TOKENHUB_API_KEY',
+      description: 'TokenHub',
+    });
+
+  const authHeaders = () => ({
+    Authorization: `Bearer ${resolveApiKey()}`,
+    ...settings.headers,
+  });
+
+  const url = ({ path }: { path: string; modelId: string }) =>
+    `${withoutTrailingSlash(baseURL)}${path}`;
+
+  const createChatModel = (modelId: string) =>
+    new OpenAICompatibleChatLanguageModel(modelId, {
+      provider: `${TOKENHUB_PROVIDER_NAME}.chat`,
+      url,
+      headers: authHeaders,
+      fetch: customFetch,
+    });
+
+  const transport = buildTokenhubTransport(settings);
+
+  const provider = (modelId: string) => createChatModel(modelId);
+  provider.specificationVersion = 'v3' as const;
+  provider.languageModel = createChatModel;
+  provider.embeddingModel = (modelId: string) =>
+    new OpenAICompatibleEmbeddingModel(modelId, {
+      provider: `${TOKENHUB_PROVIDER_NAME}.embedding`,
+      url,
+      headers: authHeaders,
+      fetch: customFetch,
+    });
+  provider.imageModel = (modelId: string) =>
+    createImageGenerationModel(modelId, { provider: TOKENHUB_PROVIDER_NAME, transport });
+
+  return provider as TokenhubProvider;
+}

--- a/packages/ai-runtime/src/provider/custom/tokenhub/tokenhub-transport.ts
+++ b/packages/ai-runtime/src/provider/custom/tokenhub/tokenhub-transport.ts
@@ -1,0 +1,360 @@
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+
+import type {
+  ImageGenerationSubmitInput,
+  ImageGenerationTransport,
+  ImageTransportDescriptor,
+} from '../imageGenerationModel';
+import { readErrorMessage } from '../readErrorMessage';
+import {
+  createAbortError,
+  fileToDataUrl,
+  isTerminalHttpStatus,
+  waitWithSignal,
+} from '../transportUtils';
+
+/**
+ * Tencent TokenHub image transport (cloud.tencent.com/document/product/1823/130080).
+ *
+ * TokenHub's image models are NOT served on the OpenAI `/v1/images/*` wire; each
+ * family has its own `/v1/wand/*` endpoint under the host root:
+ *   - hunyuan (`hy-image-v3`): `/v1/wand/hunyuan-image/v3-generation`, sync, `data[].url`
+ *   - seedream (`seedream-image-v5.0-*`): `/v1/wand/si-image/generation`, sync, `data[].url`
+ *   - vidu (`vidu-image-q2`): `/v1/wand/vidu-image/generation`, async → poll
+ *     `GET /v1/wand/vidu-image/tasks/{task_id}` until `state === 'success'`, `creations[].url`
+ *
+ * Routing comes from the registry's `modes[mode].vendorTransport` (endpoint + isSync) via
+ * `input.modelDescriptor`; the body family is picked from the endpoint path, not a model-id table.
+ */
+
+export const DEFAULT_TOKENHUB_BASE_URL = 'https://tokenhub.tencentmaas.com';
+
+const VIDU_TASKS_PATH = '/v1/wand/vidu-image/tasks';
+
+export class TokenhubApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+  ) {
+    super(message);
+    this.name = 'TokenhubApiError';
+  }
+}
+
+export class TokenhubTaskFailedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'TokenhubTaskFailedError';
+  }
+}
+
+export type TokenhubTaskState = 'created' | 'queueing' | 'processing' | 'success' | 'failed';
+
+interface TokenhubSyncImageResponse {
+  data?: Array<{ url?: string; b64_json?: string }>;
+}
+
+interface TokenhubViduSubmitResponse {
+  task_id?: string;
+  state?: TokenhubTaskState;
+}
+
+interface TokenhubViduTaskResponse {
+  state?: TokenhubTaskState;
+  creations?: Array<{ url?: string }>;
+  message?: string;
+  err_msg?: string;
+}
+
+/** Canonical camelCase params (the transport receives the vendorBag directly). */
+export interface TokenhubProviderParams {
+  /** hy-image-v3 `revise` (prompt rewriting). */
+  promptEnhancement?: boolean;
+  /** seedream `size` tier (`1K` / `2K` / …) when no explicit `WxH` size is set. */
+  imageResolution?: string;
+  outputFormat?: string;
+  addWatermark?: boolean;
+  sequentialImageGeneration?: 'auto' | 'disabled';
+  maxImages?: number;
+  /** vidu `resolution` (`1080p` / `2K` / `4K`). */
+  resolution?: string;
+}
+
+export interface TokenhubTransportSettings {
+  apiKey: string;
+  baseURL?: string;
+  headers?: Record<string, string>;
+  fetch?: FetchFunction;
+}
+
+type BodyFamily = 'hunyuan' | 'seedream' | 'vidu';
+
+function bodyFamilyFor(endpoint: string): BodyFamily | undefined {
+  switch (endpoint) {
+    case '/v1/wand/hunyuan-image/v3-generation':
+      return 'hunyuan';
+    case '/v1/wand/si-image/generation':
+      return 'seedream';
+    case '/v1/wand/vidu-image/generation':
+      return 'vidu';
+    default:
+      return undefined;
+  }
+}
+
+export function isTokenhubImageDescriptorSupported(
+  descriptor: ImageTransportDescriptor | undefined,
+): boolean {
+  return descriptor !== undefined && bodyFamilyFor(descriptor.endpoint) !== undefined;
+}
+
+function imagesOf(input: ImageGenerationSubmitInput): string[] | undefined {
+  if (!input.files?.length) return undefined;
+  return input.files.map((file) => fileToDataUrl(file));
+}
+
+function buildHunyuanBody(
+  input: ImageGenerationSubmitInput,
+  bag: TokenhubProviderParams,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { model: input.modelId, prompt: input.prompt ?? '' };
+  const images = imagesOf(input);
+  if (images) body.images = images;
+  if (input.size) body.size = input.size;
+  if (typeof input.seed === 'number') body.seed = input.seed;
+  if (bag.promptEnhancement !== undefined) body.revise = bag.promptEnhancement;
+  return body;
+}
+
+function buildSeedreamBody(
+  input: ImageGenerationSubmitInput,
+  bag: TokenhubProviderParams,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: input.modelId,
+    prompt: input.prompt ?? '',
+    response_format: 'url',
+  };
+  const images = imagesOf(input);
+  if (images) body.images = images;
+  const size = input.size ?? bag.imageResolution;
+  if (size) body.size = size;
+  if (bag.outputFormat) body.output_format = bag.outputFormat;
+  if (bag.addWatermark !== undefined) body.watermark = bag.addWatermark;
+  if (bag.sequentialImageGeneration) {
+    body.sequential_image_generation = bag.sequentialImageGeneration;
+    if (bag.sequentialImageGeneration === 'auto' && typeof bag.maxImages === 'number') {
+      body.sequential_image_generation_options = { max_images: bag.maxImages };
+    }
+  }
+  return body;
+}
+
+function buildViduBody(
+  input: ImageGenerationSubmitInput,
+  bag: TokenhubProviderParams,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { model: input.modelId, prompt: input.prompt ?? '' };
+  const images = imagesOf(input);
+  if (images) body.images = images;
+  if (input.aspectRatio) body.aspect_ratio = input.aspectRatio;
+  if (bag.resolution) body.resolution = bag.resolution;
+  if (typeof input.seed === 'number') body.seed = input.seed;
+  return body;
+}
+
+function extractSyncUrls(response: TokenhubSyncImageResponse): string[] {
+  return (response.data ?? [])
+    .map((item) => item.url ?? (item.b64_json ? `data:image/png;base64,${item.b64_json}` : ''))
+    .filter((url) => url.length > 0);
+}
+
+class TokenhubTransport implements ImageGenerationTransport {
+  private apiKey: string;
+  private baseURL: string;
+  private headers: Record<string, string>;
+  private customFetch?: FetchFunction;
+
+  constructor(settings: TokenhubTransportSettings) {
+    this.apiKey = settings.apiKey;
+    this.baseURL = settings.baseURL || DEFAULT_TOKENHUB_BASE_URL;
+    this.headers = settings.headers ?? {};
+    this.customFetch = settings.fetch;
+  }
+
+  async submit(
+    input: ImageGenerationSubmitInput,
+  ): Promise<{ taskId?: string; imageUrls?: string[] }> {
+    const descriptor = input.modelDescriptor;
+    if (!descriptor) {
+      throw new Error(`Missing modelDescriptor for TokenHub image model: ${input.modelId}`);
+    }
+
+    const bag = (input.providerParams ?? {}) as TokenhubProviderParams;
+    switch (bodyFamilyFor(descriptor.endpoint)) {
+      case 'hunyuan': {
+        const data = await this.request<TokenhubSyncImageResponse>(
+          descriptor.endpoint,
+          'POST',
+          buildHunyuanBody(input, bag),
+          {
+            signal: input.signal,
+          },
+        );
+        return { imageUrls: extractSyncUrls(data) };
+      }
+      case 'seedream': {
+        const data = await this.request<TokenhubSyncImageResponse>(
+          descriptor.endpoint,
+          'POST',
+          buildSeedreamBody(input, bag),
+          {
+            signal: input.signal,
+          },
+        );
+        return { imageUrls: extractSyncUrls(data) };
+      }
+      case 'vidu': {
+        const data = await this.request<TokenhubViduSubmitResponse>(
+          descriptor.endpoint,
+          'POST',
+          buildViduBody(input, bag),
+          {
+            signal: input.signal,
+          },
+        );
+        if (!data.task_id)
+          throw new TokenhubApiError('TokenHub async submit returned no task_id', 0);
+        return { taskId: data.task_id };
+      }
+      default:
+        throw new Error(`Unsupported TokenHub image endpoint: ${descriptor.endpoint}`);
+    }
+  }
+
+  async poll(
+    taskId: string,
+    options: { signal?: AbortSignal; onProgress?: (progress: number) => void },
+  ): Promise<string[]> {
+    const result = await this.pollTaskResult(taskId, options);
+    return (result.creations ?? [])
+      .map((entry) => entry.url)
+      .filter((url): url is string => typeof url === 'string' && url.length > 0);
+  }
+
+  async pollTaskResult(
+    taskId: string,
+    options: { interval?: number; maxAttempts?: number; signal?: AbortSignal } = {},
+  ): Promise<TokenhubViduTaskResponse> {
+    const { interval, maxAttempts = 120, signal } = options;
+    const maxTransientRetries = 10;
+    let attempts = 0;
+    let transientRetries = 0;
+    const startTime = Date.now();
+
+    while (attempts < maxAttempts) {
+      if (signal?.aborted) throw createAbortError('Task polling aborted');
+
+      try {
+        const result = await this.request<TokenhubViduTaskResponse>(
+          `${VIDU_TASKS_PATH}/${encodeURIComponent(taskId)}`,
+          'GET',
+          undefined,
+          { timeout: 10000, signal },
+        );
+        transientRetries = 0;
+        if (result.state === 'success') return result;
+        if (result.state === 'failed') {
+          throw new TokenhubTaskFailedError(
+            result.err_msg || result.message || 'TokenHub task failed',
+          );
+        }
+      } catch (error) {
+        if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+          throw createAbortError('Task polling aborted');
+        }
+        if (error instanceof TokenhubTaskFailedError) throw error;
+        if (error instanceof TokenhubApiError && isTerminalHttpStatus(error.statusCode))
+          throw error;
+
+        transientRetries++;
+        if (transientRetries >= maxTransientRetries) {
+          throw error instanceof Error ? error : new Error(String(error));
+        }
+        await waitWithSignal(interval ?? this.pollDelay(startTime), signal);
+        continue;
+      }
+
+      await waitWithSignal(interval ?? this.pollDelay(startTime), signal);
+      attempts++;
+    }
+
+    throw new Error('Task polling timeout');
+  }
+
+  private pollDelay(startTime: number): number {
+    return Date.now() - startTime < 60000 ? 3000 : 10000;
+  }
+
+  private async request<T>(
+    path: string,
+    method: 'POST' | 'GET',
+    body: Record<string, unknown> | undefined,
+    options: { timeout?: number; signal?: AbortSignal },
+  ): Promise<T> {
+    const timeout = options.timeout ?? 120000;
+    const externalSignal = options.signal;
+    const controller = new AbortController();
+    let externallyAborted = false;
+
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    const onExternalAbort = () => {
+      externallyAborted = true;
+      controller.abort();
+    };
+    if (externalSignal?.aborted) {
+      externallyAborted = true;
+      controller.abort();
+    } else {
+      externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+    }
+
+    try {
+      const doFetch = this.customFetch ?? globalThis.fetch;
+      const response = await doFetch(`${this.baseURL}${path}`, {
+        method,
+        headers: {
+          Accept: 'application/json',
+          ...this.headers,
+          Authorization: `Bearer ${this.apiKey}`,
+          ...(method === 'POST' && { 'Content-Type': 'application/json' }),
+        },
+        ...(method === 'POST' && body !== undefined && { body: JSON.stringify(body) }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const message = await readErrorMessage(response);
+        throw new TokenhubApiError(
+          `TokenHub API error: ${response.status} - ${message}`,
+          response.status,
+        );
+      }
+      return (await response.json()) as T;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        if (externallyAborted) throw createAbortError('TokenHub API request aborted');
+        throw new Error(`TokenHub API request timeout after ${timeout / 1000}s`, { cause: error });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      externalSignal?.removeEventListener('abort', onExternalAbort);
+    }
+  }
+}
+
+export function createTokenhubTransport(settings: TokenhubTransportSettings): TokenhubTransport {
+  return new TokenhubTransport(settings);
+}
+
+export type { TokenhubTransport };

--- a/packages/ai-runtime/src/provider/extensions.ts
+++ b/packages/ai-runtime/src/provider/extensions.ts
@@ -67,6 +67,10 @@ import {
   createSiliconProvider,
   type SiliconProviderSettings,
 } from './custom/silicon/siliconProvider';
+import {
+  createTokenhubProvider,
+  type TokenhubProviderSettings,
+} from './custom/tokenhub/tokenhub-provider';
 import { createZhipuProvider, type ZhipuProviderSettings } from './custom/zhipuProvider';
 
 export const GoogleVertexExtension = ProviderExtension.create({
@@ -286,6 +290,12 @@ export const PpioExtension = ProviderExtension.create({
   create: createPpioProvider,
 } as const satisfies ProviderExtensionConfig<PpioProviderSettings, ProviderV3, 'ppio'>);
 
+export const TokenhubExtension = ProviderExtension.create({
+  name: 'tokenhub',
+  supportsImageGeneration: true,
+  create: createTokenhubProvider,
+} as const satisfies ProviderExtensionConfig<TokenhubProviderSettings, ProviderV3, 'tokenhub'>);
+
 /**
  * DMXAPI Extension - unified chat + embedding + image (single-shot for painting)
  */
@@ -394,6 +404,7 @@ export const extensions = [
   AiHubMixExtension,
   NewApiExtension,
   PpioExtension,
+  TokenhubExtension,
   DmxapiExtension,
   SiliconExtension,
   ZhipuExtension,

--- a/packages/ai-runtime/src/utils/__tests__/image-request-routing.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/image-request-routing.test.ts
@@ -1,0 +1,223 @@
+import type { ImageModelV3CallOptions } from '@ai-sdk/provider';
+import type { Provider } from '@cherrystudio/universal/data/types/provider';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createDashScopeProvider } from '../../provider/custom/dashscope/dashscopeProvider';
+import type { ImageTransportDescriptor } from '../../provider/custom/imageGenerationModel';
+import { createModelscopeProvider } from '../../provider/custom/modelscope/modelscopeProvider';
+import { createPpioProvider } from '../../provider/custom/ppio/ppioProvider';
+import { createTokenhubProvider } from '../../provider/custom/tokenhub/tokenhub-provider';
+import { splitImageParamValues } from '../imageOptions';
+import { buildImageProviderOptions } from '../imageProviderOptions';
+
+const imageUrl = 'https://images.example.com/result.png';
+const referenceImage = 'data:image/png;base64,AQID';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+/** Exercise the same parameter partition and provider envelope used by AiService. */
+function callOptions(
+  providerId: string,
+  modelId: string,
+  paramValues: Record<string, unknown>,
+  modelDescriptor?: ImageTransportDescriptor,
+): ImageModelV3CallOptions {
+  const provider: Provider = {
+    id: `copy-${providerId}`,
+    presetProviderId: providerId,
+    name: providerId,
+    isEnabled: true,
+    authType: 'api-key',
+    apiKeys: [],
+    apiFeatures: {
+      arrayContent: true,
+      serviceTier: true,
+      streamOptions: true,
+      verbosity: false,
+      reportsActualCost: false,
+    },
+    settings: {},
+  };
+  const { structured, vendorBag } = splitImageParamValues(paramValues);
+  return {
+    prompt: 'a fox',
+    n: structured.n ?? 1,
+    size: structured.size as ImageModelV3CallOptions['size'],
+    aspectRatio: structured.aspectRatio as ImageModelV3CallOptions['aspectRatio'],
+    seed: structured.seed,
+    mask: undefined,
+    files: [{ type: 'file', mediaType: 'image/png', data: new Uint8Array([1, 2, 3]) }],
+    providerOptions: buildImageProviderOptions({
+      aiSdkProviderId: providerId,
+      modelId,
+      provider,
+      paramValues,
+      vendorBag: { ...vendorBag, ...(modelDescriptor && { modelDescriptor }) },
+    }),
+  };
+}
+
+describe('painting parameters through the image provider to the HTTP request', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(['qwen-image-3.0', 'qwen-image-3.0-pro'])(
+    'sends %s reference images and negative prompt to the synchronous multimodal route',
+    async (modelId) => {
+      const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({
+          output: { choices: [{ message: { content: [{ image: imageUrl }] } }] },
+        }),
+      );
+      const provider = createDashScopeProvider({
+        apiKey: 'test-key',
+        baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      });
+      const endpoint = '/api/v1/services/aigc/multimodal-generation/generation';
+      const result = await provider
+        .imageModel(modelId)
+        .doGenerate(
+          callOptions(
+            'dashscope',
+            modelId,
+            { negativePrompt: 'blur', size: '1024x1024', seed: 7, addWatermark: false },
+            { id: modelId, endpoint, isSync: true, mode: 'edit' },
+          ),
+        );
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch.mock.calls[0]?.[0]).toBe(`https://dashscope.aliyuncs.com${endpoint}`);
+      const request = fetch.mock.calls[0]?.[1];
+      expect(request?.headers).not.toHaveProperty('X-DashScope-Async');
+      expect(JSON.parse(request?.body as string)).toEqual({
+        model: modelId,
+        input: {
+          messages: [{ role: 'user', content: [{ text: 'a fox' }, { image: referenceImage }] }],
+        },
+        parameters: { size: '1024*1024', seed: 7, negative_prompt: 'blur', watermark: false },
+      });
+      expect(result.images).toEqual([imageUrl]);
+    },
+  );
+
+  it('preserves ModelScope steps, guidance and negative prompt through async generation', async () => {
+    const fetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ task_id: 'task-1' }))
+      .mockResolvedValueOnce(jsonResponse({ task_status: 'SUCCEED', output_images: [imageUrl] }));
+    const modelId = 'Qwen/Qwen-Image-Edit';
+    const provider = createModelscopeProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://api-inference.modelscope.cn/v1',
+    });
+    const result = await provider.imageModel(modelId).doGenerate(
+      callOptions('modelscope', modelId, {
+        numInferenceSteps: 25,
+        guidanceScale: 7,
+        negativePrompt: 'blur',
+        seed: 0,
+        size: '1024x1024',
+      }),
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[0]?.[0]).toBe(
+      'https://api-inference.modelscope.cn/v1/images/generations',
+    );
+    expect(JSON.parse(fetch.mock.calls[0]?.[1]?.body as string)).toEqual({
+      model: modelId,
+      prompt: 'a fox',
+      image_url: referenceImage,
+      size: '1024x1024',
+      steps: 25,
+      guidance: 7,
+      negative_prompt: 'blur',
+      seed: 0,
+    });
+    expect(fetch.mock.calls[1]?.[0]).toBe('https://api-inference.modelscope.cn/v1/tasks/task-1');
+    expect(result.images).toEqual([imageUrl]);
+  });
+
+  it.each([
+    ['seedream-4-0', '/v3/seedream-4.0', { images: [referenceImage] }],
+    ['seedream-4.0', '/v3/seedream-4.0', { images: [referenceImage] }],
+    ['seedream-4-5', '/v3/seedream-4.5', { image: ['AQID'] }],
+    ['seedream-4.5', '/v3/seedream-4.5', { image: ['AQID'] }],
+    ['seedream-5-0-lite', '/v3/seedream-5.0-lite', { image: ['AQID'] }],
+    ['seedream-5.0-lite', '/v3/seedream-5.0-lite', { image: ['AQID'] }],
+  ] as const)(
+    'keeps PPIO %s edit images for saved catalog IDs',
+    async (modelId, endpoint, images) => {
+      const fetch = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ images: [imageUrl] }));
+      const provider = createPpioProvider({
+        apiKey: 'test-key',
+        baseURL: 'https://api.ppinfra.com/v3/openai',
+      });
+      const result = await provider.imageModel(modelId).doGenerate(
+        callOptions(
+          'ppio',
+          modelId,
+          { size: '2560x1440', addWatermark: false },
+          {
+            id: modelId,
+            endpoint,
+            isSync: true,
+            mode: 'edit',
+          },
+        ),
+      );
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch.mock.calls[0]?.[0]).toBe(`https://api.ppio.com${endpoint}`);
+      expect(JSON.parse(fetch.mock.calls[0]?.[1]?.body as string)).toEqual({
+        prompt: 'a fox',
+        size: '2560x1440',
+        watermark: false,
+        sequential_image_generation: 'disabled',
+        ...images,
+      });
+      expect(result.images).toEqual([imageUrl]);
+    },
+  );
+
+  it('routes TokenHub provider options to wand without duplicating the API version', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(jsonResponse({ data: [{ url: imageUrl }] }));
+    const modelId = 'hy-image-v3';
+    const endpoint = '/v1/wand/hunyuan-image/v3-generation';
+    const provider = createTokenhubProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://proxy.example.com/tokenhub/v1/',
+      fetch,
+    });
+    const result = await provider.imageModel(modelId).doGenerate(
+      callOptions(
+        'tokenhub',
+        modelId,
+        { promptEnhancement: false, seed: 0, size: '1280x768' },
+        {
+          id: modelId,
+          endpoint,
+          isSync: true,
+          mode: 'edit',
+        },
+      ),
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0]?.[0]).toBe(`https://proxy.example.com/tokenhub${endpoint}`);
+    expect(JSON.parse(fetch.mock.calls[0]?.[1]?.body as string)).toEqual({
+      model: modelId,
+      prompt: 'a fox',
+      images: [referenceImage],
+      revise: false,
+      seed: 0,
+      size: '1280x768',
+    });
+    expect(result.images).toEqual([imageUrl]);
+  });
+});

--- a/packages/ai-runtime/src/utils/__tests__/image-request-routing.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/image-request-routing.test.ts
@@ -1,8 +1,10 @@
 import type { ImageModelV3CallOptions } from '@ai-sdk/provider';
 import type { Provider } from '@cherrystudio/universal/data/types/provider';
+import { generateImage } from 'ai';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createDashScopeProvider } from '../../provider/custom/dashscope/dashscopeProvider';
+import { createDmxapiProvider } from '../../provider/custom/dmxapi/dmxapiProvider';
 import type { ImageTransportDescriptor } from '../../provider/custom/imageGenerationModel';
 import { createModelscopeProvider } from '../../provider/custom/modelscope/modelscopeProvider';
 import { createPpioProvider } from '../../provider/custom/ppio/ppioProvider';
@@ -100,6 +102,169 @@ describe('painting parameters through the image provider to the HTTP request', (
       expect(result.images).toEqual([imageUrl]);
     },
   );
+
+  it.each([
+    ['qwen-image-3.0', 'generate', 4],
+    ['qwen-image-3.0-pro', 'edit', 6],
+  ] as const)('keeps %s %s as one native batch of %i images', async (modelId, mode, n) => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      jsonResponse({
+        output: {
+          choices: [
+            { message: { content: Array.from({ length: n }, () => ({ image: referenceImage })) } },
+          ],
+        },
+      }),
+    );
+    const provider = createDashScopeProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    });
+    const options = callOptions(
+      'dashscope',
+      modelId,
+      { numImages: n, seed: 7 },
+      {
+        id: modelId,
+        endpoint: '/api/v1/services/aigc/multimodal-generation/generation',
+        isSync: true,
+        mode,
+      },
+    );
+
+    const result = await generateImage({
+      model: provider.imageModel(modelId),
+      prompt: mode === 'edit' ? { text: 'a fox', images: [referenceImage] } : 'a fox',
+      n: options.n,
+      seed: options.seed,
+      providerOptions: options.providerOptions,
+      maxRetries: 0,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetch.mock.calls[0]?.[1]?.body as string)).toMatchObject({
+      model: modelId,
+      parameters: { n, seed: 7 },
+    });
+    expect(result.images).toHaveLength(n);
+  });
+
+  it('keeps a four-image batch intact through DashScope async submit and poll', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, request) =>
+      jsonResponse(
+        request?.method === 'POST'
+          ? { output: { task_id: 'batch-task' } }
+          : {
+              output: {
+                task_status: 'SUCCEEDED',
+                results: Array.from({ length: 4 }, () => ({ url: referenceImage })),
+              },
+            },
+      ),
+    );
+    const provider = createDashScopeProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    });
+    const options = callOptions(
+      'dashscope',
+      'qwen-image',
+      { numImages: 4, seed: 7 },
+      {
+        id: 'qwen-image',
+        endpoint: '/api/v1/services/aigc/text2image/image-synthesis',
+        mode: 'generate',
+      },
+    );
+
+    const result = await generateImage({
+      model: provider.imageModel('qwen-image'),
+      prompt: 'a fox',
+      n: options.n,
+      seed: options.seed,
+      providerOptions: options.providerOptions,
+      maxRetries: 0,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetch.mock.calls[0]?.[1]?.body as string)).toMatchObject({
+      parameters: { n: 4, seed: 7 },
+    });
+    expect(fetch.mock.calls[1]?.[1]?.method).toBe('GET');
+    expect(result.images).toHaveLength(4);
+  });
+
+  it.each(['qwen-image', 'wan2.6-t2i'])(
+    'preserves the native four-image batch for DMXAPI %s',
+    async (modelId) => {
+      const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+        jsonResponse(
+          modelId === 'qwen-image'
+            ? {
+                extra: {
+                  output: {
+                    task_status: 'SUCCEEDED',
+                    results: Array.from({ length: 4 }, () => ({ url: referenceImage })),
+                  },
+                },
+              }
+            : {
+                output: [{ content: Array.from({ length: 4 }, () => ({ image: referenceImage })) }],
+              },
+        ),
+      );
+      const provider = createDmxapiProvider({
+        apiKey: 'test-key',
+        baseURL: 'https://dmx.example.com/v1',
+      });
+
+      const result = await generateImage({
+        model: provider.imageModel(modelId),
+        prompt: 'a fox',
+        n: 4,
+        maxRetries: 0,
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(fetch.mock.calls[0]?.[1]?.body as string)).toMatchObject(
+        modelId === 'qwen-image' ? { n: 4 } : { parameters: { n: 4 } },
+      );
+      expect(result.images).toHaveLength(4);
+    },
+  );
+
+  it('retains single-image calls for TokenHub models without native n support', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockImplementation(async () => jsonResponse({ data: [{ url: referenceImage }] }));
+    const provider = createTokenhubProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://tokenhub.example.com/v1',
+      fetch,
+    });
+    const options = callOptions(
+      'tokenhub',
+      'hy-image-v3',
+      { numImages: 2 },
+      {
+        id: 'hy-image-v3',
+        endpoint: '/v1/wand/hunyuan-image/v3-generation',
+        isSync: true,
+        mode: 'generate',
+      },
+    );
+
+    const result = await generateImage({
+      model: provider.imageModel('hy-image-v3'),
+      prompt: 'a fox',
+      n: options.n,
+      providerOptions: options.providerOptions,
+      maxRetries: 0,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.images).toHaveLength(2);
+  });
 
   it('preserves ModelScope steps, guidance and negative prompt through async generation', async () => {
     const fetch = vi

--- a/packages/ai-runtime/src/utils/__tests__/imageProviderOptions.test.ts
+++ b/packages/ai-runtime/src/utils/__tests__/imageProviderOptions.test.ts
@@ -30,6 +30,7 @@ function build(
   const { vendorBag } = splitImageParamValues(paramValues);
   return buildImageProviderOptions({
     aiSdkProviderId,
+    modelId: 'test-image',
     paramValues,
     provider: currentProvider,
     vendorBag,
@@ -37,6 +38,71 @@ function build(
 }
 
 describe('image provider option routing', () => {
+  it('delivers CherryIN chat-variant image options to the key its image wrapper reads', () => {
+    expect(
+      build(
+        'cherryin-chat',
+        {
+          imageResolution: '4K',
+          personGeneration: 'ALLOW_ADULT',
+        },
+        provider('custom-cherryin', 'cherryin'),
+      ),
+    ).toEqual({
+      cherryin: { imageResolution: '4K', personGeneration: 'ALLOW_ADULT' },
+    });
+  });
+
+  it.each(['dashscope', 'modelscope', 'ppio', 'tokenhub'])(
+    'preserves canonical parameters for %s transports',
+    (providerId) => {
+      expect(
+        build(
+          providerId,
+          {
+            negativePrompt: 'blur',
+            numInferenceSteps: 25,
+            guidanceScale: 7,
+            promptEnhancement: false,
+            sequentialImageGeneration: 'auto',
+          },
+          provider(`copy-${providerId}`, providerId),
+        ),
+      ).toEqual({
+        [providerId]: {
+          negativePrompt: 'blur',
+          numInferenceSteps: 25,
+          guidanceScale: 7,
+          promptEnhancement: false,
+          sequentialImageGeneration: 'auto',
+        },
+      });
+    },
+  );
+
+  it('keeps DMXAPI custom-image fields canonical while retaining native Gemini delivery', () => {
+    const paramValues = { negativePrompt: 'blur', imageResolution: '2K' };
+    const { vendorBag } = splitImageParamValues(paramValues);
+    expect(
+      buildImageProviderOptions({
+        aiSdkProviderId: 'dmxapi',
+        modelId: 'wan2.2-t2i',
+        paramValues,
+        provider: provider('custom-dmxapi', 'dmxapi'),
+        vendorBag,
+      }),
+    ).toEqual({ dmxapi: { negativePrompt: 'blur', imageResolution: '2K' } });
+    expect(
+      buildImageProviderOptions({
+        aiSdkProviderId: 'dmxapi',
+        modelId: 'gemini-2.5-flash-image',
+        paramValues,
+        provider: provider('custom-dmxapi', 'dmxapi'),
+        vendorBag,
+      }),
+    ).toMatchObject({ google: { imageConfig: { imageSize: '2K' } } });
+  });
+
   it('routes OpenRouter image fields and only sends compression for JPEG or WebP', () => {
     expect(
       build('openrouter', {

--- a/packages/ai-runtime/src/utils/imageProviderOptions.ts
+++ b/packages/ai-runtime/src/utils/imageProviderOptions.ts
@@ -2,24 +2,31 @@ import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import type { Provider } from '@cherrystudio/universal/data/types/provider';
 import type { JSONValue } from 'ai';
 
+import { hasImageTransport } from '../provider/custom/imageTransportRegistry';
 import { buildVendorProviderOptions } from '../provider/custom/wire/buildImageRequest';
 import { DEFAULT_DIFFUSION_REGISTRATION, WIRE_REGISTRY } from '../provider/custom/wire/wireProfile';
 
 export function buildImageProviderOptions({
   aiSdkProviderId,
+  modelId,
   paramValues,
   provider,
   vendorBag,
 }: {
   aiSdkProviderId: string;
+  modelId: string;
   paramValues: Record<string, unknown>;
   provider: Provider;
   vendorBag: Record<string, unknown>;
 }): Record<string, Record<string, JSONValue>> {
+  // Custom transports own the final wire format and consume canonical parameters.
+  if (hasImageTransport(aiSdkProviderId, modelId)) {
+    return { [aiSdkProviderId]: vendorBag as Record<string, JSONValue> };
+  }
   const providerIdentity = provider.presetProviderId ?? provider.id;
   const registration =
-    WIRE_REGISTRY[providerIdentity] ??
     WIRE_REGISTRY[aiSdkProviderId] ??
+    WIRE_REGISTRY[providerIdentity] ??
     DEFAULT_DIFFUSION_REGISTRATION;
   const deliveryProviderId =
     aiSdkProviderId === 'openai-compatible' ? provider.id : aiSdkProviderId;

--- a/src/backend/ai/AiService.ts
+++ b/src/backend/ai/AiService.ts
@@ -6,6 +6,7 @@ import {
 } from '@cherrystudio/ai-core';
 import {
   buildImageProviderOptions,
+  isImageTransportDescriptorSupported,
   mergeImageProviderOptions,
   splitImageParamValues,
 } from '@cherrystudio/ai-runtime/image';
@@ -295,19 +296,23 @@ export class AiService extends BaseService {
       registryProviderId,
       model.apiModelId ?? model.modelId,
     )?.modes?.[request.mode]?.vendorTransport;
+    const modelDescriptor = vendorTransport?.endpoint
+      ? { ...vendorTransport, id: sdkConfig.modelId, mode: request.mode }
+      : undefined;
+    if (!isImageTransportDescriptorSupported(sdkConfig.providerId, modelDescriptor)) {
+      throw new Error(
+        `Unsupported image generation route for ${registryProviderId}: ${sdkConfig.modelId}`,
+      );
+    }
     const transportVendorBag = vendorTransport?.endpoint
       ? {
           ...vendorBag,
-          modelDescriptor: {
-            endpoint: vendorTransport.endpoint,
-            id: sdkConfig.modelId,
-            mode: request.mode,
-            ...(vendorTransport.isSync !== undefined && { isSync: vendorTransport.isSync }),
-          },
+          modelDescriptor,
         }
       : vendorBag;
     const imageProviderOptions = buildImageProviderOptions({
       aiSdkProviderId: sdkConfig.providerId,
+      modelId: sdkConfig.modelId,
       paramValues: request.paramValues,
       provider,
       vendorBag: transportVendorBag,

--- a/src/backend/ai/generation/__tests__/providerConfig.test.ts
+++ b/src/backend/ai/generation/__tests__/providerConfig.test.ts
@@ -1,4 +1,4 @@
-import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry';
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry';
 
 import type { ResolvedProviderApiKey } from '@/backend/data/services/ProviderService';
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
@@ -7,6 +7,33 @@ import type { AuthConfig, Provider } from '@/shared/data/types/provider';
 import { providerToAiSdkConfig, resolveProviderAiSdkConfig } from '../providerConfig';
 
 describe('providerToAiSdkConfig', () => {
+  it('selects the TokenHub image adapter for a copied preset without changing its chat adapter', async () => {
+    const provider = createProvider({
+      id: 'tokenhub-copy',
+      presetProviderId: 'tokenhub',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          adapterFamily: 'openai-compatible',
+          baseUrl: 'https://tokenhub.tencentmaas.com/v1',
+        },
+      },
+    });
+    const image = {
+      ...createModel(provider.id, 'hy-image-v3'),
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+    };
+    const config = await providerToAiSdkConfig(provider, image, createRuntime());
+    expect(config.providerId).toBe('tokenhub');
+    expect(config.providerSettings.baseURL).toBe('https://tokenhub.tencentmaas.com/v1');
+    const chatConfig = await providerToAiSdkConfig(
+      provider,
+      createModel(provider.id, 'hy4-preview'),
+      createRuntime(),
+    );
+    expect(chatConfig.providerId).toBe('openai-compatible');
+  });
+
   it('leaves generic OpenAI-compatible providers on the default fetch', async () => {
     const provider = createProvider({
       id: 'custom-openai',

--- a/src/backend/ai/generation/providerConfig.ts
+++ b/src/backend/ai/generation/providerConfig.ts
@@ -250,7 +250,7 @@ export async function resolveProviderAiSdkConfig(
       match: (p, id) =>
         id === 'openai-compatible' &&
         isImageGenerationModel(model) &&
-        (['modelscope', 'ppio', 'silicon', 'doubao', 'ovms'].some((providerId) =>
+        (['modelscope', 'ppio', 'silicon', 'doubao', 'ovms', 'tokenhub'].some((providerId) =>
           isPreset(p, providerId),
         ) ||
           (isPreset(p, 'dmxapi') && dmxapiUsesCustomTransport(model.apiModelId ?? model.id))),
@@ -262,6 +262,7 @@ export async function resolveProviderAiSdkConfig(
           | 'silicon'
           | 'doubao'
           | 'ovms'
+          | 'tokenhub'
           | 'dmxapi',
         endpoint: builderContext.endpoint,
         providerSettings: {

--- a/src/backend/ai/provider/__tests__/systemModelSupport.test.ts
+++ b/src/backend/ai/provider/__tests__/systemModelSupport.test.ts
@@ -13,6 +13,52 @@ function supportWith(
 }
 
 describe('createSystemModelSupport', () => {
+  it.each([
+    ['dashscope', 'qwen-image-3.0', '/api/v1/services/aigc/multimodal-generation/generation'],
+    ['ppio', 'seedream-4-0', '/v3/seedream-4.0'],
+    ['tokenhub', 'hy-image-v3', '/v1/wand/hunyuan-image/v3-generation'],
+  ])(
+    'admits %s catalog routes only when the required descriptor is available',
+    (presetProviderId, modelId, endpoint) => {
+      const { isModelSupportedBySystem } = supportWith(jest.fn().mockReturnValue(false));
+      const provider = createProvider({ id: 'provider-copy', presetProviderId });
+      const model = createModel({
+        capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+        apiModelId: modelId,
+        imageGeneration: { modes: { generate: { supports: {}, vendorTransport: { endpoint } } } },
+      });
+      expect(isModelSupportedBySystem(provider, model)).toBe(true);
+      expect(isModelSupportedBySystem(provider, { ...model, imageGeneration: undefined })).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each([
+    ['dashscope', 'future-image', '/api/v1/services/aigc/multimodal-generation/generation'],
+    ['dashscope', 'qwen-image-3.0', '/api/v1/services/aigc/future-image/generation'],
+    ['ppio', 'seedream-4-0', '/v3/new-image-protocol'],
+    ['tokenhub', 'hy-image-v3', '/v1/api/image/submit'],
+    ['tokenhub', 'hy-image-v3', '/v1/wand/hunyuan-image/future-generation'],
+  ])(
+    'does not offer unimplemented %s image routes as supported models',
+    (presetProviderId, modelId, endpoint) => {
+      const { isModelSupportedBySystem } = supportWith(jest.fn().mockReturnValue(false));
+      expect(
+        isModelSupportedBySystem(
+          createProvider({ presetProviderId }),
+          createModel({
+            capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+            apiModelId: modelId,
+            imageGeneration: {
+              modes: { generate: { supports: {}, vendorTransport: { endpoint } } },
+            },
+          }),
+        ),
+      ).toBe(false);
+    },
+  );
+
   it('delegates text models to the bound language serving support', () => {
     const supportsLanguageModel = jest.fn().mockReturnValue(true);
     const { isModelSupportedBySystem } = supportWith(supportsLanguageModel);

--- a/src/backend/ai/provider/systemModelSupport.ts
+++ b/src/backend/ai/provider/systemModelSupport.ts
@@ -1,4 +1,5 @@
 import { extensionRegistry } from '@cherrystudio/ai-core/provider';
+import { isImageTransportDescriptorSupported } from '@cherrystudio/ai-runtime/image';
 import { getAiSdkProviderId } from '@cherrystudio/ai-runtime/provider';
 
 import type { Model } from '@/shared/data/types/model';
@@ -50,5 +51,16 @@ export function createSystemModelSupport(language: LanguageServingSupport): Syst
 
 function isImageGenerationSupported(provider: Provider, model: Model): boolean {
   const extension = extensionRegistry.get(getAiSdkProviderId(provider, model));
-  return extension?.config.supportsImageGeneration === true;
+  if (extension?.config.supportsImageGeneration !== true) return false;
+  const providerId = provider.presetProviderId ?? provider.id;
+  const modes = Object.values(model.imageGeneration?.modes ?? {});
+  if (modes.length === 0) return isImageTransportDescriptorSupported(providerId, undefined);
+  return modes.some((definition) =>
+    isImageTransportDescriptorSupported(
+      providerId,
+      definition?.vendorTransport
+        ? { ...definition.vendorTransport, id: model.apiModelId ?? model.modelId }
+        : undefined,
+    ),
+  );
 }

--- a/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
+++ b/src/backend/services/paintings/__tests__/createPaintingsModule.test.ts
@@ -231,6 +231,40 @@ describe('createPaintingsModule', () => {
     expect(dependencies.db.withWriteTx).toHaveBeenCalledTimes(1);
   });
 
+  it('enqueues reference-image generation with the generate mode and its own image limit', async () => {
+    const { backend, dependencies } = createSubject();
+    jest.mocked(dependencies.getModel).mockResolvedValue({
+      id: modelId,
+      inputModalities: ['text', 'image'],
+      imageGeneration: { modes: { generate: { maxInputImages: 3, supports: {} } } },
+    } as Model);
+
+    await backend.startGeneration({ ...generationInput, mode: 'generate' });
+
+    expect(dependencies.files.prepareAttachments).toHaveBeenCalledWith({
+      fileEntryIds: [inputFileId],
+      target: { purpose: 'painting', acceptsImages: true, maxImages: 3 },
+    });
+    expect(dependencies.jobs.enqueueGenerateTx).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        mode: 'generate',
+        images: [{ fileEntryId: inputFileId, mediaType: 'image/png', uri: 'file:///managed.png' }],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects a stale mode before creating a painting receipt', async () => {
+    const { backend, dependencies } = createSubject();
+    await expect(
+      backend.startGeneration({ ...generationInput, mode: 'generate' }),
+    ).rejects.toMatchObject({
+      issue: { code: 'model-unsupported' },
+    });
+    expect(dependencies.db.withWriteTx).not.toHaveBeenCalled();
+  });
+
   it('delegates cancellation to the job port', async () => {
     const { backend, dependencies } = createSubject();
 

--- a/src/backend/services/paintings/createPaintingsModule.ts
+++ b/src/backend/services/paintings/createPaintingsModule.ts
@@ -12,7 +12,10 @@ import type { FileEntryId } from '@/shared/data/types/file';
 import type { Model, UniqueModelId } from '@/shared/data/types/model';
 import { parseUniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
-import { supportsPaintingGenerationMode } from '@/shared/utils/paintingModelSupport';
+import {
+  resolvePaintingGenerationMode,
+  supportsPaintingGenerationMode,
+} from '@/shared/utils/paintingModelSupport';
 
 import type {
   PaintingGenerateJobImage,
@@ -83,7 +86,8 @@ async function startGeneration(
   const signature = generationSignature({ ...input, prompt });
   const model = await dependencies.getModel(input.modelId);
   const hasImages = input.fileEntryIds.length > 0;
-  if (!model || !supportsPaintingGenerationMode(model, hasImages ? 'edit' : 'generate')) {
+  const mode = resolvePaintingGenerationMode(model ?? undefined, hasImages);
+  if (!model || !mode || input.mode !== mode) {
     throw new FileAttachmentError({ code: 'model-unsupported' });
   }
   const definition = model.imageGeneration?.modes[input.mode];

--- a/src/frontend/data/paintings/__tests__/imageGenerationParams.test.ts
+++ b/src/frontend/data/paintings/__tests__/imageGenerationParams.test.ts
@@ -6,7 +6,10 @@ import {
 } from '@cherrystudio/provider-registry';
 
 import { createUniqueModelId, type Model } from '@/shared/data/types/model';
-import { supportsPaintingGenerationMode } from '@/shared/utils/paintingModelSupport';
+import {
+  resolvePaintingGenerationMode,
+  supportsPaintingGenerationMode,
+} from '@/shared/utils/paintingModelSupport';
 
 import {
   imageParamsAspectRatio,
@@ -51,17 +54,55 @@ const support = {
 
 describe('image generation parameter resolution', () => {
   it('prefers generate without inputs and edit with inputs', () => {
-    expect(resolveImageGenerationMode(support, false)?.mode).toBe('generate');
-    expect(resolveImageGenerationMode(support, true)?.mode).toBe('edit');
+    const selected = model({ imageGeneration: support });
+    expect(resolvePaintingGenerationMode(selected, false)).toBe('generate');
+    expect(resolvePaintingGenerationMode(selected, true)).toBe('edit');
+    expect(resolveImageGenerationMode(support, 'edit')?.definition).toBe(support.modes.edit);
   });
 
-  it('falls back to the first declared mode when the preferred mode is unavailable', () => {
+  it('does not offer edit-only models without an input image', () => {
     const editOnly = {
       modes: { edit: { supports: {} } },
     } satisfies ImageGenerationSupport;
 
-    expect(resolveImageGenerationMode(editOnly, false)?.mode).toBe('edit');
-    expect(resolveImageGenerationMode(undefined, false)).toBeUndefined();
+    expect(
+      resolvePaintingGenerationMode(model({ imageGeneration: editOnly }), false),
+    ).toBeUndefined();
+    expect(resolveImageGenerationMode(editOnly, 'generate')).toBeUndefined();
+    expect(resolveImageGenerationMode(undefined, 'generate')).toBeUndefined();
+  });
+
+  it('keeps generate mode and its parameters for models accepting reference images', () => {
+    const selected = model({
+      inputModalities: [MODALITY.TEXT, MODALITY.IMAGE],
+      imageGeneration: { modes: { generate: support.modes.generate } },
+    });
+    expect(supportsPaintingGenerationMode(selected, 'edit')).toBe(true);
+    const mode = resolvePaintingGenerationMode(selected, true);
+    expect(mode).toBe('generate');
+    expect(resolveImageGenerationMode(selected.imageGeneration, mode)?.definition).toBe(
+      support.modes.generate,
+    );
+  });
+
+  it('honors reference-image limits even when modality metadata is missing or disagrees', () => {
+    expect(
+      resolvePaintingGenerationMode(
+        model({
+          imageGeneration: { modes: { generate: { maxInputImages: 3, supports: {} } } },
+        }),
+        true,
+      ),
+    ).toBe('generate');
+    expect(
+      resolvePaintingGenerationMode(
+        model({
+          inputModalities: [MODALITY.IMAGE],
+          imageGeneration: { modes: { generate: { maxInputImages: 0, supports: {} } } },
+        }),
+        true,
+      ),
+    ).toBeUndefined();
   });
 
   it('filters models by the requested generate or edit interaction', () => {
@@ -106,7 +147,7 @@ describe('image generation parameter resolution', () => {
 });
 
 describe('image generation parameter drafts', () => {
-  const generateMode = resolveImageGenerationMode(support, false);
+  const generateMode = resolveImageGenerationMode(support, 'generate');
 
   it('applies defaults and preserves supported values', () => {
     expect(

--- a/src/frontend/data/paintings/imageGenerationParams.ts
+++ b/src/frontend/data/paintings/imageGenerationParams.ts
@@ -22,24 +22,10 @@ export type ResolvedImageGenerationMode = {
 
 export function resolveImageGenerationMode(
   support: ImageGenerationSupport | undefined,
-  hasInputImages: boolean,
+  mode: ImageGenerationMode | undefined,
 ): ResolvedImageGenerationMode | undefined {
-  const modes = support?.modes;
-  if (!modes) {
-    return undefined;
-  }
-
-  const preferredMode: ImageGenerationMode = hasInputImages ? 'edit' : 'generate';
-  const preferredDefinition = modes[preferredMode];
-  if (preferredDefinition) {
-    return { definition: preferredDefinition, mode: preferredMode };
-  }
-
-  const fallbackMode = Object.keys(modes)[0] as ImageGenerationMode | undefined;
-  const fallbackDefinition = fallbackMode ? modes[fallbackMode] : undefined;
-  return fallbackMode && fallbackDefinition
-    ? { definition: fallbackDefinition, mode: fallbackMode }
-    : undefined;
+  const definition = mode ? support?.modes[mode] : undefined;
+  return mode && definition ? { definition, mode } : undefined;
 }
 
 /**

--- a/src/frontend/features/paintings/components/PaintingInput.tsx
+++ b/src/frontend/features/paintings/components/PaintingInput.tsx
@@ -33,7 +33,10 @@ import { useModelById, useModels, useProviders } from '@/frontend/hooks/chat';
 import { isUniqueModelId, type UniqueModelId } from '@/shared/data/types/model';
 import type { Painting } from '@/shared/data/types/painting';
 import { isImageGenerationModel } from '@/shared/utils/modelPurpose';
-import { supportsPaintingGenerationMode } from '@/shared/utils/paintingModelSupport';
+import {
+  resolvePaintingGenerationMode,
+  supportsPaintingGenerationMode,
+} from '@/shared/utils/paintingModelSupport';
 
 import type {
   PaintingGenerationInput,
@@ -104,18 +107,13 @@ export function PaintingInput({
   const selectedModelLabel = selectedModel?.name ?? historicalModelLabel(painting);
   const attachmentCount = attachments.length;
   const requestedMode = attachmentCount > 0 ? 'edit' : 'generate';
-  const isSelectedModelModeCompatible = supportsPaintingGenerationMode(
-    selectedModel,
-    requestedMode,
-  );
+  const selectedMode = resolvePaintingGenerationMode(selectedModel, attachmentCount > 0);
+  const isSelectedModelModeCompatible = selectedMode !== undefined;
   const resolvedMode = useMemo(
-    () =>
-      isSelectedModelModeCompatible
-        ? resolveImageGenerationMode(selectedModel?.imageGeneration, attachmentCount > 0)
-        : undefined,
-    [attachmentCount, isSelectedModelModeCompatible, selectedModel?.imageGeneration],
+    () => resolveImageGenerationMode(selectedModel?.imageGeneration, selectedMode),
+    [selectedMode, selectedModel?.imageGeneration],
   );
-  const generationMode = resolvedMode?.mode ?? requestedMode;
+  const generationMode = selectedMode ?? requestedMode;
   const paramValues = reconcileImageParamDraft(paramState?.values ?? {}, resolvedMode);
   const paramFields = getImageParamFields(resolvedMode);
   const settingsSummary = imageParamSummary(t, paramFields, paramValues);
@@ -189,12 +187,9 @@ export function PaintingInput({
         throw new Error('Select an available image generation model');
       }
       const submittedAttachmentCount = attachments.length;
-      const requestedSubmittedMode = submittedAttachmentCount > 0 ? 'edit' : 'generate';
-      const submittedMode = resolveImageGenerationMode(
-        selectedModel?.imageGeneration,
-        submittedAttachmentCount > 0,
-      );
-      const mode = submittedMode?.mode ?? requestedSubmittedMode;
+      const mode = resolvePaintingGenerationMode(selectedModel, submittedAttachmentCount > 0);
+      if (!mode) throw new Error('The selected model does not support these image inputs');
+      const submittedMode = resolveImageGenerationMode(selectedModel?.imageGeneration, mode);
       if (submittedMode?.definition.requirePrompt !== false && text.trim().length === 0) {
         throw new Error('Image prompt is required');
       }

--- a/src/shared/utils/paintingModelSupport.ts
+++ b/src/shared/utils/paintingModelSupport.ts
@@ -4,24 +4,26 @@ import type { Model } from '@/shared/data/types/model';
 
 import { isImageGenerationModel } from './modelPurpose';
 
-/**
- * Whether a model can serve the generic painting composer for the requested
- * text-to-image or image-edit interaction. Registry metadata is authoritative;
- * image endpoint declarations are the fallback for gateway models, followed by
- * legacy capability/modalities metadata.
- */
-export function supportsPaintingGenerationMode(
+/** Resolve the API mode separately from whether the user supplied reference images. */
+export function resolvePaintingGenerationMode(
   model: Model | undefined,
-  mode: Extract<ImageGenerationMode, 'edit' | 'generate'>,
-): boolean {
-  if (!model) {
-    return false;
+  hasInputImages: boolean,
+): Extract<ImageGenerationMode, 'edit' | 'generate'> | undefined {
+  if (!model) return undefined;
+
+  const modes = model.imageGeneration?.modes;
+  if (modes) {
+    if (!hasInputImages) return modes.generate ? 'generate' : undefined;
+    if (modes.edit && modes.edit.maxInputImages !== 0) return 'edit';
+    const generate = modes.generate;
+    const acceptsReferenceImages =
+      generate?.maxInputImages !== 0 &&
+      (model.inputModalities?.includes(MODALITY.IMAGE) === true ||
+        (generate?.maxInputImages ?? 0) > 0);
+    return generate && acceptsReferenceImages ? 'generate' : undefined;
   }
 
-  if (model.imageGeneration) {
-    return Boolean(model.imageGeneration.modes[mode]);
-  }
-
+  const mode = hasInputImages ? 'edit' : 'generate';
   const imageEndpointTypes =
     model.endpointTypes?.filter(
       (endpointType) =>
@@ -29,13 +31,22 @@ export function supportsPaintingGenerationMode(
         endpointType === ENDPOINT_TYPE.OPENAI_IMAGE_EDIT,
     ) ?? [];
   if (imageEndpointTypes.length > 0) {
-    const requiredEndpoint =
-      mode === 'edit' ? ENDPOINT_TYPE.OPENAI_IMAGE_EDIT : ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION;
-    return imageEndpointTypes.includes(requiredEndpoint);
+    const requiredEndpoint = hasInputImages
+      ? ENDPOINT_TYPE.OPENAI_IMAGE_EDIT
+      : ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION;
+    return imageEndpointTypes.includes(requiredEndpoint) ? mode : undefined;
   }
 
-  return (
-    isImageGenerationModel(model) &&
-    (mode === 'generate' || model.inputModalities?.includes(MODALITY.IMAGE) === true)
-  );
+  return isImageGenerationModel(model) &&
+    (!hasInputImages || model.inputModalities?.includes(MODALITY.IMAGE) === true)
+    ? mode
+    : undefined;
+}
+
+/** `edit` here describes an image-input interaction, including generate with references. */
+export function supportsPaintingGenerationMode(
+  model: Model | undefined,
+  mode: Extract<ImageGenerationMode, 'edit' | 'generate'>,
+): boolean {
+  return resolvePaintingGenerationMode(model, mode === 'edit') !== undefined;
 }


### PR DESCRIPTION
### What this PR does

Before this PR, the painting screen could offer catalog models that failed at request routing or silently lost image-generation parameters. Reference images were also rejected for models that accept them through their generate mode.

After this PR:

- DashScope Qwen Image 3.0/Pro and TokenHub Hunyuan, Seedream, and Vidu use the dedicated request and response protocols implemented on desktop.
- PPIO Seedream selects its request body from the catalog endpoint, preserving edit images, size, and watermark settings for existing model IDs.
- Custom transports receive canonical parameters, preserving negative prompts and ModelScope steps/guidance. CherryIN options reach the namespace its image wrapper reads.
- Reference-image generation resolves the same API mode in the UI and backend. Catalog-driven adapters reject unsupported model/endpoint descriptions before execution.

### Screenshots or videos

No visual layout changes. Device/UI acceptance was not run under the task's verification constraints; this PR remains a draft.

### Why we need it and why it was done in this way

The mobile catalog and execution adapters had diverged. This ports the relevant desktop behavior into the existing Mobile painting pipeline and adds regression cases for final HTTP request bodies, asynchronous task handling, provider selection, parameter delivery, and reference-image modes.

Desktop comparison: `CherryHQ/cherry-studio@e131f495a9af593ec873bea34b935e97d644f586`. PPIO endpoint dispatch also fixes an ID-matching defect shared by the desktop source. Existing model IDs and the Mobile job/data architecture are preserved; no catalog data, migrations, dependencies, or desktop synchronization baselines change.

### Breaking changes

None intended. Previously exposed catalog routes without a supported local implementation are now rejected explicitly.

### Special notes for your reviewer

Validation:

- Passed: `pnpm format:check` and `git diff --check`.
- Passed with two existing warnings: `oxlint` on changed files.
- `pnpm lint` could not pass: seven `import/no-unresolved` errors point to `@cherrystudio/ai-core` exports because `packages/ai-core/dist` is absent in this workspace. Building that package was outside the authorized checks.
- Tests were added but not run. Typechecking, builds, device acceptance, and live provider requests were not run under the user's verification constraints.
- The before/after desktop audit reports no invariant failures. Broader `provider-registry` drift and unbaselined `ai-core`/`services` classifications remain unchanged; this PR does not claim whole-domain parity.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the behavior changes and validation limits
- [ ] Preview: Device evidence is pending
- [x] Code: Changes follow the existing provider and painting boundaries
- [x] Upgrade: Existing persisted model IDs are preserved; no migration is needed
- [x] Documentation: No user-guide update is required for these compatibility fixes
- [x] Self-review: Reviewed the source changes and final diff

### Release note

```release-note
Fix painting model routing and parameter delivery for DashScope, TokenHub, PPIO, ModelScope, and CherryIN, and allow reference images for models that support them through generation mode.
```
