### PR TITLE
fix(chat-header): prevent white blur backdrop in new chats

### DIFF
--- a/src/frontend/features/chat/ChatScreen.tsx
+++ b/src/frontend/features/chat/ChatScreen.tsx
@@ -39,7 +39,11 @@ export function ChatScreen() {
   return (
     <>
       <BlurTargetView ref={blurTargetRef} style={{ flex: 1 }}>
-        <ChatRouteContent />
+        {/* Android samples the target's children, so paint the chat background
+            inside it even when the draft or loading state has no message list. */}
+        <View className="flex-1 bg-chat-background">
+          <ChatRouteContent />
+        </View>
       </BlurTargetView>
       <MainHeader blurTarget={blurTargetRef} />
     </>


### PR DESCRIPTION
### What this PR does

Before this PR: A new chat can show a white band behind the fading Android header blur because the transparent greeting leaves the blur target without the chat background.

After this PR: A full-size view inside `BlurTargetView` paints the theme-aware `chat-background` for draft, loading, and conversation states. The existing blur intensity and fade remain intact.

### Screenshots or videos

Pending light- and dark-theme device verification. No post-change capture is available; device verification was not authorized for this task.

### Why we need it and why it was done in this way

Expo Blur samples an internal Android target containing the React children. Painting the background inside that target ensures it participates in sampling even when no message list is mounted. This reuses the existing chat color token without introducing state-dependent header behavior.

### Breaking changes

None.

### Special notes for your reviewer

- Passed: `pnpm format:check` and `git diff --check`.
- `pnpm lint` failed on seven existing `import/no-unresolved` errors for `@cherrystudio/ai-core` and its provider entry in unrelated files, alongside existing warnings. No diagnostics were reported for the changed file.
- Builds, typecheck, tests, and device verification were not run under the task's verification constraints. The root typecheck command includes a package build.

### Checklist

- [x] Branch: This PR targets `v0.2`.
- [x] PR: The description explains the problem, change, and verification limits.
- [ ] Preview: Post-change screenshots or video are available.
- [x] Code: The change is limited to the chat screen's sampled background.
- [x] Upgrade: No migration or upgrade steps are required.
- [x] Documentation: No user-guide update is required for this visual bug fix.
- [x] Self-review: The local diff was reviewed.

### Release note

```release-note
Fix the white background behind the fading Android chat header when starting a new conversation.
```
