### PR TITLE
fix(android-background): restore notifications and protect chat preparation

### DIFF
--- a/docs/references/android-background-generation.md
+++ b/docs/references/android-background-generation.md
@@ -17,6 +17,10 @@ post-presentation event so task acknowledgement can follow asynchronous native d
   Chat and painting keep acquiring leases through the coordinator and never branch on platform.
   Concurrent chat and painting work share one execution service. It becomes a `dataSync` foreground
   service only while the application is not visible. The last lease stops it.
+- Chat acquires a preference-gated preparation lease before its first asynchronous admission step.
+  The generated turn acquires its session lease before preparation releases, so leaving during
+  model/tool preparation does not defer the first service start until the app is already backgrounded.
+  A failed preparation releases its lease without creating a task surface or starting generation.
 - `react-native-background-actions` uses React Native's `HeadlessJsTaskService`, which owns the
   Headless JS task and a partial wake lock. The lock supports CPU execution with the screen off;
   it does not bypass Android Doze, vendor power management, process death, or user force-stop.
@@ -124,8 +128,12 @@ while JavaScript remains alive. It does not restart paid requests. Whole-process
 requires reconciliation at the next process start.
 See [Android service timeouts](https://developer.android.com/develop/background-work/services/fgs/timeout).
 
-The notification permission is requested in context after a task's service starts. Denial does not
-prevent the foreground service, but Android hides its notification from the ordinary drawer.
+The notification permission is requested in context after a task's service admission attempt, even
+if admission failed. If the app leaves before the prompt, returning while the service runs requests
+it. A native request error permits a later attempt; a user's denial does not cause repeated prompts
+within the runtime. Denial does not prevent the foreground service, but Android hides its notification
+from the ordinary drawer. A rejected service start interrupts its unprotected callers instead of
+leaving them running with a lease that has no native execution protection.
 See [notification permission behavior](https://developer.android.com/develop/ui/compose/notifications/notification-permission).
 
 The app declares `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `WAKE_LOCK`, and
@@ -163,6 +171,11 @@ These native dependencies, both patches, and config plugins require a rebuilt de
 and EAS Updates cannot add native modules. Use [Local EAS Builds](../guides/local-builds.md) when a
 build is authorized. Compatibility with Cherry's Expo 57 / React Native 0.86 and device behavior
 must be verified in that client; source review and lint do not establish runtime compatibility.
+
+`package.json` opts `expo-notifications` into `expo.autolinking.android.buildFromSource`. Expo's
+bundled precompiled AAR does not contain our native presentation event; patching its Kotlin sources
+alone leaves that event absent from the installed app. Keep this opt-out while the native patch is
+required, and inspect the rebuilt APK as well as the installed source guards.
 
 Regression suites describe concurrent leases, foreground-only admission, permission denial,
 background-budget reset/cancellation, approval cleanup, single completion delivery, and awaiting

--- a/package.json
+++ b/package.json
@@ -5,6 +5,15 @@
   "engines": {
     "node": "24.x"
   },
+  "expo": {
+    "autolinking": {
+      "android": {
+        "buildFromSource": [
+          "expo-notifications"
+        ]
+      }
+    }
+  },
   "scripts": {
     "packages:build": "pnpm --filter @cherrystudio/ai-sdk-provider build && pnpm --filter @cherrystudio/ai-core build",
     "eas-build-post-install": "pnpm packages:build",

--- a/src/backend/ai/agent/host/MobileAgentHost.ts
+++ b/src/backend/ai/agent/host/MobileAgentHost.ts
@@ -412,6 +412,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
     this.initialAdmissions.add(admission);
     let openedRuntimeSession: AgentRuntimeSession | undefined;
     let isRuntimeSessionInstalled = false;
+    const preparationLease = this.backgroundReply.acquirePreparation((reason) =>
+      abortController.abort(reason),
+    );
 
     try {
       const plan = await prepareInitialTurn(this.turnPreparation, parsed, signal);
@@ -452,6 +455,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
           );
       }
       this.initialAdmissions.delete(admission);
+      preparationLease.release();
       completion.resolve();
     }
   }
@@ -553,6 +557,9 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       abortController,
       completion: completion.promise,
     });
+    const preparationLease = this.backgroundReply.acquirePreparation((reason) =>
+      abortController.abort(reason),
+    );
     try {
       // Every gate between admission and the first durable write lives in the
       // preparation stage; a failure there leaves nothing to reconcile.
@@ -583,6 +590,7 @@ export class MobileAgentHost extends BaseService implements AgentProtocol {
       );
     } finally {
       this.admittingSessions.delete(sessionId);
+      preparationLease.release();
       completion.resolve();
     }
   }

--- a/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
+++ b/src/backend/ai/agent/host/__tests__/MobileAgentHost.test.ts
@@ -94,6 +94,9 @@ const backgroundReplyTurn = {
   update: jest.fn(),
 };
 const backgroundReply = {
+  acquirePreparation: jest.fn((_onInterrupt: (reason: Error) => void) => ({
+    release: jest.fn(),
+  })),
   clearSession: jest.fn(),
   startTurn: jest.fn((_input: BackgroundReplyTurnInput) => backgroundReplyTurn),
   updateSessionTitle: jest.fn(),
@@ -257,6 +260,79 @@ describe('MobileAgentHost', () => {
     jest.clearAllMocks();
     store = new InMemoryAgentSessionStore();
   });
+
+  test.each(['new', 'existing'] as const)(
+    'protects %s-session preparation before awaiting and hands off before releasing',
+    async (kind) => {
+      const prepared = createDeferred();
+      const runtime = new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }).script((controller) => {
+        controller.emit({ type: 'completed' });
+      });
+      const host = createHost(runtime, noOpNaming, noFiles, noOpTools, async (model) => {
+        await prepared.promise;
+        return inferenceModel(model);
+      });
+      const sessionId = kind === 'new' ? uuidv7() : (await createStoredSession()).id;
+      const input = {
+        sessionId,
+        ...messageIds(),
+        parts: [{ type: 'text' as const, text: 'Background preparation' }],
+      };
+      const submitting =
+        kind === 'new'
+          ? host.startSession({ ...input, agentId: AGENT_ID, executionTarget: { kind: 'local' } })
+          : host.submitMessage(input);
+      const lease = backgroundReply.acquirePreparation.mock.results[0]!.value;
+      expect(backgroundReply.acquirePreparation).toHaveBeenCalledTimes(1);
+      expect(lease.release).not.toHaveBeenCalled();
+      expect(backgroundReply.startTurn).not.toHaveBeenCalled();
+
+      prepared.resolve();
+      await submitting;
+      expect(lease.release).toHaveBeenCalledTimes(1);
+      expect(backgroundReply.startTurn.mock.invocationCallOrder[0]).toBeLessThan(
+        lease.release.mock.invocationCallOrder[0],
+      );
+      await host._doStop();
+    },
+  );
+
+  test.each(['new', 'existing'] as const)(
+    'interrupting %s-session preparation releases protection without launching a turn',
+    async (kind) => {
+      const prepared = createDeferred();
+      const host = createHost(
+        new FakeRuntime({ descriptor: FAKE_DESCRIPTOR }),
+        noOpNaming,
+        noFiles,
+        noOpTools,
+        async (model) => {
+          await prepared.promise;
+          return inferenceModel(model);
+        },
+      );
+      const sessionId = kind === 'new' ? uuidv7() : (await createStoredSession()).id;
+      const input = {
+        sessionId,
+        ...messageIds(),
+        parts: [{ type: 'text' as const, text: 'Interrupted preparation' }],
+      };
+      const submitting =
+        kind === 'new'
+          ? host.startSession({ ...input, agentId: AGENT_ID, executionTarget: { kind: 'local' } })
+          : host.submitMessage(input);
+      const reason = new Error('Background service admission failed');
+      const rejected = expect(submitting).rejects.toThrow(reason);
+      backgroundReply.acquirePreparation.mock.calls[0]![0](reason);
+      prepared.resolve();
+      await rejected;
+      expect(
+        backgroundReply.acquirePreparation.mock.results[0]!.value.release,
+      ).toHaveBeenCalledTimes(1);
+      expect(backgroundReply.startTurn).not.toHaveBeenCalled();
+      await host._doStop();
+    },
+  );
 
   test('correlates Runtime spans with the durable turn and finishes tracing after persistence', async () => {
     const { traces, records } = createTraceRecorder();

--- a/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
+++ b/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
@@ -217,12 +217,6 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
     if (this.disposed) return;
     void this.enqueue(() => this.reconcile()).catch((error: unknown) => {
       logger.warn('Background service update failed', error as Error);
-      if (!this.background?.isRunning()) {
-        void this.interruptLeases(error instanceof Error ? error : new Error(String(error))).catch(
-          (interruptionError: unknown) =>
-            logger.warn('Background service interruption failed', { error: interruptionError }),
-        );
-      }
     });
   }
 
@@ -252,6 +246,15 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
       }
       await background.updateNotification(content);
       this.armDeadline();
+    } catch (error) {
+      if (!background.isRunning()) {
+        // Cancellation may enqueue surface cleanup, so never await it inside this queue.
+        void this.interruptLeases(error instanceof Error ? error : new Error(String(error))).catch(
+          (interruptionError: unknown) =>
+            logger.warn('Background service interruption failed', { error: interruptionError }),
+        );
+      }
+      throw error;
     } finally {
       // Request after admission, including a failed attempt or a return while running.
       // The permission sheet must not race admission or depend on its success.

--- a/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
+++ b/src/backend/services/backgroundActivity/AndroidBackgroundActivityRuntime.ts
@@ -112,7 +112,6 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
       name: this.environment.translate('notifications.android.attentionChannel'),
       importance: notifications.AndroidImportance.HIGH,
       lockscreenVisibility: notifications.AndroidNotificationVisibility.PRIVATE,
-      sound: 'default',
     });
     // Never restore a dead process's stream or replay paid work.
     for (const notification of await notifications.getPresentedNotificationsAsync()) {
@@ -218,6 +217,12 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
     if (this.disposed) return;
     void this.enqueue(() => this.reconcile()).catch((error: unknown) => {
       logger.warn('Background service update failed', error as Error);
+      if (!this.background?.isRunning()) {
+        void this.interruptLeases(error instanceof Error ? error : new Error(String(error))).catch(
+          (interruptionError: unknown) =>
+            logger.warn('Background service interruption failed', { error: interruptionError }),
+        );
+      }
     });
   }
 
@@ -229,33 +234,34 @@ export class AndroidBackgroundActivityRuntime extends BaseService implements Kee
       return;
     }
     const content = this.runningContent();
-    if (background.isRunning()) {
+    try {
+      if (!background.isRunning()) {
+        // Android 12+: start only from a visible Activity, never from a background retry.
+        if (AppState.currentState !== 'active' || this.backgroundLimitReached) return;
+        await background.start(holdBackgroundExecution, {
+          ...content,
+          // Native visibility changes promote the same service without restarting its task.
+          // The initial strings also name its persistent channel in system settings.
+          taskTitle: this.environment.translate('notifications.android.runningTitle'),
+          taskDesc: this.environment.translate('notifications.android.preparing'),
+          taskName: 'CherryBackgroundGeneration',
+          taskIcon: { name: 'notification_icon', type: 'drawable' },
+          foregroundServiceType: ['dataSync'],
+          progressBar: { max: 1, value: 0, indeterminate: true },
+        });
+      }
       await background.updateNotification(content);
-      return;
-    }
-    // Android 12+: start only from a visible Activity, never from a background retry.
-    if (AppState.currentState !== 'active' || this.backgroundLimitReached) return;
-    await background.start(holdBackgroundExecution, {
-      ...content,
-      // The native service starts without a notification while visible and
-      // promotes itself when the app backgrounds, without restarting its task.
-      // The library also uses these initial strings as the persistent channel
-      // name/description. Keep conversation content out of system settings.
-      taskTitle: this.environment.translate('notifications.android.runningTitle'),
-      taskDesc: this.environment.translate('notifications.android.preparing'),
-      taskName: 'CherryBackgroundGeneration',
-      taskIcon: { name: 'notification_icon', type: 'drawable' },
-      foregroundServiceType: ['dataSync'],
-      progressBar: { max: 1, value: 0, indeterminate: true },
-    });
-    await background.updateNotification(content);
-    this.armDeadline();
-    // Request after starting, so the permission sheet cannot interrupt admission.
-    if (!this.permissionRequested && AppState.currentState === 'active') {
-      this.permissionRequested = true;
-      void this.notifications?.requestPermissionsAsync().catch((error: unknown) => {
-        logger.warn('Notification permission request failed', error as Error);
-      });
+      this.armDeadline();
+    } finally {
+      // Request after admission, including a failed attempt or a return while running.
+      // The permission sheet must not race admission or depend on its success.
+      if (!this.permissionRequested && AppState.currentState === 'active') {
+        this.permissionRequested = true;
+        void this.notifications?.requestPermissionsAsync().catch((error: unknown) => {
+          this.permissionRequested = false;
+          logger.warn('Notification permission request failed', error as Error);
+        });
+      }
     }
   }
 

--- a/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
@@ -81,6 +81,62 @@ afterEach(async () => {
   jest.restoreAllMocks();
 });
 
+test('a rejected service start interrupts unprotected work and still requests notification permission', async () => {
+  const failure = new Error('Native service admission failed');
+  native.start.mockRejectedValueOnce(failure);
+  const interrupted = jest.fn();
+  runtime.acquire('chat', interrupted);
+  await flush();
+  expect(interrupted).toHaveBeenCalledTimes(1);
+  expect(interrupted).toHaveBeenCalledWith(failure);
+  expect(running).toBe(false);
+  expect(notices.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+  runtime.acquire('next-task');
+  await flush();
+  expect(running).toBe(true);
+});
+
+test('returning while the service runs requests permission skipped during startup', async () => {
+  native.start.mockImplementationOnce(async () => {
+    running = true;
+    setAppState('background');
+  });
+  runtime.acquire('chat');
+  await flush();
+  expect(notices.requestPermissionsAsync).not.toHaveBeenCalled();
+  setAppState('active');
+  await flush();
+  expect(notices.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+  expect(native.start).toHaveBeenCalledTimes(1);
+});
+
+test('a notification update failure does not interrupt a service that is still running', async () => {
+  const interrupted = jest.fn();
+  native.updateNotification.mockRejectedValueOnce(new Error('Update failed'));
+  runtime.acquire('chat', interrupted);
+  await flush();
+  expect(running).toBe(true);
+  expect(interrupted).not.toHaveBeenCalled();
+  expect(notices.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+});
+
+test('returning retries a failed permission request without repeatedly prompting after denial', async () => {
+  notices.requestPermissionsAsync.mockRejectedValueOnce(
+    new Error('Permission activity unavailable'),
+  );
+  runtime.acquire('chat');
+  await flush();
+  expect(notices.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+  setAppState('background');
+  setAppState('active');
+  await flush();
+  expect(notices.requestPermissionsAsync).toHaveBeenCalledTimes(2);
+  setAppState('background');
+  setAppState('active');
+  await flush();
+  expect(notices.requestPermissionsAsync).toHaveBeenCalledTimes(2);
+});
+
 test('shares the library service across concurrent tasks and stops on the last release', async () => {
   runtime
     .createPresenter<BackgroundReplyActivityProps>()

--- a/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
+++ b/src/backend/services/backgroundActivity/__tests__/AndroidBackgroundActivityRuntime.test.ts
@@ -96,6 +96,43 @@ test('a rejected service start interrupts unprotected work and still requests no
   expect(running).toBe(true);
 });
 
+test('a failed restart interrupts tasks admitted while earlier cancellation drains', async () => {
+  const firstFailure = new Error('Initial admission failed');
+  const restartFailure = new Error('Recovery admission failed');
+  native.start.mockRejectedValueOnce(firstFailure).mockRejectedValueOnce(restartFailure);
+  const surface = runtime.createPresenter<BackgroundReplyActivityProps>().start(props('preparing'));
+  let finishCancellation!: () => void;
+  const cancellation = new Promise<void>((resolve) => {
+    finishCancellation = resolve;
+  });
+  const oldInterrupted = jest.fn(async () => {
+    await cancellation;
+    await surface.end('immediate', props('cancelled'));
+  });
+  runtime.acquire('old-task', oldInterrupted);
+  await flush();
+  expect(oldInterrupted).toHaveBeenCalledWith(firstFailure);
+
+  const newInterrupted = jest.fn();
+  runtime.acquire('new-task', newInterrupted);
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(1);
+  expect(newInterrupted).not.toHaveBeenCalled();
+
+  finishCancellation();
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(2);
+  expect(oldInterrupted).toHaveBeenCalledTimes(1);
+  expect(newInterrupted).toHaveBeenCalledTimes(1);
+  expect(newInterrupted).toHaveBeenCalledWith(restartFailure);
+  expect(running).toBe(false);
+
+  runtime.acquire('later-task');
+  await flush();
+  expect(native.start).toHaveBeenCalledTimes(3);
+  expect(running).toBe(true);
+});
+
 test('returning while the service runs requests permission skipped during startup', async () => {
   native.start.mockImplementationOnce(async () => {
     running = true;

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -15,6 +15,7 @@ import type {
   BackgroundActivitySession,
   BackgroundActivitySessionInput,
 } from '@/backend/services/backgroundActivity/BackgroundActivityManager';
+import type { KeepAliveSource } from '@/backend/services/keepAlive/KeepAliveCoordinator';
 import type {
   BackgroundReplyActivityProps,
   BackgroundReplyContent,
@@ -85,7 +86,12 @@ type EnvironmentPort = {
  */
 @Injectable('BackgroundReplyRuntime')
 @ServicePhase(Phase.PostReady)
-@DependsOn(['BackgroundActivityManager', 'PreferenceService', 'BackgroundActivityEnvironment'])
+@DependsOn([
+  'BackgroundActivityManager',
+  'PreferenceService',
+  'BackgroundActivityEnvironment',
+  'KeepAliveCoordinator',
+])
 @AppStatePolicy('background-presentation')
 export class BackgroundReplyRuntime
   extends BaseService
@@ -100,6 +106,7 @@ export class BackgroundReplyRuntime
     private readonly activities: BackgroundActivityPort,
     private readonly preference: PreferencePort,
     private readonly environment: EnvironmentPort,
+    private readonly keepAlive: KeepAliveSource,
   ) {
     super();
   }
@@ -137,6 +144,11 @@ export class BackgroundReplyRuntime
       record.session = undefined;
     }
   }
+
+  acquirePreparation = (onInterrupt: (reason: Error) => void) => {
+    if (!this.isActivated || this.disposed) return { release() {} };
+    return this.keepAlive.acquire('chat.preparation', onInterrupt);
+  };
 
   startTurn = (input: BackgroundReplyTurnInput): BackgroundReplyTurn => {
     if (!this.isActivated || this.disposed) return noOpTurn;

--- a/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
+++ b/src/backend/services/backgroundReply/BackgroundReplyRuntime.ts
@@ -15,7 +15,10 @@ import type {
   BackgroundActivitySession,
   BackgroundActivitySessionInput,
 } from '@/backend/services/backgroundActivity/BackgroundActivityManager';
-import type { KeepAliveSource } from '@/backend/services/keepAlive/KeepAliveCoordinator';
+import type {
+  KeepAliveLease,
+  KeepAliveSource,
+} from '@/backend/services/keepAlive/KeepAliveCoordinator';
 import type {
   BackgroundReplyActivityProps,
   BackgroundReplyContent,
@@ -100,6 +103,7 @@ export class BackgroundReplyRuntime
   private disposed = false;
   private generation = 0;
   private operationTail: Promise<void> = Promise.resolve();
+  private readonly preparationLeases = new Set<KeepAliveLease>();
   private turns = new Map<string, TurnRecord>();
 
   constructor(
@@ -138,6 +142,8 @@ export class BackgroundReplyRuntime
   }
 
   private cancelSessions(): void {
+    for (const lease of this.preparationLeases) lease.release();
+    this.preparationLeases.clear();
     for (const record of this.turns.values()) {
       this.clearUpdateTimer(record);
       record.session?.cancel();
@@ -145,9 +151,15 @@ export class BackgroundReplyRuntime
     }
   }
 
-  acquirePreparation = (onInterrupt: (reason: Error) => void) => {
+  acquirePreparation = (onInterrupt: (reason: Error) => void): KeepAliveLease => {
     if (!this.isActivated || this.disposed) return { release() {} };
-    return this.keepAlive.acquire('chat.preparation', onInterrupt);
+    const lease = this.keepAlive.acquire('chat.preparation', onInterrupt);
+    this.preparationLeases.add(lease);
+    return {
+      release: () => {
+        if (this.preparationLeases.delete(lease)) lease.release();
+      },
+    };
   };
 
   startTurn = (input: BackgroundReplyTurnInput): BackgroundReplyTurn => {
@@ -241,13 +253,8 @@ export class BackgroundReplyRuntime
     if (this.disposed) return;
     this.disposed = true;
 
-    const records = [...this.turns.values()];
+    this.cancelSessions();
     this.turns.clear();
-    for (const record of records) {
-      this.clearUpdateTimer(record);
-      record.session?.cancel();
-      record.session = undefined;
-    }
     await this.operationTail;
   }
 

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -71,6 +71,37 @@ describe('BackgroundReplyRuntime', () => {
     },
   );
 
+  test.each(['disabled', 'stopped'] as const)(
+    'releases pending preparation leases once when background reply is %s',
+    async (transition) => {
+      const runtime = await createRuntime();
+      const interrupt = jest.fn();
+      const completed = runtime.acquirePreparation(interrupt);
+      const pending = [
+        runtime.acquirePreparation(interrupt),
+        runtime.acquirePreparation(interrupt),
+      ];
+      completed.release();
+      completed.release();
+      expect(preparationRelease).toHaveBeenCalledTimes(1);
+
+      if (transition === 'disabled') {
+        enabled = false;
+        preferenceListener?.();
+        await flushOperations();
+      } else {
+        await runtime._doStop();
+      }
+      expect(preparationRelease).toHaveBeenCalledTimes(3);
+      expect(interrupt).not.toHaveBeenCalled();
+
+      for (const lease of pending) lease.release();
+      completed.release();
+      await runtime._doStop();
+      expect(preparationRelease).toHaveBeenCalledTimes(3);
+    },
+  );
+
   test.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
     'opens chat activities with the current app scheme %s',
     async (scheme) => {

--- a/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
+++ b/src/backend/services/backgroundReply/__tests__/BackgroundReplyRuntime.test.ts
@@ -40,6 +40,8 @@ describe('BackgroundReplyRuntime', () => {
     return session;
   };
   const mockStartSession = jest.fn(createMockSession);
+  const preparationRelease = jest.fn();
+  const acquire = jest.fn(() => ({ release: preparationRelease }));
 
   beforeEach(() => {
     enabled = true;
@@ -52,6 +54,22 @@ describe('BackgroundReplyRuntime', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
+
+  test.each([true, false])(
+    'preparation follows the background-reply preference: %s',
+    async (value) => {
+      enabled = value;
+      const runtime = await createRuntime();
+      const interrupt = jest.fn();
+      const lease = runtime.acquirePreparation(interrupt);
+      expect(acquire).toHaveBeenCalledTimes(value ? 1 : 0);
+      if (value) expect(acquire).toHaveBeenCalledWith('chat.preparation', interrupt);
+      expect(mockStartSession).not.toHaveBeenCalled();
+      lease.release();
+      expect(preparationRelease).toHaveBeenCalledTimes(value ? 1 : 0);
+      await runtime._doStop();
+    },
+  );
 
   test.each(['cherrystudio', 'cherrystudio-dev', 'cherrystudio-preview'])(
     'opens chat activities with the current app scheme %s',
@@ -537,6 +555,7 @@ describe('BackgroundReplyRuntime', () => {
         assistantPresenter: undefined as never,
         translate,
       },
+      { acquire },
     );
     await runtime._doInit();
     return runtime;

--- a/src/backend/services/backgroundReply/backgroundReplyTypes.ts
+++ b/src/backend/services/backgroundReply/backgroundReplyTypes.ts
@@ -1,3 +1,4 @@
+import type { KeepAliveLease } from '@/backend/services/keepAlive/KeepAliveCoordinator';
 import type { BackgroundReplyPhase } from '@/shared/backgroundActivity/chatReply';
 import type { AgentMessageView } from '@/shared/contracts/agent';
 
@@ -41,6 +42,8 @@ export type BackgroundReplyTurnInput = {
 };
 
 export type BackgroundReplyLifecycle = {
+  /** Protect submission preparation until the turn acquires its own execution lease. */
+  acquirePreparation: (onInterrupt: (reason: Error) => void) => KeepAliveLease;
   clearSession: (sessionId: string) => void;
   startTurn: (input: BackgroundReplyTurnInput) => BackgroundReplyTurn;
   updateSessionTitle: (sessionId: string, title: string) => void;

--- a/src/frontend/appShell/backgroundActivity/__tests__/androidNotificationPresentationPatch.test.ts
+++ b/src/frontend/appShell/backgroundActivity/__tests__/androidNotificationPresentationPatch.test.ts
@@ -5,6 +5,11 @@ const root = dirname(require.resolve('expo-notifications/package.json'));
 const source = (path: string) => readFileSync(join(root, path), 'utf8');
 const androidRoot = 'android/src/main/java/expo/modules/notifications';
 
+test('Android builds the patched notification sources instead of the bundled unpatched AAR', () => {
+  const config = JSON.parse(readFileSync(join(__dirname, '../../../../../package.json'), 'utf8'));
+  expect(config.expo.autolinking.android.buildFromSource).toContain('expo-notifications');
+});
+
 // Installed-package guards protect the native/JS event seam; device delivery
 // still needs acceptance in a development client containing this patch.
 test('presentation emits its own event after notify, even when background receipt skips JS', () => {


### PR DESCRIPTION
### What this PR does

Before this PR, chat acquired background protection only after asynchronous model/tool preparation. Leaving the app during preparation could miss Android's service-start window. A failed start only logged an error and could also skip the notification permission prompt. Expo 57's precompiled `expo-notifications` AAR additionally omitted our patched native presentation callback.

After this PR:

- New and existing chats acquire a preference-gated preparation lease before the first asynchronous step and hand it off to the turn before releasing it. Failed preparation releases protection without launching generation.
- Failed service admission interrupts unprotected work. Notification update failures preserve work when the native service is still running.
- Notification permission is requested after the admission attempt, including failed admission and foreground return. Native request errors permit retry; denial does not repeatedly prompt within the runtime.
- Android builds `expo-notifications` from patched sources so the presentation callback reaches the APK. The attention channel uses Expo's default system sound without the misleading custom-resource warning.

### Screenshots or videos

Emulator screenshots were captured for running, completed, failed, and permission-denied scenarios. Attachment upload is currently blocked by the browser automation tool's authentication error (`unsupported Codex auth method: apikey`); images are retained in the workspace's local verification evidence and are not attached to this draft.

### Why we need it and why it was done in this way

The existing shared keepalive coordinator owns preparation protection, so concurrent work keeps sharing one native service. Native presentation acknowledgement needs the existing Kotlin patch compiled into the app; changing JavaScript alone cannot restore that callback in older APKs. Building this one Expo module from source adds native build work but preserves the patched behavior.

### Special notes for your reviewer

**A new native Android build is required. An OTA update alone cannot repair the callback in previously built APKs.** No data migration is required.

Validation:

- `pnpm lint`: passed, with 8 existing warnings and no errors.
- `pnpm format:check`, `pnpm typecheck`, and `pnpm docs:check-links`: passed.
- All 11 relevant regression suites passed: 195 tests covering admission/handoff, interruption, permission, service lifecycle, notification patches, navigation, cleanup, and service registration.
- A local EAS development APK was built and installed on an isolated Android API 36 arm64 emulator. APK DEX inspection confirmed the patched presentation callback.
- With a deterministic local OpenAI-compatible provider, a 90-second/90-chunk stream survived immediate backgrounding and repeated foreground/background transitions without a new request. Completion and failure notifications appeared; tapping completion opened the correct chat and cleared it. Foreground completion stayed silent. Services and wake locks were released at completion.
- With notifications denied, a 35-second background stream completed while the service and wake lock remained active; the ordinary notification drawer stayed silent.

Device coverage is limited to chat on this emulator with the local provider. Real cloud providers, painting device workflows, physical-device vendor power policies, prolonged Doze, and the six-hour service timeout were not exercised. The full test suite is left to remote PR CI; it has not run for this draft.

### Checklist

- [x] Branch: This PR targets `v0.2`
- [x] PR: The description explains the problem and resulting behavior
- [ ] Preview: Attach the captured emulator screenshots
- [x] Code: Changes use existing lifecycle owners and keep the fix focused
- [x] Upgrade: Native rebuild requirement documented
- [x] Documentation: Android background-generation reference updated; no separate user-guide change needed
- [x] Self-review: Reviewed the complete source and test diff

### Release note

```release-note
Fix Android background chat protection during message preparation and restore notification presentation acknowledgement in new app builds. Improve notification permission handling and stop generation when background service admission fails. Action required: install a new Android app build; an OTA update alone does not fix older APKs.
```
