### PR TITLE
fix(screen-layout): remove artificial screen-edge corners

### DIFF
--- a/docs/references/architecture-overview.md
+++ b/docs/references/architecture-overview.md
@@ -109,7 +109,7 @@ compatibility adapter or generic frontend selector for persistence services.
 - App shutdown closes Agent Runtime sessions and awaits tracked Agent turns before disposing lower
   infrastructure.
 - Navigation, translation, toast, and React Query invalidation stay in frontend owners.
-- `expo-screen-corner-radius` remains the bottom-sheet device adapter; context menus use Expo UI directly.
+- Bottom sheets own their card shape and safe-area spacing; context menus use Expo UI directly.
 
 Simple persistence classes sit behind Data API handlers. A workflow contract is introduced only
 when it hides meaningful orchestration, lifetime, platform, or third-party complexity.

--- a/docs/references/navigation-and-insets.md
+++ b/docs/references/navigation-and-insets.md
@@ -149,9 +149,9 @@ scrim, card geometry, safe areas, swipe/scrim dismissal, Android back, and acces
 Feature-level picker components pass their content into this shell, while screen callers only pass
 open/close and selection state.
 
-The card keeps a four-point inset from both screen edges and the bottom edge. Its bottom corners use
-the larger of the 28-point card radius or the display radius minus that inset, keeping rounded-screen
-geometry concentric without exposing device geometry to feature code.
+The card keeps a four-point inset from both screen edges and the bottom edge. Its own corner radii
+stay at 32 points on top and 28 points on the bottom, independent of the display's physical corners.
+The shell still applies window safe-area insets to keep its content clear of system UI.
 
 Component sheets use the shared `compact`, `medium`, `large`, and `full` height specs (40%, 60%,
 80%, and 100% of available height). Features choose or dynamically switch the semantic size; they

--- a/docs/references/navigation-and-insets.md
+++ b/docs/references/navigation-and-insets.md
@@ -149,9 +149,10 @@ scrim, card geometry, safe areas, swipe/scrim dismissal, Android back, and acces
 Feature-level picker components pass their content into this shell, while screen callers only pass
 open/close and selection state.
 
-The card keeps a four-point inset from both screen edges and the bottom edge. Its own corner radii
-stay at 32 points on top and 28 points on the bottom, independent of the display's physical corners.
-The shell still applies window safe-area insets to keep its content clear of system UI.
+The sheet fills the window width and meets its bottom edge without outer gaps or bottom corner
+radii. Only its exposed top corners use a 32-point radius. The background extends behind the bottom
+system UI, while the shell applies bottom safe-area padding to its content. Its maximum height stays
+12 points below the top safe area.
 
 Component sheets use the shared `compact`, `medium`, `large`, and `full` height specs (40%, 60%,
 80%, and 100% of available height). Features choose or dynamically switch the semantic size; they

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -37,11 +37,6 @@ jest.mock('expo-observe', () => ({
   useObserve: () => ({ markInteractive: jest.fn() }),
 }));
 
-// expo-screen-corner-radius resolves its native module at import time, so any
-// suite reaching BottomSheet throws without this. `null` is the library's own
-// "display radius unknown" answer, which every caller already handles.
-jest.mock('expo-screen-corner-radius', () => ({ getCornerRadiusSync: () => null }));
-
 // expo-media-library subclasses its native module's `Asset`/`Query` at import
 // time, and jest-expo's native stub has neither, so any suite reaching
 // DevicePermissions (through the service registry) throws without this. The

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "expo-observe": "~57.0.18",
     "expo-paste-input": "0.2.2",
     "expo-router": "~57.0.6",
-    "expo-screen-corner-radius": "^1.1.0",
     "expo-secure-store": "~57.0.2",
     "expo-sharing": "~57.0.18",
     "expo-splash-screen": "~57.0.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -102,7 +102,6 @@
     "expo-image": "*",
     "expo-linear-gradient": "*",
     "expo-paste-input": "*",
