### PR TITLE
fix(android-notifications): quiet foreground tasks and restore tapped targets

### DIFF
--- a/docs/references/android-background-generation.md
+++ b/docs/references/android-background-generation.md
@@ -7,7 +7,9 @@ and delivers local completion/approval notifications with
 The app owns task counting, content, cancellation, and route selection. A scoped
 [`react-native-background-actions` patch](../../patches/react-native-background-actions@4.1.0.patch)
 adds native visibility handling to the library's existing service. The library still owns Headless
-JS and wake locks; the app adds no service or notification receiver.
+JS and wake locks; the app adds no service or notification receiver. An
+[`expo-notifications` patch](../../patches/expo-notifications@57.0.5.patch) exposes Android's
+post-presentation event so task acknowledgement can follow asynchronous native delivery.
 
 ## Ownership And Behavior
 
@@ -28,10 +30,15 @@ JS and wake locks; the app adds no service or notification receiver.
 - Foreground completion stays silent. Failure and approval use an injected presentation event;
   App Shell shows a toast only when the corresponding task is not already visible. Neither path
   schedules a foreground system notification. Delivery rechecks app state and preserves the state
-  at the event boundary, so queued foreground completion cannot become a background alert.
+  at the event boundary, so queued foreground completion cannot become a background alert. Approval
+  and failure use the state at delivery: if the user has since left, they still receive a system
+  notification rather than losing both forms of attention.
 - A focused foreground chat or painting surface dismisses that task's presented notifications,
   including deliveries racing foreground entry. Chat behind the drawer, unloaded surfaces, other
   tasks, and unrelated notifications remain unacknowledged. In-flight reads are invalidated on blur.
+  The screen subscribes before reading presented notifications. Its second path listens to
+  `addNotificationPresentedListener`, emitted after Android's `notify()` call, including background
+  delivery that never emits a JavaScript receipt event.
 - `BackgroundActivitySession.finish()` resolves after queued platform delivery. Painting awaits
   it before returning to `JobRuntime`, so execution protection includes the final notification.
 - Job execution retains its lease while the dispatcher claims queued successors, including after
@@ -40,6 +47,9 @@ JS and wake locks; the app adds no service or notification receiver.
 - Platform interruption aborts domain work before asynchronous cancellation writes. Chat waits for
   its current turn's persistence to finish; completed old updates and budget cancellation cannot
   release execution protection owned by newer work.
+  Native service destruction also clears the library's running state before notifying this runtime
+  to interrupt its current leases. Expected stops and events from an older service generation do
+  not interrupt newer work. New foreground tasks can start protection after cancellation drains.
 - Each chat turn sends at most one terminal notification. Late title projection does not repost a
   notice the user has dismissed. Foreground completion stays silent even if the app backgrounds
   while its title is still being generated.
@@ -51,8 +61,10 @@ JS and wake locks; the app adds no service or notification receiver.
   identity; painting links open the composer/task page, which can show generating, failed, and
   completed results without a selected image. Old chat links with `agentId` and old painting paths
   remain readable. The image viewer redirects old task links lacking `fileEntryId` to the task page.
-  The painting task route uses `paintingId` as its navigation identity, so opening another task
-  cannot reuse an unrelated composer's mounted draft or generation state.
+  The painting task route uses `paintingId` as its navigation identity. Edit and resize routes use
+  their unique draft handoff token instead, even when they reference the same source painting.
+  Admission clears the route's handoff token and sets the newly created task id without remounting
+  the composer. An unsubmitted edit does not acknowledge the source painting's notifications.
   No backend navigation callback or custom pending-link registry is needed.
 - iOS keeps its existing audio/Live Activity implementation. Shared session completion and job
   handoff changes apply to both platforms. The background-actions native module is
@@ -109,10 +121,10 @@ playback, boot restarts, exact alarms, full-screen intents, or promoted Live Upd
 Android 15+ limits `dataSync` background execution to six hours; bringing the app to the foreground
 resets its budget. The adapter interrupts work one minute before that boundary, drains normal
 cancellation, and stops the library service. More background jobs are interrupted until the app
