### PR TITLE
fix(design-tokens): align inline code with theme emphasis

### DIFF
--- a/packages/design-tokens/src/styles/native.css
+++ b/packages/design-tokens/src/styles/native.css
@@ -203,7 +203,7 @@
       --error-border: var(--red-400);
       --code-block: var(--gray-100);
       --inline-code: var(--gray-alpha-100);
-      --inline-code-foreground: var(--red-900);
+      --inline-code-foreground: var(--primary);
       --brand: #ff5757;
       --chat-user: var(--gray-alpha-100);
       --chat-background: #f9f9f9;
@@ -326,7 +326,7 @@
       --error-border: var(--red-400);
       --code-block: var(--gray-100);
       --inline-code: var(--gray-alpha-100);
-      --inline-code-foreground: var(--red-900);
+      --inline-code-foreground: var(--primary);
       --brand: #ff5757;
       --chat-user: var(--gray-alpha-100);
       --chat-background: var(--background);

--- a/packages/design-tokens/src/styles/product.css
+++ b/packages/design-tokens/src/styles/product.css
@@ -59,7 +59,7 @@
   /* Stable product domain: rich text and code (MarkdownText) */
   --code-block: var(--gray-100);
   --inline-code: var(--gray-alpha-100);
-  --inline-code-foreground: var(--red-900);
+  --inline-code-foreground: var(--primary);
 
   /* Fixed logo artwork color. Actions and content must use their semantic roles. */
   --brand: #ff5757;

--- a/packages/ui/stories/foundations/tokens.ts
+++ b/packages/ui/stories/foundations/tokens.ts
@@ -40,7 +40,7 @@ export const PALETTE_SCALES: PaletteScale[] = [
   { title: 'Blue', hint: 'info、reference', variables: scale('blue', hueSteps) },
   { title: 'Green', hint: 'primary、success', variables: scale('green', hueSteps) },
   { title: 'Amber', hint: 'warning、highlight', variables: scale('amber', hueSteps) },
-  { title: 'Red', hint: 'error、destructive、inline-code', variables: scale('red', hueSteps) },
+  { title: 'Red', hint: 'error、destructive', variables: scale('red', hueSteps) },
 ];
 
 export const SEMANTIC_GROUPS: SemanticGroup[] = [
@@ -109,7 +109,7 @@ export const SEMANTIC_GROUPS: SemanticGroup[] = [
   },
   {
     title: '产品域',
-    hint: '代码块与行内代码用于 MarkdownText；chat-user 是 user 气泡底色，chat-background 是聊天业务覆盖的消息区底色。',
+    hint: '代码块与行内代码用于 MarkdownText，行内代码文字跟随 primary 主题强调色；chat-user 是 user 气泡底色，chat-background 是聊天业务覆盖的消息区底色。',
     kind: 'surface',
     variables: ['--code-block', '--inline-code', '--chat-user', '--chat-background'],
   },


### PR DESCRIPTION
### What this PR does

Before this PR: inline code in chat messages used `red-900` in both light and dark themes, so backtick-wrapped keywords appeared red despite the app's green emphasis color.

After this PR: `inline-code-foreground` references `primary`, so inline code follows the theme's emphasis color in both modes. Regenerate `native.css` and update the Foundations color descriptions to match.

### Screenshots or videos

Pending. Device/UI verification was not run for this task, so no screenshots are attached.

### Why we need it and why it was done in this way

The existing shared semantic token owns inline-code text color for both streaming and completed Markdown messages. Updating its source keeps both renderers consistent without component overrides.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm design:build`, `pnpm format:check`, and `git diff --check`.
- `pnpm lint` failed with seven existing `import/no-unresolved` errors for `@cherrystudio/ai-core` and `@cherrystudio/ai-core/provider` in unchanged backend files; existing warnings were also reported.
- Not run under the task's verification restrictions: `pnpm design:check`, `pnpm typecheck`, tests, and light/dark device verification. Only theme CSS generation was authorized; broader builds were not run.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the change and validation limits
- [ ] Preview: Light/dark screenshots or video attached
- [x] Code: The change stays within the existing shared token contract
- [x] Upgrade: No migration or upgrade steps required
- [x] Documentation: Foundations descriptions updated; no user-guide update needed
- [x] Self-review: Reviewed the complete diff against `origin/v0.2`

### Release note

```release-note
Fixed inline-code keywords in chat messages appearing red instead of following the theme's emphasis color.
```