-    "expo-screen-corner-radius": "*",
     "expo-widgets": "*",
     "heroui-native": "*",
     "@cherrystudio/app-icons": "workspace:*",

--- a/packages/ui/src/components/bottom-sheet/README.md
+++ b/packages/ui/src/components/bottom-sheet/README.md
@@ -1,7 +1,7 @@
 # Bottom Sheet
 
 `BottomSheet` is Cherry Studio's only mobile sheet shell. It uses the same regulated card heights,
-four-point side and bottom insets, fixed card corners, drag handle, scrim, safe-area
+full-width bottom-attached surface, rounded top corners, drag handle, scrim, safe-area
 handling, gestures, Android back behavior, and accessibility behavior on iOS and Android.
 
 ```tsx

--- a/packages/ui/src/components/bottom-sheet/README.md
+++ b/packages/ui/src/components/bottom-sheet/README.md
@@ -1,7 +1,7 @@
 # Bottom Sheet
 
 `BottomSheet` is Cherry Studio's only mobile sheet shell. It uses the same regulated card heights,
-four-point side and bottom insets, display-concentric bottom corners, drag handle, scrim, safe-area
+four-point side and bottom insets, fixed card corners, drag handle, scrim, safe-area
 handling, gestures, Android back behavior, and accessibility behavior on iOS and Android.
 
 ```tsx

--- a/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
+++ b/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
@@ -6,7 +6,6 @@ import { BottomSheet } from '..';
 
 let mockBottomSheetProps: Record<string, unknown> = {};
 let mockHardwareBackPress: (() => boolean | null | undefined) | undefined;
-let mockScreenCornerRadius = 0;
 
 jest.mock('@cherrystudio/app-icons/icons/arrow-left', () => {
   const { View } = jest.requireActual('react-native');
@@ -33,10 +32,6 @@ jest.mock('@swmansion/react-native-bottom-sheet', () => {
   };
 });
 
-jest.mock('expo-screen-corner-radius', () => ({
-  getCornerRadiusSync: () => mockScreenCornerRadius,
-}));
-
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 59 }),
 }));