-returns to the foreground. This timer is an application cutoff, not an observation of native service
-state: background-actions does not expose Android's `onTimeout` as a JavaScript event. Its native
-`onTimeout` stops the service if the system reaches its limit first. No library API promises recovery
-from arbitrary earlier system termination; interrupted work is reconciled at the next process start.
+returns to the foreground. This timer is an application cutoff. If native `onTimeout` or a rejected
+foreground promotion stops the service first, the patched destruction event interrupts current work
+while JavaScript remains alive. It does not restart paid requests. Whole-process termination still
+requires reconciliation at the next process start.
 See [Android service timeouts](https://developer.android.com/develop/background-work/services/fgs/timeout).
 
 The notification permission is requested in context after a task's service starts. Denial does not
@@ -145,12 +157,12 @@ Expo Notifications is pinned to `57.0.5`, the version range recommended by the c
 
 The app still needs its own domain cancellation and concurrent-task counting. Those are business
 rules, not capabilities an execution or notification library can infer. The Android background
-cutoff is deliberately explicit rather than pretending the library's iOS-only `expiration` event
-also observes Android service termination.
+cutoff remains explicit; Android destruction uses the patched `stopped` event, separately from the
+library's iOS-only `expiration` event.
 
 ## Verification And Development Client
 
-These native dependencies, the visibility patch, and config plugins require a rebuilt development client. Metro reloads
+These native dependencies, both patches, and config plugins require a rebuilt development client. Metro reloads
 and EAS Updates cannot add native modules. Use [Local EAS Builds](../guides/local-builds.md) when a
 build is authorized. Compatibility with Cherry's Expo 57 / React Native 0.86 and device behavior
 must be verified in that client; source review and lint do not establish runtime compatibility.
@@ -158,8 +170,9 @@ must be verified in that client; source review and lint do not establish runtime
 Regression suites describe concurrent leases, foreground-only admission, permission denial,
 background-budget reset/cancellation, approval cleanup, single completion delivery, and awaiting
 painting notification delivery before task completion. Additional cases cover foreground event
-delivery races, task-scoped notification cleanup, cold-start navigation, and legacy task URLs. An
-installed-source guard protects the native patch against dependency upgrades; it does not prove
+delivery races, post-presentation task cleanup, cold-start navigation, task-versus-draft route
+identity, and legacy task URLs. Library lifecycle coverage exercises stopped-event ordering and
+stale generation rejection. Installed-source guards protect both native patches against dependency upgrades; they do not prove
 Android runtime behavior. Device acceptance should cover foreground/background service transitions,
 notification-shade interaction, rapid return and exit, screen lock, concurrent chat/painting, denied
 notification permission, completion/approval taps from a cold app, and system termination without

--- a/docs/references/android-background-generation.md
+++ b/docs/references/android-background-generation.md
@@ -51,8 +51,7 @@ post-presentation event so task acknowledgement can follow asynchronous native d
   to interrupt its current leases. Expected stops and events from an older service generation do
   not interrupt newer work. New foreground tasks can start protection after cancellation drains.
 - Each chat turn sends at most one terminal notification. Late title projection does not repost a
-  notice the user has dismissed. Foreground completion stays silent even if the app backgrounds
-  while its title is still being generated.
+  notice the user has dismissed.
 - Expo retains cold notification responses. App Shell uses `useLastNotificationResponse`, waits for
   navigation to mount, consumes each response, and navigates only when its task is not already
   visible. Opened notifications are dismissed. The task URL contract
@@ -61,10 +60,8 @@ post-presentation event so task acknowledgement can follow asynchronous native d
   identity; painting links open the composer/task page, which can show generating, failed, and
   completed results without a selected image. Old chat links with `agentId` and old painting paths
   remain readable. The image viewer redirects old task links lacking `fileEntryId` to the task page.
-  The painting task route uses `paintingId` as its navigation identity. Edit and resize routes use
-  their unique draft handoff token instead, even when they reference the same source painting.
-  Admission clears the route's handoff token and sets the newly created task id without remounting
-  the composer. An unsubmitted edit does not acknowledge the source painting's notifications.
+  Task and draft route identities follow [Navigation And Insets](./navigation-and-insets.md).
+  An unsubmitted edit does not acknowledge the source painting's notifications.
   No backend navigation callback or custom pending-link registry is needed.
 - iOS keeps its existing audio/Live Activity implementation. Shared session completion and job
   handoff changes apply to both platforms. The background-actions native module is

--- a/docs/references/android-background-generation.md
+++ b/docs/references/android-background-generation.md
@@ -4,23 +4,34 @@ Android continues user-started chat and image generation with
 [`react-native-background-actions`](https://github.com/Rapsssito/react-native-background-actions)
 and delivers local completion/approval notifications with
 [`expo-notifications`](https://docs.expo.dev/versions/latest/sdk/notifications/).
-The app owns task counting, content, cancellation, and route selection. It does not implement or
-patch a native service, native notification receiver, or wake-lock manager.
+The app owns task counting, content, cancellation, and route selection. A scoped
+[`react-native-background-actions` patch](../../patches/react-native-background-actions@4.1.0.patch)
+adds native visibility handling to the library's existing service. The library still owns Headless
+JS and wake locks; the app adds no service or notification receiver.
 
 ## Ownership And Behavior
 
 - `KeepAliveCoordinator` selects `AndroidBackgroundActivityRuntime` as its lease source on Android.
   Chat and painting keep acquiring leases through the coordinator and never branch on platform.
-  Concurrent chat and painting work share one `dataSync` foreground service. The last lease stops it.
+  Concurrent chat and painting work share one execution service. It becomes a `dataSync` foreground
+  service only while the application is not visible. The last lease stops it.
 - `react-native-background-actions` uses React Native's `HeadlessJsTaskService`, which owns the
   Headless JS task and a partial wake lock. The lock supports CPU execution with the screen off;
   it does not bypass Android Doze, vendor power management, process death, or user force-stop.
-- The library's ordinary ongoing notification shows task progress and opens the current task via
-  `linkingURI`. Stopping a task uses its existing in-app control; Android also exposes its system
+- The library's ongoing notification is silent and shows task progress only outside the app. A
+  single task opens its task surface via `linkingURI`; an aggregate restores the app rather than
+  selecting an arbitrary task. Stopping a task uses its existing in-app control; Android also exposes its system
   foreground-service stop control. There is no custom notification stop receiver.
 - Chat and painting share the existing presenter contract. Completion, failure, and pending tool
   approval produce Expo local notifications in the background. Approval requires opening the app;
   there is no notification action that approves a tool.
+- Foreground completion stays silent. Failure and approval use an injected presentation event;
+  App Shell shows a toast only when the corresponding task is not already visible. Neither path
+  schedules a foreground system notification. Delivery rechecks app state and preserves the state
+  at the event boundary, so queued foreground completion cannot become a background alert.
+- A focused foreground chat or painting surface dismisses that task's presented notifications,
+  including deliveries racing foreground entry. Chat behind the drawer, unloaded surfaces, other
+  tasks, and unrelated notifications remain unacknowledged. In-flight reads are invalidated on blur.
 - `BackgroundActivitySession.finish()` resolves after queued platform delivery. Painting awaits
   it before returning to `JobRuntime`, so execution protection includes the final notification.
 - Job execution retains its lease while the dispatcher claims queued successors, including after
@@ -33,10 +44,16 @@ patch a native service, native notification receiver, or wake-lock manager.
   notice the user has dismissed. Foreground completion stays silent even if the app backgrounds
   while its title is still being generated.
 - Expo retains cold notification responses. App Shell uses `useLastNotificationResponse`, waits for
-  navigation to mount, and passes allowed task destinations to Expo Router. The task URL contract
+  navigation to mount, consumes each response, and navigates only when its task is not already
+  visible. Opened notifications are dismissed. The task URL contract
   lives in [`taskLink.ts`](../../src/shared/backgroundActivity/taskLink.ts): the backend builds
-  every task URL with it and App Shell maps its parsed links to routes. No backend navigation
-  callback or custom pending-link registry is needed.
+  every task URL with it and App Shell maps its parsed links to routes. Chat links use session
+  identity; painting links open the composer/task page, which can show generating, failed, and
+  completed results without a selected image. Old chat links with `agentId` and old painting paths
+  remain readable. The image viewer redirects old task links lacking `fileEntryId` to the task page.
+  The painting task route uses `paintingId` as its navigation identity, so opening another task
+  cannot reuse an unrelated composer's mounted draft or generation state.
+  No backend navigation callback or custom pending-link registry is needed.
 - iOS keeps its existing audio/Live Activity implementation. Shared session completion and job
   handoff changes apply to both platforms. The background-actions native module is
   excluded from iOS autolinking. Expo Notifications is installed through its standard Expo plugin;
@@ -73,8 +90,20 @@ result processing. This maps the feature to Android's documented fetching/cloud-
 Google Play review still determines whether a distribution is accepted. See
 [foreground service types](https://developer.android.com/develop/background-work/services/fgs/service-types#data-sync).
 
-A new service starts only while the application is visible. Running services can update in the
-background. There are no timer-triggered background restarts, battery exemptions, silent media
+A new service starts only while the application is visible, using `startService` without a
+notification. The native service observes AndroidX `ProcessLifecycleOwner`: `ON_STOP` promotes the
+existing service using Android's visible-to-background exemption; `ON_START` removes foreground
+status and its notification. Both transitions retain the same Headless JS task and business
+requests. Process visibility also avoids treating notification-shade focus changes or activity
+recreation as a request to restart execution.
+
+Content updates go through the service's visibility gate; a delayed JavaScript update cannot repost
+the ongoing notification over a foreground screen. Update intents never start another Headless JS
+task, and a late update to a stopped service ends without reviving work. The service returns
+`START_NOT_STICKY` to prevent replay after process death. The patch also scopes ongoing notification
+intents to this package and reuses the existing Activity when tapped.
+
+There are no timer-triggered background restarts, battery exemptions, silent media
 playback, boot restarts, exact alarms, full-screen intents, or promoted Live Updates.
 
 Android 15+ limits `dataSync` background execution to six hours; bringing the app to the foreground
@@ -93,6 +122,8 @@ See [notification permission behavior](https://developer.android.com/develop/ui/
 The app declares `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `WAKE_LOCK`, and
 `POST_NOTIFICATIONS`. [The Expo config plugin](../../scripts/withAndroidBackgroundGeneration.js)
 only declares the existing library service as `dataSync`; Expo Notifications supplies the icon.
+The native patch explicitly depends on the same AndroidX lifecycle-process version as Expo
+Notifications, rather than relying on that dependency being transitively available.
 Unused boot-receiver permission is blocked. Before Play distribution, complete its
 [foreground-service declaration](https://support.google.com/googleplay/android-developer/answer/13392821).
 
@@ -105,7 +136,7 @@ Expo Notifications is pinned to `57.0.5`, the version range recommended by the c
 
 | Option | Decision |
 | --- | --- |
-| `react-native-background-actions` + `expo-notifications` | Selected. Standard RN background execution owns the wake lock; Expo owns local alerts, permission requests, and notification responses. The running notification uses the execution library's built-in content and deep link. |
+| `react-native-background-actions` + `expo-notifications` | Selected. Standard RN background execution owns the wake lock; Expo owns local alerts, permission requests, and notification responses. A scoped native patch separates service execution from foreground-notification visibility. |
 | `react-native-notify-kit` alone | Rejected for this integration. Its foreground-service Headless JS path does not hold a task-lifetime wake lock. Our prior approach also required three native corrections and a private timeout event mapping; all are removed. |
 | `expo-notifications` alone | Does not provide a long-running foreground execution service. |
 | `expo-background-task` / WorkManager | Useful for deferrable persistent work; does not directly preserve the in-progress interactive JS stream. |
@@ -119,14 +150,18 @@ also observes Android service termination.
 
 ## Verification And Development Client
 
-These native dependencies and config plugins require a rebuilt development client. Metro reloads
+These native dependencies, the visibility patch, and config plugins require a rebuilt development client. Metro reloads
 and EAS Updates cannot add native modules. Use [Local EAS Builds](../guides/local-builds.md) when a
 build is authorized. Compatibility with Cherry's Expo 57 / React Native 0.86 and device behavior
 must be verified in that client; source review and lint do not establish runtime compatibility.
 
 Regression suites describe concurrent leases, foreground-only admission, permission denial,
 background-budget reset/cancellation, approval cleanup, single completion delivery, and awaiting
-painting notification delivery before task completion. Device acceptance should cover screen lock,
-concurrent chat/painting, denied notification permission, completion/approval taps from a cold app,
-and system termination without replaying paid requests. Follow
+painting notification delivery before task completion. Additional cases cover foreground event
+delivery races, task-scoped notification cleanup, cold-start navigation, and legacy task URLs. An
+installed-source guard protects the native patch against dependency upgrades; it does not prove
+Android runtime behavior. Device acceptance should cover foreground/background service transitions,
+notification-shade interaction, rapid return and exit, screen lock, concurrent chat/painting, denied
+notification permission, completion/approval taps from a cold app, and system termination without
+replaying paid requests. Follow
 [Testing And CI](../guides/testing-and-ci.md) and the active task's authorization before running checks.

--- a/docs/references/navigation-and-insets.md
+++ b/docs/references/navigation-and-insets.md
@@ -90,6 +90,12 @@ and other entity-owned state reset through a keyed component boundary. Data from
 identity must not be used as placeholder data. Cached data for the same identity may render while it
 refreshes in the background when that product surface permits stale-while-revalidate behavior.
 
+The `/paintings` route distinguishes an existing task from a new editing draft. A task is identified
+by `paintingId`; an edit or resize is identified by its unique `handoff` token, with `paintingId`
+only selecting the source painting/model. When generation is admitted, the route clears `handoff`
+and adopts the new task's `paintingId` without remounting its composer. Task notification navigation
+can then reuse that page, while another edit always owns a fresh draft.
+
 ## Chat Identity Contract
 
 The chat route has two complete identities:

--- a/patches/expo-notifications@57.0.5.patch
+++ b/patches/expo-notifications@57.0.5.patch
@@ -1,0 +1,157 @@
+diff --git a/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.kt b/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.kt
+index 2e51957f7f60aee86b86c068fda34f1174d61185..64b25dfa0b237ac131ee8365536c83c68d31bcef 100644
+--- a/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.kt
++++ b/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.kt
+@@ -72,6 +72,13 @@ object NotificationManager {
+     }
+   }
+ 
++  /** Presentation is a separate event: background delivery may skip onNotificationReceived. */
++  fun onNotificationPresented(notification: Notification) {
++    for (listener in listeners) {
++      listener.onNotificationPresented(notification)
++    }
++  }
++
+   /**
+    * Used by [expo.modules.notifications.service.delegates.ExpoSchedulingDelegate] to notify of new notification responses.
+    * Calls [NotificationListener.onNotificationResponseReceived] on all registered [listeners].
+diff --git a/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt b/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+index af020ccaa28c2ecefce5c5c7a4830cd4d953347d..8a0bd5ae8f9fe119c6c2c7e5458d736ebe56cc1f 100644
+--- a/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
++++ b/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+@@ -22,6 +22,7 @@ open class NotificationsEmitter : Module(), NotificationListener {
+ 
+     Events(
+       "onDidReceiveNotification",
++      "onDidPresentNotification",
+       "onNotificationsDeleted",
+       "onDidReceiveNotificationResponse"
+     )
+@@ -57,6 +58,10 @@ open class NotificationsEmitter : Module(), NotificationListener {
+     sendEvent(NEW_MESSAGE_EVENT_NAME, bundle)
+   }
+ 
++  override fun onNotificationPresented(notification: Notification) {
++    sendEvent("onDidPresentNotification", NotificationSerializer.toBundle(notification))
++  }
++
+   /**
+    * Callback called when [NotificationManager] gets notified of a new notification response.
+    * Emits a [NEW_RESPONSE_EVENT_NAME] event.
+diff --git a/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.kt b/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.kt
+index 10392b94027261af3e6827a09bddeea4492b2d0b..e036c646ad70a1b85474f00d46449a2363adc37f 100644
+--- a/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.kt
++++ b/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.kt
+@@ -12,6 +12,9 @@ interface NotificationListener {
+   /** Callback called when new notification is received while the app is in foreground. */
+   fun onNotificationReceived(notification: Notification) {}
+ 
++  /** Callback after the notification has been posted to the system notification manager. */
++  fun onNotificationPresented(notification: Notification) {}
++
+   /**
+    * Callback called when new notification response is received.
+    * @return Whether the notification response has been handled
+diff --git a/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt b/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+index 38f6fbaf0c595009031fff8659dcd2def12e5205..88be89da9f0ce44a8e9f11c7852c8a61ab489a0f 100644
+--- a/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
++++ b/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+@@ -24,6 +24,7 @@ import expo.modules.notifications.service.interfaces.PresentationDelegate
+ import kotlinx.coroutines.CoroutineScope
+ import kotlinx.coroutines.Dispatchers
+ import kotlinx.coroutines.launch
++import kotlinx.coroutines.withContext
+ import org.json.JSONException
+ import org.json.JSONObject
+ import java.util.Date
+@@ -110,6 +111,11 @@ open class ExpoPresentationDelegate(
+         getNotifyId(notification.notificationRequest),
+         androidNotification
+       )
++      // Publish only after notify(), including deliveries admitted in the background.
++      // A focused screen can now dismiss a post that raced its foreground snapshot.
++      withContext(Dispatchers.Main) {
++        expo.modules.notifications.notifications.NotificationManager.onNotificationPresented(notification)
++      }
+     }
+   }
+ 
+diff --git a/build/NotificationsEmitter.d.ts b/build/NotificationsEmitter.d.ts
+index d1325837c89dbbbb93941e83315b4212cf8de0c3..f86620f3943562a49442b325f7cdcea46bd3e144 100644
+--- a/build/NotificationsEmitter.d.ts
++++ b/build/NotificationsEmitter.d.ts
+@@ -26,6 +26,12 @@ export declare const DEFAULT_ACTION_IDENTIFIER = "expo.modules.notifications.act
+  * @header listen
+  */
+ export declare function addNotificationReceivedListener(listener: (event: Notification) => void): EventSubscription;
++/**
++ * Called after Android posts a notification, including asynchronous background delivery.
++ * This is distinct from receipt, which can precede presentation or suppress it entirely.
++ * @platform android
++ */
++export declare function addNotificationPresentedListener(listener: (event: Notification) => void): EventSubscription;
+ /**
+  * Listeners registered by this method will be called whenever some notifications have been dropped by the server.
+  * Applicable only to Firebase Cloud Messaging which we use as a notifications service on Android. It corresponds to `onDeletedMessages()` callback.
+diff --git a/build/NotificationsEmitter.js b/build/NotificationsEmitter.js
+index 3496828885611f40ec60e0136e8f99ca379771d4..ce3908b63fe5872cab1133032f4f79a437012fb0 100644
+--- a/build/NotificationsEmitter.js
++++ b/build/NotificationsEmitter.js
+@@ -4,6 +4,7 @@ import { mapNotification, mapNotificationResponse } from './utils/mapNotificatio
+ // Web uses SyntheticEventEmitter
+ const emitter = new LegacyEventEmitter(NotificationsEmitterModule);
+ const didReceiveNotificationEventName = 'onDidReceiveNotification';
++const didPresentNotificationEventName = 'onDidPresentNotification';
+ const didDropNotificationsEventName = 'onNotificationsDeleted';
+ const didReceiveNotificationResponseEventName = 'onDidReceiveNotificationResponse';
+ const didClearNotificationResponseEventName = 'onDidClearNotificationResponse';
+@@ -39,6 +40,16 @@ export function addNotificationReceivedListener(listener) {
+         listener(mappedNotification);
+     });
+ }
++/**
++ * Called after Android posts a notification, including asynchronous background delivery.
++ * This is distinct from receipt, which can precede presentation or suppress it entirely.
++ * @platform android
++ */
++export function addNotificationPresentedListener(listener) {
++    return emitter.addListener(didPresentNotificationEventName, (notification) => {
++        listener(mapNotification(notification));
++    });
++}
+ /**
+  * Listeners registered by this method will be called whenever some notifications have been dropped by the server.
+  * Applicable only to Firebase Cloud Messaging which we use as a notifications service on Android. It corresponds to `onDeletedMessages()` callback.
+diff --git a/src/NotificationsEmitter.ts b/src/NotificationsEmitter.ts
+index 99bc0e235d49688721e0b80e8bdfd98156c6207b..ab4b2da2fdd0bea296c0ae0220ae59d92304f0dd 100644
+--- a/src/NotificationsEmitter.ts
++++ b/src/NotificationsEmitter.ts
+@@ -8,6 +8,7 @@ import { mapNotification, mapNotificationResponse } from './utils/mapNotificatio
+ const emitter = new LegacyEventEmitter(NotificationsEmitterModule);
+ 
+ const didReceiveNotificationEventName = 'onDidReceiveNotification';
++const didPresentNotificationEventName = 'onDidPresentNotification';
+ const didDropNotificationsEventName = 'onNotificationsDeleted';
+ const didReceiveNotificationResponseEventName = 'onDidReceiveNotificationResponse';
+ const didClearNotificationResponseEventName = 'onDidClearNotificationResponse';
+@@ -51,6 +52,19 @@ export function addNotificationReceivedListener(
+   );
+ }
+ 
++/**
++ * Called after Android posts a notification, including asynchronous background delivery.
++ * This is distinct from receipt, which can precede presentation or suppress it entirely.
++ * @platform android
++ */
++export function addNotificationPresentedListener(
++  listener: (event: Notification) => void
++): EventSubscription {
++  return emitter.addListener<Notification>(didPresentNotificationEventName, (notification) => {
++    listener(mapNotification(notification));
++  });
++}
++
+ /**
+  * Listeners registered by this method will be called whenever some notifications have been dropped by the server.
+  * Applicable only to Firebase Cloud Messaging which we use as a notifications service on Android. It corresponds to `onDeletedMessages()` callback.

--- a/patches/react-native-background-actions@4.1.0.patch
+++ b/patches/react-native-background-actions@4.1.0.patch
@@ -1,0 +1,273 @@
+diff --git a/android/build.gradle b/android/build.gradle
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -19,6 +19,8 @@
+ }
+ 
+ dependencies {
++    // Matches Expo Notifications; owns process visibility across activity switches.
++    implementation 'androidx.lifecycle:lifecycle-process:2.9.3'
+     //noinspection GradleDynamicVersion
+     implementation 'com.facebook.react:react-native:+'  // From node_modules
+ }
+diff --git a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java b/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java
+--- a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java
++++ b/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java
+@@ -1,12 +1,8 @@
+ package com.asterinet.react.bgactions;
+ 
+-import android.app.Notification;
+-import android.app.NotificationManager;
+-import android.content.Context;
+ import android.content.Intent;
+ 
+ import androidx.annotation.NonNull;
+-import androidx.core.content.ContextCompat;
+ 
+ import com.facebook.react.bridge.Promise;
+ import com.facebook.react.bridge.ReactApplicationContext;
+@@ -14,6 +10,7 @@
+ import com.facebook.react.bridge.ReactContextBaseJavaModule;
+ import com.facebook.react.bridge.ReactMethod;
+ import com.facebook.react.bridge.ReadableMap;
++import com.facebook.react.bridge.UiThreadUtil;
+ 
+ @SuppressWarnings("WeakerAccess")
+ public class BackgroundActionsModule extends ReactContextBaseJavaModule {
+@@ -38,49 +35,63 @@
+     @SuppressWarnings("unused")
+     @ReactMethod
+     public void start(@NonNull final ReadableMap options, @NonNull final Promise promise) {
+-        try {
+-            // Stop any other intent
+-            if (currentServiceIntent != null) {
+-                reactContext.stopService(currentServiceIntent);
++        UiThreadUtil.runOnUiThread(() -> {
++            try {
++                if (!RNBackgroundActionsTask.isAppVisible()) {
++                    throw new IllegalStateException("Background tasks must be admitted while the app is visible");
++                }
++                // Stop any other intent
++                if (currentServiceIntent != null) {
++                    reactContext.stopService(currentServiceIntent);
++                }
++                // Create the service
++                currentServiceIntent = new Intent(reactContext, RNBackgroundActionsTask.class);
++                // Get the task info from the options
++                final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(reactContext, options);
++                currentServiceIntent.putExtras(bgOptions.getExtras());
++                // The visible app owns execution. The service promotes itself at
++                // the native visibility boundary without restarting Headless JS.
++                reactContext.startService(currentServiceIntent);
++                promise.resolve(null);
++            } catch (Exception e) {
++                currentServiceIntent = null;
++                promise.reject(e);
+             }
+-            // Create the service
+-            currentServiceIntent = new Intent(reactContext, RNBackgroundActionsTask.class);
+-            // Get the task info from the options
+-            final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(reactContext, options);
+-            currentServiceIntent.putExtras(bgOptions.getExtras());
+-            // Start the task
+-            // startForegroundService on Android 8+ (API 26+), startService below
+-            ContextCompat.startForegroundService(reactContext, currentServiceIntent);
+-            promise.resolve(null);
+-        } catch (Exception e) {
+-            promise.reject(e);
+-        }
++        });
+     }
+ 
+     @SuppressWarnings("unused")
+     @ReactMethod
+     public void stop(@NonNull final Promise promise) {
+-        if (currentServiceIntent != null) {
+-            reactContext.stopService(currentServiceIntent);
+-            currentServiceIntent = null;
+-        }
+-        promise.resolve(null);
++        UiThreadUtil.runOnUiThread(() -> {
++            if (currentServiceIntent != null) {
++                reactContext.stopService(currentServiceIntent);
++                currentServiceIntent = null;
++            }
++            promise.resolve(null);
++        });
+     }
+ 
+     @SuppressWarnings("unused")
+     @ReactMethod
+     public void updateNotification(@NonNull final ReadableMap options, @NonNull final Promise promise) {
+-        // Get the task info from the options
+-        try {
+-            final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(reactContext, options);
+-            final Notification notification = RNBackgroundActionsTask.buildNotification(reactContext, bgOptions);
+-            final NotificationManager notificationManager = (NotificationManager) reactContext.getSystemService(Context.NOTIFICATION_SERVICE);
+-            notificationManager.notify(RNBackgroundActionsTask.SERVICE_NOTIFICATION_ID, notification);
+-        } catch (Exception e) {
+-            promise.reject(e);
+-            return;
+-        }
+-        promise.resolve(null);
++        UiThreadUtil.runOnUiThread(() -> {
++            try {
++                if (currentServiceIntent != null) {
++                    final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(reactContext, options);
++                    final Intent update = new Intent(reactContext, RNBackgroundActionsTask.class);
++                    update.setAction(RNBackgroundActionsTask.ACTION_UPDATE);
++                    update.putExtras(bgOptions.getExtras());
++                    // Only the service may post: delayed JS updates must not
++                    // recreate the notification after native foreground entry.
++                    reactContext.startService(update);
++                }
++            } catch (Exception e) {
++                promise.reject(e);
++                return;
++            }
++            promise.resolve(null);
++        });
+     }
+ 
+     @SuppressWarnings("unused")
+diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+--- a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
++++ b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+@@ -15,15 +15,52 @@
+ import androidx.annotation.Nullable;
+ import androidx.core.app.NotificationCompat;
+ import androidx.core.app.ServiceCompat;
++import androidx.lifecycle.DefaultLifecycleObserver;
++import androidx.lifecycle.Lifecycle;
++import androidx.lifecycle.LifecycleOwner;
++import androidx.lifecycle.ProcessLifecycleOwner;
+ 
+ import com.facebook.react.HeadlessJsTaskService;
+ import com.facebook.react.bridge.Arguments;
+ import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+ 
+-final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
++final public class RNBackgroundActionsTask extends HeadlessJsTaskService implements DefaultLifecycleObserver {
+ 
+     public static final int SERVICE_NOTIFICATION_ID = 92901;
+     private static final String CHANNEL_ID = "RN_BACKGROUND_ACTIONS_CHANNEL";
++    static final String ACTION_UPDATE = "com.asterinet.react.bgactions.UPDATE";
++    private BackgroundTaskOptions currentOptions;
++    private boolean foreground = false;
++
++    static boolean isAppVisible() {
++        return ProcessLifecycleOwner.get().getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED);
++    }
++
++    @Override
++    public void onCreate() {
++        super.onCreate();
++        ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
++    }
++
++    @Override
++    public void onStart(@NonNull LifecycleOwner owner) {
++        updateForeground();
++    }
++
++    @Override
++    public void onStop(@NonNull LifecycleOwner owner) {
++        // Native delivery uses Android's visible-to-background exemption,
++        // independently of how busy the JS thread is.
++        updateForeground();
++    }
++
++    @Override
++    public void onDestroy() {
++        ProcessLifecycleOwner.get().getLifecycle().removeObserver(this);
++        currentOptions = null;
++        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
++        super.onDestroy();
++    }
+ 
+     @SuppressLint("UnspecifiedImmutableFlag")
+     @NonNull
+@@ -37,6 +74,8 @@
+         Intent notificationIntent;
+         if (linkingURI != null) {
+             notificationIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(linkingURI));
++            notificationIntent.setPackage(context.getPackageName());
++            notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+         } else {
+             //as RN works on single activity architecture - we don't need to find current activity on behalf of react context
+             notificationIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+@@ -59,7 +98,9 @@
+                 .setSmallIcon(iconInt)
+                 .setContentIntent(contentIntent)
+                 .setOngoing(true)
+-                .setPriority(NotificationCompat.PRIORITY_MIN)
++                .setOnlyAlertOnce(true)
++                .setSilent(true)
++                .setPriority(NotificationCompat.PRIORITY_LOW)
+                 .setColor(color);
+ 
+         final Bundle progressBarBundle = bgOptions.getProgressBar();
+@@ -92,28 +133,49 @@
+         if (extras == null) {
+             throw new IllegalArgumentException("Extras cannot be null");
+         }
+-        final BackgroundTaskOptions bgOptions = new BackgroundTaskOptions(extras);
+-        createNotificationChannel(bgOptions.getTaskTitle(), bgOptions.getTaskDesc()); // Necessary creating channel for API 26+
+-        // Create the notification
+-        final Notification notification = buildNotification(this, bgOptions);
+-
++        final boolean update = ACTION_UPDATE.equals(intent.getAction());
++        if (update && currentOptions == null) {
++            // A late update may never revive a stopped task.
++            stopSelf(startId);
++            return START_NOT_STICKY;
++        }
++        currentOptions = new BackgroundTaskOptions(extras);
++        if (!update) {
++            createNotificationChannel(currentOptions.getTaskTitle(), currentOptions.getTaskDesc());
++        }
++        if (!updateForeground()) return START_NOT_STICKY;
++        // Content and visibility changes do not create another Headless JS task.
++        if (!update) super.onStartCommand(intent, flags, startId);
++        return START_NOT_STICKY;
++    }
++
++    private boolean updateForeground() {
++        if (currentOptions == null) return true;
++        if (isAppVisible()) {
++            if (foreground) {
++                ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
++                foreground = false;
++            }
++            return true;
++        }
++        final Notification notification = buildNotification(this, currentOptions);
+         try {
+-            ServiceCompat.startForeground(
+-                this,
+-                SERVICE_NOTIFICATION_ID,
+-                notification,
+-                bgOptions.getForegroundServiceType()
+-            );
++            if (foreground) {
++                getSystemService(NotificationManager.class).notify(SERVICE_NOTIFICATION_ID, notification);
++            } else {
++                ServiceCompat.startForeground(this, SERVICE_NOTIFICATION_ID, notification, currentOptions.getForegroundServiceType());
++                foreground = true;
++            }
+         } catch (RuntimeException e) {
+             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                     && e instanceof android.app.ForegroundServiceStartNotAllowedException) {
+                 // Android 12+: not allowed to start foreground service from background
+-                stopSelf(startId);
+-                return START_NOT_STICKY;
++                stopSelf();
++                return false;
+             }
+             throw e;
+         }
+-        return super.onStartCommand(intent, flags, startId);
++        return true;
+     }
+ 
+     @Override

--- a/patches/react-native-background-actions@4.1.0.patch
+++ b/patches/react-native-background-actions@4.1.0.patch
@@ -1,7 +1,8 @@
 diff --git a/android/build.gradle b/android/build.gradle
+index a5edbb79734e1c42f3c95da467838802c743e7b2..a792d7f0c0a48a7dce932959a96ea846f59d5e1b 100644
 --- a/android/build.gradle
 +++ b/android/build.gradle
-@@ -19,6 +19,8 @@
+@@ -19,6 +19,8 @@ android {
  }
  
  dependencies {
@@ -11,6 +12,7 @@ diff --git a/android/build.gradle b/android/build.gradle
      implementation 'com.facebook.react:react-native:+'  // From node_modules
  }
 diff --git a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java b/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java
+index 46375fd98ce4dc36efa6a3f5f0fb9a199f297280..068775c3a8f06a003b986a7e3f144704f74e3e65 100644
 --- a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java
 +++ b/android/src/main/java/com/asterinet/react/bgactions/BackgroundActionsModule.java
 @@ -1,12 +1,8 @@
@@ -26,7 +28,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActio
  
  import com.facebook.react.bridge.Promise;
  import com.facebook.react.bridge.ReactApplicationContext;
-@@ -14,6 +10,7 @@
+@@ -14,6 +10,7 @@ import com.facebook.react.bridge.ReactContext;
  import com.facebook.react.bridge.ReactContextBaseJavaModule;
  import com.facebook.react.bridge.ReactMethod;
  import com.facebook.react.bridge.ReadableMap;
@@ -34,7 +36,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActio
  
  @SuppressWarnings("WeakerAccess")
  public class BackgroundActionsModule extends ReactContextBaseJavaModule {
-@@ -38,49 +35,63 @@
+@@ -38,49 +35,63 @@ public class BackgroundActionsModule extends ReactContextBaseJavaModule {
      @SuppressWarnings("unused")
      @ReactMethod
      public void start(@NonNull final ReadableMap options, @NonNull final Promise promise) {
@@ -131,9 +133,10 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/BackgroundActio
  
      @SuppressWarnings("unused")
 diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
+index 963b7889356454d12c150398631a3d493f53b5b2..6d46dc14d2e96f36f43bfe3454a3afe60e5495e5 100644
 --- a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
 +++ b/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundActionsTask.java
-@@ -15,15 +15,52 @@
+@@ -15,15 +15,61 @@ import androidx.annotation.NonNull;
  import androidx.annotation.Nullable;
  import androidx.core.app.NotificationCompat;
  import androidx.core.app.ServiceCompat;
@@ -144,7 +147,9 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
  
  import com.facebook.react.HeadlessJsTaskService;
  import com.facebook.react.bridge.Arguments;
++import com.facebook.react.bridge.ReactContext;
  import com.facebook.react.jstasks.HeadlessJsTaskConfig;
++import com.facebook.react.modules.core.DeviceEventManagerModule;
  
 -final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
 +final public class RNBackgroundActionsTask extends HeadlessJsTaskService implements DefaultLifecycleObserver {
@@ -153,6 +158,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
      private static final String CHANNEL_ID = "RN_BACKGROUND_ACTIONS_CHANNEL";
 +    static final String ACTION_UPDATE = "com.asterinet.react.bgactions.UPDATE";
 +    private BackgroundTaskOptions currentOptions;
++    private String taskName;
 +    private boolean foreground = false;
 +
 +    static boolean isAppVisible() {
@@ -183,11 +189,17 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
 +        currentOptions = null;
 +        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
 +        super.onDestroy();
++        // JS filters expected stops and stale generations by the original task name.
++        final ReactContext context = getReactContext();
++        if (taskName != null && context != null && context.hasActiveReactInstance()) {
++            context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
++                    .emit("stopped", taskName);
++        }
 +    }
  
      @SuppressLint("UnspecifiedImmutableFlag")
      @NonNull
-@@ -37,6 +74,8 @@
+@@ -37,6 +83,8 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
          Intent notificationIntent;
          if (linkingURI != null) {
              notificationIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(linkingURI));
@@ -196,7 +208,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
          } else {
              //as RN works on single activity architecture - we don't need to find current activity on behalf of react context
              notificationIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
-@@ -59,7 +98,9 @@
+@@ -59,7 +107,9 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
                  .setSmallIcon(iconInt)
                  .setContentIntent(contentIntent)
                  .setOngoing(true)
@@ -207,7 +219,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
                  .setColor(color);
  
          final Bundle progressBarBundle = bgOptions.getProgressBar();
-@@ -92,28 +133,49 @@
+@@ -92,28 +142,50 @@ final public class RNBackgroundActionsTask extends HeadlessJsTaskService {
          if (extras == null) {
              throw new IllegalArgumentException("Extras cannot be null");
          }
@@ -215,7 +227,6 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
 -        createNotificationChannel(bgOptions.getTaskTitle(), bgOptions.getTaskDesc()); // Necessary creating channel for API 26+
 -        // Create the notification
 -        final Notification notification = buildNotification(this, bgOptions);
--
 +        final boolean update = ACTION_UPDATE.equals(intent.getAction());
 +        if (update && currentOptions == null) {
 +            // A late update may never revive a stopped task.
@@ -224,6 +235,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
 +        }
 +        currentOptions = new BackgroundTaskOptions(extras);
 +        if (!update) {
++            taskName = extras.getString("taskName");
 +            createNotificationChannel(currentOptions.getTaskTitle(), currentOptions.getTaskDesc());
 +        }
 +        if (!updateForeground()) return START_NOT_STICKY;
@@ -231,7 +243,7 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
 +        if (!update) super.onStartCommand(intent, flags, startId);
 +        return START_NOT_STICKY;
 +    }
-+
+ 
 +    private boolean updateForeground() {
 +        if (currentOptions == null) return true;
 +        if (isAppVisible()) {
@@ -271,3 +283,127 @@ diff --git a/android/src/main/java/com/asterinet/react/bgactions/RNBackgroundAct
      }
  
      @Override
+diff --git a/lib/types/index.d.ts b/lib/types/index.d.ts
+index cc9906f27b2d988ec01fc07e4096ec24b075b22e..9deaaf22e58b7bb5a31b04d376842bf8d4c791b8 100644
+--- a/lib/types/index.d.ts
++++ b/lib/types/index.d.ts
+@@ -28,15 +28,16 @@ declare const backgroundServer: BackgroundServer;
+  *            progressBar?: {max: number, value: number, indeterminate?: boolean},
+  *            foregroundServiceType?: Array<'dataSync'|'mediaPlayback'|'phoneCall'|'location'|'connectedDevice'|'mediaProjection'|'camera'|'microphone'|'health'|'remoteMessaging'|'systemExempted'|'shortService'|'specialUse'>
+  *            }} BackgroundTaskOptions
+- * @extends EventEmitter<'expiration',any>
++ * @extends EventEmitter<'expiration'|'stopped',any>
+  */
+-declare class BackgroundServer extends EventEmitter<"expiration", any> {
++declare class BackgroundServer extends EventEmitter<"expiration" | "stopped", any> {
+     /** @private */
+     private _runnedTasks;
+     /** @private @type {(arg0?: any) => void} */
+     private _stopTask;
+     /** @private */
+     private _isRunning;
++    private _activeTaskName;
+     /** @private @type {BackgroundTaskOptions} */
+     private _currentOptions;
+     /**
+@@ -112,7 +113,8 @@ declare class BackgroundServer extends EventEmitter<"expiration", any> {
+      * @private
+      * @template T
+      * @param {(taskData?: T) => Promise<void>} task
+-     * @param {T} [parameters]
++     * @param {T | undefined} parameters
++     * @param {string} taskName
+      */
+     private _generateTask;
+     /**
+diff --git a/src/index.js b/src/index.js
+index b744e685308297bb3e0f250ae18ec43c5ff2f971..92b895557a529374f2b5f0820ee9cf09a6df79cc 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -12,7 +12,7 @@ import EventEmitter from 'eventemitter3';
+  *            progressBar?: {max: number, value: number, indeterminate?: boolean},
+  *            foregroundServiceType?: Array<'dataSync'|'mediaPlayback'|'phoneCall'|'location'|'connectedDevice'|'mediaProjection'|'camera'|'microphone'|'health'|'remoteMessaging'|'systemExempted'|'shortService'|'specialUse'>
+  *            }} BackgroundTaskOptions
+- * @extends EventEmitter<'expiration',any>
++ * @extends EventEmitter<'expiration'|'stopped',any>
+  */
+ class BackgroundServer extends EventEmitter {
+     constructor() {
+@@ -23,6 +23,8 @@ class BackgroundServer extends EventEmitter {
+         this._stopTask = () => {};
+         /** @private */
+         this._isRunning = false;
++        /** @private @type {string | undefined} */
++        this._activeTaskName;
+         /** @private @type {BackgroundTaskOptions} */
+         this._currentOptions;
+         this._addListeners();
+@@ -33,6 +35,13 @@ class BackgroundServer extends EventEmitter {
+      */
+     _addListeners() {
+         nativeEventEmitter.addListener('expiration', () => this.emit('expiration'));
++        nativeEventEmitter.addListener('stopped', (taskName) => {
++            if (taskName !== this._activeTaskName) return;
++            this._activeTaskName = undefined;
++            this._isRunning = false;
++            this._stopTask();
++            this.emit('stopped');
++        });
+     }
+ 
+     /**
+@@ -78,11 +87,21 @@ class BackgroundServer extends EventEmitter {
+     async start(task, options) {
+         this._runnedTasks++;
+         this._currentOptions = this._normalizeOptions(options);
+-        const finalTask = this._generateTask(task, options.parameters);
++        const taskName = this._currentOptions.taskName;
++        const finalTask = this._generateTask(task, options.parameters, taskName);
+         if (Platform.OS === 'android') {
+-            AppRegistry.registerHeadlessTask(this._currentOptions.taskName, () => finalTask);
+-            await RNBackgroundActions.start(this._currentOptions);
+-            this._isRunning = true;
++            this._activeTaskName = taskName;
++            AppRegistry.registerHeadlessTask(taskName, () => finalTask);
++            try {
++                await RNBackgroundActions.start(this._currentOptions);
++                if (this._activeTaskName !== taskName) {
++                    throw new Error('Background service stopped while starting');
++                }
++                this._isRunning = true;
++            } catch (error) {
++                if (this._activeTaskName === taskName) this._activeTaskName = undefined;
++                throw error;
++            }
+         } else {
+             await RNBackgroundActions.start(this._currentOptions);
+             this._isRunning = true;
+@@ -94,11 +113,13 @@ class BackgroundServer extends EventEmitter {
+      * @private
+      * @template T
+      * @param {(taskData?: T) => Promise<void>} task
+-     * @param {T} [parameters]
++     * @param {T | undefined} parameters
++     * @param {string} taskName
+      */
+-    _generateTask(task, parameters) {
++    _generateTask(task, parameters, taskName) {
+         const self = this;
+         return async () => {
++            if (Platform.OS === 'android' && self._activeTaskName !== taskName) return;
+             await new Promise((resolve) => {
+                 self._stopTask = resolve;
+                 task(parameters).then(() => self.stop());
+@@ -129,9 +150,11 @@ class BackgroundServer extends EventEmitter {
+      * @returns {Promise<void>}
+      */
+     async stop() {
++        // Invalidate before native destruction can emit its asynchronous event.
++        this._activeTaskName = undefined;
++        this._isRunning = false;
+         this._stopTask();
+         await RNBackgroundActions.stop();
+-        this._isRunning = false;
+     }
+ }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,7 @@ patchedDependencies:
   metro-runtime@0.84.4: 7f83ec93fe717bebba70d6301eac128b36bbb0b46d5db476fb5c43bac9daea6a
   metro@0.84.4: bc3c69aec12bccf391b5180caffd62a4043c81bcf5848949a4b50e79184be6f7
   ollama-ai-provider-v2@3.3.1: 4cb5921e69158814eeeed8d71c80621bd261f33d769b6afabba0db40931155eb
+  react-native-background-actions@4.1.0: 4596baeca5902adb61e5e382a75e49b33f62591ad57525195c3b426ca887caca
   react-native-drawer-layout@4.2.4: 5d567d547b418913c11d2dfe413fc9c1caa72027b12a4a212d23447fc3efe934
   react-native-enriched-markdown@1.0.1: 93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9
   react-native-keyboard-controller@1.21.13: 6f5bed7a836aae55a44a2b0a97532e6d73d9dfb87032457499dfe3ff2c239186
@@ -443,7 +444,7 @@ importers:
         version: 0.4.1(react-native-nitro-modules@0.36.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
       react-native-background-actions:
         specifier: 4.1.0
-        version: 4.1.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
+        version: 4.1.0(patch_hash=4596baeca5902adb61e5e382a75e49b33f62591ad57525195c3b426ca887caca)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
       react-native-chart-kit:
         specifier: 7.0.2
         version: 7.0.2(react-native-svg@15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -18220,7 +18221,7 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
       react-native-nitro-modules: 0.36.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
 
-  react-native-background-actions@4.1.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)):
+  react-native-background-actions@4.1.0(patch_hash=4596baeca5902adb61e5e382a75e49b33f62591ad57525195c3b426ca887caca)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,11 +135,12 @@ patchedDependencies:
   '@opeoginni/github-copilot-openai-compatible@1.0.0': 4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25
   ai@6.0.185: 61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711
   expo-calendar@57.0.1: 8beef60fa807954dcb90cbafcc54ede98c1da48a9236c2ca4755a4ee53e51df1
+  expo-notifications@57.0.5: 55bca70eb685c796e301383bc54270de4d2c8c9d2d277982567ee2c7e8745440
   expo-router@57.0.6: 36b45ad1cfe874395609f849cd53644b41e58ff77d4d9f033ae548ad2af5cd83
   metro-runtime@0.84.4: 7f83ec93fe717bebba70d6301eac128b36bbb0b46d5db476fb5c43bac9daea6a
   metro@0.84.4: bc3c69aec12bccf391b5180caffd62a4043c81bcf5848949a4b50e79184be6f7
   ollama-ai-provider-v2@3.3.1: 4cb5921e69158814eeeed8d71c80621bd261f33d769b6afabba0db40931155eb
-  react-native-background-actions@4.1.0: 4596baeca5902adb61e5e382a75e49b33f62591ad57525195c3b426ca887caca
+  react-native-background-actions@4.1.0: 60bb15bc1307b6c314737b61285e5795504d45460c49beae751035ad91f522d4
   react-native-drawer-layout@4.2.4: 5d567d547b418913c11d2dfe413fc9c1caa72027b12a4a212d23447fc3efe934
   react-native-enriched-markdown@1.0.1: 93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9
   react-native-keyboard-controller@1.21.13: 6f5bed7a836aae55a44a2b0a97532e6d73d9dfb87032457499dfe3ff2c239186
@@ -372,7 +373,7 @@ importers:
         version: 57.0.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
       expo-notifications:
         specifier: 57.0.5
-        version: 57.0.5(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 57.0.5(patch_hash=55bca70eb685c796e301383bc54270de4d2c8c9d2d277982567ee2c7e8745440)(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       expo-observe:
         specifier: ~57.0.18
         version: 57.0.18(expo-router@57.0.6)(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -444,7 +445,7 @@ importers:
         version: 0.4.1(react-native-nitro-modules@0.36.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
       react-native-background-actions:
         specifier: 4.1.0
-        version: 4.1.0(patch_hash=4596baeca5902adb61e5e382a75e49b33f62591ad57525195c3b426ca887caca)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
+        version: 4.1.0(patch_hash=60bb15bc1307b6c314737b61285e5795504d45460c49beae751035ad91f522d4)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))
       react-native-chart-kit:
         specifier: 7.0.2
         version: 7.0.2(react-native-svg@15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -483,7 +484,7 @@ importers:
         version: 4.25.2(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-streamdown:
         specifier: 0.2.0
-        version: 0.2.0(b0f14ae949a048080a645852f5f97901)
+        version: 0.2.0(a9c5041d792855957ae33e1c79d10fc5)
       react-native-svg:
         specifier: 15.15.4
         version: 15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -928,7 +929,7 @@ importers:
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-streamdown:
         specifier: '*'
-        version: 0.2.0(b0f14ae949a048080a645852f5f97901)
+        version: 0.2.0(a9c5041d792855957ae33e1c79d10fc5)
       react-native-worklets:
         specifier: '*'
         version: 0.10.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
@@ -15757,7 +15758,7 @@ snapshots:
     dependencies:
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
 
-  expo-notifications@57.0.5(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3):
+  expo-notifications@57.0.5(patch_hash=55bca70eb685c796e301383bc54270de4d2c8c9d2d277982567ee2c7e8745440)(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.4(supports-color@8.1.1)(typescript@6.0.3)
       abort-controller: 3.0.0
@@ -18221,7 +18222,7 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
       react-native-nitro-modules: 0.36.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
 
-  react-native-background-actions@4.1.0(patch_hash=4596baeca5902adb61e5e382a75e49b33f62591ad57525195c3b426ca887caca)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)):
+  react-native-background-actions@4.1.0(patch_hash=60bb15bc1307b6c314737b61285e5795504d45460c49beae751035ad91f522d4)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
@@ -18334,7 +18335,7 @@ snapshots:
 
   react-native-skia-apple-tvos@147.1.0: {}
 
-  react-native-streamdown@0.2.0(b0f14ae949a048080a645852f5f97901):
+  react-native-streamdown@0.2.0(a9c5041d792855957ae33e1c79d10fc5):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,6 +71,7 @@ patchedDependencies:
   react-native-drawer-layout@4.2.4: patches/react-native-drawer-layout@4.2.4.patch
   expo-calendar@57.0.1: patches/expo-calendar@57.0.1.patch
   react-native-background-actions@4.1.0: patches/react-native-background-actions@4.1.0.patch
+  expo-notifications@57.0.5: patches/expo-notifications@57.0.5.patch
 
 minimumReleaseAgeExclude:
   - '@expo/cli@57.0.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,6 +70,7 @@ patchedDependencies:
   react-native-enriched-markdown@1.0.1: patches/react-native-enriched-markdown@1.0.1.patch
   react-native-drawer-layout@4.2.4: patches/react-native-drawer-layout@4.2.4.patch
   expo-calendar@57.0.1: patches/expo-calendar@57.0.1.patch
+  react-native-background-actions@4.1.0: patches/react-native-background-actions@4.1.0.patch
 
 minimumReleaseAgeExclude:
   - '@expo/cli@57.0.3'

--- a/scripts/withAndroidBackgroundGeneration.js
+++ b/scripts/withAndroidBackgroundGeneration.js
@@ -2,8 +2,8 @@ const { AndroidConfig, withAndroidManifest } = require('expo/config-plugins');
 
 const SERVICE_NAME = 'com.asterinet.react.bgactions.RNBackgroundActionsTask';
 
-// Configure the library's existing service through Expo CNG; no native service
-// or library patch belongs to the application.
+// Expo CNG declares the existing library service; its visibility lifecycle lives
+// in the versioned background-actions patch, not generated application code.
 module.exports = (config) =>
   withAndroidManifest(config, (mod) => {
     const application = AndroidConfig.Manifest.getMainApplicationOrThrow(mod.modResults);

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -22,6 +22,7 @@ import {
   getRootHeaderStyle,
   getTransparentHeaderStyle,
   NavigationThemeProvider,
+  paintingRouteId,
   paintingViewerHeaderShown,
 } from '@/frontend/appShell/navigation';
 import { configureObserve, configureSentry } from '@/frontend/appShell/observability';
@@ -142,11 +143,8 @@ function RootStack() {
           stack only needs to push the page without adding another header. */}
       <Stack.Screen name="settings" options={{ headerShown: false }} />
       <Stack.Screen
-        // Each task owns its composer's draft and generation state. Navigating
-        // to another notification must not reuse an unrelated mounted composer.
-        getId={({ params }) =>
-          typeof params?.paintingId === 'string' ? params.paintingId : undefined
-        }
+        // Task notifications reuse their task; each edit/resize starts a separate draft.
+        getId={({ params }) => paintingRouteId(params)}
         name="paintings/index"
         options={{
           contentStyle: { backgroundColor },

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -16,7 +16,7 @@ import { withUniwind } from 'uniwind';
 
 import { AppBootstrapGate, AppBootstrapProvider, useAppBootstrapState } from '@/bootstrap';
 import { reportStartupCoverPresented } from '@/bootstrap/runtime/startupCoverHandoff';
-import { useBackgroundActivityNavigation } from '@/frontend/appShell/backgroundActivity/useBackgroundActivityNavigation';
+import { BackgroundActivityBridge } from '@/frontend/appShell/backgroundActivity';
 import { headerScreenOptions, RouteHeaderProvider } from '@/frontend/appShell/header';
 import {
   getRootHeaderStyle,
@@ -58,6 +58,7 @@ function RootLayout() {
                           <AppAlertProvider>
                             <BottomSheetProvider>
                               <RouteHeaderProvider rootAction="back">
+                                <BackgroundActivityBridge />
                                 <RootStack />
                               </RouteHeaderProvider>
                             </BottomSheetProvider>
@@ -105,7 +106,6 @@ function BootstrapStartupCoordinator({ children }: PropsWithChildren) {
 }
 
 function RootStack() {
-  useBackgroundActivityNavigation();
   const [backgroundColor, foregroundColor, constantBlack, constantWhite] = useThemeColor([
     'background',
     'foreground',
@@ -142,6 +142,11 @@ function RootStack() {
           stack only needs to push the page without adding another header. */}
       <Stack.Screen name="settings" options={{ headerShown: false }} />
       <Stack.Screen
+        // Each task owns its composer's draft and generation state. Navigating
+        // to another notification must not reuse an unrelated mounted composer.
+        getId={({ params }) =>
+          typeof params?.paintingId === 'string' ? params.paintingId : undefined
+        }
         name="paintings/index"
         options={{
           contentStyle: { backgroundColor },

--- a/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
+++ b/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
@@ -81,6 +81,13 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
     const notifications = require('expo-notifications') as Notifications;
     this.background = background;
     this.notifications = notifications;
+    const handleServiceStopped = () => {
+      void this.interruptLeases(new Error('Android background execution service stopped.')).catch(
+        (error: unknown) => logger.warn('Background service interruption failed', { error }),
+      );
+    };
+    background.on('stopped', handleServiceStopped);
+    this.registerDisposable(() => background.off('stopped', handleServiceStopped));
     notifications.setNotificationHandler({
       handleNotification: async () => ({
         shouldPlaySound: AppState.currentState === 'background',
@@ -291,14 +298,15 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
     // One terminal notification per turn; late title projection must not repost
     // a notification that the user has already opened or dismissed.
     if (terminal) record.terminalNotified = true;
-    if (!occurredInBackground || AppState.currentState !== 'background') {
-      if (
-        AppState.currentState === 'active' &&
-        (record.props.phase === 'awaiting-approval' || record.props.phase === 'failed')
-      ) {
+    const phase = record.props.phase;
+    const requiresAttention = phase === 'awaiting-approval' || phase === 'failed';
+    // Only successful foreground completion stays silent after a queued delivery.
+    // Approval and failure must still reach the user if they have since left.
+    if ((!occurredInBackground && !requiresAttention) || AppState.currentState !== 'background') {
+      if (AppState.currentState === 'active' && requiresAttention) {
         this.environment.onForegroundAttention({
           detail: record.props.detail,
-          phase: record.props.phase,
+          phase,
           title: record.props.title,
           url: record.deepLinkUrl,
         });
@@ -335,11 +343,16 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
   private async interruptAtDeadline(): Promise<void> {
     if (this.disposed || AppState.currentState === 'active') return;
     this.backgroundLimitReached = true;
+    await this.interruptLeases(backgroundLimitError());
+  }
+
+  private async interruptLeases(reason: Error): Promise<void> {
+    if (this.disposed || this.interrupting) return;
+    this.clearDeadline();
     this.interrupting = true;
     const leases = [...this.leases];
     this.leases.clear();
     try {
-      const reason = backgroundLimitError();
       for (const result of await Promise.allSettled(
         leases.map((lease) => Promise.resolve().then(() => lease.onInterrupt?.(reason))),
       )) {

--- a/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
+++ b/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
@@ -61,7 +61,12 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
   private operationTail: Promise<void> = Promise.resolve();
   private permissionRequested = false;
 
-  constructor(private readonly environment: Pick<BackgroundActivityEnvironment, 'translate'>) {
+  constructor(
+    private readonly environment: Pick<
+      BackgroundActivityEnvironment,
+      'translate' | 'onForegroundAttention'
+    >,
+  ) {
     super();
   }
 
@@ -78,10 +83,10 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
     this.notifications = notifications;
     notifications.setNotificationHandler({
       handleNotification: async () => ({
-        shouldPlaySound: AppState.currentState !== 'active',
+        shouldPlaySound: AppState.currentState === 'background',
         shouldSetBadge: false,
-        shouldShowBanner: AppState.currentState !== 'active',
-        shouldShowList: AppState.currentState !== 'active',
+        shouldShowBanner: AppState.currentState === 'background',
+        shouldShowList: AppState.currentState === 'background',
       }),
     });
     this.registerDisposable(() => notifications.setNotificationHandler(null));
@@ -145,8 +150,10 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
         if (!this.disposed) this.activities.add(record);
         this.scheduleReconcile();
         return {
-          update: (nextProps) =>
-            this.enqueue(async () => {
+          update: (nextProps, context) => {
+            const occurredInBackground =
+              context?.phaseStartedInBackground ?? AppState.currentState === 'background';
+            return this.enqueue(async () => {
               if (!this.activities.has(record) || this.disposed) return;
               const previousPhase = record.props.phase;
               record.props = nextProps;
@@ -158,26 +165,30 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
                 await this.notifications?.dismissNotificationAsync(record.id);
               }
               if (isTerminal(nextProps.phase)) {
-                await this.showAttention(record, true);
+                await this.showAttention(record, true, occurredInBackground);
               } else if (
                 nextProps.phase === 'awaiting-approval' &&
                 previousPhase !== nextProps.phase
               ) {
-                await this.showAttention(record, false);
+                await this.showAttention(record, false, occurredInBackground);
               }
               await this.reconcile();
-            }),
-          end: (policy, finalProps) =>
-            this.enqueue(async () => {
+            });
+          },
+          end: (policy, finalProps, context) => {
+            const occurredInBackground =
+              context?.phaseStartedInBackground ?? AppState.currentState === 'background';
+            return this.enqueue(async () => {
               if (!this.activities.delete(record) || this.disposed) return;
               record.props = finalProps;
               if (policy === 'default' && finalProps.phase !== 'cancelled') {
-                await this.showAttention(record, true);
+                await this.showAttention(record, true, occurredInBackground);
               } else {
                 await this.notifications?.dismissNotificationAsync(record.id);
               }
               await this.reconcile();
-            }),
+            });
+          },
         };
       },
     };
@@ -219,6 +230,8 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
     if (AppState.currentState !== 'active' || this.backgroundLimitReached) return;
     await background.start(holdBackgroundExecution, {
       ...content,
+      // The native service starts without a notification while visible and
+      // promotes itself when the app backgrounds, without restarting its task.
       // The library also uses these initial strings as the persistent channel
       // name/description. Keep conversation content out of system settings.
       taskTitle: this.environment.translate('notifications.android.runningTitle'),
@@ -261,18 +274,37 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
           ? [first.props.detail, first.props.preview].filter(Boolean).join('\n')
           : this.environment.translate('notifications.android.preparing')
       ).slice(0, 600),
-      linkingURI: first?.deepLinkUrl,
+      // An aggregate has no single task destination. Restore the app instead
+      // of choosing whichever task happened to enter the Set first.
+      linkingURI: multiple ? undefined : first?.deepLinkUrl,
     };
   }
 
-  private async showAttention(record: ActivityRecord, terminal: boolean): Promise<void> {
+  private async showAttention(
+    record: ActivityRecord,
+    terminal: boolean,
+    occurredInBackground: boolean,
+  ): Promise<void> {
     const notifications = this.notifications;
     if (!notifications || this.disposed || record.props.phase === 'cancelled') return;
     if (terminal && record.terminalNotified) return;
     // One terminal notification per turn; late title projection must not repost
     // a notification that the user has already opened or dismissed.
     if (terminal) record.terminalNotified = true;
-    if (AppState.currentState === 'active') return;
+    if (!occurredInBackground || AppState.currentState !== 'background') {
+      if (
+        AppState.currentState === 'active' &&
+        (record.props.phase === 'awaiting-approval' || record.props.phase === 'failed')
+      ) {
+        this.environment.onForegroundAttention({
+          detail: record.props.detail,
+          phase: record.props.phase,
+          title: record.props.title,
+          url: record.deepLinkUrl,
+        });
+      }
+      return;
+    }
     await notifications.scheduleNotificationAsync({
       identifier: record.id,
       content: {

--- a/src/backend/services/backgroundActivity/BackgroundActivityEnvironment.ts
+++ b/src/backend/services/backgroundActivity/BackgroundActivityEnvironment.ts
@@ -2,6 +2,7 @@ import { CHERRY_ACTIVITY_LOGO_BASE64 } from '@cherrystudio/ui/background-activit
 import { File } from 'expo-file-system';
 
 import { BaseService, Injectable, Phase, ServicePhase } from '@/backend/core/lifecycle';
+import type { ForegroundActivityAttention } from '@/shared/backgroundActivity/attention';
 import type { BackgroundReplyActivityProps } from '@/shared/backgroundActivity/chatReply';
 import type { PaintingActivityProps } from '@/shared/backgroundActivity/painting';
 import { loggerService } from '@/shared/core/logger/LoggerService';
@@ -15,6 +16,7 @@ export type BackgroundActivityTranslate = (key: string) => string;
 export type BackgroundActivityEnvironmentConfig = {
   assistantPresenter: BackgroundActivityPresenter<BackgroundReplyActivityProps>;
   getColorScheme: () => 'dark' | 'light';
+  onForegroundAttention?: (attention: ForegroundActivityAttention) => void;
   paintingPresenter: BackgroundActivityPresenter<PaintingActivityProps>;
   translate: BackgroundActivityTranslate;
 };
@@ -54,6 +56,10 @@ export class BackgroundActivityEnvironment extends BaseService {
   }
 
   translate = (key: string): string => this.config.translate(key);
+
+  onForegroundAttention = (attention: ForegroundActivityAttention): void => {
+    this.config.onForegroundAttention?.(attention);
+  };
 
   get presenters(): readonly { clearOrphans(): Promise<number> }[] {
     return [this.config.assistantPresenter, this.config.paintingPresenter];

--- a/src/backend/services/backgroundActivity/BackgroundActivityManager.ts
+++ b/src/backend/services/backgroundActivity/BackgroundActivityManager.ts
@@ -52,6 +52,7 @@ type SessionRecord = {
   lease?: KeepAliveLease;
   onInterrupt?: (reason: Error) => void | Promise<void>;
   presenter: BackgroundActivityPresenter<BackgroundActivityBaseProps>;
+  phaseStartedInBackground: boolean;
   props: BackgroundActivityBaseProps;
   surface: SurfaceState;
   tag: string;
@@ -117,6 +118,7 @@ export class BackgroundActivityManager extends BaseService {
       lastNativeUpdateAt: 0,
       onInterrupt: input.onInterrupt,
       presenter: input.presenter as BackgroundActivityPresenter<BackgroundActivityBaseProps>,
+      phaseStartedInBackground: this.appState === 'background',
       props: input.props,
       surface: { status: 'pending' },
       tag: input.tag,
@@ -132,6 +134,7 @@ export class BackgroundActivityManager extends BaseService {
       },
       finish: (props) => {
         if (record.surface.status === 'ended' || this.disposed) return Promise.resolve();
+        this.capturePhaseVisibility(record, props);
         record.props = {
           ...props,
           finishedAtEpochMs: props.finishedAtEpochMs ?? Date.now(),
@@ -184,6 +187,7 @@ export class BackgroundActivityManager extends BaseService {
     if (record.surface.status === 'ended' || this.disposed) return;
 
     const changed = !shallowEqualProps(record.props, props);
+    this.capturePhaseVisibility(record, props);
     record.props = props;
     if (options?.keepAlive !== undefined && options.keepAlive !== record.keepAlive) {
       record.keepAlive = options.keepAlive;
@@ -250,7 +254,9 @@ export class BackgroundActivityManager extends BaseService {
     if (this.disposed || record.surface.status !== 'active') return;
     const submittedProps = record.props;
     try {
-      await record.surface.handle.update(this.toNativeProps(record));
+      await record.surface.handle.update(this.toNativeProps(record), {
+        phaseStartedInBackground: record.phaseStartedInBackground,
+      });
       record.lastNativeUpdateAt = Date.now();
     } catch (error) {
       logger.warn('Background activity update failed', error as Error, { tag: record.tag });
@@ -272,7 +278,9 @@ export class BackgroundActivityManager extends BaseService {
     policy: 'default' | 'immediate',
   ): Promise<void> {
     try {
-      await handle.end(policy, this.toNativeProps(record));
+      await handle.end(policy, this.toNativeProps(record), {
+        phaseStartedInBackground: record.phaseStartedInBackground,
+      });
       logger.info('Background activity ended', { policy, tag: record.tag });
     } catch (error) {
       logger.warn('Background activity cleanup failed', error as Error, { tag: record.tag });
@@ -294,6 +302,12 @@ export class BackgroundActivityManager extends BaseService {
       ...record.props,
       finishedAtEpochMs: record.props.finishedAtEpochMs ?? Date.now(),
     };
+  }
+
+  private capturePhaseVisibility(record: SessionRecord, props: BackgroundActivityBaseProps): void {
+    if (record.props.phase !== props.phase) {
+      record.phaseStartedInBackground = this.appState === 'background';
+    }
   }
 
   /** Mirrors the session's keep-alive bit into a coordinator lease. */

--- a/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
@@ -29,6 +29,8 @@ jest.mock('expo-notifications', () => ({
 
 const native = jest.mocked(background);
 const notices = jest.mocked(notifications);
+const foregroundAttention = jest.fn();
+const environment = { translate: (key: string) => key, onForegroundAttention: foregroundAttention };
 let running: boolean;
 let runtime: AndroidBackgroundActivityRuntime;
 const listeners = new Set<(state: AppStateStatus) => void>();
@@ -57,7 +59,7 @@ beforeEach(async () => {
   notices.requestPermissionsAsync.mockResolvedValue({
     granted: false,
   } as notifications.NotificationPermissionsStatus);
-  runtime = new AndroidBackgroundActivityRuntime({ translate: (key) => key });
+  runtime = new AndroidBackgroundActivityRuntime(environment);
   await runtime._doInit();
 });
 
@@ -187,7 +189,7 @@ test('cleans abandoned approval notifications while retaining completed and unre
     notice('completed', { owner: BACKGROUND_NOTIFICATION_OWNER, terminal: true }),
     notice('unrelated', {}),
   ]);
-  runtime = new AndroidBackgroundActivityRuntime({ translate: (key) => key });
+  runtime = new AndroidBackgroundActivityRuntime(environment);
   await runtime._doInit();
   expect(notices.dismissNotificationAsync).toHaveBeenCalledWith('approval');
   expect(notices.dismissNotificationAsync).not.toHaveBeenCalledWith('completed');
@@ -263,6 +265,79 @@ test('returning to the foreground resets the Android background budget', async (
   jest.advanceTimersByTime(100 * 60_000);
   await flush();
   expect(interrupted).not.toHaveBeenCalled();
+});
+
+test('foreground approvals and failures use in-app attention while completion stays silent', async () => {
+  const surface = runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'), 'cherrystudio:///?sessionId=s');
+  await surface.update(props('awaiting-approval'));
+  expect(foregroundAttention).toHaveBeenLastCalledWith(
+    expect.objectContaining({ phase: 'awaiting-approval', url: 'cherrystudio:///?sessionId=s' }),
+  );
+  await surface.update(props('responding'));
+  await surface.update(props('failed'));
+  await surface.end('default', { ...props('failed'), title: 'Late title' });
+  expect(foregroundAttention).toHaveBeenCalledTimes(2);
+  expect(foregroundAttention).toHaveBeenLastCalledWith(
+    expect.objectContaining({ phase: 'failed' }),
+  );
+  const completed = runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'));
+  await completed.end('default', props('completed'));
+  expect(foregroundAttention).toHaveBeenCalledTimes(2);
+  expect(notices.scheduleNotificationAsync).not.toHaveBeenCalled();
+});
+
+test('a queued foreground completion is not announced after the app backgrounds', async () => {
+  const surface = runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'));
+  const delivery = surface.update(props('completed'));
+  setAppState('background');
+  await delivery;
+  await surface.end('default', props('completed'));
+  expect(notices.scheduleNotificationAsync).not.toHaveBeenCalled();
+});
+
+test('returning before queued background delivery suppresses the system alert', async () => {
+  const surface = runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'));
+  setAppState('background');
+  const delivery = surface.end('default', props('completed'));
+  setAppState('active');
+  await delivery;
+  expect(notices.scheduleNotificationAsync).not.toHaveBeenCalled();
+});
+
+test('honors foreground phase entry even when the manager invokes delivery from the background', async () => {
+  const surface = runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'));
+  setAppState('background');
+  await surface.end('default', props('completed'), { phaseStartedInBackground: false });
+  expect(notices.scheduleNotificationAsync).not.toHaveBeenCalled();
+});
+
+test('an aggregate restores the app and becomes task-specific again when one task remains', async () => {
+  const first = runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'), 'cherrystudio:///?sessionId=first');
+  runtime
+    .createPresenter<BackgroundReplyActivityProps>()
+    .start(props('responding'), 'cherrystudio:///?sessionId=second');
+  runtime.acquire('tasks');
+  await flush();
+  expect(native.updateNotification).toHaveBeenLastCalledWith(
+    expect.objectContaining({ linkingURI: undefined }),
+  );
+  await first.end('immediate', props('cancelled'));
+  expect(native.updateNotification).toHaveBeenLastCalledWith(
+    expect.objectContaining({ linkingURI: 'cherrystudio:///?sessionId=second' }),
+  );
+  expect(notices.scheduleNotificationAsync).not.toHaveBeenCalled();
 });
 
 function props(phase: BackgroundReplyActivityProps['phase']): BackgroundReplyActivityProps {

--- a/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
@@ -11,6 +11,8 @@ jest.mock('react-native-background-actions', () => ({
   __esModule: true,
   default: {
     isRunning: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn(),
     start: jest.fn(),
     stop: jest.fn(),
     updateNotification: jest.fn(),
@@ -34,12 +36,14 @@ const environment = { translate: (key: string) => key, onForegroundAttention: fo
 let running: boolean;
 let runtime: AndroidBackgroundActivityRuntime;
 const listeners = new Set<(state: AppStateStatus) => void>();
+const serviceStoppedListeners = new Set<() => void>();
 
 beforeEach(async () => {
   jest.clearAllMocks();
   jest.useFakeTimers();
   running = false;
   listeners.clear();
+  serviceStoppedListeners.clear();
   Object.defineProperty(Platform, 'OS', { configurable: true, value: 'android' });
   setAppState('active');
   jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, listener) => {
@@ -48,6 +52,14 @@ beforeEach(async () => {
   });
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   native.isRunning.mockImplementation(() => running);
+  native.on.mockImplementation((_event, listener) => {
+    serviceStoppedListeners.add(listener);
+    return background;
+  });
+  native.off.mockImplementation((_event, listener) => {
+    if (listener) serviceStoppedListeners.delete(listener);
+    return background;
+  });
   native.start.mockImplementation(async () => {
     running = true;
   });
@@ -267,6 +279,52 @@ test('returning to the foreground resets the Android background budget', async (
   expect(interrupted).not.toHaveBeenCalled();
 });
 
+test('unexpected native destruction interrupts every protected task without restarting in background', async () => {
+  const chatInterrupted = jest.fn();
+  const paintingInterrupted = jest.fn();
+  runtime.acquire('chat', chatInterrupted);
+  runtime.acquire('painting', paintingInterrupted);
+  await flush();
+  setAppState('background');
+  running = false;
+  for (const listener of serviceStoppedListeners) listener();
+  await flush();
+  expect(chatInterrupted).toHaveBeenCalledWith(expect.any(Error));
+  expect(paintingInterrupted).toHaveBeenCalledWith(expect.any(Error));
+  expect(native.start).toHaveBeenCalledTimes(1);
+  setAppState('active');
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(1);
+  runtime.acquire('new-task');
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(2);
+});
+
+test('a new foreground task survives cancellation draining after native service loss', async () => {
+  let finishCancellation!: () => void;
+  const cancellation = new Promise<void>((resolve) => {
+    finishCancellation = resolve;
+  });
+  const oldLease = runtime.acquire('old-task', () => cancellation);
+  await flush();
+  setAppState('background');
+  running = false;
+  for (const listener of serviceStoppedListeners) listener();
+  await flush();
+  setAppState('active');
+  runtime.acquire('new-task');
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(1);
+  finishCancellation();
+  await flush();
+  oldLease.release();
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(2);
+  expect(running).toBe(true);
+  await runtime._doStop();
+  expect(serviceStoppedListeners.size).toBe(0);
+});
+
 test('foreground approvals and failures use in-app attention while completion stays silent', async () => {
   const surface = runtime
     .createPresenter<BackgroundReplyActivityProps>()
@@ -300,6 +358,26 @@ test('a queued foreground completion is not announced after the app backgrounds'
   await surface.end('default', props('completed'));
   expect(notices.scheduleNotificationAsync).not.toHaveBeenCalled();
 });
+
+test.each(['awaiting-approval', 'failed'] as const)(
+  'a queued foreground %s still notifies when delivered in the background',
+  async (phase) => {
+    const surface = runtime
+      .createPresenter<BackgroundReplyActivityProps>()
+      .start(props('responding'));
+    const delivery = surface.update(props(phase), { phaseStartedInBackground: false });
+    setAppState('background');
+    await delivery;
+    expect(foregroundAttention).not.toHaveBeenCalled();
+    expect(notices.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.objectContaining({ body: phase }) }),
+    );
+    if (phase === 'failed') {
+      await surface.end('default', props(phase), { phaseStartedInBackground: false });
+      expect(notices.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    }
+  },
+);
 
 test('returning before queued background delivery suppresses the system alert', async () => {
   const surface = runtime

--- a/src/backend/services/backgroundActivity/__tests__/BackgroundActivityManager.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/BackgroundActivityManager.test.ts
@@ -106,6 +106,7 @@ describe.each(['ios', 'android'])('BackgroundActivityManager on %s', (platform) 
     expect(handles[0]?.end).toHaveBeenCalledWith(
       'immediate',
       expect.objectContaining({ finishedAtEpochMs: expect.any(Number) }),
+      expect.objectContaining({ phaseStartedInBackground: expect.any(Boolean) }),
     );
     await manager._doStop();
   });
@@ -277,6 +278,7 @@ describe.each(['ios', 'android'])('BackgroundActivityManager on %s', (platform) 
     expect(handles[0]!.end).toHaveBeenCalledWith(
       'default',
       expect.objectContaining({ detail: 'completed' }),
+      expect.objectContaining({ phaseStartedInBackground: expect.any(Boolean) }),
     );
     await manager._doStop();
   });
@@ -339,10 +341,12 @@ describe.each(['ios', 'android'])('BackgroundActivityManager on %s', (platform) 
     expect(handles[0]?.end).toHaveBeenCalledWith(
       'default',
       expect.objectContaining({ detail: 'done', finishedAtEpochMs: expect.any(Number) }),
+      expect.objectContaining({ phaseStartedInBackground: expect.any(Boolean) }),
     );
     expect(handles[0]?.end).not.toHaveBeenCalledWith(
       'default',
       expect.objectContaining({ detail: 'late-finish' }),
+      expect.objectContaining({ phaseStartedInBackground: expect.any(Boolean) }),
     );
 
     session.update(makeProps('after-finish'), { urgent: true });
@@ -428,6 +432,7 @@ describe.each(['ios', 'android'])('BackgroundActivityManager on %s', (platform) 
     expect(handles[0]?.end).toHaveBeenCalledWith(
       'immediate',
       expect.objectContaining({ finishedAtEpochMs: expect.any(Number) }),
+      expect.objectContaining({ phaseStartedInBackground: expect.any(Boolean) }),
     );
     expect(mockLeases[0]?.release).toHaveBeenCalledTimes(1);
 
@@ -438,6 +443,37 @@ describe.each(['ios', 'android'])('BackgroundActivityManager on %s', (platform) 
       tag: 'chat.topic-2',
     });
     expect(mockAcquire).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves phase-entry visibility through the delivery queue and late title projection', async () => {
+    const { presenter, handles } = createMockPresenter();
+    const manager = await createManager([presenter]);
+    const session = manager.startSession({
+      presenter,
+      props: { ...makeProps('running'), phase: 'responding' },
+      tag: 'chat',
+    });
+    let releaseUpdate!: () => void;
+    handles[0]!.update.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseUpdate = resolve;
+        }),
+    );
+    session.update({ ...makeProps('streaming'), phase: 'responding' }, { urgent: true });
+    await flushMicrotasks();
+    session.update({ ...makeProps('done'), phase: 'completed' }, { urgent: true });
+    appStateListener?.('background');
+    session.update({ ...makeProps('final title'), phase: 'completed' }, { urgent: true });
+    const finished = session.finish({ ...makeProps('final title'), phase: 'completed' });
+    releaseUpdate();
+    await finished;
+    expect(handles[0]!.end).toHaveBeenCalledWith(
+      'default',
+      expect.objectContaining({ phase: 'completed' }),
+      { phaseStartedInBackground: false },
+    );
+    await manager._doStop();
   });
 
   async function createManager(presenters: readonly { clearOrphans(): Promise<number> }[]) {

--- a/src/backend/services/backgroundActivity/__tests__/androidBackgroundNativePatch.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/androidBackgroundNativePatch.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const root = dirname(require.resolve('react-native-background-actions/package.json'));
+const source = (name: string) =>
+  readFileSync(join(root, 'android/src/main/java/com/asterinet/react/bgactions', name), 'utf8');
+const service = source('RNBackgroundActionsTask.java');
+const moduleSource = source('BackgroundActionsModule.java');
+
+// Upgrade guards for the installed native implementation; these do not replace
+// device acceptance of Android's service admission and notification delivery.
+test('native visibility owns foreground promotion and removes the observer on destruction', () => {
+  expect(service).toContain('getCurrentState().isAtLeast(Lifecycle.State.STARTED)');
+  expect(service).toContain('getLifecycle().addObserver(this)');
+  expect(service).toContain('getLifecycle().removeObserver(this)');
+  expect(service).toMatch(/void onStop\([^)]*\)\s*\{[\s\S]*?updateForeground\(\)/);
+  expect(service).toMatch(/if \(isAppVisible\(\)\)\s*\{[\s\S]*?STOP_FOREGROUND_REMOVE/);
+  expect(moduleSource).not.toContain('startForegroundService(');
+});
+
+test('updates cannot post outside the visibility gate or launch another headless task', () => {
+  expect(moduleSource).not.toContain('.notify(');
+  expect(moduleSource).toContain('update.setAction(RNBackgroundActionsTask.ACTION_UPDATE)');
+  expect(service).toContain('if (update && currentOptions == null)');
+  expect(service).toContain('if (!update) super.onStartCommand(intent, flags, startId)');
+  expect(service).not.toContain('START_REDELIVER_INTENT');
+});
+
+test('ongoing notification updates stay silent and route taps to the existing application', () => {
+  expect(service).toContain('.setOnlyAlertOnce(true)');
+  expect(service).toContain('.setSilent(true)');
+  expect(service).toContain('notificationIntent.setPackage(context.getPackageName())');
+  expect(service).toContain('Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP');
+});

--- a/src/backend/services/backgroundActivity/__tests__/androidBackgroundNativePatch.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/androidBackgroundNativePatch.test.ts
@@ -32,3 +32,8 @@ test('ongoing notification updates stay silent and route taps to the existing ap
   expect(service).toContain('notificationIntent.setPackage(context.getPackageName())');
   expect(service).toContain('Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP');
 });
+
+test('native destruction reports the admitted task name instead of changing notification options', () => {
+  expect(service).toContain('taskName = extras.getString("taskName")');
+  expect(service).toMatch(/void onDestroy\(\)[\s\S]*?\.emit\("stopped", taskName\)/);
+});

--- a/src/backend/services/backgroundActivity/__tests__/androidBackgroundServiceLifecycle.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/androidBackgroundServiceLifecycle.test.ts
@@ -1,0 +1,100 @@
+import type BackgroundService from 'react-native-background-actions';
+import type { BackgroundTaskOptions } from 'react-native-background-actions';
+
+const mockNativeStart = jest.fn<Promise<void>, [BackgroundTaskOptions]>();
+const mockNativeStop = jest.fn(async () => {});
+const mockNativeUpdate = jest.fn(async () => {});
+const mockNativeListeners = new Map<string, (taskName: string) => void>();
+const mockHeadlessFactories = new Map<string, () => () => Promise<void>>();
+let background: typeof BackgroundService;
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  AppRegistry: {
+    registerHeadlessTask: (name: string, factory: () => () => Promise<void>) => {
+      mockHeadlessFactories.set(name, factory);
+    },
+  },
+}));
+jest.mock('react-native-background-actions/src/RNBackgroundActionsModule', () => ({
+  RNBackgroundActions: {
+    start: (options: BackgroundTaskOptions) => mockNativeStart(options),
+    stop: () => mockNativeStop(),
+    updateNotification: () => mockNativeUpdate(),
+  },
+  nativeEventEmitter: {
+    addListener: (name: string, listener: (taskName: string) => void) => {
+      mockNativeListeners.set(name, listener);
+    },
+  },
+}));
+
+const options: BackgroundTaskOptions = {
+  taskName: 'Task',
+  taskTitle: 'Task',
+  taskDesc: 'Running',
+  taskIcon: { name: 'notification_icon', type: 'drawable' },
+};
+const hold = () => new Promise<void>(() => {});
+
+beforeAll(() => {
+  background = jest.requireActual<{ default: typeof BackgroundService }>(
+    'react-native-background-actions',
+  ).default;
+});
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNativeStart.mockResolvedValue(undefined);
+});
+afterEach(async () => {
+  await background.stop();
+  background.removeAllListeners('stopped');
+  mockHeadlessFactories.clear();
+});
+
+test('unexpected destruction resets running state before interrupting and finishes the headless task', async () => {
+  const observedRunning: boolean[] = [];
+  background.on('stopped', () => observedRunning.push(background.isRunning()));
+  await background.start(hold, options);
+  const taskName = mockNativeStart.mock.calls[0]![0].taskName;
+  const task = mockHeadlessFactories.get(taskName)!()();
+  await background.updateNotification({ taskTitle: 'Updated' });
+  mockNativeListeners.get('stopped')?.(taskName);
+  expect(observedRunning).toEqual([false]);
+  await task;
+  expect(mockNativeStop).not.toHaveBeenCalled();
+});
+
+test('expected stops and late events from an older service cannot interrupt a newer task', async () => {
+  const interrupted = jest.fn();
+  background.on('stopped', interrupted);
+  await background.start(hold, options);
+  const oldName = mockNativeStart.mock.calls[0]![0].taskName;
+  await background.stop();
+  mockNativeListeners.get('stopped')?.(oldName);
+  expect(interrupted).not.toHaveBeenCalled();
+  await background.start(hold, options);
+  mockNativeListeners.get('stopped')?.(oldName);
+  expect(background.isRunning()).toBe(true);
+  expect(interrupted).not.toHaveBeenCalled();
+  const delayedOldTask = mockHeadlessFactories.get(oldName)!()();
+  await delayedOldTask;
+  expect(background.isRunning()).toBe(true);
+});
+
+test('a stop arriving before the start promise resolves cannot restore a stale running flag', async () => {
+  let finishStart!: () => void;
+  mockNativeStart.mockImplementationOnce(
+    () =>
+      new Promise<void>((resolve) => {
+        finishStart = resolve;
+      }),
+  );
+  const starting = background.start(hold, options);
+  const rejected = expect(starting).rejects.toThrow('Background service stopped while starting');
+  const taskName = mockNativeStart.mock.calls[0]![0].taskName;
+  mockNativeListeners.get('stopped')?.(taskName);
+  finishStart();
+  await rejected;
+  expect(background.isRunning()).toBe(false);
+});

--- a/src/backend/services/backgroundActivity/presenter.ts
+++ b/src/backend/services/backgroundActivity/presenter.ts
@@ -7,8 +7,17 @@ import type {
 // strictFunctionTypes, so a Presenter<FeatureProps> stays assignable to the
 // type-erased Presenter the manager stores (same trick as JobHandler).
 export type BackgroundActivityHandle<Props extends BackgroundActivityBaseProps> = {
-  end(policy: BackgroundActivityEndPolicy, props: Props): Promise<void>;
-  update(props: Props): Promise<void>;
+  end(
+    policy: BackgroundActivityEndPolicy,
+    props: Props,
+    context?: BackgroundActivityDeliveryContext,
+  ): Promise<void>;
+  update(props: Props, context?: BackgroundActivityDeliveryContext): Promise<void>;
+};
+
+export type BackgroundActivityDeliveryContext = {
+  /** Captured before the manager's queue/throttle, preserved through same-phase title updates. */
+  phaseStartedInBackground: boolean;
 };
 
 /**

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -442,7 +442,6 @@ function normalizeTurnInput(input: BackgroundReplyTurnInput): {
     actorName: input.agentName,
     conversationTitle: input.sessionTitle,
     deepLinkUrl: createBackgroundTaskUrl(resolveScheme({}), {
-      agentId: input.agentId,
       kind: 'chat',
       sessionId: input.sessionId,
     }),

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -74,7 +74,7 @@ describe('BackgroundReplyRuntime', () => {
       expect(first).not.toBe(second);
       expect(mockStartSession).toHaveBeenCalledTimes(2);
       expect(mockSessions[0]?.input).toMatchObject({
-        deepLinkUrl: `${scheme}:///?agentId=agent-1&sessionId=session-1`,
+        deepLinkUrl: `${scheme}:///?sessionId=session-1`,
         keepAlive: true,
         props: expect.objectContaining({
           attribution: 'Alpha',
@@ -87,7 +87,7 @@ describe('BackgroundReplyRuntime', () => {
         tag: 'chat.backgroundReply',
       });
       expect(mockSessions[1]?.input).toMatchObject({
-        deepLinkUrl: `${scheme}:///?agentId=agent-2&sessionId=session-2`,
+        deepLinkUrl: `${scheme}:///?sessionId=session-2`,
         props: expect.objectContaining({
           attribution: 'Beta',
           detail: 'chat.backgroundReply.preparing',

--- a/src/backend/services/paintings/tasks/__tests__/paintingGenerateJobHandler.test.ts
+++ b/src/backend/services/paintings/tasks/__tests__/paintingGenerateJobHandler.test.ts
@@ -255,7 +255,7 @@ describe('createPaintingGenerateJobHandler', () => {
 
         expect(startSession).toHaveBeenCalledWith(
           expect.objectContaining({
-            deepLinkUrl: `${scheme}://paintings/painting-1`,
+            deepLinkUrl: `${scheme}://paintings?paintingId=painting-1`,
             keepAlive: false,
             props: expect.objectContaining({
               attribution: 'GPT Image 2',

--- a/src/bootstrap/runtime/__tests__/createAppBootstrapRuntime.test.ts
+++ b/src/bootstrap/runtime/__tests__/createAppBootstrapRuntime.test.ts
@@ -42,6 +42,9 @@ jest.mock('@/backend/data/api/handlers/apiHandlers', () => ({
 jest.mock('@/bootstrap/runtime/initializeAppRuntime', () => ({
   initializeAppRuntime: (services: unknown) => mockInitializeAppRuntime(services),
 }));
+jest.mock('@/frontend/appShell/backgroundActivity', () => ({
+  publishForegroundActivityAttention: jest.fn(),
+}));
 jest.mock('@/bootstrap/composition/createBackendServices', () => ({
   createBackendServices: (infrastructure: unknown) => mockCreateBackendServices(infrastructure),
 }));
@@ -121,6 +124,7 @@ describe('createAppBootstrapRuntime', () => {
     expect(mockBackgroundActivityEnvironment.configure).toHaveBeenCalledWith({
       assistantPresenter: expect.any(Object),
       getColorScheme: expect.any(Function),
+      onForegroundAttention: expect.any(Function),
       paintingPresenter: expect.any(Object),
       translate: expect.any(Function),
     });

--- a/src/bootstrap/runtime/createAppBootstrapRuntime.ts
+++ b/src/bootstrap/runtime/createAppBootstrapRuntime.ts
@@ -24,6 +24,7 @@ import type { WebSearchService } from '@/backend/services/webSearch/WebSearchSer
 import { createBackend } from '@/bootstrap/composition/createBackend';
 import { createBackendServices } from '@/bootstrap/composition/createBackendServices';
 import { initializeAppRuntime } from '@/bootstrap/runtime/initializeAppRuntime';
+import { publishForegroundActivityAttention } from '@/frontend/appShell/backgroundActivity';
 import AssistantActivity from '@/frontend/appShell/backgroundActivity/AssistantActivity/AssistantActivity';
 import PaintingActivity from '@/frontend/appShell/backgroundActivity/PaintingActivity/PaintingActivity';
 import i18n from '@/frontend/i18n';
@@ -61,6 +62,7 @@ export function createAppBootstrapRuntime(
     assistantPresenter:
       androidActivities?.createPresenter() ?? createLiveActivityPresenter(AssistantActivity),
     getColorScheme: () => (Uniwind.currentTheme === 'dark' ? 'dark' : 'light'),
+    onForegroundAttention: publishForegroundActivityAttention,
     paintingPresenter:
       androidActivities?.createPresenter() ?? createLiveActivityPresenter(PaintingActivity),
     translate: (key) => i18n.t(key),

--- a/src/frontend/appShell/backgroundActivity/BackgroundActivityBridge.tsx
+++ b/src/frontend/appShell/backgroundActivity/BackgroundActivityBridge.tsx
@@ -1,0 +1,34 @@
+import { useToast } from '@cherrystudio/ui/components';
+import { resolveScheme } from 'expo-linking';
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+
+import { parseBackgroundTaskUrl } from '@/shared/backgroundActivity/taskLink';
+
+import {
+  isBackgroundTaskVisible,
+  subscribeForegroundActivityAttention,
+} from './foregroundActivityAttention';
+import { useBackgroundActivityNavigation } from './useBackgroundActivityNavigation';
+
+/** Isolates notification subscriptions from the root navigator's render surface. */
+export function BackgroundActivityBridge() {
+  useBackgroundActivityNavigation();
+  const { toast } = useToast();
+  useEffect(
+    () =>
+      subscribeForegroundActivityAttention((attention) => {
+        if (
+          AppState.currentState !== 'active' ||
+          isBackgroundTaskVisible(parseBackgroundTaskUrl(attention.url, resolveScheme({})))
+        )
+          return;
+        toast.show({
+          label: `${attention.title}: ${attention.detail}`,
+          variant: attention.phase === 'failed' ? 'danger' : 'warning',
+        });
+      }),
+    [toast],
+  );
+  return null;
+}

--- a/src/frontend/appShell/backgroundActivity/README.md
+++ b/src/frontend/appShell/backgroundActivity/README.md
@@ -1,6 +1,15 @@
 # Background Activity
 
 This App Shell module owns the iOS Live Activity factories registered during app bootstrap and
-Android notification navigation after the Router mounts. These are app-level presentation adapters
-rather than page components. Android service and notification lifetimes belong to the backend's
+Android notification navigation after the Router mounts. `BackgroundActivityBridge` isolates those
+subscriptions from the navigator and shows foreground failure/approval toasts for tasks outside the
+visible surface. Bootstrap injects the presentation event into the host's environment; backend
+services never import frontend code.
+
+Chat and painting surfaces call `useBackgroundTaskNotifications` while their content is available.
+On Android it registers the focused foreground task and dismisses only that task's notifications;
+blur and drawer coverage release visibility. Other platforms retain their existing presentation.
+
+These are app-level presentation adapters rather than page components. Android service and
+notification delivery lifetimes belong to the backend's
 `AndroidBackgroundActivityRuntime`; see [Android Background Generation](../../../../docs/references/android-background-generation.md).

--- a/src/frontend/appShell/backgroundActivity/README.md
+++ b/src/frontend/appShell/backgroundActivity/README.md
@@ -1,18 +1,14 @@
 # Background Activity
 
 This App Shell module owns the iOS Live Activity factories registered during app bootstrap and
-Android notification navigation after the Router mounts. `BackgroundActivityBridge` isolates those
-subscriptions from the navigator and shows foreground failure/approval toasts for tasks outside the
-visible surface. Bootstrap injects the presentation event into the host's environment; backend
-services never import frontend code.
+Android notification navigation after the Router mounts. `BackgroundActivityBridge` connects
+navigation and foreground failure/approval toasts. Bootstrap injects presentation events into the
+host's environment; backend services never import frontend code.
 
-Chat and painting surfaces call `useBackgroundTaskNotifications` while their content is available.
-On Android it registers the focused foreground task and dismisses only that task's notifications;
-blur and drawer coverage release visibility. It reads existing notifications and observes the patched
-Expo post-presentation event, so asynchronous background delivery cannot escape the initial read.
-An unsubmitted painting edit observes no task until admission replaces its source with a new task id.
-Other platforms retain their existing presentation.
+Chat and painting surfaces use `useBackgroundTaskNotifications` to register the visible task and
+acknowledge its notifications on Android.
 
-These are app-level presentation adapters rather than page components. Android service and
-notification delivery lifetimes belong to the backend's
-`AndroidBackgroundActivityRuntime`; see [Android Background Generation](../../../../docs/references/android-background-generation.md).
+Android execution and notification delivery belong to the backend's `AndroidBackgroundActivityRuntime`.
+See [Android Background Generation](../../../../docs/references/android-background-generation.md)
+for notification behavior and [Navigation And Insets](../../../../docs/references/navigation-and-insets.md)
+for task and draft route identity.

--- a/src/frontend/appShell/backgroundActivity/README.md
+++ b/src/frontend/appShell/backgroundActivity/README.md
@@ -8,7 +8,10 @@ services never import frontend code.
 
 Chat and painting surfaces call `useBackgroundTaskNotifications` while their content is available.
 On Android it registers the focused foreground task and dismisses only that task's notifications;
-blur and drawer coverage release visibility. Other platforms retain their existing presentation.
+blur and drawer coverage release visibility. It reads existing notifications and observes the patched
+Expo post-presentation event, so asynchronous background delivery cannot escape the initial read.
+An unsubmitted painting edit observes no task until admission replaces its source with a new task id.
+Other platforms retain their existing presentation.
 
 These are app-level presentation adapters rather than page components. Android service and
 notification delivery lifetimes belong to the backend's

--- a/src/frontend/appShell/backgroundActivity/__tests__/androidNotificationPresentationPatch.test.ts
+++ b/src/frontend/appShell/backgroundActivity/__tests__/androidNotificationPresentationPatch.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const root = dirname(require.resolve('expo-notifications/package.json'));
+const source = (path: string) => readFileSync(join(root, path), 'utf8');
+const androidRoot = 'android/src/main/java/expo/modules/notifications';
+
+// Installed-package guards protect the native/JS event seam; device delivery
+// still needs acceptance in a development client containing this patch.
+test('presentation emits its own event after notify, even when background receipt skips JS', () => {
+  const presentation = source(`${androidRoot}/service/delegates/ExpoPresentationDelegate.kt`);
+  expect(presentation).toMatch(
+    /\.notify\([\s\S]*?withContext\(Dispatchers.Main\)[\s\S]*?onNotificationPresented\(notification\)/,
+  );
+  expect(source(`${androidRoot}/notifications/NotificationManager.kt`)).toContain(
+    'listener.onNotificationPresented(notification)',
+  );
+  expect(source(`${androidRoot}/notifications/emitting/NotificationsEmitter.kt`)).toContain(
+    'sendEvent("onDidPresentNotification", NotificationSerializer.toBundle(notification))',
+  );
+});
+
+test('both shipped JavaScript and TypeScript expose the presentation subscription', () => {
+  for (const path of ['src/NotificationsEmitter.ts', 'build/NotificationsEmitter.js']) {
+    expect(source(path)).toContain("didPresentNotificationEventName = 'onDidPresentNotification'");
+    expect(source(path)).toContain('export function addNotificationPresentedListener(');
+  }
+  expect(source('build/NotificationsEmitter.d.ts')).toContain(
+    'export declare function addNotificationPresentedListener(',
+  );
+});

--- a/src/frontend/appShell/backgroundActivity/__tests__/backgroundActivityNavigation.test.ts
+++ b/src/frontend/appShell/backgroundActivity/__tests__/backgroundActivityNavigation.test.ts
@@ -1,14 +1,19 @@
+import { chatHref } from '@/frontend/appShell/navigation/chat';
+
 import { backgroundActivityHref } from '../backgroundActivityNavigation';
 
 test.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
   'routes task links for the %s variant and opens nothing for other destinations',
   (scheme) => {
-    expect(backgroundActivityHref(`${scheme}:///?agentId=a&sessionId=s`, scheme)).toEqual({
-      pathname: '/',
-      params: { agentId: 'a', sessionId: 's' },
-    });
+    expect(backgroundActivityHref(`${scheme}:///?agentId=a&sessionId=s`, scheme)).toEqual(
+      chatHref({ kind: 'session', sessionId: 's' }),
+    );
     expect(backgroundActivityHref(`${scheme}://paintings/p`, scheme)).toEqual({
-      pathname: '/paintings/[paintingId]',
+      pathname: '/paintings',
+      params: { paintingId: 'p' },
+    });
+    expect(backgroundActivityHref(`${scheme}://paintings?paintingId=p`, scheme)).toEqual({
+      pathname: '/paintings',
       params: { paintingId: 'p' },
     });
     expect(backgroundActivityHref('https://example.com/paintings/p', scheme)).toBeUndefined();

--- a/src/frontend/appShell/backgroundActivity/__tests__/backgroundActivityNavigation.test.ts
+++ b/src/frontend/appShell/backgroundActivity/__tests__/backgroundActivityNavigation.test.ts
@@ -2,23 +2,18 @@ import { chatHref } from '@/frontend/appShell/navigation/chat';
 
 import { backgroundActivityHref } from '../backgroundActivityNavigation';
 
-test.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
-  'routes task links for the %s variant and opens nothing for other destinations',
-  (scheme) => {
-    expect(backgroundActivityHref(`${scheme}:///?agentId=a&sessionId=s`, scheme)).toEqual(
-      chatHref({ kind: 'session', sessionId: 's' }),
-    );
-    expect(backgroundActivityHref(`${scheme}://paintings/p`, scheme)).toEqual({
-      pathname: '/paintings',
-      params: { paintingId: 'p' },
-    });
-    expect(backgroundActivityHref(`${scheme}://paintings?paintingId=p`, scheme)).toEqual({
-      pathname: '/paintings',
-      params: { paintingId: 'p' },
-    });
-    expect(backgroundActivityHref('https://example.com/paintings/p', scheme)).toBeUndefined();
-    expect(backgroundActivityHref(`${scheme}://settings`, scheme)).toBeUndefined();
-    expect(backgroundActivityHref(`${scheme}:///?agentId=a`, scheme)).toBeUndefined();
-    expect(backgroundActivityHref(`${scheme}://paintings/%E0%A4`, scheme)).toBeUndefined();
-  },
-);
+test('maps current and legacy task links to their owning routes', () => {
+  const scheme = 'cherrystudio-dev';
+  expect(backgroundActivityHref(`${scheme}:///?sessionId=s`, scheme)).toEqual(
+    chatHref({ kind: 'session', sessionId: 's' }),
+  );
+  expect(backgroundActivityHref(`${scheme}://paintings/p`, scheme)).toEqual({
+    pathname: '/paintings',
+    params: { paintingId: 'p' },
+  });
+  expect(backgroundActivityHref(`${scheme}://paintings?paintingId=p`, scheme)).toEqual({
+    pathname: '/paintings',
+    params: { paintingId: 'p' },
+  });
+  expect(backgroundActivityHref(`${scheme}://settings`, scheme)).toBeUndefined();
+});

--- a/src/frontend/appShell/backgroundActivity/__tests__/foregroundActivityAttention.test.ts
+++ b/src/frontend/appShell/backgroundActivity/__tests__/foregroundActivityAttention.test.ts
@@ -1,0 +1,16 @@
+import {
+  isBackgroundTaskVisible,
+  registerVisibleBackgroundTask,
+} from '../foregroundActivityAttention';
+
+test('an outgoing screen cannot clear visibility registered by the next screen', () => {
+  const first = { kind: 'chat', sessionId: 'first' } as const;
+  const second = { kind: 'painting', paintingId: 'second' } as const;
+  const releaseFirst = registerVisibleBackgroundTask(first);
+  const releaseSecond = registerVisibleBackgroundTask(second);
+  releaseFirst();
+  expect(isBackgroundTaskVisible(first)).toBe(false);
+  expect(isBackgroundTaskVisible(second)).toBe(true);
+  releaseSecond();
+  expect(isBackgroundTaskVisible(second)).toBe(false);
+});

--- a/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundActivityNavigation.android.test.tsx
+++ b/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundActivityNavigation.android.test.tsx
@@ -90,6 +90,20 @@ test('ignores unrelated notifications and consumes invalid owned destinations wi
 function response(url: string, owner = BACKGROUND_NOTIFICATION_OWNER): NotificationResponse {
   return {
     actionIdentifier: 'default',
-    notification: { request: { identifier: 'notice', content: { data: { owner, url } } } },
-  } as NotificationResponse;
+    notification: {
+      date: 0,
+      request: {
+        identifier: 'notice',
+        trigger: null,
+        content: {
+          title: null,
+          subtitle: null,
+          body: null,
+          categoryIdentifier: null,
+          sound: null,
+          data: { owner, url },
+        },
+      },
+    },
+  };
 }

--- a/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundActivityNavigation.android.test.tsx
+++ b/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundActivityNavigation.android.test.tsx
@@ -1,0 +1,95 @@
+import type { NotificationResponse } from 'expo-notifications';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { BACKGROUND_NOTIFICATION_OWNER } from '@/shared/backgroundActivity/types';
+
+import { registerVisibleBackgroundTask } from '../foregroundActivityAttention';
+import { useBackgroundActivityNavigation } from '../useBackgroundActivityNavigation/useBackgroundActivityNavigation.android';
+
+let mockResponse: NotificationResponse | null;
+let mockNavigationKey: string | undefined;
+const mockRouter = { navigate: jest.fn() };
+const mockClear = jest.fn(() => {
+  mockResponse = null;
+});
+const mockDismiss = jest.fn(async (_id: string) => {});
+let renderer: ReactTestRenderer | undefined;
+
+jest.mock('expo-linking', () => ({ resolveScheme: () => 'cherrystudio' }));
+jest.mock('expo-notifications', () => ({
+  DEFAULT_ACTION_IDENTIFIER: 'default',
+  useLastNotificationResponse: () => mockResponse,
+  clearLastNotificationResponse: () => mockClear(),
+  dismissNotificationAsync: (id: string) => mockDismiss(id),
+}));
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+  useRootNavigationState: () => ({ key: mockNavigationKey }),
+}));
+
+function Probe() {
+  useBackgroundActivityNavigation();
+  return null;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNavigationKey = 'root';
+  mockResponse = response('cherrystudio://paintings/p');
+});
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = undefined;
+});
+
+test('retains a cold-start response until navigation mounts, then opens the task once', async () => {
+  mockNavigationKey = undefined;
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  expect(mockClear).not.toHaveBeenCalled();
+  expect(mockRouter.navigate).not.toHaveBeenCalled();
+  mockNavigationKey = 'root';
+  await act(async () => renderer?.update(<Probe />));
+  expect(mockRouter.navigate).toHaveBeenCalledWith({
+    pathname: '/paintings',
+    params: { paintingId: 'p' },
+  });
+  expect(mockDismiss).toHaveBeenCalledWith('notice');
+  await act(async () => renderer?.update(<Probe />));
+  expect(mockRouter.navigate).toHaveBeenCalledTimes(1);
+});
+
+test('consumes a tap for the already visible task without adding navigation history', async () => {
+  const release = registerVisibleBackgroundTask({ kind: 'painting', paintingId: 'p' });
+  try {
+    await act(async () => {
+      renderer = create(<Probe />);
+    });
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockDismiss).toHaveBeenCalledWith('notice');
+  } finally {
+    release();
+  }
+});
+
+test('ignores unrelated notifications and consumes invalid owned destinations without navigation', async () => {
+  mockResponse = response('cherrystudio://settings', 'other');
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  expect(mockClear).not.toHaveBeenCalled();
+  expect(mockDismiss).not.toHaveBeenCalled();
+  mockResponse = response('cherrystudio://settings');
+  await act(async () => renderer?.update(<Probe />));
+  expect(mockRouter.navigate).not.toHaveBeenCalled();
+  expect(mockClear).toHaveBeenCalledTimes(1);
+});
+
+function response(url: string, owner = BACKGROUND_NOTIFICATION_OWNER): NotificationResponse {
+  return {
+    actionIdentifier: 'default',
+    notification: { request: { identifier: 'notice', content: { data: { owner, url } } } },
+  } as NotificationResponse;
+}

--- a/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
+++ b/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
@@ -12,6 +12,7 @@ let mockFocused = true;
 const mockPresented = jest.fn<Promise<Notification[]>, []>();
 const mockDismiss = jest.fn(async (_id: string) => {});
 const mockNotificationListeners = new Set<(notification: Notification) => void>();
+const mockPresentationListeners = new Set<(notification: Notification) => void>();
 const appStateListeners = new Set<(state: AppStateStatus) => void>();
 const task = { kind: 'chat', sessionId: 's' } as const;
 let renderer: ReactTestRenderer | undefined;
@@ -23,6 +24,10 @@ jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: (listener: (notification: Notification) => void) => {
     mockNotificationListeners.add(listener);
     return { remove: () => mockNotificationListeners.delete(listener) };
+  },
+  addNotificationPresentedListener: (listener: (notification: Notification) => void) => {
+    mockPresentationListeners.add(listener);
+    return { remove: () => mockPresentationListeners.delete(listener) };
   },
 }));
 jest.mock('expo-router', () => ({
@@ -91,6 +96,7 @@ test('acknowledges only a foreground focused page and releases subscriptions on 
   expect(isBackgroundTaskVisible(task)).toBe(false);
   expect(appStateListeners.size).toBe(0);
   expect(mockNotificationListeners.size).toBe(0);
+  expect(mockPresentationListeners.size).toBe(0);
 });
 
 test('a drawer-covered or unloaded surface does not acknowledge its task', async () => {
@@ -122,12 +128,43 @@ test('clears a matching late delivery while preserving unrelated task notificati
     renderer = create(<Probe target={{ kind: 'painting', paintingId: 'p' }} />);
   });
   await act(async () => {
-    for (const listener of mockNotificationListeners) {
+    for (const listener of mockPresentationListeners) {
       listener(notice('paint', 'cherrystudio://paintings/p'));
       listener(notice('chat', 'cherrystudio:///?sessionId=p'));
     }
   });
   expect(mockDismiss.mock.calls).toEqual([['paint']]);
+});
+
+test('clears a background post that lands after the foreground snapshot without any receipt event', async () => {
+  setAppState('background');
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  // Native background handling skips the received event and starts asynchronous
+  // presentation. The user returns before that work calls the system notify API.
+  await act(async () => setAppState('active'));
+  expect(mockPresented).toHaveBeenCalledTimes(1);
+  expect(mockDismiss).not.toHaveBeenCalled();
+  await act(async () => {
+    for (const listener of mockPresentationListeners) {
+      listener(notice('late-post', 'cherrystudio:///?sessionId=s'));
+    }
+  });
+  expect(mockDismiss.mock.calls).toEqual([['late-post']]);
+});
+
+test('presentation events preserve notifications when the task is in the background', async () => {
+  setAppState('background');
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  await act(async () => {
+    for (const listener of mockPresentationListeners) {
+      listener(notice('unread', 'cherrystudio:///?sessionId=s'));
+    }
+  });
+  expect(mockDismiss).not.toHaveBeenCalled();
 });
 
 function setAppState(state: AppStateStatus) {

--- a/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
+++ b/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
@@ -136,5 +136,19 @@ function setAppState(state: AppStateStatus) {
 }
 
 function notice(id: string, url: string, owner = BACKGROUND_NOTIFICATION_OWNER): Notification {
-  return { request: { identifier: id, content: { data: { owner, url } } } } as Notification;
+  return {
+    date: 0,
+    request: {
+      identifier: id,
+      trigger: null,
+      content: {
+        title: null,
+        subtitle: null,
+        body: null,
+        categoryIdentifier: null,
+        sound: null,
+        data: { owner, url },
+      },
+    },
+  };
 }

--- a/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
+++ b/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
@@ -1,0 +1,140 @@
+import type { Notification } from 'expo-notifications';
+import { AppState, type AppStateStatus } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { BackgroundTaskLink } from '@/shared/backgroundActivity/taskLink';
+import { BACKGROUND_NOTIFICATION_OWNER } from '@/shared/backgroundActivity/types';
+
+import { isBackgroundTaskVisible } from '../foregroundActivityAttention';
+import { useBackgroundTaskNotifications } from '../useBackgroundTaskNotifications/useBackgroundTaskNotifications.android';
+
+let mockFocused = true;
+const mockPresented = jest.fn<Promise<Notification[]>, []>();
+const mockDismiss = jest.fn(async (_id: string) => {});
+const mockNotificationListeners = new Set<(notification: Notification) => void>();
+const appStateListeners = new Set<(state: AppStateStatus) => void>();
+const task = { kind: 'chat', sessionId: 's' } as const;
+let renderer: ReactTestRenderer | undefined;
+
+jest.mock('expo-linking', () => ({ resolveScheme: () => 'cherrystudio' }));
+jest.mock('expo-notifications', () => ({
+  getPresentedNotificationsAsync: () => mockPresented(),
+  dismissNotificationAsync: (id: string) => mockDismiss(id),
+  addNotificationReceivedListener: (listener: (notification: Notification) => void) => {
+    mockNotificationListeners.add(listener);
+    return { remove: () => mockNotificationListeners.delete(listener) };
+  },
+}));
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => void | (() => void)) => {
+    const { useEffect } = jest.requireActual<typeof import('react')>('react');
+    const focused = mockFocused;
+    useEffect(() => (focused ? effect() : undefined), [effect, focused]);
+  },
+}));
+
+function Probe({
+  target = task,
+  enabled = true,
+}: {
+  target?: BackgroundTaskLink;
+  enabled?: boolean;
+}) {
+  useBackgroundTaskNotifications(target, enabled);
+  return null;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFocused = true;
+  mockPresented.mockResolvedValue([]);
+  setAppState('active');
+  jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, listener) => {
+    appStateListeners.add(listener);
+    return { remove: () => appStateListeners.delete(listener) };
+  });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = undefined;
+  jest.restoreAllMocks();
+});
+
+test('clears old and new notices for the viewed task while retaining other unread tasks', async () => {
+  mockPresented.mockResolvedValue([
+    notice('old', 'cherrystudio:///?agentId=a&sessionId=s'),
+    notice('new', 'cherrystudio:///?sessionId=s'),
+    notice('other-chat', 'cherrystudio:///?sessionId=other'),
+    notice('painting', 'cherrystudio://paintings?paintingId=s'),
+    notice('foreign-owner', 'cherrystudio:///?sessionId=s', 'other'),
+  ]);
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  expect(mockDismiss.mock.calls).toEqual([['old'], ['new']]);
+  expect(isBackgroundTaskVisible(task)).toBe(true);
+});
+
+test('acknowledges only a foreground focused page and releases subscriptions on blur', async () => {
+  setAppState('background');
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  expect(mockPresented).not.toHaveBeenCalled();
+  expect(isBackgroundTaskVisible(task)).toBe(false);
+  await act(async () => setAppState('active'));
+  expect(mockPresented).toHaveBeenCalledTimes(1);
+  expect(isBackgroundTaskVisible(task)).toBe(true);
+  mockFocused = false;
+  await act(async () => renderer?.update(<Probe />));
+  expect(isBackgroundTaskVisible(task)).toBe(false);
+  expect(appStateListeners.size).toBe(0);
+  expect(mockNotificationListeners.size).toBe(0);
+});
+
+test('a drawer-covered or unloaded surface does not acknowledge its task', async () => {
+  await act(async () => {
+    renderer = create(<Probe enabled={false} />);
+  });
+  expect(mockPresented).not.toHaveBeenCalled();
+  expect(isBackgroundTaskVisible(task)).toBe(false);
+});
+
+test('an in-flight drawer read cannot clear notices after the user leaves the task', async () => {
+  let resolvePresented!: (notifications: Notification[]) => void;
+  mockPresented.mockReturnValue(
+    new Promise((resolve) => {
+      resolvePresented = resolve;
+    }),
+  );
+  await act(async () => {
+    renderer = create(<Probe />);
+  });
+  mockFocused = false;
+  await act(async () => renderer?.update(<Probe />));
+  await act(async () => resolvePresented([notice('late', 'cherrystudio:///?sessionId=s')]));
+  expect(mockDismiss).not.toHaveBeenCalled();
+});
+
+test('clears a matching late delivery while preserving unrelated task notifications', async () => {
+  await act(async () => {
+    renderer = create(<Probe target={{ kind: 'painting', paintingId: 'p' }} />);
+  });
+  await act(async () => {
+    for (const listener of mockNotificationListeners) {
+      listener(notice('paint', 'cherrystudio://paintings/p'));
+      listener(notice('chat', 'cherrystudio:///?sessionId=p'));
+    }
+  });
+  expect(mockDismiss.mock.calls).toEqual([['paint']]);
+});
+
+function setAppState(state: AppStateStatus) {
+  Object.defineProperty(AppState, 'currentState', { configurable: true, value: state });
+  for (const listener of appStateListeners) listener(state);
+}
+
+function notice(id: string, url: string, owner = BACKGROUND_NOTIFICATION_OWNER): Notification {
+  return { request: { identifier: id, content: { data: { owner, url } } } } as Notification;
+}

--- a/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
+++ b/src/frontend/appShell/backgroundActivity/__tests__/useBackgroundTaskNotifications.android.test.tsx
@@ -11,7 +11,6 @@ import { useBackgroundTaskNotifications } from '../useBackgroundTaskNotification
 let mockFocused = true;
 const mockPresented = jest.fn<Promise<Notification[]>, []>();
 const mockDismiss = jest.fn(async (_id: string) => {});
-const mockNotificationListeners = new Set<(notification: Notification) => void>();
 const mockPresentationListeners = new Set<(notification: Notification) => void>();
 const appStateListeners = new Set<(state: AppStateStatus) => void>();
 const task = { kind: 'chat', sessionId: 's' } as const;
@@ -21,10 +20,6 @@ jest.mock('expo-linking', () => ({ resolveScheme: () => 'cherrystudio' }));
 jest.mock('expo-notifications', () => ({
   getPresentedNotificationsAsync: () => mockPresented(),
   dismissNotificationAsync: (id: string) => mockDismiss(id),
-  addNotificationReceivedListener: (listener: (notification: Notification) => void) => {
-    mockNotificationListeners.add(listener);
-    return { remove: () => mockNotificationListeners.delete(listener) };
-  },
   addNotificationPresentedListener: (listener: (notification: Notification) => void) => {
     mockPresentationListeners.add(listener);
     return { remove: () => mockPresentationListeners.delete(listener) };
@@ -95,7 +90,6 @@ test('acknowledges only a foreground focused page and releases subscriptions on 
   await act(async () => renderer?.update(<Probe />));
   expect(isBackgroundTaskVisible(task)).toBe(false);
   expect(appStateListeners.size).toBe(0);
-  expect(mockNotificationListeners.size).toBe(0);
   expect(mockPresentationListeners.size).toBe(0);
 });
 

--- a/src/frontend/appShell/backgroundActivity/backgroundActivityNavigation.ts
+++ b/src/frontend/appShell/backgroundActivity/backgroundActivityNavigation.ts
@@ -1,5 +1,6 @@
 import type { Href } from 'expo-router';
 
+import { chatHref } from '@/frontend/appShell/navigation/chat';
 import { parseBackgroundTaskUrl } from '@/shared/backgroundActivity/taskLink';
 
 /** Maps a task link to the route that owns it; anything else opens nothing. */
@@ -7,9 +8,9 @@ export function backgroundActivityHref(url: unknown, scheme: string): Href | und
   const link = parseBackgroundTaskUrl(url, scheme);
   switch (link?.kind) {
     case 'chat':
-      return { pathname: '/', params: { agentId: link.agentId, sessionId: link.sessionId } };
+      return chatHref({ kind: 'session', sessionId: link.sessionId });
     case 'painting':
-      return { pathname: '/paintings/[paintingId]', params: { paintingId: link.paintingId } };
+      return { pathname: '/paintings', params: { paintingId: link.paintingId } };
     default:
       return undefined;
   }

--- a/src/frontend/appShell/backgroundActivity/foregroundActivityAttention.ts
+++ b/src/frontend/appShell/backgroundActivity/foregroundActivityAttention.ts
@@ -1,0 +1,33 @@
+import type { ForegroundActivityAttention } from '@/shared/backgroundActivity/attention';
+import {
+  type BackgroundTaskLink,
+  isSameBackgroundTask,
+} from '@/shared/backgroundActivity/taskLink';
+
+type AttentionListener = (attention: ForegroundActivityAttention) => void;
+const listeners = new Set<AttentionListener>();
+let visibleTask: BackgroundTaskLink | undefined;
+
+/** Only a focused, foreground task surface registers itself as visible. */
+export function registerVisibleBackgroundTask(task: BackgroundTaskLink): () => void {
+  visibleTask = task;
+  return () => {
+    if (visibleTask === task) visibleTask = undefined;
+  };
+}
+
+export function isBackgroundTaskVisible(task: BackgroundTaskLink | undefined): boolean {
+  return isSameBackgroundTask(visibleTask, task);
+}
+
+/** Bootstrap injects this presentation port; backend code never imports the app shell. */
+export function publishForegroundActivityAttention(attention: ForegroundActivityAttention): void {
+  for (const listener of listeners) listener(attention);
+}
+
+export function subscribeForegroundActivityAttention(listener: AttentionListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/frontend/appShell/backgroundActivity/index.ts
+++ b/src/frontend/appShell/backgroundActivity/index.ts
@@ -1,0 +1,3 @@
+export { BackgroundActivityBridge } from './BackgroundActivityBridge';
+export { publishForegroundActivityAttention } from './foregroundActivityAttention';
+export { useBackgroundTaskNotifications } from './useBackgroundTaskNotifications/useBackgroundTaskNotifications';

--- a/src/frontend/appShell/backgroundActivity/useBackgroundActivityNavigation/useBackgroundActivityNavigation.android.ts
+++ b/src/frontend/appShell/backgroundActivity/useBackgroundActivityNavigation/useBackgroundActivityNavigation.android.ts
@@ -2,14 +2,20 @@ import { resolveScheme } from 'expo-linking';
 import {
   clearLastNotificationResponse,
   DEFAULT_ACTION_IDENTIFIER,
+  dismissNotificationAsync,
   useLastNotificationResponse,
 } from 'expo-notifications';
 import { useRootNavigationState, useRouter } from 'expo-router';
 import { useEffect } from 'react';
 
+import { parseBackgroundTaskUrl } from '@/shared/backgroundActivity/taskLink';
 import { BACKGROUND_NOTIFICATION_OWNER } from '@/shared/backgroundActivity/types';
+import { loggerService } from '@/shared/core/logger/LoggerService';
 
 import { backgroundActivityHref } from '../backgroundActivityNavigation';
+import { isBackgroundTaskVisible } from '../foregroundActivityAttention';
+
+const logger = loggerService.withContext('BackgroundActivityNavigation');
 
 export function useBackgroundActivityNavigation(): void {
   const router = useRouter();
@@ -25,8 +31,16 @@ export function useBackgroundActivityNavigation(): void {
       response.actionIdentifier !== DEFAULT_ACTION_IDENTIFIER
     )
       return;
+    const scheme = resolveScheme({});
+    const href = backgroundActivityHref(data.url, scheme);
+    if (href && !isBackgroundTaskVisible(parseBackgroundTaskUrl(data.url, scheme))) {
+      router.navigate(href);
+    }
     clearLastNotificationResponse();
-    const href = backgroundActivityHref(data.url, resolveScheme({}));
-    if (href) router.push(href);
+    void dismissNotificationAsync(response.notification.request.identifier).catch(
+      (error: unknown) => {
+        logger.warn('Could not dismiss opened notification', { error });
+      },
+    );
   }, [navigationKey, response, router]);
 }

--- a/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.android.ts
+++ b/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.android.ts
@@ -1,0 +1,77 @@
+import { resolveScheme } from 'expo-linking';
+import {
+  addNotificationReceivedListener,
+  dismissNotificationAsync,
+  getPresentedNotificationsAsync,
+  type Notification,
+} from 'expo-notifications';
+import { useFocusEffect } from 'expo-router';
+import { useCallback } from 'react';
+import { AppState } from 'react-native';
+
+import {
+  type BackgroundTaskLink,
+  createBackgroundTaskUrl,
+  isSameBackgroundTask,
+  parseBackgroundTaskUrl,
+} from '@/shared/backgroundActivity/taskLink';
+import { BACKGROUND_NOTIFICATION_OWNER } from '@/shared/backgroundActivity/types';
+import { loggerService } from '@/shared/core/logger/LoggerService';
+
+import { registerVisibleBackgroundTask } from '../foregroundActivityAttention';
+
+const logger = loggerService.withContext('BackgroundTaskNotifications');
+
+export function useBackgroundTaskNotifications(
+  task: BackgroundTaskLink | undefined,
+  enabled = true,
+): void {
+  const scheme = resolveScheme({});
+  const url = task ? createBackgroundTaskUrl(scheme, task) : undefined;
+
+  useFocusEffect(
+    useCallback(() => {
+      const target = parseBackgroundTaskUrl(url, scheme);
+      if (!enabled || !target) return;
+      let releaseVisibility: (() => void) | undefined;
+      let focused = true;
+
+      const dismissViewed = async (notification: Notification) => {
+        const { data } = notification.request.content;
+        if (
+          focused &&
+          AppState.currentState === 'active' &&
+          data?.owner === BACKGROUND_NOTIFICATION_OWNER &&
+          isSameBackgroundTask(target, parseBackgroundTaskUrl(data.url, scheme))
+        ) {
+          await dismissNotificationAsync(notification.request.identifier);
+        }
+      };
+      const reportError = (error: unknown) =>
+        logger.warn('Could not clear viewed notification', { error });
+      const updateVisibility = () => {
+        releaseVisibility?.();
+        releaseVisibility = undefined;
+        if (AppState.currentState !== 'active') return;
+        releaseVisibility = registerVisibleBackgroundTask(target);
+        void getPresentedNotificationsAsync()
+          .then((notifications) => Promise.all(notifications.map(dismissViewed)))
+          .catch(reportError);
+      };
+
+      // Delivery can finish after the initial drawer snapshot. Only this task
+      // is acknowledged, and pending reads cannot acknowledge a blurred page.
+      const received = addNotificationReceivedListener((notification) => {
+        void dismissViewed(notification).catch(reportError);
+      });
+      const appState = AppState.addEventListener('change', updateVisibility);
+      updateVisibility();
+      return () => {
+        focused = false;
+        releaseVisibility?.();
+        appState.remove();
+        received.remove();
+      };
+    }, [enabled, scheme, url]),
+  );
+}

--- a/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.android.ts
+++ b/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.android.ts
@@ -1,6 +1,6 @@
 import { resolveScheme } from 'expo-linking';
 import {
-  addNotificationReceivedListener,
+  addNotificationPresentedListener,
   dismissNotificationAsync,
   getPresentedNotificationsAsync,
   type Notification,
@@ -59,9 +59,9 @@ export function useBackgroundTaskNotifications(
           .catch(reportError);
       };
 
-      // Delivery can finish after the initial drawer snapshot. Only this task
-      // is acknowledged, and pending reads cannot acknowledge a blurred page.
-      const received = addNotificationReceivedListener((notification) => {
+      // The native presentation event follows the actual post, including background
+      // delivery. Receipt alone can happen before posting or never reach JS at all.
+      const presented = addNotificationPresentedListener((notification) => {
         void dismissViewed(notification).catch(reportError);
       });
       const appState = AppState.addEventListener('change', updateVisibility);
@@ -70,7 +70,7 @@ export function useBackgroundTaskNotifications(
         focused = false;
         releaseVisibility?.();
         appState.remove();
-        received.remove();
+        presented.remove();
       };
     }, [enabled, scheme, url]),
   );

--- a/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.android.ts
+++ b/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.android.ts
@@ -11,7 +11,6 @@ import { AppState } from 'react-native';
 
 import {
   type BackgroundTaskLink,
-  createBackgroundTaskUrl,
   isSameBackgroundTask,
   parseBackgroundTaskUrl,
 } from '@/shared/backgroundActivity/taskLink';
@@ -27,12 +26,16 @@ export function useBackgroundTaskNotifications(
   enabled = true,
 ): void {
   const scheme = resolveScheme({});
-  const url = task ? createBackgroundTaskUrl(scheme, task) : undefined;
+  const taskKind = task?.kind;
+  const taskId = task?.kind === 'chat' ? task.sessionId : task?.paintingId;
 
   useFocusEffect(
     useCallback(() => {
-      const target = parseBackgroundTaskUrl(url, scheme);
-      if (!enabled || !target) return;
+      if (!enabled || !taskKind || !taskId) return;
+      const target: BackgroundTaskLink =
+        taskKind === 'chat'
+          ? { kind: taskKind, sessionId: taskId }
+          : { kind: taskKind, paintingId: taskId };
       let releaseVisibility: (() => void) | undefined;
       let focused = true;
 
@@ -72,6 +75,6 @@ export function useBackgroundTaskNotifications(
         appState.remove();
         presented.remove();
       };
-    }, [enabled, scheme, url]),
+    }, [enabled, scheme, taskId, taskKind]),
   );
 }

--- a/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.ts
+++ b/src/frontend/appShell/backgroundActivity/useBackgroundTaskNotifications/useBackgroundTaskNotifications.ts
@@ -1,0 +1,7 @@
+import type { BackgroundTaskLink } from '@/shared/backgroundActivity/taskLink';
+
+/** iOS Live Activities retain their own presentation lifecycle. */
+export function useBackgroundTaskNotifications(
+  _task: BackgroundTaskLink | undefined,
+  _enabled = true,
+): void {}

--- a/src/frontend/appShell/navigation/__tests__/paintingRoute.test.ts
+++ b/src/frontend/appShell/navigation/__tests__/paintingRoute.test.ts
@@ -1,0 +1,23 @@
+import { paintingRouteId } from '../paintingRoute';
+
+test('edits and resizes of the same painting own distinct drafts instead of reusing its task', () => {
+  const task = paintingRouteId({ paintingId: 'p' });
+  const edit = paintingRouteId({ paintingId: 'p', handoff: 'edit' });
+  const resize = paintingRouteId({ paintingId: 'p', handoff: 'resize' });
+  expect(new Set([task, edit, resize]).size).toBe(3);
+  expect(paintingRouteId({ paintingId: 'p', handoff: 'edit' })).toBe(edit);
+});
+
+test('an admitted draft matches its new task notification after releasing its handoff parameter', () => {
+  const draft = { paintingId: 'source', handoff: 'edit' };
+  const admitted = { ...draft, handoff: undefined, paintingId: 'generated' };
+  expect(paintingRouteId(admitted)).toBe(paintingRouteId({ paintingId: 'generated' }));
+  expect(paintingRouteId(admitted)).not.toBe(paintingRouteId(draft));
+  expect(paintingRouteId(admitted)).not.toBe(paintingRouteId({ paintingId: 'source' }));
+});
+
+test('fresh canvases have no shared identity and task ids cannot collide with draft tokens', () => {
+  expect(paintingRouteId()).toBeUndefined();
+  expect(paintingRouteId({ paintingId: undefined, handoff: undefined })).toBeUndefined();
+  expect(paintingRouteId({ paintingId: 'same' })).not.toBe(paintingRouteId({ handoff: 'same' }));
+});

--- a/src/frontend/appShell/navigation/index.ts
+++ b/src/frontend/appShell/navigation/index.ts
@@ -3,6 +3,7 @@ export type { ContextMenuLinkItem } from './components/ContextMenuLink';
 export { NavigationThemeProvider } from './components/NavigationThemeProvider';
 export { FirstUseGate } from './components/FirstUseGate';
 export { resolveHeaderContentInset } from './headerContentInset/headerContentInset';
+export { paintingRouteId } from './paintingRoute';
 export {
   providerSetupHref,
   readProviderSetupReturnTo,

--- a/src/frontend/appShell/navigation/paintingRoute.ts
+++ b/src/frontend/appShell/navigation/paintingRoute.ts
@@ -1,0 +1,12 @@
+import { getSingleRouteParam } from '@/frontend/utils/routeParams';
+
+/** A new edit owns its draft; its source painting is not the task it will create. */
+export function paintingRouteId(params?: {
+  handoff?: string | string[];
+  paintingId?: string | string[];
+}): string | undefined {
+  const handoff = getSingleRouteParam(params?.handoff);
+  if (handoff) return `draft:${handoff}`;
+  const paintingId = getSingleRouteParam(params?.paintingId);
+  return paintingId ? `painting:${paintingId}` : undefined;
+}

--- a/src/frontend/features/chat/hooks/__tests__/useSessionReadReceipt.test.tsx
+++ b/src/frontend/features/chat/hooks/__tests__/useSessionReadReceipt.test.tsx
@@ -18,6 +18,9 @@ jest.mock('expo-router', () => ({
 }));
 
 jest.mock('expo-router/drawer', () => ({ useDrawerStatus: () => mockDrawerStatus }));
+jest.mock('@/frontend/appShell/backgroundActivity', () => ({
+  useBackgroundTaskNotifications: jest.fn(),
+}));
 jest.mock('@/frontend/hooks/agent', () => ({
   useAgentSessionStatus: () => ({ markSeen: mockMarkSeen }),
 }));

--- a/src/frontend/features/chat/hooks/useSessionReadReceipt.ts
+++ b/src/frontend/features/chat/hooks/useSessionReadReceipt.ts
@@ -3,12 +3,14 @@ import { useDrawerStatus } from 'expo-router/drawer';
 import { useCallback } from 'react';
 import { AppState } from 'react-native';
 
+import { useBackgroundTaskNotifications } from '@/frontend/appShell/backgroundActivity';
 import { useAgentSessionStatus } from '@/frontend/hooks/agent';
 
 /** Only the visible chat acknowledges completion; drawers and background routes do not. */
 export function useSessionReadReceipt(sessionId: string) {
   const { markSeen } = useAgentSessionStatus(sessionId);
   const drawerStatus = useDrawerStatus();
+  useBackgroundTaskNotifications({ kind: 'chat', sessionId }, drawerStatus === 'closed');
 
   useFocusEffect(
     useCallback(() => {

--- a/src/frontend/features/paintings/PaintingScreen.tsx
+++ b/src/frontend/features/paintings/PaintingScreen.tsx
@@ -3,6 +3,7 @@ import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useCallback, useState } from 'react';
 import { View } from 'react-native';
 
+import { useBackgroundTaskNotifications } from '@/frontend/appShell/backgroundActivity';
 import { RouteHeader } from '@/frontend/appShell/header';
 import { usePainting, useResolvedPaintingFiles } from '@/frontend/data/paintings/usePaintings';
 import { consumePaintingDraftHandoff } from '@/frontend/utils/paintingDraftHandoff';
@@ -42,6 +43,10 @@ export function PaintingScreen() {
     openedPaintingId !== undefined &&
     paintingId === openedPaintingId &&
     (paintingQuery.isLoading || filesQuery.isLoading);
+  useBackgroundTaskNotifications(
+    paintingId ? { kind: 'painting', paintingId } : undefined,
+    Boolean(painting) && !isLoading,
+  );
   const handleReceipt = useCallback(
     (receiptId: string | undefined) => navigation.setParams({ paintingId: receiptId }),
     [navigation],

--- a/src/frontend/features/paintings/PaintingScreen.tsx
+++ b/src/frontend/features/paintings/PaintingScreen.tsx
@@ -18,7 +18,7 @@ export function PaintingScreen() {
   // `RootParamList` is empty here (no generated route types), so the default
   // `setParams` signature takes `undefined`; name the params this screen owns.
   const navigation = useNavigation<{
-    setParams(params: { paintingId: string | undefined }): void;
+    setParams(params: { handoff: undefined; paintingId: string | undefined }): void;
   }>();
   const params = useLocalSearchParams<{
     handoff?: string | string[];
@@ -45,10 +45,13 @@ export function PaintingScreen() {
     (paintingQuery.isLoading || filesQuery.isLoading);
   useBackgroundTaskNotifications(
     paintingId ? { kind: 'painting', paintingId } : undefined,
-    Boolean(painting) && !isLoading,
+    !handoffToken && Boolean(painting) && !isLoading,
   );
   const handleReceipt = useCallback(
-    (receiptId: string | undefined) => navigation.setParams({ paintingId: receiptId }),
+    // Admission changes the draft's route identity to its own task. Keep its
+    // mounted composer state, but stop identifying it with the source painting.
+    (receiptId: string | undefined) =>
+      navigation.setParams({ handoff: undefined, paintingId: receiptId }),
     [navigation],
   );
   const initialAttachments = handoff?.attachments ?? [];

--- a/src/frontend/features/paintings/viewer/PaintingViewerScreen.tsx
+++ b/src/frontend/features/paintings/viewer/PaintingViewerScreen.tsx
@@ -1,11 +1,12 @@
 /* oxlint-disable react/style-prop-object -- Expo StatusBar style is a string union. */
 import { ContentState, Spinner } from '@cherrystudio/ui/components';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 
+import { useBackgroundTaskNotifications } from '@/frontend/appShell/backgroundActivity';
 import { RouteHeader } from '@/frontend/appShell/header';
 import {
   type ResolvedPaintingAttachment,
@@ -36,6 +37,10 @@ export function PaintingViewerScreen() {
   const outputs = files.data?.outputs ?? [];
   const currentIndex = outputs.findIndex((output) => output.fileEntryId === fileEntryId);
   const current = currentIndex >= 0 ? outputs[currentIndex] : undefined;
+  useBackgroundTaskNotifications(
+    paintingId ? { kind: 'painting', paintingId } : undefined,
+    Boolean(painting.data && current),
+  );
   const constantWhite = useThemeColor('constant-white');
   const closeViewer = useCallback(() => {
     if (router.canGoBack()) {
@@ -44,6 +49,12 @@ export function PaintingViewerScreen() {
       router.replace('/drawings');
     }
   }, [router]);
+
+  // Old ongoing notifications use this path but have no selected output.
+  // A task can also be running or failed, so open its task surface.
+  if (paintingId && !fileEntryId) {
+    return <Redirect href={{ pathname: '/paintings', params: { paintingId } }} />;
+  }
 
   if (!painting.data || !current) {
     if (!painting.isLoading && !files.isLoading) {

--- a/src/shared/backgroundActivity/__tests__/taskLink.test.ts
+++ b/src/shared/backgroundActivity/__tests__/taskLink.test.ts
@@ -1,10 +1,10 @@
-import { createBackgroundTaskUrl, parseBackgroundTaskUrl } from '../taskLink';
+import { createBackgroundTaskUrl, isSameBackgroundTask, parseBackgroundTaskUrl } from '../taskLink';
 
 describe.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
   'background task links for the %s scheme',
   (scheme) => {
     test('chat and painting links round-trip, including ids that need encoding', () => {
-      const chat = { agentId: 'agent/1', kind: 'chat', sessionId: 'session?2&3' } as const;
+      const chat = { kind: 'chat', sessionId: 'session?2&3' } as const;
       const painting = { kind: 'painting', paintingId: 'painting #4/5' } as const;
 
       expect(parseBackgroundTaskUrl(createBackgroundTaskUrl(scheme, chat), scheme)).toEqual(chat);
@@ -13,13 +13,24 @@ describe.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
       );
     });
 
-    test('keeps the URL shapes that Live Activities and Expo Router already open', () => {
-      expect(createBackgroundTaskUrl(scheme, { agentId: 'a', kind: 'chat', sessionId: 's' })).toBe(
-        `${scheme}:///?agentId=a&sessionId=s`,
+    test('opens the task surfaces without requiring a redundant agent or generated image id', () => {
+      expect(createBackgroundTaskUrl(scheme, { kind: 'chat', sessionId: 's' })).toBe(
+        `${scheme}:///?sessionId=s`,
       );
       expect(createBackgroundTaskUrl(scheme, { kind: 'painting', paintingId: 'p' })).toBe(
-        `${scheme}://paintings/p`,
+        `${scheme}://paintings?paintingId=p`,
       );
+    });
+
+    test('accepts notifications delivered by previous app versions', () => {
+      expect(parseBackgroundTaskUrl(`${scheme}:///?agentId=a&sessionId=s`, scheme)).toEqual({
+        kind: 'chat',
+        sessionId: 's',
+      });
+      expect(parseBackgroundTaskUrl(`${scheme}://paintings/p`, scheme)).toEqual({
+        kind: 'painting',
+        paintingId: 'p',
+      });
     });
 
     test('rejects other schemes, unknown routes, incomplete links, and malformed encoding', () => {
@@ -27,10 +38,19 @@ describe.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
       expect(parseBackgroundTaskUrl(`${scheme}://settings`, scheme)).toBeUndefined();
       expect(parseBackgroundTaskUrl(`${scheme}://paintings/p/extra`, scheme)).toBeUndefined();
       expect(parseBackgroundTaskUrl(`${scheme}:///?agentId=a`, scheme)).toBeUndefined();
-      expect(parseBackgroundTaskUrl(`${scheme}:///?agentId=&sessionId=s`, scheme)).toBeUndefined();
+      expect(parseBackgroundTaskUrl(`${scheme}:///?sessionId=`, scheme)).toBeUndefined();
+      expect(parseBackgroundTaskUrl(`${scheme}://paintings?paintingId=`, scheme)).toBeUndefined();
       expect(parseBackgroundTaskUrl(`${scheme}://paintings/%E0%A4`, scheme)).toBeUndefined();
       expect(parseBackgroundTaskUrl(undefined, scheme)).toBeUndefined();
       expect(parseBackgroundTaskUrl(42, scheme)).toBeUndefined();
     });
   },
 );
+
+test('notification identity includes the task kind and compares decoded ids', () => {
+  const chat = { kind: 'chat', sessionId: 'same' } as const;
+  expect(isSameBackgroundTask(chat, { ...chat })).toBe(true);
+  expect(isSameBackgroundTask(chat, { kind: 'painting', paintingId: 'same' })).toBe(false);
+  expect(isSameBackgroundTask(chat, { kind: 'chat', sessionId: 'other' })).toBe(false);
+  expect(isSameBackgroundTask(undefined, undefined)).toBe(false);
+});

--- a/src/shared/backgroundActivity/attention.ts
+++ b/src/shared/backgroundActivity/attention.ts
@@ -1,0 +1,6 @@
+export type ForegroundActivityAttention = {
+  detail: string;
+  phase: 'awaiting-approval' | 'failed';
+  title: string;
+  url?: string;
+};

--- a/src/shared/backgroundActivity/taskLink.ts
+++ b/src/shared/backgroundActivity/taskLink.ts
@@ -4,7 +4,7 @@
  * result to a route. Nothing else needs to know the URL shape.
  */
 export type BackgroundTaskLink =
-  | { kind: 'chat'; agentId: string; sessionId: string }
+  | { kind: 'chat'; sessionId: string }
   | { kind: 'painting'; paintingId: string };
 
 const PAINTINGS_SEGMENT = 'paintings';
@@ -13,13 +13,13 @@ const PAINTINGS_SEGMENT = 'paintings';
 export function createBackgroundTaskUrl(scheme: string, link: BackgroundTaskLink): string {
   switch (link.kind) {
     case 'chat':
-      return `${scheme}:///?agentId=${encodeURIComponent(link.agentId)}&sessionId=${encodeURIComponent(link.sessionId)}`;
+      return `${scheme}:///?sessionId=${encodeURIComponent(link.sessionId)}`;
     case 'painting':
-      return `${scheme}://${PAINTINGS_SEGMENT}/${encodeURIComponent(link.paintingId)}`;
+      return `${scheme}://${PAINTINGS_SEGMENT}?paintingId=${encodeURIComponent(link.paintingId)}`;
   }
 }
 
-/** Reads a URL produced by `createBackgroundTaskUrl`; any other URL is `undefined`. */
+/** Reads a current or legacy task URL; unrelated destinations are `undefined`. */
 export function parseBackgroundTaskUrl(
   url: unknown,
   scheme: string,
@@ -32,18 +32,33 @@ export function parseBackgroundTaskUrl(
   try {
     if (segments.length === 0) {
       const params = parseQuery(query);
-      const agentId = params.get('agentId');
       const sessionId = params.get('sessionId');
-      return agentId && sessionId ? { agentId, kind: 'chat', sessionId } : undefined;
+      // Older notifications also carry agentId; the persisted session owns it.
+      return sessionId ? { kind: 'chat', sessionId } : undefined;
     }
     if (segments.length === 2 && segments[0] === PAINTINGS_SEGMENT) {
+      // Legacy task links pointed to the image viewer without an image id.
       const paintingId = decodeURIComponent(segments[1] ?? '');
+      return paintingId ? { kind: 'painting', paintingId } : undefined;
+    }
+    if (segments.length === 1 && segments[0] === PAINTINGS_SEGMENT) {
+      const paintingId = parseQuery(query).get('paintingId');
       return paintingId ? { kind: 'painting', paintingId } : undefined;
     }
   } catch {
     // Malformed percent-encoding is not one of our links.
   }
   return undefined;
+}
+
+export function isSameBackgroundTask(
+  left: BackgroundTaskLink | undefined,
+  right: BackgroundTaskLink | undefined,
+): boolean {
+  if (!left || !right || left.kind !== right.kind) return false;
+  return left.kind === 'chat' && right.kind === 'chat'
+    ? left.sessionId === right.sessionId
+    : left.kind === 'painting' && right.kind === 'painting' && left.paintingId === right.paintingId;
 }
 
 function parseQuery(query: string): Map<string, string> {

--- a/src/shared/backgroundActivity/types.ts
+++ b/src/shared/backgroundActivity/types.ts
@@ -11,4 +11,7 @@ export type BackgroundActivityEndPolicy = 'default' | 'immediate';
  * resolved app `colorScheme` and `logoUri`, and stamps `finishedAtEpochMs`
  * when a session finishes; features own everything else.
  */
-export type BackgroundActivityBaseProps = BackgroundActivityBasePresentation;
+export type BackgroundActivityBaseProps = BackgroundActivityBasePresentation & {
+  /** Opaque domain phase; its entry time determines foreground notification policy. */
+  phase?: string;
+};


### PR DESCRIPTION
### What this PR does

Android generation previously kept its ongoing notification visible while the app was open. Notification taps could duplicate screens or open a painting viewer without the image identifier it requires, and returning to a task could miss notifications delivered just afterward.

This PR keeps the execution service running across visibility changes and shows its silent progress notification only in the background. Successful foreground completion stays quiet, including delayed delivery; failure and tool approval still receive attention when needed.

- Notification taps restore the corresponding task and dismiss the opened notification. Focused task pages clear only their own notifications, including late native delivery. Aggregate progress notifications restore the app without selecting an arbitrary task.
- Painting notifications open the task/composer page. Existing tasks and edit/resize drafts have separate navigation identities; submitting a draft adopts its new task identity without remounting the composer. Legacy task URLs remain supported.
- Native service destruction clears the library's running state and interrupts currently protected work. Expected stops and stale service events cannot interrupt a newer task.

Regression coverage targets notification timing, service lifecycle, task navigation, draft identity, and installed patch contracts. Notification subscriptions use primitive task identity, and parser validation remains in the shared link tests.

### Screenshots or videos

Not captured. Native behavior still needs acceptance in a rebuilt Android development client.

### Why we need it and why it was done in this way

The `react-native-background-actions` patch observes native process visibility so ongoing notification changes do not restart execution. The library continues to own Headless JS and wake locks. Its stopped event synchronizes native destruction with application cancellation.

The `expo-notifications` patch emits a separate event after Android posts a notification. This closes the cleanup race because receipt can precede presentation or skip JavaScript during background delivery. App Shell owns task visibility, navigation, and foreground toasts through an injected presentation callback.

### Breaking changes

No user-data migration. Existing notification URLs remain readable. The native patches require a new Android client build; a JavaScript-only update cannot install them.

### Special notes for your reviewer

- Local checks passed: changed-file static checks, full `pnpm format:check`, and whitespace checks.
- Full local `pnpm lint` reports the same 7 unresolved `@cherrystudio/ai-core` imports in unchanged files because this workspace lacks the package's generated exports. CI builds the workspace packages before linting.
- Local tests, typecheck, builds, and device verification were not run. [PR CI for `8568f49ee`](https://github.com/CherryHQ/cherry-studio-app/actions/runs/34581332479) is running; its result applies to the current changes.
- CI does not establish Android native compilation or device behavior. Device acceptance should cover visibility transitions, lock screen execution, concurrent tasks, notification taps from a cold app, and late notification cleanup.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the final behavior and implementation
- [ ] Preview: Screenshots or video captured in a rebuilt development client
- [x] Code: Implementation and coverage are scoped to task notifications
- [x] Upgrade: Existing task URLs remain supported; the native rebuild requirement is documented
- [x] Documentation: Android notification behavior and route identity are documented
- [x] Self-review: Reviewed the final local diff

### Release note

```release-note
Android task notifications stay quiet while the app is open. Opening a notification restores the correct task and clears its viewed notifications. Painting notifications support generating, failed, and completed tasks without interfering with new editing drafts.
```
