### PR TITLE
fix(native-build): sync generated props and iOS build numbers

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -24,6 +24,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     scheme: `cherrystudio${suffix.replace('.', '-')}`,
     ios: {
       ...config.ios,
+      buildNumber: process.env.EAS_BUILD_IOS_BUILD_NUMBER ?? config.ios?.buildNumber,
       bundleIdentifier,
       entitlements: {
         ...config.ios?.entitlements,

--- a/packages/ui/src/components/composer/__tests__/composer-native-patch.test.ts
+++ b/packages/ui/src/components/composer/__tests__/composer-native-patch.test.ts
@@ -13,6 +13,26 @@ describe('react-native-enriched-markdown iOS patch', () => {
     expect(patch).toContain('variant.getString("icon")');
   });
 
+  test.each([
+    'ios/generated/ReactCodegen/EnrichedMarkdownTextSpec/Props.h',
+    'android/generated/jni/react/renderer/components/EnrichedMarkdownTextSpec/Props.h',
+  ])('ships inline icon fields and serialization in %s', (headerPath) => {
+    const header = readFileSync(
+      `${process.cwd()}/node_modules/react-native-enriched-markdown/${headerPath}`,
+      'utf8',
+    );
+    const linkVariant = header
+      .split('struct EnrichedMarkdownTextInputMarkdownStyleLinkVariantsStruct {')[1]
+      ?.split('struct EnrichedMarkdownTextInputMarkdownStyle')[0];
+
+    expect(linkVariant).toContain('std::string icon{};');
+    expect(linkVariant).toContain('bool iconTint{false};');
+    expect(linkVariant).toContain('result["icon"] = icon;');
+    expect(linkVariant).toContain('result["iconTint"] = iconTint;');
+    expect(linkVariant).toContain('fromRawValue(context, tmp_icon->second, result.icon);');
+    expect(linkVariant).toContain('fromRawValue(context, tmp_iconTint->second, result.iconTint);');
+  });
+
   test('limits attachments to the leading object character and clears their old formatting', () => {
     const patch = readFileSync(
       `${process.cwd()}/patches/react-native-enriched-markdown@1.0.1.patch`,

--- a/patches/react-native-enriched-markdown@1.0.1.patch
+++ b/patches/react-native-enriched-markdown@1.0.1.patch
@@ -775,3 +775,77 @@ index 240cd3e5d736d370160dc1907c0760f18d5ed478..b5b6edcceb083c4345e3a717f1173541
          color: normalizeColor(override.color) ?? linkBase.color,
          underline: override.underline ?? linkBase.underline,
          backgroundColor:
+diff --git a/android/generated/jni/react/renderer/components/EnrichedMarkdownTextSpec/Props.h b/android/generated/jni/react/renderer/components/EnrichedMarkdownTextSpec/Props.h
+index 1416540317cfe30b8f54c04643afd7296e6e707f..26ef02bc62c39869f9e2d4fedff1cb0633dde65d 100644
+--- a/android/generated/jni/react/renderer/components/EnrichedMarkdownTextSpec/Props.h
++++ b/android/generated/jni/react/renderer/components/EnrichedMarkdownTextSpec/Props.h
+@@ -2923,6 +2923,8 @@ static inline folly::dynamic toDynamic(const EnrichedMarkdownTextInputMarkdownSt
+ 
+ struct EnrichedMarkdownTextInputMarkdownStyleLinkVariantsStruct {
+   std::string pattern{};
++  std::string icon{};
++  bool iconTint{false};
+   SharedColor color{};
+   bool underline{false};
+   SharedColor backgroundColor{};
+@@ -2934,6 +2936,8 @@ struct EnrichedMarkdownTextInputMarkdownStyleLinkVariantsStruct {
+   folly::dynamic toDynamic() const {
+     folly::dynamic result = folly::dynamic::object();
+     result["pattern"] = pattern;
++    result["icon"] = icon;
++    result["iconTint"] = iconTint;
+     result["color"] = ::facebook::react::toDynamic(color);
+     result["underline"] = underline;
+     result["backgroundColor"] = ::facebook::react::toDynamic(backgroundColor);
+@@ -2949,6 +2953,14 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
+   if (tmp_pattern != map.end()) {
+     fromRawValue(context, tmp_pattern->second, result.pattern);
+   }
++  auto tmp_icon = map.find("icon");
++  if (tmp_icon != map.end()) {
++    fromRawValue(context, tmp_icon->second, result.icon);
++  }
++  auto tmp_iconTint = map.find("iconTint");
++  if (tmp_iconTint != map.end()) {
++    fromRawValue(context, tmp_iconTint->second, result.iconTint);
++  }
+   auto tmp_color = map.find("color");
+   if (tmp_color != map.end()) {
+     fromRawValue(context, tmp_color->second, result.color);
+diff --git a/ios/generated/ReactCodegen/EnrichedMarkdownTextSpec/Props.h b/ios/generated/ReactCodegen/EnrichedMarkdownTextSpec/Props.h
+index 1416540317cfe30b8f54c04643afd7296e6e707f..26ef02bc62c39869f9e2d4fedff1cb0633dde65d 100644
+--- a/ios/generated/ReactCodegen/EnrichedMarkdownTextSpec/Props.h
++++ b/ios/generated/ReactCodegen/EnrichedMarkdownTextSpec/Props.h
+@@ -2923,6 +2923,8 @@ static inline folly::dynamic toDynamic(const EnrichedMarkdownTextInputMarkdownSt
+ 
+ struct EnrichedMarkdownTextInputMarkdownStyleLinkVariantsStruct {
+   std::string pattern{};
++  std::string icon{};
++  bool iconTint{false};
+   SharedColor color{};
+   bool underline{false};
+   SharedColor backgroundColor{};
+@@ -2934,6 +2936,8 @@ struct EnrichedMarkdownTextInputMarkdownStyleLinkVariantsStruct {
+   folly::dynamic toDynamic() const {
+     folly::dynamic result = folly::dynamic::object();
+     result["pattern"] = pattern;
++    result["icon"] = icon;
++    result["iconTint"] = iconTint;
+     result["color"] = ::facebook::react::toDynamic(color);
+     result["underline"] = underline;
+     result["backgroundColor"] = ::facebook::react::toDynamic(backgroundColor);
+@@ -2949,6 +2953,14 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
+   if (tmp_pattern != map.end()) {
+     fromRawValue(context, tmp_pattern->second, result.pattern);
+   }
++  auto tmp_icon = map.find("icon");
++  if (tmp_icon != map.end()) {
++    fromRawValue(context, tmp_icon->second, result.icon);
++  }
++  auto tmp_iconTint = map.find("iconTint");
++  if (tmp_iconTint != map.end()) {
++    fromRawValue(context, tmp_iconTint->second, result.iconTint);
++  }
+   auto tmp_color = map.find("color");
+   if (tmp_color != map.end()) {
+     fromRawValue(context, tmp_color->second, result.color);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ patchedDependencies:
   ollama-ai-provider-v2@3.3.1: 4cb5921e69158814eeeed8d71c80621bd261f33d769b6afabba0db40931155eb
   react-native-background-actions@4.1.0: 60bb15bc1307b6c314737b61285e5795504d45460c49beae751035ad91f522d4
   react-native-drawer-layout@4.2.4: 5d567d547b418913c11d2dfe413fc9c1caa72027b12a4a212d23447fc3efe934
-  react-native-enriched-markdown@1.0.1: 93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9
+  react-native-enriched-markdown@1.0.1: c9396134a6063b440bfc38675e863b7e2031521093c91d99e8e151be2b0cb749
   react-native-keyboard-controller@1.21.13: 6f5bed7a836aae55a44a2b0a97532e6d73d9dfb87032457499dfe3ff2c239186
   react-native-nitro-healthkit@1.0.0: 7cf6de1a057d10ee9606b9dc88a45d7c8e1e13b97806b1baf1a2fc19dfb28f31
   react-native-reanimated@4.5.0: 98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1
@@ -451,7 +451,7 @@ importers:
         version: 7.0.2(react-native-svg@15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-enriched-markdown:
         specifier: 1.0.1
-        version: 1.0.1(patch_hash=93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+        version: 1.0.1(patch_hash=c9396134a6063b440bfc38675e863b7e2031521093c91d99e8e151be2b0cb749)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -484,7 +484,7 @@ importers:
         version: 4.25.2(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-streamdown:
         specifier: 0.2.0
-        version: 0.2.0(a9c5041d792855957ae33e1c79d10fc5)
+        version: 0.2.0(6bc205d908d691e2130b125eb71610f6)
       react-native-svg:
         specifier: 15.15.4
         version: 15.15.4(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -911,7 +911,7 @@ importers:
         version: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
       react-native-enriched-markdown:
         specifier: '*'
-        version: 1.0.1(patch_hash=93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+        version: 1.0.1(patch_hash=c9396134a6063b440bfc38675e863b7e2031521093c91d99e8e151be2b0cb749)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-gesture-handler:
         specifier: '*'
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -929,7 +929,7 @@ importers:
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-streamdown:
         specifier: '*'
-        version: 0.2.0(a9c5041d792855957ae33e1c79d10fc5)
+        version: 0.2.0(6bc205d908d691e2130b125eb71610f6)
       react-native-worklets:
         specifier: '*'
         version: 0.10.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
@@ -18310,7 +18310,7 @@ snapshots:
       react-native-reanimated: 4.5.0(patch_hash=98a5ad9821aaded8cb131bcc4d0b77f31aa2489850cccfd2f13db70259fe1bd1)(react-native-worklets@0.10.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-enriched-markdown@1.0.1(patch_hash=93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+  react-native-enriched-markdown@1.0.1(patch_hash=c9396134a6063b440bfc38675e863b7e2031521093c91d99e8e151be2b0cb749)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
@@ -18402,11 +18402,11 @@ snapshots:
 
   react-native-skia-apple-tvos@147.1.0: {}
 
-  react-native-streamdown@0.2.0(a9c5041d792855957ae33e1c79d10fc5):
+  react-native-streamdown@0.2.0(6bc205d908d691e2130b125eb71610f6):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1)
-      react-native-enriched-markdown: 1.0.1(patch_hash=93d4f1cf71709a54b4b0cef5910ffb81f63e24a015f2ee42269113116d25f0d9)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      react-native-enriched-markdown: 1.0.1(patch_hash=c9396134a6063b440bfc38675e863b7e2031521093c91d99e8e151be2b0cb749)(@expo/config-plugins@57.0.5(supports-color@8.1.1)(typescript@6.0.3))(katex@0.17.0)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-worklets: 0.10.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
       remend: 1.3.0
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- iOS builds fail because the Markdown input native code references `icon` and `iconTint`, but the dependency's bundled generated props do not contain those fields.
- EAS can assign the main iOS app a new build number while Expo Widgets retains the old number (for example, app `19` and widget `1`).

After this PR:
- Both Android and iOS bundled `Props.h` files include the inline icon fields and their serialization. Regression guards check the installed headers, and the lockfile records the updated patch hash without changing dependency versions.
- Expo config reads `EAS_BUILD_IOS_BUILD_NUMBER` before native generation, keeping the app and widget build numbers aligned while preserving the configured fallback.

### Screenshots or videos

N/A — native build configuration and generated prop contracts; no visual changes.

### Why we need it and why it was done in this way

`react-native-enriched-markdown` ships generated code with `includesGeneratedCode: true`, so builds do not regenerate the missing fields from the already-patched TypeScript interface. Updating the shipped headers makes the existing native implementation compile. Passing the EAS build number through Expo config lets widget generation use the same number as the app.

### Breaking changes

None.

### Special notes for your reviewer

Validation:
- `pnpm format:check` and `git diff --check` passed; the commit formatting hook also passed.
- `pnpm lint` failed with seven unresolved imports from `@cherrystudio/ai-core`; both `packages/ai-core/dist` and `packages/ai-sdk-provider/dist` are absent locally. Other lint warnings are outside this diff.
- `pnpm typecheck:packages` and `pnpm typecheck:app` failed on missing workspace package declarations and resulting type errors. The root `pnpm typecheck` also compiles packages, so it was not run for this PR-only request under the user's local build restrictions.
- The new regression tests have not been run. No new builds, test suites, or device acceptance were run while preparing this PR.
- Earlier authorized local Android development, iOS development, and iOS production packaging completed with artifact signature checks. The final iOS production IPA has matching app/widget build number `20` and was successfully uploaded for TestFlight processing.

Keep this PR as a draft until the outstanding checks are completed.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the problem, fix, and validation limits
- [x] Preview: No visible change; screenshots are not applicable
- [x] Code: Changes are limited to the native build fixes and their regression guards
- [x] Upgrade: No dependency version changes or migration requirements
- [x] Self-review: Reviewed the complete diff before submission

### Release note

```release-note
NONE
```