@@ -52,7 +47,6 @@ describe('BottomSheet', () => {
   beforeEach(() => {
     mockBottomSheetProps = {};
     mockHardwareBackPress = undefined;
-    mockScreenCornerRadius = 0;
     backHandlerSpy = jest
       .spyOn(BackHandler, 'addEventListener')
       .mockImplementation((_event, handler) => {
@@ -322,28 +316,6 @@ describe('BottomSheet', () => {
       borderTopRightRadius: 32,
       height: 420,
       width: Dimensions.get('window').width - 8,
-    });
-  });
-
-  test('keeps the bottom corners concentric with a rounded display', () => {
-    mockScreenCornerRadius = 62;
-
-    act(() => {
-      renderer = create(
-        <BottomSheet onClose={jest.fn()} open size="medium" testID="rounded" title="Options">
-          <Text>Content</Text>
-        </BottomSheet>,
-      );
-    });
-
-    const card = renderer?.root
-      .findAllByProps({ testID: 'rounded' })
-      .find((node) => typeof node.type === 'string');
-    expect(StyleSheet.flatten(card?.props.style)).toMatchObject({
-      borderBottomLeftRadius: 58,
-      borderBottomRightRadius: 58,
-      borderTopLeftRadius: 32,
-      borderTopRightRadius: 32,
     });
   });
 });

--- a/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
+++ b/packages/ui/src/components/bottom-sheet/__tests__/bottom-sheet.test.tsx
@@ -296,7 +296,7 @@ describe('BottomSheet', () => {
     expect(mockBottomSheetProps.index).toBe(2);
   });
 
-  test('uses a caller-provided fixed height on an inset rounded card', () => {
+  test('uses a caller-provided fixed height on a full-width sheet with only top corners rounded', () => {
     act(() => {
       renderer = create(
         <BottomSheet height={420} onClose={jest.fn()} open testID="fixed-height" title="Approval">
@@ -308,14 +308,15 @@ describe('BottomSheet', () => {
     const card = renderer?.root
       .findAllByProps({ testID: 'fixed-height' })
       .find((node) => typeof node.type === 'string');
-    expect(mockBottomSheetProps.detents).toEqual([0, 424]);
-    expect(StyleSheet.flatten(card?.props.style)).toMatchObject({
-      borderBottomLeftRadius: 28,
-      borderBottomRightRadius: 28,
+    const cardStyle = StyleSheet.flatten(card?.props.style);
+    expect(mockBottomSheetProps.detents).toEqual([0, 420]);
+    expect(cardStyle).toMatchObject({
       borderTopLeftRadius: 32,
       borderTopRightRadius: 32,
       height: 420,
-      width: Dimensions.get('window').width - 8,
+      width: Dimensions.get('window').width,
     });
+    expect(cardStyle.borderBottomLeftRadius ?? cardStyle.borderRadius ?? 0).toBe(0);
+    expect(cardStyle.borderBottomRightRadius ?? cardStyle.borderRadius ?? 0).toBe(0);
   });
 });

--- a/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
@@ -23,9 +23,7 @@ import { cn } from '../../utils';
 
 const CLOSED_INDEX = 0;
 const OPEN_INDEX = 1;
-const OUTER_INSET = 4;
 const TOP_INSET = 12;
-const BOTTOM_CORNER_RADIUS = 28;
 const TOP_CORNER_RADIUS = 32;
 const HEIGHT_RATIOS = {
   compact: 0.4,
@@ -101,14 +99,12 @@ export function BottomSheet(props: BottomSheetProps) {
   const scrimStyle = useResolveClassNames('bg-scrim');
   const scrimColor =
     typeof scrimStyle.backgroundColor === 'string' ? scrimStyle.backgroundColor : undefined;
-  const availableCardHeight = Math.max(0, windowHeight - insets.top - TOP_INSET - OUTER_INSET);
+  const availableCardHeight = Math.max(0, windowHeight - insets.top - TOP_INSET);
   const { height, size, sizes } = props;
   const { cardHeight, detents } = useMemo(
     () => resolveSheetHeights(availableCardHeight, dismissible, height, size, sizes),
     [availableCardHeight, dismissible, height, size, sizes],
   );
-  const cardWidth = Math.max(0, windowWidth - OUTER_INSET * 2);
-  const detentHeight = cardHeight + OUTER_INSET;
   const hasFooter = footer != null;
   const isCloseActionVisible = Boolean(closeAction && !backAction);
   const [index, setIndex] = useState(open ? OPEN_INDEX : CLOSED_INDEX);
@@ -179,7 +175,7 @@ export function BottomSheet(props: BottomSheetProps) {
       onSettle={handleSettle}
       scrimColor={scrimColor}
     >
-      <View style={[styles.layout, { height: detentHeight, width: '100%' }]}>
+      <View style={[styles.layout, { height: cardHeight, width: '100%' }]}>
         <View
           accessibilityElementsHidden={!open}
           accessibilityViewIsModal
@@ -190,7 +186,7 @@ export function BottomSheet(props: BottomSheetProps) {
             styles.card,
             {
               height: cardHeight,
-              width: cardWidth,
+              width: windowWidth,
             },
           ]}
           testID={testID}
@@ -254,7 +250,6 @@ export function BottomSheet(props: BottomSheetProps) {
             </View>
           ) : null}
         </View>
-        <View style={styles.bottomGap} />
       </View>
     </ModalBottomSheet>
   );
@@ -281,19 +276,14 @@ function resolveSheetHeights(
     .filter((height, index, heights) => index === 0 || height !== heights[index - 1]);
   const cardHeight = cardHeights.at(-1) ?? 0;
   const closedDetent = dismissible ? 0 : programmatic(0);
-  const detents: Detent[] = [closedDetent, ...cardHeights.map((height) => height + OUTER_INSET)];
+  const detents: Detent[] = [closedDetent, ...cardHeights];
 
   return { cardHeight, detents };
 }
 
 const styles = StyleSheet.create({
-  bottomGap: {
-    height: OUTER_INSET,
-  },
   card: {
     borderCurve: 'continuous',
-    borderBottomLeftRadius: BOTTOM_CORNER_RADIUS,
-    borderBottomRightRadius: BOTTOM_CORNER_RADIUS,
     borderTopLeftRadius: TOP_CORNER_RADIUS,
     borderTopRightRadius: TOP_CORNER_RADIUS,
   },

--- a/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/packages/ui/src/components/bottom-sheet/bottom-sheet.tsx
@@ -6,7 +6,6 @@ import {
   ModalBottomSheet,
   programmatic,
 } from '@swmansion/react-native-bottom-sheet';
-import { getCornerRadiusSync } from 'expo-screen-corner-radius';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   BackHandler,
@@ -99,7 +98,6 @@ export function BottomSheet(props: BottomSheetProps) {
   } = props;
   const insets = useSafeAreaInsets();
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
-  const screenCornerRadius = getCornerRadiusSync() ?? 0;
   const scrimStyle = useResolveClassNames('bg-scrim');
   const scrimColor =
     typeof scrimStyle.backgroundColor === 'string' ? scrimStyle.backgroundColor : undefined;
@@ -111,7 +109,6 @@ export function BottomSheet(props: BottomSheetProps) {
   );
   const cardWidth = Math.max(0, windowWidth - OUTER_INSET * 2);
   const detentHeight = cardHeight + OUTER_INSET;
-  const bottomCornerRadius = Math.max(BOTTOM_CORNER_RADIUS, screenCornerRadius - OUTER_INSET);
   const hasFooter = footer != null;
   const isCloseActionVisible = Boolean(closeAction && !backAction);
   const [index, setIndex] = useState(open ? OPEN_INDEX : CLOSED_INDEX);
@@ -192,8 +189,6 @@ export function BottomSheet(props: BottomSheetProps) {
           style={[
             styles.card,
             {
-              borderBottomLeftRadius: bottomCornerRadius,
-              borderBottomRightRadius: bottomCornerRadius,
               height: cardHeight,
               width: cardWidth,
             },
@@ -297,6 +292,8 @@ const styles = StyleSheet.create({
   },
   card: {
     borderCurve: 'continuous',
+    borderBottomLeftRadius: BOTTOM_CORNER_RADIUS,
+    borderBottomRightRadius: BOTTOM_CORNER_RADIUS,
     borderTopLeftRadius: TOP_CORNER_RADIUS,
     borderTopRightRadius: TOP_CORNER_RADIUS,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,9 +381,6 @@ importers:
       expo-router:
         specifier: ~57.0.6
         version: 57.0.6(patch_hash=36b45ad1cfe874395609f849cd53644b41e58ff77d4d9f033ae548ad2af5cd83)(755b2fb3800bff8c76884b3e38d3e8ce)
-      expo-screen-corner-radius:
-        specifier: ^1.1.0
-        version: 1.1.0(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-secure-store:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.6)
@@ -482,7 +479,7 @@ importers:
         version: 4.25.2(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-streamdown:
         specifier: 0.2.0
-        version: 0.2.0(b0f14ae949a048080a645852f5f97901)
+        version: 0.2.0(a9c5041d792855957ae33e1c79d10fc5)
       react-native-svg:
         specifier: 15.15.4
         version: 15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -892,9 +889,6 @@ importers:
       expo-paste-input:
         specifier: '*'
         version: 0.2.2(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      expo-screen-corner-radius:
-        specifier: '*'
-        version: 1.1.0(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-widgets:
         specifier: '*'
         version: 57.0.8(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.2.14)(expo@57.0.6)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -927,7 +921,7 @@ importers:
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-streamdown:
         specifier: '*'
-        version: 0.2.0(b0f14ae949a048080a645852f5f97901)
+        version: 0.2.0(a9c5041d792855957ae33e1c79d10fc5)
       react-native-worklets:
         specifier: '*'
         version: 0.10.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
@@ -6529,13 +6523,6 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
-
-  expo-screen-corner-radius@1.1.0:
-    resolution: {integrity: sha512-haF5BW/c72WKINNwtjW8OT9MoVIHQci9jrTBAqG/Omrr8DqCXnPg1RuhsVblRpeUXFCEuTC0NQlY+qS0taaYLA==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
-      react-native: '*'
 
   expo-secure-store@57.0.2:
     resolution: {integrity: sha512-PhrPMKnI7YSObLEQZOoP9evB2ZOCv9kFuG2L7cZfNlOwWjGbir711PlppkXVoM3JE8vamDrTqzMLGv266FhJJg==}
@@ -15837,12 +15824,6 @@ snapshots:
       - react-native-worklets
       - supports-color
 
-  expo-screen-corner-radius@1.1.0(expo@57.0.6)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
-    dependencies:
-      expo: 57.0.6(d5f991ac186e51872435ca0bcd5a72a5)
-      react: 19.2.3
-      react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
-
   expo-secure-store@57.0.2(expo@57.0.6):
     dependencies:
       expo: 57.0.6(d5f991ac186e51872435ca0bcd5a72a5)
@@ -18333,7 +18314,7 @@ snapshots:
 
   react-native-skia-apple-tvos@147.1.0: {}
 
-  react-native-streamdown@0.2.0(b0f14ae949a048080a645852f5f97901):
+  react-native-streamdown@0.2.0(a9c5041d792855957ae33e1c79d10fc5):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)

--- a/src/app/(drawer)/_layout.tsx
+++ b/src/app/(drawer)/_layout.tsx
@@ -1,5 +1,4 @@
 import { type DrawerContentComponentProps, Drawer } from 'expo-router/drawer';
-import { getCornerRadiusSync } from 'expo-screen-corner-radius';
 import { useWindowDimensions } from 'react-native';
 import type { PanGesture } from 'react-native-gesture-handler';
 
@@ -26,7 +25,6 @@ function configureDrawerGesture(gesture: PanGesture) {
 }
 
 export default function DrawerLayout() {
-  // Also re-reads the corner radius when a foldable switches displays.
   const { width } = useWindowDimensions();
   const [backgroundColor, overlayColor] = useThemeColor(['background', 'scrim']);
 
@@ -51,10 +49,8 @@ export default function DrawerLayout() {
             // Keep the scene opaque where a screen leaves its own content style
             // transparent, including beneath the overlaid sidebar.
             backgroundColor,
-            // The device's own radius, so the surface is already screen-shaped at
-            // rest and its corners disappear into the bezel.
-            borderCurve: 'continuous',
-            borderRadius: getCornerRadiusSync() ?? appSidebar.fallbackCornerRadius,
+            // The full-screen scene reaches every window edge. Let the display
+            // handle physical corners without clipping the header's blur.
             overflow: 'hidden',
           },
           // Only chat belongs to this navigator, so the full-width gesture can

--- a/src/frontend/appShell/sidebar/hooks/useDockMetrics.ts
+++ b/src/frontend/appShell/sidebar/hooks/useDockMetrics.ts
@@ -1,5 +1,4 @@
 import { getComposerActionCenterOffset } from '@cherrystudio/ui/components';
-import { getCornerRadiusSync } from 'expo-screen-corner-radius';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { appSidebar } from '@/frontend/utils/constants';
@@ -8,16 +7,14 @@ import { appSidebar } from '@/frontend/utils/constants';
  * Geometry of the floating dock, shared by the dock itself and by the body that
  * has to scroll clear of it.
  *
- * Horizontal spacing follows the display's corner radius, mirrored at the
- * drawer's straight right edge. Vertical placement aligns both button centers
- * with the chat composer's send action through its public layout contract.
+ * Horizontal spacing uses the dock's minimum inset and the window's safe area.
+ * Vertical placement aligns both button centers with the chat composer's send
+ * action through its public layout contract.
  */
 export function useDockMetrics() {
   const insets = useSafeAreaInsets();
   const buttonRadius = appSidebar.dockHeight / 2;
-  const screenRadius = getCornerRadiusSync() ?? appSidebar.fallbackCornerRadius;
-  // Floored for the (hypothetical) device whose radius is under the pill's.
-  const inset = Math.max(screenRadius - buttonRadius, appSidebar.dockMinInset);
+  const inset = Math.max(appSidebar.dockMinInset, insets.left, insets.right);
 
   return {
     /** Horizontal inset from the sidebar's edges. */

--- a/src/frontend/utils/constants.ts
+++ b/src/frontend/utils/constants.ts
@@ -78,9 +78,8 @@ export const appSidebar = {
   // than both so those surfaces win and cancel it; the library default of 5
   // beats them and steals their scroll.
   swipeActivationDistance: 20,
-  fallbackCornerRadius: 55, // surface radius when the device is missing from expo-screen-corner-radius' table
   dockHeight: 48, // floating bottom dock's button height, shared by both buttons
-  dockMinInset: 16, // floor for the dock's concentric inset (see SidebarDock)
+  dockMinInset: 16, // minimum horizontal inset, expanded when the safe area requires it
   headerRowHeight: 40, // brand row's height below the status bar; the body scrolls under it
   headerGapY: 8, // header's breathing room above and below the brand row
   recentSessionLimit: 10, // most-recent sessions shown before the "view all" row


### PR DESCRIPTION
### What this PR does

Before this PR: the full-screen chat scene was clipped to a device-derived radius, falling back to 55dp when unavailable. This could cut the top blur on square displays. Sidebar dock spacing and bottom-sheet corners also depended on the same screen-radius lookup, which reads only the top-left corner on Android.

After this PR:

- The chat scene fills the window without artificial corner clipping.
- Sidebar dock spacing uses a 16dp minimum and the window's horizontal safe-area insets.
- Bottom sheets fill the window width and reach its bottom edge, with no outer gaps or bottom corner radius. Only their exposed top corners retain a 32dp radius; bottom safe-area padding still protects their content.
- The unused screen-radius dependency, mocks, and obsolete display-concentric test are removed. Existing geometry assertions now cover the full-width sheet and its unrounded bottom edge, and layout documentation describes the final behavior.

### Screenshots or videos

Not captured. Device/UI acceptance was intentionally not run under the task's verification policy. Visual review on square and rounded displays in both themes remains pending.

### Why we need it and why it was done in this way

Screen-attached backgrounds reach the window edges without a second rounded outline. The bottom sheet's top edge remains inside the display, so that exposed edge keeps its own corners. Component shapes and safe-area spacing stay with their layout owners. Existing header blur, input styling, and keyboard avoidance are preserved.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm format:check`: passed across the repository.
- Scoped Oxlint and Expo lint: no errors; five existing `jest.setup.ts` warnings.
- `git diff --check`: passed.
- Dependency lockfile updated and deduplicated with lifecycle scripts disabled.
- `pnpm lint`: failed with seven `import/no-unresolved` errors in unchanged backend files. The `@cherrystudio/ai-core` exports reference its missing `dist/` directory in this workspace. Building the workspace packages was intentionally not run.
- Tests, type checks, builds, and device acceptance were not run under the task's verification policy.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the resulting behavior and validation limits.
- [ ] Preview: Screenshots or video are attached.
- [x] Code: Changes are limited to layout geometry and the dependency cleanup it enables.
- [x] Upgrade: No user migration is required.
- [x] Documentation: Internal layout references are updated; no user-guide change is needed.
- [x] Self-review: Reviewed the final diff before creating this draft.

### Release note

```release-note
Fix chat-header clipping on displays with square or unknown corners. Bottom sheets now fill the screen width and reach its bottom edge without artificial bottom corners, while sidebar spacing follows the window safe area.
```
